### PR TITLE
Remove session tokens from URLs and rely on cookies

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -1418,7 +1418,7 @@
 
           hideAllAlerts();
           setLoading(false);
-          setupRedirect(buildPageUrl('dashboard', { token: resolvedToken }), resumedUser);
+          setupRedirect(buildPageUrl('dashboard'), resumedUser);
         })
         .withFailureHandler(error => {
           setLoading(false);
@@ -1450,6 +1450,24 @@
       }
 
       return normalized;
+    }
+
+    function stripTokenFromUrl(url) {
+      if (!url) {
+        return url;
+      }
+
+      try {
+        const parsed = new URL(url, window.location.href);
+        if (parsed.searchParams.has('token')) {
+          parsed.searchParams.delete('token');
+        }
+        return parsed.toString();
+      } catch (err) {
+        console.warn('Unable to sanitize redirect URL.', err);
+      }
+
+      return url;
     }
 
     function buildPageUrl(page, params = {}) {
@@ -1501,7 +1519,7 @@
       return baseUrl.toString();
     }
 
-    function normalizeRedirectUrl(serverUrl, sessionToken) {
+    function normalizeRedirectUrl(serverUrl) {
       let page = 'dashboard';
       const params = {};
 
@@ -1511,6 +1529,7 @@
           page = parsed.searchParams.get('page') || page;
           parsed.searchParams.forEach((value, key) => {
             if (key === 'page') return;
+            if (key === 'token') return;
             params[key] = value;
           });
         } catch (err) {
@@ -1518,11 +1537,7 @@
         }
       }
 
-      if (sessionToken && !params.token) {
-        params.token = sessionToken;
-      }
-
-      return buildPageUrl(page, params);
+      return stripTokenFromUrl(buildPageUrl(page, params));
     }
 
     function openPage(page, params = {}) {
@@ -2352,15 +2367,16 @@
     // REDIRECT MANAGEMENT
     // ───────────────────────────────────────────────────────────────────────────────
     function setupRedirect(url, userInfo = {}) {
-      console.log('Setting up redirect to:', url);
-      
-      state.redirectUrl = url;
+      const safeUrl = stripTokenFromUrl(url);
+      console.log('Setting up redirect to:', safeUrl);
+
+      state.redirectUrl = safeUrl;
       state.isRedirecting = true;
       state.countdownValue = 3;
-      
+
       // Update UI
       if (elements.continueButton) {
-        elements.continueButton.href = url;
+        elements.continueButton.href = safeUrl;
       }
 
       if (elements.loginForm) {
@@ -2553,8 +2569,8 @@
               response.sessionTtlSeconds
             );
 
-            // Setup redirect with token in URL
-            const destinationUrl = normalizeRedirectUrl(response.redirectUrl, response.sessionToken);
+            // Setup redirect using a sanitized destination URL
+            const destinationUrl = normalizeRedirectUrl(response.redirectUrl);
             setupRedirect(destinationUrl, response.user);
 
             hideNextSteps();
@@ -2653,6 +2669,14 @@
       const urlParams = new URLSearchParams(window.location.search);
       const message = urlParams.get('message');
       const error = urlParams.get('error');
+
+      if (urlParams.has('token')) {
+        const sanitizedParams = new URLSearchParams(urlParams);
+        sanitizedParams.delete('token');
+        const newQuery = sanitizedParams.toString();
+        const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash || ''}`;
+        window.history.replaceState({}, document.title, newUrl);
+      }
       
       if (error) {
         showAlert('error', decodeURIComponent(error));

--- a/chatHeader.html
+++ b/chatHeader.html
@@ -411,21 +411,20 @@
         document.getElementById('sidebar').classList.toggle('collapsed')
       );
 
-    let rawToken = new URLSearchParams(location.search).get('token') || readAuthCookie();
-    if (rawToken) {
+    const currentUrl = new URL(window.location.href);
+    const urlToken = currentUrl.searchParams.get('token');
+    let rawToken = readAuthCookie();
+
+    if (urlToken) {
+      rawToken = urlToken;
+      persistAuthCookie(urlToken);
+      currentUrl.searchParams.delete('token');
+      const updatedSearch = currentUrl.searchParams.toString();
+      const cleanedUrl = `${currentUrl.pathname}${updatedSearch ? `?${updatedSearch}` : ''}${currentUrl.hash || ''}`;
+      window.history.replaceState({}, document.title, cleanedUrl);
+    } else if (rawToken) {
       persistAuthCookie(rawToken);
     }
-
-    document.body.addEventListener('click', e => {
-      const a = e.target.closest('a[href]');
-      if (!a) return;
-      const href = a.getAttribute('href');
-      if (href.startsWith('http') || href.includes('token=')) return;
-      e.preventDefault();
-      const next = new URL(href, location.origin + location.pathname);
-      next.searchParams.set('token', rawToken || readAuthCookie());
-      window.location.href = next.toString();
-    });
 
     function scheduleKeepAlive() {
       if (!rawToken) {

--- a/headerConf.html
+++ b/headerConf.html
@@ -437,21 +437,20 @@
         document.getElementById('sidebar').classList.toggle('collapsed')
       );
 
-    let rawToken = new URLSearchParams(location.search).get('token') || readAuthCookie();
-    if (rawToken) {
+    const currentUrl = new URL(window.location.href);
+    const urlToken = currentUrl.searchParams.get('token');
+    let rawToken = readAuthCookie();
+
+    if (urlToken) {
+      rawToken = urlToken;
+      persistAuthCookie(urlToken);
+      currentUrl.searchParams.delete('token');
+      const updatedSearch = currentUrl.searchParams.toString();
+      const cleanedUrl = `${currentUrl.pathname}${updatedSearch ? `?${updatedSearch}` : ''}${currentUrl.hash || ''}`;
+      window.history.replaceState({}, document.title, cleanedUrl);
+    } else if (rawToken) {
       persistAuthCookie(rawToken);
     }
-
-    document.body.addEventListener('click', e => {
-      const a = e.target.closest('a[href]');
-      if (!a) return;
-      const href = a.getAttribute('href');
-      if (href.startsWith('http') || href.includes('token=')) return;
-      e.preventDefault();
-      const next = new URL(href, location.origin + location.pathname);
-      next.searchParams.set('token', rawToken || readAuthCookie());
-      window.location.href = next.toString();
-    });
 
     function scheduleKeepAlive() {
       if (!rawToken) {


### PR DESCRIPTION
## Summary
- sanitize the login redirect flow to strip session tokens from URLs and rely on persisted cookies
- update shared header scripts to store session tokens in cookies and clean up navigation URLs
- drop lingering token query parameters from the login page address bar once the page loads

## Testing
- No automated tests (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9192057c083269f761012149e8bd8