### PR TITLE
Fix login redirects to use deployed web app URL

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -459,7 +459,27 @@ function getAuthenticatedUrl(page, campaignId, additionalParams = {}) {
 }
 
 function getBaseUrl() {
-  return SCRIPT_URL;
+  try {
+    if (typeof resolveScriptUrl === 'function') {
+      const resolved = resolveScriptUrl();
+      if (resolved) {
+        return resolved;
+      }
+    }
+  } catch (err) {
+    console.warn('getBaseUrl: resolveScriptUrl failed', err);
+  }
+
+  if (typeof SCRIPT_URL !== 'undefined' && SCRIPT_URL) {
+    return SCRIPT_URL;
+  }
+
+  try {
+    return ScriptApp.getService().getUrl();
+  } catch (error) {
+    console.warn('getBaseUrl: unable to determine script URL', error);
+    return '';
+  }
 }
 
 // ───────────────────────────────────────────────────────────────────────────────

--- a/Login.html
+++ b/Login.html
@@ -875,15 +875,61 @@
       redirectDelay: 3000 // 3 seconds
     };
 
-    CONFIG.baseUrl = (CONFIG.baseUrl || '').trim();
-    if (!CONFIG.baseUrl || CONFIG.baseUrl.toLowerCase() === 'undefined') {
-      const scriptUrl = (CONFIG.scriptUrl || '').trim();
-      if (scriptUrl && scriptUrl.toLowerCase() !== 'undefined') {
-        CONFIG.baseUrl = scriptUrl;
-      } else {
-        const current = new URL(window.location.href);
-        CONFIG.baseUrl = current.origin + current.pathname;
+    function sanitizeBaseUrl(candidate, fallback) {
+      const invalidPattern = /usercodeapppanel/i;
+
+      const normalize = value => {
+        if (value === null || value === undefined) return '';
+        const trimmed = String(value).trim();
+        if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+          return '';
+        }
+        return trimmed;
+      };
+
+      const ensureNotPanel = value => {
+        if (!value) return '';
+        if (!invalidPattern.test(value)) {
+          return value;
+        }
+        return value.replace(/\/userCodeAppPanel.*$/i, '/exec');
+      };
+
+      const isInvalid = value => {
+        return !value || invalidPattern.test(value);
+      };
+
+      const primary = ensureNotPanel(normalize(candidate));
+      if (!isInvalid(primary)) {
+        return primary;
       }
+
+      const secondary = ensureNotPanel(normalize(fallback));
+      if (!isInvalid(secondary)) {
+        return secondary;
+      }
+
+      try {
+        const current = new URL(window.location.href);
+        current.search = '';
+        current.hash = '';
+        const derived = ensureNotPanel(current.origin + current.pathname);
+        if (!isInvalid(derived)) {
+          return derived;
+        }
+      } catch (err) {
+        console.warn('Unable to derive base URL from current location', err);
+      }
+
+      return secondary || primary || '';
+    }
+
+    CONFIG.baseUrl = sanitizeBaseUrl(CONFIG.baseUrl, CONFIG.scriptUrl);
+    CONFIG.scriptUrl = sanitizeBaseUrl(CONFIG.scriptUrl, CONFIG.baseUrl);
+
+    if (!CONFIG.baseUrl) {
+      const current = new URL(window.location.href);
+      CONFIG.baseUrl = current.origin + current.pathname;
     }
 
     const SUPPORT_EMAIL = 'support@vlbpo.com';

--- a/header.html
+++ b/header.html
@@ -29,14 +29,46 @@
 
   <script>
     // Base URLs for navigation
-    const BASE_URL = '<?= baseUrl ?>';
-    const SCRIPT_URL = '<?= SCRIPT_URL ?>';
+    let BASE_URL = '<?= baseUrl ?>';
+    let SCRIPT_URL = '<?= scriptUrl || baseUrl ?>';
+
+    const __invalidPanelPattern = /usercodeapppanel/i;
+
+    function sanitizeNavigationUrl(url, fallback) {
+      const normalize = value => {
+        if (value === null || typeof value === 'undefined') return '';
+        const trimmed = String(value).trim();
+        if (!trimmed || trimmed.toLowerCase() === 'undefined') return '';
+        return trimmed;
+      };
+
+      const fixPanel = value => {
+        if (!value) return '';
+        if (!__invalidPanelPattern.test(value)) {
+          return value;
+        }
+        return value.replace(/\/userCodeAppPanel.*$/i, '/exec');
+      };
+
+      const primary = fixPanel(normalize(url));
+      if (primary) {
+        return primary;
+      }
+
+      return fixPanel(normalize(fallback));
+    }
+
+    const __BASE_URL = sanitizeNavigationUrl(BASE_URL, SCRIPT_URL);
+    const __SCRIPT_URL = sanitizeNavigationUrl(SCRIPT_URL, BASE_URL);
+
+    BASE_URL = __BASE_URL || __SCRIPT_URL || BASE_URL;
+    SCRIPT_URL = __SCRIPT_URL || __BASE_URL || SCRIPT_URL;
 
     /**
      * Generate URLs for navigation
      */
     function generateUrl(page, campaign = null, additionalParams = {}) {
-      let url = BASE_URL;
+      let url = BASE_URL || SCRIPT_URL;
       const params = new URLSearchParams();
       
       if (page) {


### PR DESCRIPTION
## Summary
- sanitize all script URLs to strip the userCodeAppPanel preview host and fall back to the deployed /exec link
- resolve the base URL dynamically on both server and client so navigation and redirects always target the live web app
- harden shared header utilities to reuse the sanitized base URL for navigation and logout flows

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8164465bc83269f046c3127b4b7d6