### PR TITLE
Centralize session cookie handling

### DIFF
--- a/CookieHandler.html
+++ b/CookieHandler.html
@@ -1,0 +1,153 @@
+<script>
+  (function (global) {
+    const COOKIE_NAME = 'authToken';
+    const MIN_MAX_AGE_SECONDS = 300;
+    const DEFAULT_SESSION_SECONDS = 60 * 60; // 1 hour fallback
+    const DEFAULT_REMEMBER_SECONDS = 24 * 60 * 60; // 24 hours fallback
+
+    function safeParseDate(input) {
+      if (!input) return null;
+      const value = (typeof input === 'string' || input instanceof String) ? input : String(input);
+      const timestamp = Date.parse(value);
+      return Number.isNaN(timestamp) ? null : timestamp;
+    }
+
+    function resolveMaxAgeSeconds(options = {}) {
+      const { ttlSeconds, maxAgeSeconds, expiresAt, rememberMe } = options;
+      let resolved = null;
+
+      if (typeof ttlSeconds === 'number' && Number.isFinite(ttlSeconds) && ttlSeconds > 0) {
+        resolved = Math.floor(ttlSeconds);
+      } else if (typeof maxAgeSeconds === 'number' && Number.isFinite(maxAgeSeconds) && maxAgeSeconds > 0) {
+        resolved = Math.floor(maxAgeSeconds);
+      } else {
+        const expiresAtTimestamp = safeParseDate(expiresAt);
+        if (expiresAtTimestamp && expiresAtTimestamp > Date.now()) {
+          resolved = Math.floor((expiresAtTimestamp - Date.now()) / 1000);
+        }
+      }
+
+      if (resolved === null) {
+        resolved = rememberMe ? DEFAULT_REMEMBER_SECONDS : DEFAULT_SESSION_SECONDS;
+      }
+
+      return Math.max(MIN_MAX_AGE_SECONDS, resolved);
+    }
+
+    function readCookieValue(name) {
+      try {
+        const cookies = typeof document !== 'undefined' && document.cookie ? document.cookie.split(';') : [];
+        for (let i = 0; i < cookies.length; i += 1) {
+          const part = cookies[i] ? cookies[i].trim() : '';
+          if (!part) continue;
+          if (part.startsWith(`${name}=`)) {
+            return decodeURIComponent(part.substring(name.length + 1));
+          }
+        }
+      } catch (err) {
+        console.warn('CookieHandler: unable to read cookie', name, err);
+      }
+      return '';
+    }
+
+    function writeCookie(name, value, options = {}) {
+      if (typeof document === 'undefined') return '';
+
+      const maxAgeSeconds = resolveMaxAgeSeconds(options);
+      const expiresDate = new Date(Date.now() + maxAgeSeconds * 1000);
+      const attributes = {
+        path: '/',
+        sameSite: 'Lax',
+        secure: false,
+        ...options.attributes
+      };
+
+      const parts = [
+        `${name}=${encodeURIComponent(value)}`,
+        `path=${attributes.path || '/'}`,
+        `max-age=${maxAgeSeconds}`,
+        `expires=${expiresDate.toUTCString()}`,
+        `SameSite=${attributes.sameSite || 'Lax'}`
+      ];
+
+      if (attributes.domain) {
+        parts.push(`domain=${attributes.domain}`);
+      }
+      if (attributes.secure) {
+        parts.push('Secure');
+      }
+
+      try {
+        document.cookie = parts.join('; ');
+      } catch (err) {
+        console.warn('CookieHandler: unable to write cookie', name, err);
+      }
+
+      return value;
+    }
+
+    function clearCookie(name, options = {}) {
+      if (typeof document === 'undefined') return;
+
+      const attributes = {
+        path: '/',
+        sameSite: 'Lax',
+        secure: false,
+        ...options.attributes
+      };
+
+      const parts = [
+        `${name}=`,
+        `path=${attributes.path || '/'}`,
+        'max-age=0',
+        'expires=Thu, 01 Jan 1970 00:00:00 GMT',
+        `SameSite=${attributes.sameSite || 'Lax'}`
+      ];
+
+      if (attributes.domain) {
+        parts.push(`domain=${attributes.domain}`);
+      }
+      if (attributes.secure) {
+        parts.push('Secure');
+      }
+
+      try {
+        document.cookie = parts.join('; ');
+      } catch (err) {
+        console.warn('CookieHandler: unable to clear cookie', name, err);
+      }
+    }
+
+    function readAuthToken() {
+      return readCookieValue(COOKIE_NAME);
+    }
+
+    function persistAuthToken(token, options = {}) {
+      if (!token) {
+        clearCookie(COOKIE_NAME, options);
+        return '';
+      }
+      return writeCookie(COOKIE_NAME, token, options);
+    }
+
+    function clearAuthToken(options = {}) {
+      clearCookie(COOKIE_NAME, options);
+    }
+
+    const api = {
+      AUTH_COOKIE_NAME: COOKIE_NAME,
+      readCookieValue,
+      writeCookie,
+      clearCookie,
+      readAuthToken,
+      persistAuthToken,
+      clearAuthToken,
+      resolveMaxAgeSeconds
+    };
+
+    global.CookieHandler = api;
+    global.readAuthCookie = readAuthToken;
+    global.persistAuthCookie = persistAuthToken;
+    global.clearAuthCookie = clearAuthToken;
+  })(typeof window !== 'undefined' ? window : this);
+</script>

