### PR TITLE
Add lazy loading to static images for improved performance

### DIFF
--- a/ChangePassword.html
+++ b/ChangePassword.html
@@ -209,7 +209,7 @@
           <!-- Logos -->
           <div class="text-center mb-1">
             <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png"
-                 alt="lumina" class="img-fluid mt-1" style="width: 15%;">
+                 alt="lumina" class="img-fluid mt-1" style="width: 15%;" loading="lazy">
           </div>
 
           <h1 class="h3 text-dark mb-1" id="pageTitle">Set Your Password</h1>
@@ -344,7 +344,7 @@
           <polygon points="0,450 800,600 800,450 0,600" fill="url(#fade)"/>
         </svg>
         <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754789161/vlbpo/gradient-ssl-illustration_hjphtp.png"
-             alt="Security Illustration" class="img-fluid" style="max-width: 80%; z-index: 1;">
+             alt="Security Illustration" class="img-fluid" style="max-width: 80%; z-index: 1;" loading="lazy">
       </div>
 
     </div>

--- a/EmailConfirmed.html
+++ b/EmailConfirmed.html
@@ -257,10 +257,10 @@
     <div class="confirmation-card">
       <!-- Logo -->
       <div class="logo-container">
-        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo">
+        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo" loading="lazy">
         <br>
