### PR TITLE
Wire sheet helpers into DatabaseManager CRUD

### DIFF
--- a/DatabaseBindings.gs
+++ b/DatabaseBindings.gs
@@ -1,0 +1,448 @@
+/**
+ * DatabaseBindings.gs
+ * Bridges legacy sheet helpers with the centralized DatabaseManager CRUD abstraction.
+ * - Automatically registers known sheet schemas with DatabaseManager
+ * - Provides global CRUD helpers (dbSelect/dbCreate/dbUpdate/dbDelete/dbUpsert)
+ * - Falls back to direct Spreadsheet operations if DatabaseManager is unavailable
+ */
+
+(function (global) {
+  if (!global) return;
+
+  var schemaRegistry = global.__DB_SCHEMA_REGISTRY__ || {};
+  global.__DB_SCHEMA_REGISTRY__ = schemaRegistry;
+
+  function getManager() {
+    return typeof global.DatabaseManager !== 'undefined' ? global.DatabaseManager : null;
+  }
+
+  function inferIdFromHeaders(headers) {
+    if (!Array.isArray(headers) || headers.length === 0) return null;
+    var normalized = headers.map(function (h) { return String(h || '').trim(); });
+    var preferred = ['ID', 'Id', 'Uuid', 'UUID'];
+    for (var i = 0; i < preferred.length; i++) {
+      var idx = normalized.indexOf(preferred[i]);
+      if (idx !== -1) return headers[idx];
+    }
+    for (var j = 0; j < normalized.length; j++) {
+      if (/Id$/i.test(normalized[j])) return headers[j];
+      if (/Key$/i.test(normalized[j])) return headers[j];
+    }
+    return null;
+  }
+
+  function cloneHeaders(headers) {
+    return Array.isArray(headers) ? headers.slice() : undefined;
+  }
+
+  function registerIfDefined(sheetName, headers, idColumn, extra) {
+    if (!sheetName || !Array.isArray(headers)) return;
+    if (schemaRegistry[sheetName] && schemaRegistry[sheetName].headers && schemaRegistry[sheetName].headers.length) return;
+    var config = { headers: cloneHeaders(headers) };
+    if (typeof idColumn !== 'undefined') config.idColumn = idColumn;
+    if (extra) {
+      for (var key in extra) {
+        if (Object.prototype.hasOwnProperty.call(extra, key)) {
+          config[key] = extra[key];
+        }
+      }
+    }
+    registerTableSchema(sheetName, config);
+  }
+
+  function attemptRegisterKnownSchemas() {
+    registerIfDefined(global.USERS_SHEET || 'Users', global.USERS_HEADERS, 'ID');
+    registerIfDefined(global.ROLES_SHEET || 'Roles', global.ROLES_HEADER, 'ID');
+    registerIfDefined(global.USER_ROLES_SHEET || 'UserRoles', global.USER_ROLES_HEADER, 'UserId');
+    registerIfDefined(global.USER_CLAIMS_SHEET || 'UserClaims', global.CLAIMS_HEADERS, 'ID');
+    registerIfDefined(global.SESSIONS_SHEET || 'Sessions', global.SESSIONS_HEADERS, 'Token');
+    registerIfDefined(global.CAMPAIGNS_SHEET || 'Campaigns', global.CAMPAIGNS_HEADERS, 'ID');
+    registerIfDefined(global.PAGES_SHEET || 'Pages', global.PAGES_HEADERS, 'PageKey');
+    registerIfDefined(global.CAMPAIGN_PAGES_SHEET || 'CampaignPages', global.CAMPAIGN_PAGES_HEADERS, 'ID');
+    registerIfDefined(global.PAGE_CATEGORIES_SHEET || 'PageCategories', global.PAGE_CATEGORIES_HEADERS, 'ID');
+    registerIfDefined(global.CAMPAIGN_USER_PERMISSIONS_SHEET || 'CampaignUserPermissions', global.CAMPAIGN_USER_PERMISSIONS_HEADERS, 'ID');
+    registerIfDefined(global.USER_MANAGERS_SHEET || 'UserManagers', global.USER_MANAGERS_HEADERS, 'ID');
+    registerIfDefined(global.USER_CAMPAIGNS_SHEET || 'UserCampaigns', global.USER_CAMPAIGNS_HEADERS, 'ID');
+    registerIfDefined(global.NOTIFICATIONS_SHEET || 'Notifications', global.NOTIFICATIONS_HEADERS, 'ID');
+    registerIfDefined(global.DEBUG_LOGS_SHEET || 'DebugLogs', global.DEBUG_LOGS_HEADERS, 'Timestamp', { timestamps: false, idColumn: 'Timestamp' });
+    registerIfDefined(global.ERROR_LOGS_SHEET || 'ErrorLogs', global.ERROR_LOGS_HEADERS, 'Timestamp', { timestamps: false, idColumn: 'Timestamp' });
+
+    registerIfDefined(global.CHAT_GROUPS_SHEET || 'ChatGroups', global.CHAT_GROUPS_HEADERS, 'ID');
+    registerIfDefined(global.CHAT_CHANNELS_SHEET || 'ChatChannels', global.CHAT_CHANNELS_HEADERS, 'ID');
+    registerIfDefined(global.CHAT_MESSAGES_SHEET || 'ChatMessages', global.CHAT_MESSAGES_HEADERS, 'ID');
+    registerIfDefined(global.CHAT_GROUP_MEMBERS_SHEET || 'ChatGroupMembers', global.CHAT_GROUP_MEMBERS_HEADERS, 'ID');
+    registerIfDefined(global.CHAT_MESSAGE_REACTIONS_SHEET || 'ChatMessageReactions', global.CHAT_MESSAGE_REACTIONS_HEADERS, 'ID');
+    registerIfDefined(global.CHAT_USER_PREFERENCES_SHEET || 'ChatUserPreferences', global.CHAT_USER_PREFERENCES_HEADERS, 'UserId');
+    registerIfDefined(global.CHAT_ANALYTICS_SHEET || 'ChatAnalytics', global.CHAT_ANALYTICS_HEADERS, 'Timestamp', { timestamps: false, idColumn: 'Timestamp' });
+    registerIfDefined(global.CHAT_CHANNEL_MEMBERS_SHEET || 'ChatChannelMembers', global.CHAT_CHANNEL_MEMBERS_HEADERS, 'ID');
+
+    registerIfDefined(global.ATTENDANCE_LOG_SHEET || global.ATTENDANCE_SHEET || 'AttendanceLog', global.ATTENDANCE_LOG_HEADERS, 'ID');
+  }
+
+  function applySchemaToManager(name) {
+    var manager = getManager();
+    if (!manager) return;
+    var schema = schemaRegistry[name];
+    if (!schema) return;
+    manager.defineTable(name, schema);
+  }
+
+  function inferSchemaFromSheet(name) {
+    var schema = { headers: [], idColumn: null };
+    try {
+      var ss = SpreadsheetApp.getActiveSpreadsheet();
+      if (!ss) return schema;
+      var sh = ss.getSheetByName(name);
+      if (!sh) return schema;
+      var lastCol = sh.getLastColumn();
+      if (lastCol < 1) return schema;
+      var headerRow = sh.getRange(1, 1, 1, lastCol).getValues()[0];
+      schema.headers = headerRow.map(function (h) { return String(h || '').trim(); });
+      schema.idColumn = inferIdFromHeaders(schema.headers);
+      return schema;
+    } catch (err) {
+      if (global.safeWriteError) {
+        try { global.safeWriteError('inferSchemaFromSheet', err); } catch (_) { }
+      }
+      return schema;
+    }
+  }
+
+  function ensureSchema(name) {
+    attemptRegisterKnownSchemas();
+    if (!schemaRegistry[name]) {
+      schemaRegistry[name] = inferSchemaFromSheet(name);
+    }
+    applySchemaToManager(name);
+    return schemaRegistry[name];
+  }
+
+  function registerTableSchema(name, options) {
+    if (!name) return null;
+    var schema = options ? Object.assign({}, options) : {};
+    if (schema.headers) schema.headers = cloneHeaders(schema.headers);
+    if (!Object.prototype.hasOwnProperty.call(schema, 'idColumn')) {
+      schema.idColumn = inferIdFromHeaders(schema.headers);
+    }
+    schemaRegistry[name] = schema;
+    applySchemaToManager(name);
+    return schema;
+  }
+
+  function dbTable(name) {
+    if (!name) throw new Error('Sheet name is required');
+    var manager = getManager();
+    ensureSchema(name);
+    if (!manager) return null;
+    return manager.table(name);
+  }
+
+  function dbSelect(name, options) {
+    var manager = getManager();
+    ensureSchema(name);
+    var query = options ? Object.assign({}, options) : {};
+    if (manager) {
+      try {
+        return manager.table(name).find(query);
+      } catch (err) {
+        if (global.safeWriteError) {
+          try { global.safeWriteError('dbSelect', err); } catch (_) { }
+        }
+      }
+    }
+    return applyQueryOptions(legacyReadSheetData(name), query);
+  }
+
+  function dbCreate(name, record) {
+    if (!record || typeof record !== 'object') return null;
+    var table = dbTable(name);
+    if (table) {
+      return table.insert(record);
+    }
+    return legacyInsert(name, record);
+  }
+
+  function buildWhereFromIdentifier(table, identifier) {
+    if (identifier && typeof identifier === 'object') return identifier;
+    if (!table || !table.idColumn) return null;
+    if (identifier === null || typeof identifier === 'undefined') return null;
+    var where = {};
+    where[table.idColumn] = identifier;
+    return where;
+  }
+
+  function dbUpdate(name, identifier, updates) {
+    if (!updates || typeof updates !== 'object') return null;
+    var table = dbTable(name);
+    if (table) {
+      if (table.idColumn && typeof identifier !== 'object') {
+        return table.update(identifier, updates);
+      }
+      var whereClause = buildWhereFromIdentifier(table, identifier) || (identifier && typeof identifier === 'object' ? identifier : null);
+      if (!whereClause) throw new Error('Update requires an ID or where clause');
+      var existing = table.findOne(whereClause);
+      if (existing && table.idColumn && existing[table.idColumn]) {
+        return table.update(existing[table.idColumn], updates);
+      }
+      if (existing) {
+        return legacyUpdate(name, whereClause, updates);
+      }
+      return null;
+    }
+    var where = identifier && typeof identifier === 'object' ? identifier : null;
+    if (!where) throw new Error('Update requires an ID or where clause');
+    return legacyUpdate(name, where, updates);
+  }
+
+  function dbUpsert(name, where, updates) {
+    var table = dbTable(name);
+    if (table) {
+      return table.upsert(where || {}, updates || {});
+    }
+    var existing = applyQueryOptions(legacyReadSheetData(name), { where: where, limit: 1 });
+    if (existing.length) {
+      return legacyUpdate(name, where, updates || {});
+    }
+    return legacyInsert(name, Object.assign({}, where || {}, updates || {}));
+  }
+
+  function dbDelete(name, identifier) {
+    var table = dbTable(name);
+    if (table) {
+      if (table.idColumn && typeof identifier !== 'object') {
+        return table.delete(identifier);
+      }
+      var whereClause = buildWhereFromIdentifier(table, identifier) || (identifier && typeof identifier === 'object' ? identifier : null);
+      if (!whereClause) throw new Error('Delete requires an ID or where clause');
+      if (table.idColumn) {
+        var existing = table.findOne(whereClause);
+        if (existing && existing[table.idColumn]) {
+          return table.delete(existing[table.idColumn]);
+        }
+      }
+      return legacyDelete(name, whereClause);
+    }
+    var where = identifier && typeof identifier === 'object' ? identifier : null;
+    if (!where) throw new Error('Delete requires an ID or where clause');
+    return legacyDelete(name, where);
+  }
+
+  function legacyInsert(name, record) {
+    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    if (!ss) return null;
+    var sh = ss.getSheetByName(name);
+    var headers;
+    if (sh) {
+      var lastCol = sh.getLastColumn();
+      headers = lastCol > 0 ? sh.getRange(1, 1, 1, lastCol).getValues()[0].map(function (h) { return String(h || '').trim(); }) : [];
+    } else {
+      var headerKeys = Object.keys(record || {});
+      if (typeof ensureSheetWithHeaders === 'function' && headerKeys.length) {
+        sh = ensureSheetWithHeaders(name, headerKeys);
+        headers = headerKeys;
+      } else {
+        sh = ss.insertSheet(name);
+        headers = headerKeys;
+        if (headers.length) {
+          sh.getRange(1, 1, 1, headers.length).setValues([headers]);
+          sh.setFrozenRows(1);
+        }
+      }
+    }
+    if (!headers || headers.length === 0) {
+      headers = Object.keys(record || {});
+      if (headers.length) {
+        sh.getRange(1, 1, 1, headers.length).setValues([headers]);
+        sh.setFrozenRows(1);
+      }
+    }
+    var row = headers.map(function (header) { return typeof record[header] === 'undefined' ? '' : record[header]; });
+    sh.appendRow(row);
+    return record;
+  }
+
+  function legacyUpdate(name, where, updates) {
+    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    if (!ss) return null;
+    var sh = ss.getSheetByName(name);
+    if (!sh || !where) return null;
+    var lastRow = sh.getLastRow();
+    var lastCol = sh.getLastColumn();
+    if (lastRow < 2 || lastCol < 1) return null;
+    var headers = sh.getRange(1, 1, 1, lastCol).getValues()[0].map(function (h) { return String(h || '').trim(); });
+    var range = sh.getRange(2, 1, lastRow - 1, lastCol);
+    var values = range.getValues();
+    for (var i = 0; i < values.length; i++) {
+      var rowObj = {};
+      for (var j = 0; j < headers.length; j++) {
+        rowObj[headers[j]] = values[i][j];
+      }
+      if (!matchesWhere(rowObj, where)) continue;
+      Object.keys(updates || {}).forEach(function (key) {
+        rowObj[key] = updates[key];
+      });
+      var serialized = headers.map(function (header) { return typeof rowObj[header] === 'undefined' ? '' : rowObj[header]; });
+      range.getCell(i + 1, 1).offset(0, 0, 1, lastCol).setValues([serialized]);
+      return rowObj;
+    }
+    return null;
+  }
+
+  function legacyDelete(name, where) {
+    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    if (!ss) return false;
+    var sh = ss.getSheetByName(name);
+    if (!sh || !where) return false;
+    var lastRow = sh.getLastRow();
+    var lastCol = sh.getLastColumn();
+    if (lastRow < 2 || lastCol < 1) return false;
+    var headers = sh.getRange(1, 1, 1, lastCol).getValues()[0].map(function (h) { return String(h || '').trim(); });
+    var range = sh.getRange(2, 1, lastRow - 1, lastCol);
+    var values = range.getValues();
+    for (var i = 0; i < values.length; i++) {
+      var rowObj = {};
+      for (var j = 0; j < headers.length; j++) {
+        rowObj[headers[j]] = values[i][j];
+      }
+      if (!matchesWhere(rowObj, where)) continue;
+      sh.deleteRow(i + 2);
+      return true;
+    }
+    return false;
+  }
+
+  function legacyReadSheetData(name) {
+    try {
+      var ss = SpreadsheetApp.getActiveSpreadsheet();
+      if (!ss) return [];
+      var sh = ss.getSheetByName(name);
+      if (!sh) return [];
+      var lastRow = sh.getLastRow();
+      var lastCol = sh.getLastColumn();
+      if (lastRow < 2 || lastCol < 1) return [];
+      var values = sh.getRange(1, 1, lastRow, lastCol).getValues();
+      var headers = values.shift().map(function (h) { return String(h || '').trim(); });
+      if (headers.some(function (h) { return !h; })) return [];
+      var unique = {};
+      for (var i = 0; i < headers.length; i++) {
+        if (unique[headers[i]]) return [];
+        unique[headers[i]] = true;
+      }
+      return values.map(function (row) {
+        var obj = {};
+        for (var j = 0; j < headers.length; j++) {
+          obj[headers[j]] = typeof row[j] === 'undefined' ? '' : row[j];
+        }
+        return obj;
+      });
+    } catch (err) {
+      if (global.safeWriteError) {
+        try { global.safeWriteError('legacyReadSheetData', err); } catch (_) { }
+      }
+      return [];
+    }
+  }
+
+  function applyQueryOptions(rows, options) {
+    if (!Array.isArray(rows)) return [];
+    var result = rows.slice();
+    if (options && options.where) {
+      result = result.filter(function (row) { return matchesWhere(row, options.where); });
+    }
+    if (options && typeof options.filter === 'function') {
+      result = result.filter(options.filter);
+    }
+    if (options && typeof options.map === 'function') {
+      result = result.map(options.map);
+    }
+    if (options && options.sortBy) {
+      var key = options.sortBy;
+      var desc = !!options.sortDesc;
+      result.sort(function (a, b) {
+        var av = a[key];
+        var bv = b[key];
+        if (av === bv) return 0;
+        if (av === undefined || av === null || av === '') return desc ? 1 : -1;
+        if (bv === undefined || bv === null || bv === '') return desc ? -1 : 1;
+        if (av > bv) return desc ? -1 : 1;
+        if (av < bv) return desc ? 1 : -1;
+        return 0;
+      });
+    }
+    if (options && (options.offset || typeof options.limit === 'number')) {
+      var start = options.offset || 0;
+      var end = typeof options.limit === 'number' ? start + options.limit : result.length;
+      result = result.slice(start, end);
+    }
+    if (options && Array.isArray(options.columns) && options.columns.length) {
+      result = result.map(function (row) {
+        var projected = {};
+        options.columns.forEach(function (col) { projected[col] = row[col]; });
+        return projected;
+      });
+    }
+    return result;
+  }
+
+  function matchesWhere(row, where) {
+    if (!where || typeof where !== 'object') return true;
+    var keys = Object.keys(where);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var expected = where[key];
+      var actual = row[key];
+      if (expected instanceof RegExp) {
+        if (!expected.test(String(actual || ''))) return false;
+      } else if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
+        if (!evaluateWhereOperator(actual, expected)) return false;
+      } else if (String(actual) !== String(expected)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function evaluateWhereOperator(actual, expression) {
+    var ops = Object.keys(expression);
+    for (var i = 0; i < ops.length; i++) {
+      var op = ops[i];
+      var value = expression[op];
+      switch (op) {
+        case '$gt':
+          if (!(actual > value)) return false;
+          break;
+        case '$gte':
+          if (!(actual >= value)) return false;
+          break;
+        case '$lt':
+          if (!(actual < value)) return false;
+          break;
+        case '$lte':
+          if (!(actual <= value)) return false;
+          break;
+        case '$ne':
+          if (actual === value) return false;
+          break;
+        case '$in':
+          if (!Array.isArray(value) || value.indexOf(actual) === -1) return false;
+          break;
+        case '$nin':
+          if (Array.isArray(value) && value.indexOf(actual) !== -1) return false;
+          break;
+        default:
+          if (String(actual) !== String(expression[op])) return false;
+      }
+    }
+    return true;
+  }
+
+  global.registerTableSchema = registerTableSchema;
+  global.dbTable = dbTable;
+  global.dbSelect = dbSelect;
+  global.dbCreate = dbCreate;
+  global.dbUpdate = dbUpdate;
+  global.dbUpsert = dbUpsert;
+  global.dbDelete = dbDelete;
+  global.__dbApplyQueryOptions = applyQueryOptions;
+
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/DatabaseManager.gs
+++ b/DatabaseManager.gs
@@ -1,0 +1,644 @@
+/**
+ * DatabaseManager.gs
+ * Unified Google Sheets database abstraction for CRUD operations across all sheets.
+ *
+ * Usage:
+ *   const usersTable = DatabaseManager.defineTable('Users', {
+ *     headers: ['ID', 'UserName', 'Email'],
+ *     defaults: { CanLogin: true },
+ *   });
+ *   const user = usersTable.insert({ UserName: 'alice', Email: 'alice@example.com' });
+ *
+ *   const schedules = DatabaseManager.table('Schedules').find({ where: { UserId: user.ID } });
+ *
+ * The manager automatically:
+ *   - Ensures sheet + headers exist (appends missing headers without overwriting data)
+ *   - Provides strongly-typed CRUD helpers with optional caching and timestamps
+ *   - Treats Google Sheets like database tables that can be registered at runtime
+ */
+
+(function (global) {
+  if (global.DatabaseManager) return;
+
+  var DEFAULT_CACHE_TTL = 300; // seconds
+  var DEFAULT_ID_COLUMN = 'ID';
+  var DEFAULT_CREATED_AT = 'CreatedAt';
+  var DEFAULT_UPDATED_AT = 'UpdatedAt';
+  var tables = {};
+  var logger = (typeof console !== 'undefined') ? console : {
+    log: function () { },
+    info: function () { },
+    warn: function () { },
+    error: function () { }
+  };
+
+  function isObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function clone(value) {
+    if (!isObject(value)) return value;
+    var copy = {};
+    Object.keys(value).forEach(function (key) {
+      copy[key] = value[key];
+    });
+    return copy;
+  }
+
+  function SpreadsheetHandle(table) {
+    this.table = table;
+  }
+
+  SpreadsheetHandle.prototype.getSheet = function () {
+    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    var sh = ss.getSheetByName(this.table.name);
+    if (!sh) {
+      sh = ss.insertSheet(this.table.name);
+    }
+    this.table.ensureHeaders(sh);
+    return sh;
+  };
+
+  SpreadsheetHandle.prototype.readAllRows = function () {
+    var sheet = this.getSheet();
+    var lastRow = sheet.getLastRow();
+    var headerCount = this.table.headers.length;
+    if (lastRow < 2 || headerCount === 0) {
+      return [];
+    }
+    var range = sheet.getRange(2, 1, lastRow - 1, headerCount);
+    return range.getValues();
+  };
+
+  SpreadsheetHandle.prototype.writeRow = function (rowIndex, rowValues) {
+    var sheet = this.getSheet();
+    var headerCount = this.table.headers.length;
+    var range = sheet.getRange(rowIndex, 1, 1, headerCount);
+    range.setValues([rowValues]);
+  };
+
+  SpreadsheetHandle.prototype.appendRow = function (rowValues) {
+    var sheet = this.getSheet();
+    sheet.appendRow(rowValues);
+  };
+
+  SpreadsheetHandle.prototype.deleteRow = function (rowIndex) {
+    var sheet = this.getSheet();
+    sheet.deleteRow(rowIndex);
+  };
+
+  function Table(name, config) {
+    this.name = name;
+    if (config && Object.prototype.hasOwnProperty.call(config, 'idColumn')) {
+      this.idColumn = config.idColumn;
+    } else {
+      this.idColumn = DEFAULT_ID_COLUMN;
+    }
+    this.cacheTTL = (config && config.cacheTTL) || DEFAULT_CACHE_TTL;
+    if (config && config.timestamps === false) {
+      this.timestamps = null;
+    } else if (config && config.timestamps) {
+      this.timestamps = {
+        created: config.timestamps.created || DEFAULT_CREATED_AT,
+        updated: config.timestamps.updated || DEFAULT_UPDATED_AT
+      };
+    } else {
+      this.timestamps = {
+        created: DEFAULT_CREATED_AT,
+        updated: DEFAULT_UPDATED_AT
+      };
+    }
+    this.defaults = (config && config.defaults) || {};
+    this.validators = (config && config.validators) || {};
+    this.cacheKey = 'DB_TABLE_' + name;
+
+    var providedHeaders = [];
+    if (config && Array.isArray(config.headers)) {
+      providedHeaders = config.headers.slice();
+    } else if (config && Array.isArray(config.columns)) {
+      providedHeaders = config.columns.slice();
+    }
+
+    this.headers = normalizeHeaders(this, providedHeaders);
+    this.sheetHandle = new SpreadsheetHandle(this);
+  }
+
+  Table.prototype.ensureHeaders = function (sheet) {
+    var desiredHeaders = this.headers.slice();
+    var lastColumn = sheet.getLastColumn();
+    var existingHeaders = [];
+    if (lastColumn > 0) {
+      existingHeaders = sheet.getRange(1, 1, 1, lastColumn).getValues()[0].map(String);
+    }
+
+    var finalHeaders;
+    var changed = false;
+
+    if (existingHeaders.length === 0) {
+      finalHeaders = desiredHeaders.slice();
+      if (finalHeaders.length) {
+        sheet.getRange(1, 1, 1, finalHeaders.length).setValues([finalHeaders]);
+        sheet.setFrozenRows(1);
+      }
+    } else {
+      finalHeaders = existingHeaders.slice();
+      desiredHeaders.forEach(function (header) {
+        if (finalHeaders.indexOf(header) === -1) {
+          finalHeaders.push(header);
+          changed = true;
+        }
+      });
+      if (changed) {
+        sheet.getRange(1, 1, 1, finalHeaders.length).setValues([finalHeaders]);
+      }
+    }
+
+    this.headers = finalHeaders;
+  };
+
+  Table.prototype.toObjects = function (rows) {
+    var headers = this.headers;
+    return rows.map(function (row) {
+      var obj = {};
+      headers.forEach(function (header, index) {
+        obj[header] = typeof row[index] === 'undefined' ? '' : row[index];
+      });
+      return obj;
+    });
+  };
+
+  Table.prototype.serialize = function (record) {
+    var row = [];
+    var headers = this.headers;
+    for (var i = 0; i < headers.length; i++) {
+      var header = headers[i];
+      row.push(typeof record[header] === 'undefined' ? '' : record[header]);
+    }
+    return row;
+  };
+
+  Table.prototype.validateRecord = function (record) {
+    var validators = this.validators;
+    var keys = Object.keys(validators);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var validator = validators[key];
+      if (typeof validator === 'function') {
+        var result = validator(record[key], record);
+        if (result === false) {
+          throw new Error('Validation failed for column "' + key + '"');
+        }
+      }
+    }
+  };
+
+  Table.prototype.applyDefaults = function (record, isInsert) {
+    var defaults = this.defaults;
+    var keys = Object.keys(defaults);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (typeof record[key] === 'undefined' || record[key] === null || record[key] === '') {
+        if (typeof defaults[key] === 'function') {
+          record[key] = defaults[key](record, isInsert);
+        } else {
+          record[key] = defaults[key];
+        }
+      }
+    }
+    return record;
+  };
+
+  Table.prototype.ensureId = function (record) {
+    if (!this.idColumn) return record;
+    if (!record[this.idColumn]) {
+      record[this.idColumn] = Utilities.getUuid();
+    }
+    return record;
+  };
+
+  Table.prototype.touchTimestamps = function (record, isInsert) {
+    if (!this.timestamps) return record;
+    var now = new Date();
+    if (isInsert && this.timestamps.created && !record[this.timestamps.created]) {
+      record[this.timestamps.created] = now;
+    }
+    if (this.timestamps.updated) {
+      record[this.timestamps.updated] = now;
+    }
+    return record;
+  };
+
+  Table.prototype.invalidateCache = function () {
+    try {
+      CacheService.getScriptCache().remove(this.cacheKey);
+    } catch (err) {
+      logger.error('Failed to invalidate cache for table ' + this.name + ': ' + err);
+    }
+  };
+
+  Table.prototype.read = function (options) {
+    options = options || {};
+    var useCache = options.cache !== false;
+    var cache = CacheService.getScriptCache();
+    var headers = this.headers;
+
+    if (useCache) {
+      var cached = cache.get(this.cacheKey);
+      if (cached) {
+        try {
+          var parsed = JSON.parse(cached);
+          return applyQueryOptions(parsed, headers, options);
+        } catch (err) {
+          logger.warn('Cache parse failed for table ' + this.name + ': ' + err);
+        }
+      }
+    }
+
+    var rows = this.sheetHandle.readAllRows();
+    var objects = this.toObjects(rows);
+
+    if (useCache) {
+      try {
+        cache.put(this.cacheKey, JSON.stringify(objects), this.cacheTTL);
+      } catch (err) {
+        logger.warn('Cache put failed for table ' + this.name + ': ' + err);
+      }
+    }
+
+    return applyQueryOptions(objects, headers, options);
+  };
+
+  Table.prototype.find = function (options) {
+    return this.read(options || {});
+  };
+
+  Table.prototype.findOne = function (where) {
+    var options = { where: where, limit: 1 };
+    var results = this.read(options);
+    return results.length ? results[0] : null;
+  };
+
+  Table.prototype.findById = function (id) {
+    if (!this.idColumn) return null;
+    return this.findOne(createWhereClause(this.idColumn, id));
+  };
+
+  Table.prototype.insert = function (record) {
+    if (!record || typeof record !== 'object') {
+      throw new Error('Record must be an object for insert');
+    }
+    var copy = clone(record);
+    this.ensureId(copy);
+    this.applyDefaults(copy, true);
+    this.touchTimestamps(copy, true);
+    this.validateRecord(copy);
+
+    var rowValues = this.serialize(copy);
+    this.sheetHandle.appendRow(rowValues);
+    this.invalidateCache();
+    return copy;
+  };
+
+  Table.prototype.batchInsert = function (records) {
+    if (!Array.isArray(records) || records.length === 0) {
+      return [];
+    }
+    var sheet = this.sheetHandle.getSheet();
+    var processed = [];
+    var rows = [];
+
+    for (var i = 0; i < records.length; i++) {
+      var copy = clone(records[i]);
+      this.ensureId(copy);
+      this.applyDefaults(copy, true);
+      this.touchTimestamps(copy, true);
+      this.validateRecord(copy);
+      processed.push(copy);
+      rows.push(this.serialize(copy));
+    }
+
+    if (rows.length) {
+      var startRow = sheet.getLastRow() + 1;
+      sheet.getRange(startRow, 1, rows.length, this.headers.length).setValues(rows);
+      this.invalidateCache();
+    }
+
+    return processed;
+  };
+
+  Table.prototype.update = function (id, updates) {
+    if (!this.idColumn) {
+      throw new Error('Cannot update without idColumn configuration');
+    }
+    var sheet = this.sheetHandle.getSheet();
+    var headers = this.headers;
+    var idIndex = headers.indexOf(this.idColumn);
+    if (idIndex === -1) {
+      throw new Error('ID column ' + this.idColumn + ' not found in headers');
+    }
+
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return null;
+    }
+
+    var range = sheet.getRange(2, 1, lastRow - 1, headers.length);
+    var values = range.getValues();
+
+    var updatedRecord = null;
+    for (var i = 0; i < values.length; i++) {
+      if (String(values[i][idIndex]) === String(id)) {
+        var record = {};
+        for (var j = 0; j < headers.length; j++) {
+          record[headers[j]] = values[i][j];
+        }
+
+        Object.keys(updates || {}).forEach(function (key) {
+          record[key] = updates[key];
+        });
+
+        this.touchTimestamps(record, false);
+        this.validateRecord(record);
+        var serialized = this.serialize(record);
+        range.getCell(i + 1, 1).offset(0, 0, 1, headers.length).setValues([serialized]);
+        updatedRecord = record;
+        break;
+      }
+    }
+
+    if (updatedRecord) {
+      this.invalidateCache();
+    }
+    return updatedRecord;
+  };
+
+  Table.prototype.upsert = function (where, updates) {
+    var existing = this.findOne(where);
+    if (existing) {
+      var id = this.idColumn ? existing[this.idColumn] : null;
+      if (id) {
+        return this.update(id, updates);
+      }
+      var merged = clone(existing);
+      Object.keys(updates || {}).forEach(function (key) {
+        merged[key] = updates[key];
+      });
+      return this.insert(merged);
+    }
+    var insertRecord = clone(where || {});
+    Object.keys(updates || {}).forEach(function (key) {
+      insertRecord[key] = updates[key];
+    });
+    return this.insert(insertRecord);
+  };
+
+  Table.prototype.delete = function (id) {
+    if (!this.idColumn) {
+      throw new Error('Cannot delete without idColumn configuration');
+    }
+    var sheet = this.sheetHandle.getSheet();
+    var headers = this.headers;
+    var idIndex = headers.indexOf(this.idColumn);
+    if (idIndex === -1) {
+      throw new Error('ID column ' + this.idColumn + ' not found in headers');
+    }
+
+    var lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return false;
+    }
+
+    var range = sheet.getRange(2, 1, lastRow - 1, headers.length);
+    var values = range.getValues();
+
+    for (var i = 0; i < values.length; i++) {
+      if (String(values[i][idIndex]) === String(id)) {
+        sheet.deleteRow(i + 2);
+        this.invalidateCache();
+        return true;
+      }
+    }
+    return false;
+  };
+
+  Table.prototype.clear = function () {
+    var sheet = this.sheetHandle.getSheet();
+    var headers = this.headers;
+    sheet.clearContents();
+    if (headers.length) {
+      sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+      sheet.setFrozenRows(1);
+    }
+    this.invalidateCache();
+  };
+
+  Table.prototype.count = function (where) {
+    var options = where ? { where: where } : {};
+    return this.read(options).length;
+  };
+
+  Table.prototype.listColumns = function () {
+    return this.headers.slice();
+  };
+
+  function normalizeHeaders(table, providedHeaders) {
+    var headers = providedHeaders.slice();
+    if (table.idColumn && headers.indexOf(table.idColumn) === -1) {
+      headers.unshift(table.idColumn);
+    }
+    if (table.timestamps) {
+      if (table.timestamps.created && headers.indexOf(table.timestamps.created) === -1) {
+        headers.push(table.timestamps.created);
+      }
+      if (table.timestamps.updated && headers.indexOf(table.timestamps.updated) === -1) {
+        headers.push(table.timestamps.updated);
+      }
+    }
+    Object.keys(table.defaults).forEach(function (key) {
+      if (headers.indexOf(key) === -1) {
+        headers.push(key);
+      }
+    });
+    Object.keys(table.validators).forEach(function (key) {
+      if (headers.indexOf(key) === -1) {
+        headers.push(key);
+      }
+    });
+    return headers;
+  }
+
+  function applyQueryOptions(rows, headers, options) {
+    var filtered = rows.slice();
+
+    if (options.where && isObject(options.where)) {
+      filtered = filtered.filter(function (row) {
+        return matchesWhere(row, options.where);
+      });
+    }
+
+    if (options.filter && typeof options.filter === 'function') {
+      filtered = filtered.filter(options.filter);
+    }
+
+    if (options.map && typeof options.map === 'function') {
+      filtered = filtered.map(options.map);
+    }
+
+    if (options.sortBy) {
+      var sortKey = options.sortBy;
+      var descending = !!options.sortDesc;
+      filtered.sort(function (a, b) {
+        var av = a[sortKey];
+        var bv = b[sortKey];
+        if (av === bv) return 0;
+        if (av === undefined || av === null || av === '') return descending ? 1 : -1;
+        if (bv === undefined || bv === null || bv === '') return descending ? -1 : 1;
+        if (av > bv) return descending ? -1 : 1;
+        if (av < bv) return descending ? 1 : -1;
+        return 0;
+      });
+    }
+
+    var offset = options.offset || 0;
+    var limit = typeof options.limit === 'number' ? options.limit : null;
+    if (offset || limit !== null) {
+      var start = offset;
+      var end = limit !== null ? offset + limit : filtered.length;
+      filtered = filtered.slice(start, end);
+    }
+
+    if (options.columns && Array.isArray(options.columns) && options.columns.length) {
+      filtered = filtered.map(function (row) {
+        var projected = {};
+        options.columns.forEach(function (col) {
+          projected[col] = row[col];
+        });
+        return projected;
+      });
+    }
+
+    return filtered;
+  }
+
+  function matchesWhere(row, where) {
+    var keys = Object.keys(where);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var expected = where[key];
+      var actual = row[key];
+      if (expected instanceof RegExp) {
+        if (!expected.test(String(actual || ''))) {
+          return false;
+        }
+      } else if (isObject(expected)) {
+        if (!evaluateWhereOperator(actual, expected)) {
+          return false;
+        }
+      } else if (String(actual) !== String(expected)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function evaluateWhereOperator(actual, expression) {
+    var ops = Object.keys(expression);
+    for (var i = 0; i < ops.length; i++) {
+      var op = ops[i];
+      var value = expression[op];
+      switch (op) {
+        case '$gt':
+          if (!(actual > value)) return false;
+          break;
+        case '$gte':
+          if (!(actual >= value)) return false;
+          break;
+        case '$lt':
+          if (!(actual < value)) return false;
+          break;
+        case '$lte':
+          if (!(actual <= value)) return false;
+          break;
+        case '$ne':
+          if (actual === value) return false;
+          break;
+        case '$in':
+          if (!Array.isArray(value) || value.indexOf(actual) === -1) return false;
+          break;
+        case '$nin':
+          if (Array.isArray(value) && value.indexOf(actual) !== -1) return false;
+          break;
+        default:
+          if (String(actual) !== String(expression[op])) return false;
+      }
+    }
+    return true;
+  }
+
+  function createWhereClause(column, value) {
+    var where = {};
+    where[column] = value;
+    return where;
+  }
+
+  function ensureTable(name, config) {
+    if (!tables[name]) {
+      tables[name] = new Table(name, config || {});
+    } else if (config) {
+      tables[name] = new Table(name, mergeConfigs(tables[name], config));
+    }
+    return tables[name];
+  }
+
+  function mergeConfigs(existingTable, config) {
+    var merged = {
+      idColumn: existingTable.idColumn,
+      cacheTTL: typeof config.cacheTTL === 'number' ? config.cacheTTL : existingTable.cacheTTL,
+      timestamps: existingTable.timestamps,
+      defaults: Object.assign({}, existingTable.defaults || {}, config.defaults || {}),
+      validators: Object.assign({}, existingTable.validators || {}, config.validators || {}),
+      headers: config.headers || existingTable.headers,
+      columns: config.columns || existingTable.headers
+    };
+
+    if (Object.prototype.hasOwnProperty.call(config, 'idColumn')) {
+      merged.idColumn = config.idColumn;
+    }
+
+    if (config.timestamps === false) {
+      merged.timestamps = false;
+    } else if (config.timestamps) {
+      merged.timestamps = config.timestamps;
+    }
+
+    return merged;
+  }
+
+  var DatabaseManager = {
+    defineTable: function (name, config) {
+      if (!name) {
+        throw new Error('Table name is required');
+      }
+      return ensureTable(name, config || {});
+    },
+    table: function (name) {
+      if (!name) {
+        throw new Error('Table name is required');
+      }
+      return ensureTable(name);
+    },
+    listTables: function () {
+      return Object.keys(tables);
+    },
+    dropTableCache: function (name) {
+      if (tables[name]) {
+        tables[name].invalidateCache();
+      }
+    }
+  };
+
+  global.DatabaseManager = DatabaseManager;
+  global.defineTable = DatabaseManager.defineTable;
+  global.getTable = DatabaseManager.table;
+
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # Lumina-Sheets
-Call center management systems with google sheets
+
+Call center management system built on Google Apps Script + Google Sheets.
+
+## Google Sheets database manager
+
+The `DatabaseManager.gs` module turns any worksheet into a CRUD-ready table. Define
+schema defaults once and re-use the same interface across every client campaign.
+
+### Quick start
+
+```javascript
+const users = DatabaseManager.defineTable('Users', {
+  headers: ['ID', 'UserName', 'Email', 'CampaignID'],
+  defaults: { CanLogin: true },
+});
+
+// Create
+const user = users.insert({
+  UserName: 'jsmith',
+  Email: 'jsmith@example.com',
+  CampaignID: 'credit-suite'
+});
+
+// Read
+const perCampaign = users.find({ where: { CampaignID: 'credit-suite' } });
+
+// Update
+users.update(user.ID, { CanLogin: false });
+
+// Delete
+users.delete(user.ID);
+```
+
+The manager automatically ensures each sheet exists, appends missing headers, and
+stores `CreatedAt`/`UpdatedAt` timestamps for every record. Cached reads keep lookups
+fast while still honoring sheet edits from other services.
+
+### Global CRUD helpers
+
+`DatabaseBindings.gs` registers the common sheets used across the call center platform
+and exposes lightweight helpers so existing Apps Script functions can switch to the
+database abstraction without rewriting business logic:
+
+```javascript
+// Read data with optional filters/sorting/pagination
+const activeUsers = dbSelect(USERS_SHEET, {
+  where: { CampaignID: campaignId, CanLogin: true },
+  sortBy: 'FullName'
+});
+
+// Create/update/delete
+const created = dbCreate(USERS_SHEET, payload);
+const updated = dbUpdate(USERS_SHEET, created.ID, { ResetRequired: false });
+dbDelete(USERS_SHEET, created.ID);
+
+// Upsert by any condition (automatically creates IDs when needed)
+dbUpsert(CAMPAIGN_USER_PERMISSIONS_SHEET, { UserID, CampaignID }, {
+  PermissionLevel: 'Manager',
+  CanManageUsers: true
+});
+```
+
+The existing `readSheet`/`ensureSheetWithHeaders` helpers now rely on these bindings,
+so all services automatically share cached queries and schema registration through
+`DatabaseManager`.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,94 @@
+# Call Center Management Platform Requirements
+
+This document consolidates the functional requirements that surfaced during
+recent discovery sessions. The platform is built on Google Apps Script with
+Google Sheets as the primary data store and HTML/JavaScript (with jQuery) for
+the client-side experience.
+
+## Core Application Goals
+
+1. Provide a secure, multi-tenant Software-as-a-Service (SaaS) experience that
+   supports multiple client organizations ("campaigns") within a single
+   deployment.
+2. Deliver comprehensive call center management workflows spanning
+   authentication, scheduling, performance tracking, coaching, reporting, and
+   collaboration.
+3. Maintain transparent data sharing between the call center operator and each
+   client, while enforcing least-privilege access for agents and optional guest
+   users from the client side.
+
+## Authentication & Authorization
+
+- **Strict login policies** ensure that all access is scoped to the specific
+  client campaign(s) a user belongs to.
+- **Role tiers**:
+  - **Executives (CEO/CFO/HR, etc.)** – full access to every module across all
+    clients and campaigns.
+  - **Managers** – access limited to the campaigns and agents they oversee;
+    ability to manage rosters, review metrics, and handle coaching actions.
+  - **Agents** – default read-only access to personal schedules, QA scores,
+    coaching acknowledgements, and performance dashboards. Additional
+    privileges can be granted selectively.
+  - **Client guests** – limited visibility, primarily QA and performance
+    reporting, with optional elevation to broader access by internal admins.
+- **Campaign-aware sessions** guarantee that users cannot act on behalf of
+  other clients without explicit authorization.
+
+## Multi-Campaign Management
+
+- Support for multiple concurrent client campaigns, each with isolated datasets
+  and configurable access rules.
+- Managers can administer their assigned campaigns, including agent rosters,
+  schedules, and targeted communications.
+- Executive users retain the ability to view cross-campaign analytics for
+  organizational oversight.
+
+## Agent Experience
+
+- Personal dashboards featuring:
+  - Upcoming schedules and shift assignments.
+  - QA performance summaries and detailed score breakdowns.
+  - Coaching records and acknowledgement workflows.
+  - Recognition components highlighting top performers across attendance,
+    adherence, QA scores, and other KPIs.
+- Lightweight messaging interface to receive managerial updates, coaching
+  notifications, and performance feedback.
+
+## Manager & Executive Experience
+
+- Campaign dashboards consolidating agent metrics, attendance, QA outcomes, and
+  coaching statuses.
+- Ability to issue coaching items, request acknowledgements, and monitor
+  follow-up actions.
+- Messaging tools to communicate quick updates regarding agent performance and
+  compliance.
+- Administrative controls for onboarding users, assigning roles, and managing
+  client guest access.
+
+## Collaboration & Reporting
+
+- QA collaboration forms and dashboards to capture audits and quality reviews.
+- Attendance and adherence reporting views.
+- Executive-level summaries aggregating KPIs across campaigns for strategic
+  decision making.
+- Chat modules to facilitate targeted discussion threads between managers,
+  agents, and executives.
+
+## Extensibility Considerations
+
+- Modular HTML views (e.g., Top Performers, QA dashboards, Coaching lists)
+  should remain loosely coupled so new KPIs or workflows can be added without
+  disrupting existing modules.
+- Google Apps Script services should expose clear CRUD interfaces for users,
+  schedules, QA records, and coaching entries to support automation and future
+  integrations.
+
+## Next Steps
+
+1. Audit existing Apps Script services to confirm they enforce campaign-aware
+   access and role-based permissions as described.
+2. Inventory current HTML/JS modules to map each requirement to its UI
+   counterpart, identifying gaps.
+3. Prioritize implementation of strict login flows, campaign scoping, and role
+   management updates before layering additional feature work.
+


### PR DESCRIPTION
## Summary
- add DatabaseBindings.gs to register common sheet schemas and expose dbSelect/dbCreate/dbUpdate/dbDelete/dbUpsert helpers
- route readSheet/ensureSheetWithHeaders through DatabaseManager with query-aware caching and legacy fallbacks
- document the new CRUD helpers and guard legacy readSheet definitions that used custom caching

## Testing
- no automated tests were run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6dc6d127083269962f546bf2fce13