--- a/Login.html
+++ b/Login.html
@@ -7,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login – LuminaHQ</title>
 
+  <?!= includeOnce('CookieHandler') ?>
+
   <!-- Bootstrap 5 & FontAwesome -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
@@ -936,7 +938,6 @@
 
     const SUPPORT_EMAIL = 'support@vlbpo.com';
     const REMEMBER_DURATION_MS = 24 * 60 * 60 * 1000;
-    const AUTH_COOKIE_NAME = 'authToken';
     const SESSION_COOKIE_MAX_AGE = 60 * 60; // 1 hour
     const REMEMBER_COOKIE_MAX_AGE = 24 * 60 * 60; // 24 hours
     const STORAGE_KEYS = {
@@ -1313,13 +1314,8 @@
 
     function readAuthCookie() {
       try {
-        const cookies = document.cookie ? document.cookie.split(';') : [];
-        for (let i = 0; i < cookies.length; i++) {
-          const part = cookies[i].trim();
-          if (!part) continue;
-          if (part.startsWith(`${AUTH_COOKIE_NAME}=`)) {
-            return decodeURIComponent(part.substring(AUTH_COOKIE_NAME.length + 1));
-          }
+        if (window.CookieHandler && typeof CookieHandler.readAuthToken === 'function') {
+          return CookieHandler.readAuthToken();
         }
       } catch (err) {
         console.warn('Unable to read auth cookie', err);
@@ -1329,7 +1325,9 @@
 
     function clearAuthCookie() {
       try {
-        document.cookie = `${AUTH_COOKIE_NAME}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
+        if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
+          CookieHandler.clearAuthToken();
+        }
       } catch (err) {
         console.warn('Unable to clear auth cookie', err);
       }
@@ -1360,17 +1358,10 @@
 
       maxAgeSeconds = Math.max(300, maxAgeSeconds); // ensure at least 5 minutes
 
-      const expiresDate = new Date(Date.now() + maxAgeSeconds * 1000);
-      const cookieParts = [
-        `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}`,
-        'path=/',
-        `max-age=${maxAgeSeconds}`,
-        `expires=${expiresDate.toUTCString()}`,
-        'SameSite=Lax'
-      ];
-
       try {
-        document.cookie = cookieParts.join('; ');
+        if (window.CookieHandler && typeof CookieHandler.persistAuthToken === 'function') {
+          CookieHandler.persistAuthToken(token, { maxAgeSeconds });
+        }
       } catch (err) {
         console.warn('Unable to persist auth cookie', err);
       }
@@ -1418,7 +1409,7 @@
 
           hideAllAlerts();
           setLoading(false);
-          setupRedirect(buildPageUrl('dashboard', { token: resolvedToken }), resumedUser);
+          setupRedirect(buildPageUrl('dashboard'), resumedUser);
         })
         .withFailureHandler(error => {
           setLoading(false);
@@ -1450,6 +1441,24 @@
       }
 
       return normalized;
+    }
+
+    function stripTokenFromUrl(url) {
+      if (!url) {
+        return url;
+      }
+
+      try {
+        const parsed = new URL(url, window.location.href);
+        if (parsed.searchParams.has('token')) {
+          parsed.searchParams.delete('token');
+        }
+        return parsed.toString();
+      } catch (err) {
+        console.warn('Unable to sanitize redirect URL.', err);
+      }
+
+      return url;
     }
 
     function buildPageUrl(page, params = {}) {
@@ -1501,7 +1510,7 @@
       return baseUrl.toString();
     }
 
-    function normalizeRedirectUrl(serverUrl, sessionToken) {
+    function normalizeRedirectUrl(serverUrl) {
       let page = 'dashboard';
       const params = {};
 
@@ -1511,6 +1520,7 @@
           page = parsed.searchParams.get('page') || page;
           parsed.searchParams.forEach((value, key) => {
             if (key === 'page') return;
+            if (key === 'token') return;
             params[key] = value;
           });
         } catch (err) {
@@ -1518,11 +1528,7 @@
         }
       }
 
-      if (sessionToken && !params.token) {
-        params.token = sessionToken;
-      }
-
-      return buildPageUrl(page, params);
+      return stripTokenFromUrl(buildPageUrl(page, params));
     }
 
     function openPage(page, params = {}) {
@@ -2352,15 +2358,16 @@
     // REDIRECT MANAGEMENT
     // ───────────────────────────────────────────────────────────────────────────────
     function setupRedirect(url, userInfo = {}) {
-      console.log('Setting up redirect to:', url);
-      
-      state.redirectUrl = url;
+      const safeUrl = stripTokenFromUrl(url);
+      console.log('Setting up redirect to:', safeUrl);
+
+      state.redirectUrl = safeUrl;
       state.isRedirecting = true;
       state.countdownValue = 3;
-      
+
       // Update UI
       if (elements.continueButton) {
-        elements.continueButton.href = url;
+        elements.continueButton.href = safeUrl;
       }
 
       if (elements.loginForm) {
@@ -2553,8 +2560,8 @@
               response.sessionTtlSeconds
             );
 
-            // Setup redirect with token in URL
-            const destinationUrl = normalizeRedirectUrl(response.redirectUrl, response.sessionToken);
+            // Setup redirect using a sanitized destination URL
+            const destinationUrl = normalizeRedirectUrl(response.redirectUrl);
             setupRedirect(destinationUrl, response.user);
 
             hideNextSteps();
@@ -2653,6 +2660,14 @@
       const urlParams = new URLSearchParams(window.location.search);
       const message = urlParams.get('message');
       const error = urlParams.get('error');
+
+      if (urlParams.has('token')) {
+        const sanitizedParams = new URLSearchParams(urlParams);
+        sanitizedParams.delete('token');
+        const newQuery = sanitizedParams.toString();
+        const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash || ''}`;
+        window.history.replaceState({}, document.title, newUrl);
+      }
       
       if (error) {
         showAlert('error', decodeURIComponent(error));

--- a/chatHeader.html
+++ b/chatHeader.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
 
+  <?!= includeOnce('CookieHandler') ?>
+
   <!-- Bootstrap & FontAwesome -->
   <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
@@ -371,38 +373,45 @@
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    const AUTH_COOKIE_NAME = 'authToken';
-
     function readAuthCookie() {
-      const cookies = document.cookie ? document.cookie.split(';') : [];
-      for (let i = 0; i < cookies.length; i++) {
-        const part = cookies[i].trim();
-        if (!part) continue;
-        if (part.startsWith(`${AUTH_COOKIE_NAME}=`)) {
-          return decodeURIComponent(part.substring(AUTH_COOKIE_NAME.length + 1));
+      try {
+        if (window.CookieHandler && typeof CookieHandler.readAuthToken === 'function') {
+          return CookieHandler.readAuthToken();
         }
+      } catch (err) {
+        console.warn('Unable to read auth cookie', err);
       }
       return '';
     }
 
     function persistAuthCookie(token, ttlSeconds) {
-      if (!token) return;
-      const seconds = (typeof ttlSeconds === 'number' && ttlSeconds > 0)
-        ? Math.floor(ttlSeconds)
-        : 60 * 60;
-      const safeSeconds = Math.max(300, seconds);
-      const expires = new Date(Date.now() + safeSeconds * 1000);
-      document.cookie = [
-        `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}`,
-        'path=/',
-        `max-age=${safeSeconds}`,
-        `expires=${expires.toUTCString()}`,
-        'SameSite=Lax'
-      ].join('; ');
+      if (!token) {
+        clearAuthCookie();
+        return;
+      }
+
+      const options = {};
+      if (typeof ttlSeconds === 'number' && ttlSeconds > 0) {
+        options.ttlSeconds = ttlSeconds;
+      }
+
+      try {
+        if (window.CookieHandler && typeof CookieHandler.persistAuthToken === 'function') {
+          CookieHandler.persistAuthToken(token, options);
+        }
+      } catch (err) {
+        console.warn('Unable to persist auth cookie', err);
+      }
     }
 
     function clearAuthCookie() {
-      document.cookie = `${AUTH_COOKIE_NAME}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
+      try {
+        if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
+          CookieHandler.clearAuthToken();
+        }
+      } catch (err) {
+        console.warn('Unable to clear auth cookie', err);
+      }
     }
 
     // collapse toggle
@@ -411,21 +420,20 @@
         document.getElementById('sidebar').classList.toggle('collapsed')
       );
 
-    let rawToken = new URLSearchParams(location.search).get('token') || readAuthCookie();
-    if (rawToken) {
+    const currentUrl = new URL(window.location.href);
+    const urlToken = currentUrl.searchParams.get('token');
+    let rawToken = readAuthCookie();
+
+    if (urlToken) {
+      rawToken = urlToken;
+      persistAuthCookie(urlToken);
+      currentUrl.searchParams.delete('token');
+      const updatedSearch = currentUrl.searchParams.toString();
+      const cleanedUrl = `${currentUrl.pathname}${updatedSearch ? `?${updatedSearch}` : ''}${currentUrl.hash || ''}`;
+      window.history.replaceState({}, document.title, cleanedUrl);
+    } else if (rawToken) {
       persistAuthCookie(rawToken);
     }
-
-    document.body.addEventListener('click', e => {
-      const a = e.target.closest('a[href]');
-      if (!a) return;
-      const href = a.getAttribute('href');
-      if (href.startsWith('http') || href.includes('token=')) return;
-      e.preventDefault();
-      const next = new URL(href, location.origin + location.pathname);
-      next.searchParams.set('token', rawToken || readAuthCookie());
-      window.location.href = next.toString();
-    });
 
     function scheduleKeepAlive() {
       if (!rawToken) {

--- a/headerConf.html
+++ b/headerConf.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <base target="_top">
+
+  <?!= includeOnce('CookieHandler') ?>
  <link rel="icon" 
         href="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754586751/vlbpo/lumina/4_mdomle.png" 
         type="image/x-icon" />
@@ -397,38 +399,45 @@
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    const AUTH_COOKIE_NAME = 'authToken';
-
     function readAuthCookie() {
-      const cookies = document.cookie ? document.cookie.split(';') : [];
-      for (let i = 0; i < cookies.length; i++) {
-        const part = cookies[i].trim();
-        if (!part) continue;
-        if (part.startsWith(`${AUTH_COOKIE_NAME}=`)) {
-          return decodeURIComponent(part.substring(AUTH_COOKIE_NAME.length + 1));
+      try {
+        if (window.CookieHandler && typeof CookieHandler.readAuthToken === 'function') {
+          return CookieHandler.readAuthToken();
         }
+      } catch (err) {
+        console.warn('Unable to read auth cookie', err);
       }
       return '';
     }
 
     function persistAuthCookie(token, ttlSeconds) {
-      if (!token) return;
-      const seconds = (typeof ttlSeconds === 'number' && ttlSeconds > 0)
-        ? Math.floor(ttlSeconds)
-        : 60 * 60;
-      const safeSeconds = Math.max(300, seconds);
-      const expires = new Date(Date.now() + safeSeconds * 1000);
-      document.cookie = [
-        `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}`,
-        'path=/',
-        `max-age=${safeSeconds}`,
-        `expires=${expires.toUTCString()}`,
-        'SameSite=Lax'
-      ].join('; ');
+      if (!token) {
+        clearAuthCookie();
+        return;
+      }
+
+      const options = {};
+      if (typeof ttlSeconds === 'number' && ttlSeconds > 0) {
+        options.ttlSeconds = ttlSeconds;
+      }
+
+      try {
+        if (window.CookieHandler && typeof CookieHandler.persistAuthToken === 'function') {
+          CookieHandler.persistAuthToken(token, options);
+        }
+      } catch (err) {
+        console.warn('Unable to persist auth cookie', err);
+      }
     }
 
     function clearAuthCookie() {
-      document.cookie = `${AUTH_COOKIE_NAME}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
+      try {
+        if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
+          CookieHandler.clearAuthToken();
+        }
+      } catch (err) {
+        console.warn('Unable to clear auth cookie', err);
+      }
     }
 
     // collapse toggle
@@ -437,21 +446,20 @@
         document.getElementById('sidebar').classList.toggle('collapsed')
       );
 
-    let rawToken = new URLSearchParams(location.search).get('token') || readAuthCookie();
-    if (rawToken) {
+    const currentUrl = new URL(window.location.href);
+    const urlToken = currentUrl.searchParams.get('token');
+    let rawToken = readAuthCookie();
+
+    if (urlToken) {
+      rawToken = urlToken;
+      persistAuthCookie(urlToken);
+      currentUrl.searchParams.delete('token');
+      const updatedSearch = currentUrl.searchParams.toString();
+      const cleanedUrl = `${currentUrl.pathname}${updatedSearch ? `?${updatedSearch}` : ''}${currentUrl.hash || ''}`;
+      window.history.replaceState({}, document.title, cleanedUrl);
+    } else if (rawToken) {
       persistAuthCookie(rawToken);
     }
-
-    document.body.addEventListener('click', e => {
-      const a = e.target.closest('a[href]');
-      if (!a) return;
-      const href = a.getAttribute('href');
-      if (href.startsWith('http') || href.includes('token=')) return;
-      e.preventDefault();
-      const next = new URL(href, location.origin + location.pathname);
-      next.searchParams.set('token', rawToken || readAuthCookie());
-      window.location.href = next.toString();
-    });
 
     function scheduleKeepAlive() {
       if (!rawToken) {


### PR DESCRIPTION
## Summary
- sanitize the login redirect flow to strip session tokens from URLs and rely on persisted cookies
- update shared header scripts to store session tokens in cookies and clean up navigation URLs
- drop lingering token query parameters from the login page address bar once the page loads
- introduce a shared CookieHandler partial and route login/header cookie reads and writes through it for centralized control

## Testing
- No automated tests (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9192057c083269f761012149e8bd8