### PR TITLE
Remove campaign IDs from navigation URLs

### DIFF
--- a/Dashboard.html
+++ b/Dashboard.html
@@ -1370,7 +1370,7 @@
                         <div class="campaign-body">
                             <div class="metrics-header">
                                 <h4 class="metrics-title">OKR Metrics</h4>
-                                <button class="view-details-btn" onclick="event.stopPropagation(); window.open('?page=dashboard&campaign=${encodeURIComponent(campaign.name)}', '_blank')">
+                                <button class="view-details-btn" onclick="event.stopPropagation(); window.open('?page=dashboard', '_blank')">
                                     <i class="fas fa-external-link-alt"></i> View Details
                                 </button>
                             </div>
@@ -1855,7 +1855,7 @@
 
             navigateToCampaign(campaignName) {
                 try {
-                    const url = `?page=dashboard&campaign=${encodeURIComponent(campaignName)}`;
+                    const url = `?page=dashboard`;
                     window.open(url, '_blank');
                 } catch (error) {
                     console.error('Error navigating to campaign:', error);

--- a/QADashboard.html
+++ b/QADashboard.html
@@ -865,13 +865,9 @@
 <!-- Modern Action Buttons -->
 <div class="modern-actions fade-in">
   <? 
-        // Build clean URLs with campaign context using cookie-based auth
+        // Build clean URLs without exposing campaign context
         function buildUrl(page) {
-          var url = baseUrl + '?page=' + page;
-          if (typeof campaignId !== 'undefined' && campaignId) {
-            url += '&campaign=' + encodeURIComponent(campaignId);
-          }
-          return url;
+          return baseUrl + '?page=' + page;
         }
       ?>
   <a href="<?= buildUrl('qualityform') ?>" class="modern-btn modern-btn-primary">
@@ -1702,12 +1698,8 @@
           if (reportTypeSelect) {
             reportTypeSelect.addEventListener('change', function(e) {
               const baseUrl = '<?= baseUrl ?>';
-              const campaignId = '<?= typeof campaignId !== "undefined" ? campaignId : "" ?>';
-              let url = `${baseUrl}?page=${e.target.value}`;
-              if (campaignId) {
-                url += `&campaign=${encodeURIComponent(campaignId)}`;
-              }
-              window.location.href = url;
+              const nextPage = e.target.value;
+              window.location.href = `${baseUrl}?page=${nextPage}`;
             });
           } else {
             console.warn('reportTypeSelect not found');

--- a/UnifiedQADashboard.html
+++ b/UnifiedQADashboard.html
@@ -1099,12 +1099,12 @@
         
         if (currentCampaign === 'independence') {
             // Use the correct page names for Independence Insurance
-            newQABtn.href = `${baseUrl}&page=independencequality${campaignId ? '&campaign=' + encodeURIComponent(campaignId) : ''}`;
-            qaListBtn.href = `${baseUrl}&page=qalist${campaignId ? '&campaign=' + encodeURIComponent(campaignId) : ''}`;
+            newQABtn.href = `${baseUrl}&page=independencequality`;
+            qaListBtn.href = `${baseUrl}&page=qalist`;
         } else {
             // Use the correct page names for Credit Suite
-            newQABtn.href = `${baseUrl}&creditsuiteqa${campaignId ? '&campaign=' + encodeURIComponent(campaignId) : ''}`;
-            qaListBtn.href = `${baseUrl}&page=qalist${campaignId ? '&campaign=' + encodeURIComponent(campaignId) : ''}`;
+            newQABtn.href = `${baseUrl}&creditsuiteqa`;
+            qaListBtn.href = `${baseUrl}&page=qalist`;
         }
         
         console.log('Updated button URLs:', {

--- a/header.html
+++ b/header.html
@@ -67,18 +67,15 @@
     /**
      * Generate URLs for navigation
      */
-    function generateUrl(page, campaign = null, additionalParams = {}) {
+    function generateUrl(page, _campaign = null, additionalParams = {}) {
+      // _campaign is kept for backward compatibility but intentionally unused to avoid exposing it in URLs
       let url = BASE_URL || SCRIPT_URL;
       const params = new URLSearchParams();
-      
+
       if (page) {
         params.set('page', page);
       }
-      
-      if (campaign) {
-        params.set('campaign', campaign);
-      }
-      
+
       // Add any additional parameters
       Object.entries(additionalParams).forEach(([key, value]) => {
         if (value !== null && value !== undefined) {
@@ -93,8 +90,8 @@
     /**
      * Navigate to a page
      */
-    function navigateToPage(page, campaign = null, additionalParams = {}) {
-      const url = generateUrl(page, campaign, additionalParams);
+    function navigateToPage(page, _campaign = null, additionalParams = {}) {
+      const url = generateUrl(page, _campaign, additionalParams);
       window.location.href = url;
     }
 
@@ -1096,12 +1093,8 @@
         }
         
         // Helper function to generate URLs in server-side template
-        function generateLink(page, campaign) {
-          var url = baseUrl + '?page=' + encodeURIComponent(page);
-          if (campaign) {
-            url += '&campaign=' + encodeURIComponent(campaign);
-          }
-          return url;
+        function generateLink(page) {
+          return baseUrl + '?page=' + encodeURIComponent(page);
         }
         ?>
 
@@ -1133,7 +1126,7 @@
         <div class="sidebar-group">
           <? category.pages.forEach(function(page) { ?>
           <? if (page && page.PageKey && page.PageTitle) { ?>
-          <a href="<?= generateLink(page.PageKey, campaignId) ?>"
+          <a href="<?= generateLink(page.PageKey) ?>"
             class="<?= (currentPage === page.PageTitle || currentPage === page.PageKey) ? 'active' : '' ?>"
             data-bs-toggle="tooltip" data-bs-placement="right" title="<?= page.PageDescription || page.PageTitle ?>">
             <i class="<?= page.PageIcon || 'fas fa-file' ?>"></i>
@@ -1157,7 +1150,7 @@
         <div class="sidebar-group">
           <? navigation.uncategorizedPages.forEach(function(page) { ?>
           <? if (page && page.PageKey && page.PageTitle) { ?>
-          <a href="<?= generateLink(page.PageKey, campaignId) ?>"
+          <a href="<?= generateLink(page.PageKey) ?>"
             class="<?= (currentPage === page.PageTitle || currentPage === page.PageKey) ? 'active' : '' ?>"
             data-bs-toggle="tooltip" data-bs-placement="right" title="<?= page.PageDescription || page.PageTitle ?>">
             <i class="<?= page.PageIcon || 'fas fa-file' ?>"></i>
@@ -1177,19 +1170,19 @@
             <span>Global</span>
           </div>
           <div class="sidebar-group">
-            <a href="<?= generateLink('chat', null) ?>" class="<?= currentPage==='Chat'?'active':'' ?>" data-bs-toggle="tooltip"
+            <a href="<?= generateLink('chat') ?>" class="<?= currentPage==='Chat'?'active':'' ?>" data-bs-toggle="tooltip"
               data-bs-placement="right" title="Team Chat">
               <i class="fas fa-comments"></i><span>Chat</span>
             </a>
-            <a href="<?= generateLink('collaboration-reporting', null) ?>" class="<?= currentPage==='Collaboration Reporting'?'active':'' ?>"
+            <a href="<?= generateLink('collaboration-reporting') ?>" class="<?= currentPage==='Collaboration Reporting'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="Collaboration &amp; Reporting Hub">
               <i class="fas fa-diagram-project"></i><span>Collab &amp; Reporting</span>
             </a>
-            <a href="<?= generateLink('search', null) ?>" class="<?= currentPage==='Search'?'active':'' ?>"
+            <a href="<?= generateLink('search') ?>" class="<?= currentPage==='Search'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="Web Search">
               <i class="fas fa-search"></i><span>Search</span>
             </a>
-            <a href="<?= generateLink('bookmarks', null) ?>" class="<?= currentPage==='Bookmarks'?'active':'' ?>"
+            <a href="<?= generateLink('bookmarks') ?>" class="<?= currentPage==='Bookmarks'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="Bookmarks">
               <i class="fas fa-bookmark"></i><span>Bookmarks</span>
             </a>
@@ -1204,15 +1197,15 @@
             <span>Administration</span>
           </div>
           <div class="sidebar-group">
-            <a href="<?= generateLink('manageuser', null) ?>" class="<?= currentPage==='Users'?'active':'' ?>"
+            <a href="<?= generateLink('manageuser') ?>" class="<?= currentPage==='Users'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="User Management">
               <i class="fas fa-users"></i><span>Users</span>
             </a>
-            <a href="<?= generateLink('manageroles', null) ?>" class="<?= currentPage==='Settings'?'active':'' ?>"
+            <a href="<?= generateLink('manageroles') ?>" class="<?= currentPage==='Settings'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="Role Management">
               <i class="fas fa-user-shield"></i><span>Roles</span>
             </a>
-            <a href="<?= generateLink('managecampaign', null) ?>" class="<?= currentPage==='Campaigns'?'active':'' ?>"
+            <a href="<?= generateLink('managecampaign') ?>" class="<?= currentPage==='Campaigns'?'active':'' ?>"
               data-bs-toggle="tooltip" data-bs-placement="right" title="Campaign Management">
               <i class="fas fa-bullhorn"></i><span>Campaigns</span>
             </a>
@@ -1276,13 +1269,13 @@
             <div class="notification-badge"></div>
         </button>
 
-      <a href="<?= generateLink('search', null) ?>" class="notification-btn" data-bs-toggle="tooltip" title="Search">
+      <a href="<?= generateLink('search') ?>" class="notification-btn" data-bs-toggle="tooltip" title="Search">
         <i class="fas fa-search"></i>
       </a>
 
       <!-- Employment Report Link for Admins -->
       <? if (isAdmin) { ?>
-      <a href="<?= generateLink('manageuser', null) ?>#employment-report" class="notification-btn" data-bs-toggle="tooltip"
+      <a href="<?= generateLink('manageuser') ?>#employment-report" class="notification-btn" data-bs-toggle="tooltip"
         title="Employment Report">
         <i class="fas fa-chart-bar"></i>
       </a>

--- a/headerConf.html
+++ b/headerConf.html
@@ -272,9 +272,9 @@
       <div class="sidebar-group">
       <!-- Home -->
       <? if (allowed.indexOf('dashboard') >= 0) { ?>
-        <a href="<?= baseUrl ?>&page=dashboard&campaign=<?= campaignId ?>"
+        <a href="<?= baseUrl ?>&page=dashboard"
            class="<?=
-             currentPage==='Dashboard' && e.parameter.campaign===campaignId
+             currentPage==='Dashboard'
              ? 'active' : '' ?>">
           <i class="fas fa-gauge"></i><span>Dashboard</span>
         </a>
@@ -285,25 +285,25 @@
       <div class="sidebar-section">Reports</div>
       <div class="sidebar-group">
       <? if (allowed.indexOf('callreports') >= 0) { ?>
-        <a href="<?= baseUrl ?>&page=callreports&campaign=<?= campaignId ?>"
+        <a href="<?= baseUrl ?>&page=callreports"
            class="<?=
-             currentPage==='CallReports' && e.parameter.campaign===campaignId
+             currentPage==='CallReports'
              ? 'active' : '' ?>">
           <i class="fas fa-square-phone-flip"></i><span>Call Reports</span>
         </a>
       <? } ?>
       <? if (allowed.indexOf('attendance') >= 0 || allowed.indexOf('attendancereports') >= 0) { ?>
-        <a href="<?= baseUrl ?>&page=attendance&campaign=<?= campaignId ?>"
+        <a href="<?= baseUrl ?>&page=attendance"
            class="<?=
-             currentPage==='Attendance' && e.parameter.campaign===campaignId
+             currentPage==='Attendance'
              ? 'active' : '' ?>">
           <i class="fas fa-business-time"></i><span>Attendance</span>
         </a>
       <? } ?>
       <? if (allowed.indexOf('qadashboard') >= 0) { ?>
-        <a href="<?= baseUrl ?>&page=qadashboard&campaign=<?= campaignId ?>"
+        <a href="<?= baseUrl ?>&page=qadashboard"
            class="<?=
-             currentPage==='Quality' && e.parameter.campaign===campaignId
+             currentPage==='Quality'
              ? 'active' : '' ?>">
           <i class="fas fa-chart-column"></i><span>QA Dashboard</span>
         </a>
@@ -314,33 +314,33 @@
       <div class="sidebar-section">MANAGEMENT</div>
       <div class="sidebar-group">
         <? if (allowed.indexOf('coachingdashboard') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=coachingdashboard&campaign=<?= campaignId ?>"
+          <a href="<?= baseUrl ?>&page=coachingdashboard"
             class="<?=
-              currentPage==='Coaching' && e.parameter.campaign===campaignId
+              currentPage==='Coaching'
               ? 'active' : '' ?>">
             <i class="fas fa-chart-line"></i><span>Coaching</span>
           </a>
         <? } ?>
         <? if (allowed.indexOf('schedulemanagement') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=schedulemanagement&campaign=<?= campaignId ?>"
+          <a href="<?= baseUrl ?>&page=schedulemanagement"
             class="<?=
-              currentPage==='Schedule' && e.parameter.campaign===campaignId
+              currentPage==='Schedule'
               ? 'active' : '' ?>">
             <i class="fas fa-calendar-week"></i><span>Schedule</span>
           </a>
         <? } ?>
         <? if (allowed.indexOf('tasklist') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=taskboard&campaign=<?= campaignId ?>"
+          <a href="<?= baseUrl ?>&page=taskboard"
             class="<?=
-              currentPage==='Task' && e.parameter.campaign===campaignId
+              currentPage==='Task'
               ? 'active' : '' ?>">
             <i class="fas fa-tasks"></i><span>Tasks</span>
           </a>
         <? } ?>
         <? if (allowed.indexOf('calendar') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=calendar&campaign=<?= campaignId ?>"
+          <a href="<?= baseUrl ?>&page=calendar"
             class="<?=
-              currentPage==='Calendar' && e.parameter.campaign===campaignId
+              currentPage==='Calendar'
               ? 'active' : '' ?>">
             <i class="fas fa-calendar-alt"></i><span>Calendar</span>
           </a>
@@ -351,18 +351,18 @@
       <div class="sidebar-section">OTHER</div>   
       <div class="sidebar-group">
         <? if (allowed.indexOf('escalations') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=escalations&campaign=<?= campaignId ?>"
+          <a href="<?= baseUrl ?>&page=escalations"
             class="<?=
-              currentPage==='Escalations' && e.parameter.campaign===campaignId
+              currentPage==='Escalations'
               ? 'active' : '' ?>">
             <i class="fas fa-exclamation-triangle"></i><span>Escalations</span>
           </a>
         <? } ?>
         <? if (allowed.indexOf('settings') >= 0) { ?>
-          <a href="<?= baseUrl ?>&page=settings&campaign=<?= campaignId ?>"
-            class="<?=
-              currentPage==='Settings' && e.parameter.campaign===campaignId
-              ? 'active' : '' ?>">
+          <a href="<?= baseUrl ?>&page=settings"
+             class="<?=
+               currentPage==='Settings'
+               ? 'active' : '' ?>">
             <i class="fas fa-cog"></i><span>Settings</span>
           </a>
         <? } ?>


### PR DESCRIPTION
## Summary
- update both sidebar templates so navigation links no longer append campaign identifiers to query strings
- adjust dashboard and QA pages to open related views without adding the campaign parameter to generated URLs
- retain navigation helper signatures while documenting that the campaign argument is ignored to keep URLs clean

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d90a3974288326ada9dd9314388cf5