### PR TITLE
Fix SearchService identifier redeclaration

### DIFF
--- a/SearchService.js
+++ b/SearchService.js
@@ -4,8 +4,14 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Replace with your actual CSE engine ID (the "cx=" value) and your API key.
-const CSE_ID  = '130aba31c8a2d439c';
-const API_KEY = 'AIzaSyAg-puM5l9iQpjz_NplMJaKbUNRH7ld7sY';
+// Use var with a guard so the identifiers aren't redeclared if this file is
+// loaded alongside other scripts that define the same configuration (e.g.
+// Code.js). Google Apps Script evaluates all top-level statements, so
+// re-declaring a const would raise "Identifier has already been declared".
+// eslint-disable-next-line no-var
+var CSE_ID = typeof CSE_ID !== 'undefined' ? CSE_ID : '130aba31c8a2d439c';
+// eslint-disable-next-line no-var
+var API_KEY = typeof API_KEY !== 'undefined' ? API_KEY : 'AIzaSyAg-puM5l9iQpjz_NplMJaKbUNRH7ld7sY';
 
 /**
  * Performs a web search via Google Custom Search JSON API.


### PR DESCRIPTION
## Summary
- guard the CSE_ID and API_KEY definitions in SearchService so the script can coexist with other search helpers without const redeclaration errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7cb29236883268e39e23843f69747