### PR TITLE
Add requirements overview for call center platform

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,94 @@
+# Call Center Management Platform Requirements
+
+This document consolidates the functional requirements that surfaced during
+recent discovery sessions. The platform is built on Google Apps Script with
+Google Sheets as the primary data store and HTML/JavaScript (with jQuery) for
+the client-side experience.
+
+## Core Application Goals
+
+1. Provide a secure, multi-tenant Software-as-a-Service (SaaS) experience that
+   supports multiple client organizations ("campaigns") within a single
+   deployment.
+2. Deliver comprehensive call center management workflows spanning
+   authentication, scheduling, performance tracking, coaching, reporting, and
+   collaboration.
+3. Maintain transparent data sharing between the call center operator and each
+   client, while enforcing least-privilege access for agents and optional guest
+   users from the client side.
+
+## Authentication & Authorization
+
+- **Strict login policies** ensure that all access is scoped to the specific
+  client campaign(s) a user belongs to.
+- **Role tiers**:
+  - **Executives (CEO/CFO/HR, etc.)** – full access to every module across all
+    clients and campaigns.
+  - **Managers** – access limited to the campaigns and agents they oversee;
+    ability to manage rosters, review metrics, and handle coaching actions.
+  - **Agents** – default read-only access to personal schedules, QA scores,
+    coaching acknowledgements, and performance dashboards. Additional
+    privileges can be granted selectively.
+  - **Client guests** – limited visibility, primarily QA and performance
+    reporting, with optional elevation to broader access by internal admins.
+- **Campaign-aware sessions** guarantee that users cannot act on behalf of
+  other clients without explicit authorization.
+
+## Multi-Campaign Management
+
+- Support for multiple concurrent client campaigns, each with isolated datasets
+  and configurable access rules.
+- Managers can administer their assigned campaigns, including agent rosters,
+  schedules, and targeted communications.
+- Executive users retain the ability to view cross-campaign analytics for
+  organizational oversight.
+
+## Agent Experience
+
+- Personal dashboards featuring:
+  - Upcoming schedules and shift assignments.
+  - QA performance summaries and detailed score breakdowns.
+  - Coaching records and acknowledgement workflows.
+  - Recognition components highlighting top performers across attendance,
+    adherence, QA scores, and other KPIs.
+- Lightweight messaging interface to receive managerial updates, coaching
+  notifications, and performance feedback.
+
+## Manager & Executive Experience
+
+- Campaign dashboards consolidating agent metrics, attendance, QA outcomes, and
+  coaching statuses.
+- Ability to issue coaching items, request acknowledgements, and monitor
+  follow-up actions.
+- Messaging tools to communicate quick updates regarding agent performance and
+  compliance.
+- Administrative controls for onboarding users, assigning roles, and managing
+  client guest access.
+
+## Collaboration & Reporting
+
+- QA collaboration forms and dashboards to capture audits and quality reviews.
+- Attendance and adherence reporting views.
+- Executive-level summaries aggregating KPIs across campaigns for strategic
+  decision making.
+- Chat modules to facilitate targeted discussion threads between managers,
+  agents, and executives.
+
+## Extensibility Considerations
+
+- Modular HTML views (e.g., Top Performers, QA dashboards, Coaching lists)
+  should remain loosely coupled so new KPIs or workflows can be added without
+  disrupting existing modules.
+- Google Apps Script services should expose clear CRUD interfaces for users,
+  schedules, QA records, and coaching entries to support automation and future
+  integrations.
+
+## Next Steps
+
+1. Audit existing Apps Script services to confirm they enforce campaign-aware
+   access and role-based permissions as described.
+2. Inventory current HTML/JS modules to map each requirement to its UI
+   counterpart, identifying gaps.
+3. Prioritize implementation of strict login flows, campaign scoping, and role
+   management updates before layering additional feature work.
+


### PR DESCRIPTION
## Summary
- add documentation describing multi-tenant call center management requirements
- capture role-based access expectations and campaign-specific workflows
- outline next steps for auditing existing services against requirements

## Testing
- no tests were run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6dc6d127083269962f546bf2fce13