### PR TITLE
Fix password hashing to avoid login errors

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -472,7 +472,14 @@ var AuthenticationService = (function () {
   }
 
   function hashPwd(raw) {
-    return Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, raw)
+    const normalized = raw == null ? '' : String(raw);
+    const digest = Utilities.computeDigest(
+      Utilities.DigestAlgorithm.SHA_256,
+      normalized,
+      Utilities.Charset.UTF_8
+    );
+
+    return digest
       .map(b => ('0' + (b & 0xFF).toString(16)).slice(-2))
       .join('');
   }


### PR DESCRIPTION
## Summary
- fix the password hashing helper to normalize input strings
- compute the SHA-256 digest using UTF-8 encoding to avoid runtime errors during login

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7eb46d19c83268d73b00345f34e3a