-        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png" 
-             alt="Datalog Logo" style="max-height: 20px;">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png"
+             alt="Datalog Logo" style="max-height: 20px;" loading="lazy">
       </div>
 
       <? if (success) { ?>

--- a/EmailService.js
+++ b/EmailService.js
@@ -550,7 +550,7 @@ function renderEmail_({ headerTitle, headerGradient, logoUrl, preheader, content
 <span class="preheader">${safePreheader}</span>
 <div class="email-container">
     <div class="header" style="background:${hdrGrad};">
-        <img src="${logo}" alt="${escapeHtml_(EMAIL_CONFIG.orgName)} Logo" class="logo">
+        <img src="${logo}" alt="${escapeHtml_(EMAIL_CONFIG.orgName)} Logo" class="logo" loading="lazy">
         <h1 class="header-title">${escapeHtml_(headerTitle || EMAIL_CONFIG.brandName)}</h1>
     </div>
     <div class="content">

--- a/ForgotPassword.html
+++ b/ForgotPassword.html
@@ -299,10 +299,10 @@
     <div class="forgot-card">
       <!-- Logo -->
       <div class="logo-container">
-        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo">
+        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo" loading="lazy">
         <br>
-        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png" 
-             alt="Datalog Logo" style="max-height: 20px;">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png"
+             alt="Datalog Logo" style="max-height: 20px;" loading="lazy">
       </div>
 
       <!-- Icon -->

--- a/IndependenceQAServices.js
+++ b/IndependenceQAServices.js
@@ -690,7 +690,7 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; line-height
 </style></head>
 <body>
   <div class="header">
-    <img src="${INDEPENDENCE_COMPANY_LOGO}" class="logo"/>
+    <img src="${INDEPENDENCE_COMPANY_LOGO}" class="logo" loading="lazy"/>
     <div class="header-content">
       <h1>Independence Insurance Quality Assessment Report</h1>
       <p>Call Quality Evaluation & Performance Analysis</p>

--- a/Login.html
+++ b/Login.html
@@ -753,7 +753,7 @@
           <!-- Logo Section -->
           <div class="logo-container">
             <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png"
-                 alt="LuminaHQ" class="img-fluid" style="width: 400px; height: auto;">
+                 alt="LuminaHQ" class="img-fluid" style="width: 400px; height: auto;" loading="lazy">
           </div>
 
           <div class="welcome-text">
@@ -859,7 +859,7 @@
       <!-- RIGHT: Illustration -->
       <div class="col-md-6 gradient-bg d-none d-md-flex align-items-center justify-content-center right-panel">
         <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1743438226/vlbpo/huowvct9gus48rwy8sfy.svg"
-             alt="Welcome Illustration" class="img-fluid" style="max-width: 70%; filter: drop-shadow(0 10px 20px rgba(0,0,0,0.1));">
+             alt="Welcome Illustration" class="img-fluid" style="max-width: 70%; filter: drop-shadow(0 10px 20px rgba(0,0,0,0.1));" loading="lazy">
       </div>
 
     </div>

--- a/ProxyService.js
+++ b/ProxyService.js
@@ -192,7 +192,7 @@ function createProxyToolbar(currentUrl) {
             border-bottom: 1px solid rgba(255,255,255,0.2);
         ">
             <div style="display: flex; align-items: center; gap: 10px; flex: 1;">
-                <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMTMuMDkgOC4yNkwyMCA5TDEzLjA5IDE1Ljc0TDEyIDIyTDEwLjkxIDE1Ljc0TDQgOUwxMC45MSA4LjI2TDEyIDJaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K" alt="LuminaHQ" style="width: 24px; height: 24px;">
+                <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDJMMTMuMDkgOC4yNkwyMCA5TDEzLjA5IDE1Ljc0TDEyIDIyTDEwLjkxIDE1Ljc0TDQgOUwxMC45MSA4LjI2TDEyIDJaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K" alt="LuminaHQ" style="width: 24px; height: 24px;" loading="lazy">
                 <span style="font-weight: 600; color: #fff;">LuminaHQ Browser</span>
                 <div style="margin-left: 20px; display: flex; align-items: center; gap: 8px;">
                     <button onclick="luminaProxy.goBack()" style="

--- a/ResendVerification.html
+++ b/ResendVerification.html
@@ -259,10 +259,10 @@
     <div class="verification-card">
       <!-- Logo -->
       <div class="logo-container">
-        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo">
+        <img src="https://vlbpo.com/wp-content/uploads/2022/03/Asset-1-8.png.webp" alt="VLBPO Logo" loading="lazy">
         <br>
-        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png" 
-             alt="Datalog Logo" style="max-height: 20px;">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1751630242/vlbpo/as_is_-_Edited_yq58rt.png"
+             alt="Datalog Logo" style="max-height: 20px;" loading="lazy">
       </div>
 
       <!-- Icon -->

--- a/chatHeader.html
+++ b/chatHeader.html
@@ -253,6 +253,7 @@
       <img
         src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1743464480/vlbpo/freepik-simple-flat-data-logo-20250331234108dUWu_k2ee6t.png"
         alt="DATALOG Logo"
+        loading="lazy"
       />
       <span>DATA<span>LOG</span></span>
     </div>

--- a/header.html
+++ b/header.html
@@ -995,6 +995,7 @@
         src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png"
         alt="LuminaHQ Icon"
         class="logo-icon"
+        loading="lazy"
         onerror="this.style.display='none'"
       />
 
@@ -1005,6 +1006,7 @@
           src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763929/vlbpo/lumina/Lumina_aa8rch.png"
           alt="LuminaHQ"
           class="logo-text"
+          loading="lazy"
           onerror="this.style.display='none'; this.nextElementSibling.style.display='block'"
         />
 

--- a/headerConf.html
+++ b/headerConf.html
@@ -252,8 +252,8 @@
 <nav id="sidebar">
   <!-- Logo -->
 <div class="sidebar-logo" id="sidebarToggle">
-  <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754586750/vlbpo/lumina/1_e0ykfc.png" alt="datalog_logo"/>
-    <span><img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754587234/vlbpo/lumina/Lumina_ladp5s.png" alt="DATA" class="logo-part"/></span>
+  <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754586750/vlbpo/lumina/1_e0ykfc.png" alt="datalog_logo" loading="lazy"/>
+    <span><img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754587234/vlbpo/lumina/Lumina_ladp5s.png" alt="DATA" class="logo-part" loading="lazy"/></span>
 </div>
 
 


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to shared layout logos so navigation imagery defers loading until needed
- update authentication and notification templates to lazily load hero illustrations and email branding assets
- extend service templates with lazy loading so embedded logos don’t block initial render

## Testing
- not run (HTML/JS updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d901ed0a448326a555402636afb3cb