### PR TITLE
Prevent duplicate realtime triggers

### DIFF
--- a/IBTRUtilities.js
+++ b/IBTRUtilities.js
@@ -1110,14 +1110,22 @@
     try {
       var TRIGGER_FUNC = 'checkRealtimeUpdatesJob';
       var triggers = ScriptApp.getProjectTriggers() || [];
-      var exists = false;
-      for (var i=0;i<triggers.length;i++){
+      var matching = [];
+      for (var i = 0; i < triggers.length; i++) {
         var t = triggers[i];
-        if (t.getHandlerFunction && t.getHandlerFunction() === TRIGGER_FUNC) { exists = true; break; }
+        if (t.getHandlerFunction && t.getHandlerFunction() === TRIGGER_FUNC) {
+          matching.push(t);
+        }
       }
-      if (!exists) {
+
+      if (matching.length === 0) {
         ScriptApp.newTrigger(TRIGGER_FUNC).timeBased().everyMinutes(1).create();
         console.log('Realtime trigger created (every 1 minute).');
+      } else if (matching.length > 1) {
+        for (var j = 1; j < matching.length; j++) {
+          ScriptApp.deleteTrigger(matching[j]);
+        }
+        console.log('Duplicate realtime triggers removed: ' + (matching.length - 1));
       }
     } catch (e) { logError('_ensureRealtimeTrigger', e); }
   }


### PR DESCRIPTION
## Summary
- ensure the realtime trigger setup removes duplicate checkRealtimeUpdatesJob triggers
- add logging when duplicates are cleaned up while keeping the existing creation logic

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d85f47af2c8326bfb5c86374ea1d55