### PR TITLE
Add manager campaign dashboards and executive analytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ CallCenterWorkflowService.acknowledgeCoaching(agentId, coaching.ID, {
   Notes: 'Reviewed and will implement feedback',
 });
 
+// Campaign-specific manager dashboard and communications
+const managerDashboard = CallCenterWorkflowService.getManagerCampaignDashboard(managerId, activeCampaignId, {
+  includeRoster: true,
+  maxMessages: 10,
+});
+
+CallCenterWorkflowService.sendCampaignCommunication(managerId, activeCampaignId, {
+  title: 'Script refresh',
+  message: 'Please review the updated talk track before tomorrow\'s shift.',
+  userIds: [agentId],
+});
+
+// Executive view across campaigns
+const executiveOverview = CallCenterWorkflowService.getExecutiveAnalytics(executiveId);
+
 // Post tenant-scoped collaboration updates
 CallCenterWorkflowService.postCollaborationMessage(agentId, channelId, 'QA review completed', {
   campaignId: activeCampaignId,


### PR DESCRIPTION
## Summary
- add campaign snapshot helpers, manager dashboards, targeted communications, and executive analytics flows to `CallCenterWorkflowService`
- document the new multi-campaign management APIs in the README for managers and executives

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78c0e149883268ea60e3a93f0a3ee