### PR TITLE
Centralize password utilities usage and harden login base URL

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -875,19 +875,22 @@
       redirectDelay: 3000 // 3 seconds
     };
 
+    CONFIG.baseUrl = (CONFIG.baseUrl || '').trim();
+    if (!CONFIG.baseUrl || CONFIG.baseUrl.toLowerCase() === 'undefined') {
+      const scriptUrl = (CONFIG.scriptUrl || '').trim();
+      if (scriptUrl && scriptUrl.toLowerCase() !== 'undefined') {
+        CONFIG.baseUrl = scriptUrl;
+      } else {
+        const current = new URL(window.location.href);
+        CONFIG.baseUrl = current.origin + current.pathname;
+      }
+    }
+
     const SUPPORT_EMAIL = 'support@vlbpo.com';
     const REMEMBER_DURATION_MS = 24 * 60 * 60 * 1000;
     const AUTH_COOKIE_NAME = 'authToken';
     const SESSION_COOKIE_MAX_AGE = 60 * 60; // 1 hour
     const REMEMBER_COOKIE_MAX_AGE = 24 * 60 * 60; // 24 hours
-    const STORAGE_KEYS = {
-      rememberedEmail: 'lumina.auth.rememberedEmail',
-      rememberExpiry: 'lumina.auth.rememberExpiry',
-      lastEmail: 'lumina.auth.lastEmail'
-    };
-
-    const SUPPORT_EMAIL = 'support@vlbpo.com';
-    const REMEMBER_DURATION_MS = 24 * 60 * 60 * 1000;
     const STORAGE_KEYS = {
       rememberedEmail: 'lumina.auth.rememberedEmail',
       rememberExpiry: 'lumina.auth.rememberExpiry',
@@ -1300,7 +1303,8 @@
       let baseUrl = null;
 
       const configuredBase = (CONFIG.baseUrl || '').trim();
-      if (configuredBase) {
+      const hasConfiguredBase = !!configuredBase;
+      if (hasConfiguredBase) {
         try {
           baseUrl = new URL(configuredBase, current);
         } catch (err) {
@@ -1312,7 +1316,9 @@
         baseUrl = new URL(current.toString());
       }
 
-      baseUrl = alignUrlToCurrentContext(baseUrl);
+      if (!hasConfiguredBase) {
+        baseUrl = alignUrlToCurrentContext(baseUrl);
+      }
 
       const keysToRemove = new Set(['page']);
       Object.keys(params || {}).forEach(key => keysToRemove.add(key));
@@ -1824,7 +1830,8 @@
       let baseUrl = null;
 
       const configuredBase = (CONFIG.baseUrl || '').trim();
-      if (configuredBase) {
+      const hasConfiguredBase = !!configuredBase;
+      if (hasConfiguredBase) {
         try {
           baseUrl = new URL(configuredBase, current);
         } catch (err) {
@@ -1836,7 +1843,9 @@
         baseUrl = new URL(current.toString());
       }
 
-      baseUrl = alignUrlToCurrentContext(baseUrl);
+      if (!hasConfiguredBase) {
+        baseUrl = alignUrlToCurrentContext(baseUrl);
+      }
 
       const keysToRemove = new Set(['page']);
       Object.keys(params || {}).forEach(key => keysToRemove.add(key));

--- a/PasswordUtilities.js
+++ b/PasswordUtilities.js
@@ -1,0 +1,89 @@
+/**
+ * PasswordUtilities.js
+ * -----------------------------------------------------------------------------
+ * Centralized helpers for password hashing and verification across the Lumina
+ * Sheets codebase. These utilities wrap the Google Apps Script `Utilities`
+ * cryptographic helpers and provide a consistent API for creating, storing, and
+ * validating password hashes.
+ */
+
+function __createPasswordUtilitiesModule() {
+  function normalizePasswordInput(raw) {
+    return raw == null ? '' : String(raw);
+  }
+
+  function normalizeHash(hash) {
+    if (hash === null || typeof hash === 'undefined') return '';
+    if (hash instanceof Date) return hash.toISOString();
+    return String(hash).trim().toLowerCase();
+  }
+
+  function digestToHex(digest) {
+    if (!digest || typeof digest.map !== 'function') return '';
+    return digest
+      .map(function (b) { return ('0' + (b & 0xFF).toString(16)).slice(-2); })
+      .join('');
+  }
+
+  function hashPassword(raw) {
+    var normalized = normalizePasswordInput(raw);
+    var digest = Utilities.computeDigest(
+      Utilities.DigestAlgorithm.SHA_256,
+      normalized,
+      Utilities.Charset.UTF_8
+    );
+    return digestToHex(digest);
+  }
+
+  function constantTimeEquals(a, b) {
+    if (a == null || b == null) return false;
+    var strA = String(a);
+    var strB = String(b);
+    if (strA.length !== strB.length) return false;
+    var diff = 0;
+    for (var i = 0; i < strA.length; i++) {
+      diff |= strA.charCodeAt(i) ^ strB.charCodeAt(i);
+    }
+    return diff === 0;
+  }
+
+  function verifyPassword(raw, expectedHash) {
+    var normalizedExpected = normalizeHash(expectedHash);
+    if (!normalizedExpected) return false;
+    var hashed = hashPassword(raw);
+    return constantTimeEquals(hashed, normalizedExpected);
+  }
+
+  function createPasswordHash(raw) {
+    return hashPassword(raw);
+  }
+
+  function decodePasswordHash(hash) {
+    return normalizeHash(hash);
+  }
+
+  return {
+    normalizePasswordInput: normalizePasswordInput,
+    normalizeHash: normalizeHash,
+    decodePasswordHash: decodePasswordHash,
+    digestToHex: digestToHex,
+    hashPassword: hashPassword,
+    createPasswordHash: createPasswordHash,
+    verifyPassword: verifyPassword,
+    comparePassword: verifyPassword,
+    constantTimeEquals: constantTimeEquals
+  };
+}
+
+if (typeof PasswordUtilities === 'undefined' || !PasswordUtilities) {
+  var PasswordUtilities = __createPasswordUtilitiesModule();
+}
+
+var ensurePasswordUtilities = (typeof ensurePasswordUtilities === 'function')
+  ? ensurePasswordUtilities
+  : function ensurePasswordUtilities() {
+    if (typeof PasswordUtilities === 'undefined' || !PasswordUtilities) {
+      PasswordUtilities = __createPasswordUtilitiesModule();
+    }
+    return PasswordUtilities;
+  };


### PR DESCRIPTION
## Summary
- expose a shared password utility factory and update authentication + seeding flows to require the centralized helpers instead of embedding their own hashing logic
- sanitize the login page base URL so it falls back to the deployed script URL constant when the templated value is blank or undefined, keeping redirects on the correct host

## Testing
- not run (Google Apps Script environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7f06b77c88326bc32e361069bbeaa