### PR TITLE
Add advanced services for call center management

### DIFF
--- a/appscripts.json
+++ b/appscripts.json
@@ -48,6 +48,36 @@
         "userSymbol": "Docs",
         "serviceId": "docs",
         "version": "v1"
+      },
+      {
+        "userSymbol": "Forms",
+        "serviceId": "forms",
+        "version": "v1"
+      },
+      {
+        "userSymbol": "Slides",
+        "serviceId": "slides",
+        "version": "v1"
+      },
+      {
+        "userSymbol": "People",
+        "serviceId": "peopleapi",
+        "version": "v1"
+      },
+      {
+        "userSymbol": "DriveActivity",
+        "serviceId": "driveactivity",
+        "version": "v2"
+      },
+      {
+        "userSymbol": "AppsActivity",
+        "serviceId": "appsactivity",
+        "version": "v1"
+      },
+      {
+        "userSymbol": "AdminReports",
+        "serviceId": "admin",
+        "version": "reports_v1"
       }
     ]
   },
@@ -72,6 +102,12 @@
     "https://www.googleapis.com/auth/script.scriptapp",
     "https://www.googleapis.com/auth/script.webapp.deploy",
     "https://www.googleapis.com/auth/admin.directory.user.readonly",
-    "https://www.googleapis.com/auth/admin.directory.group.readonly"
+    "https://www.googleapis.com/auth/admin.directory.group.readonly",
+    "https://www.googleapis.com/auth/forms",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/contacts.readonly",
+    "https://www.googleapis.com/auth/drive.activity.readonly",
+    "https://www.googleapis.com/auth/appsactivity"
   ]
 }


### PR DESCRIPTION
## Summary
- expand the Apps Script manifest to enable additional advanced services needed for call center workflows
- grant the OAuth scopes required for forms, presentations, contacts, and activity data access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ce770c508326bdf159dca7311946