### PR TITLE
Add layout slug and return URL helpers

### DIFF
--- a/AgentExperience.html
+++ b/AgentExperience.html
@@ -1,5 +1,5 @@
 <!-- AgentExperience.html -->
-<?!= include('layout', { baseUrl: baseUrl || '', user: user || {}, currentPage: currentPage || 'agent-experience', pageTitle: 'Agent Experience Hub', pageDescription: 'Personalized operations cockpit for support specialists' }) ?>
+<?!= include('layout', { baseUrl: baseUrl || '', scriptUrl: scriptUrl, user: user || {}, currentPage: currentPage || 'agent-experience', pageTitle: 'Agent Experience Hub', pageDescription: 'Personalized operations cockpit for support specialists' }) ?>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-9xK8gX1SO1kVpWw2X2gYdEx+kt1/3uzMdGII4XESyqCCpt5TR1+t0NenE2no0RvrRZtGJPD7W82dMan3Z8Ykg==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/BookmarkManager.html
+++ b/BookmarkManager.html
@@ -1,5 +1,5 @@
 <!-- BookmarkManager.html -->
-<?!= include('layout', {baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <link
   rel="stylesheet"

--- a/Calendar.html
+++ b/Calendar.html
@@ -1,4 +1,4 @@
-<?!= include('layout',{ baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout',{ baseUrl, scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <!-- FullCalendar CSS -->
 <link

--- a/CallReports.html
+++ b/CallReports.html
@@ -1,4 +1,4 @@
-<?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"></script>
 

--- a/Chat.html
+++ b/Chat.html
@@ -1,7 +1,7 @@
 <!-- ====================================== -->
 <!-- ChatWindow.html - Enhanced Main Chat Interface -->
 <!-- ====================================== -->
-<?!= include('layout',{ baseUrl, user, currentPage }) ?>
+<?!= include('layout',{ baseUrl, scriptUrl, user, currentPage }) ?>
 <? 
   const adminRoles = ['CEO','CTO','COO','CFO','Director','Account Manager'];
   const isAdmin = (user.roleNames||[]).some(r => adminRoles.includes(r));

--- a/CoachingDashboard.html
+++ b/CoachingDashboard.html
@@ -1,5 +1,5 @@
 <!-- CoachingDashboard.html -->
-<?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <style>

--- a/CollaborationReporting.html
+++ b/CollaborationReporting.html
@@ -1,6 +1,7 @@
 <!-- CollaborationReporting.html -->
 <?!= include('layout', {
   baseUrl: baseUrl || '',
+  scriptUrl: scriptUrl,
   user: user || {},
   currentPage: currentPage || 'Collaboration Reporting',
   pageTitle: 'Collaboration & Reporting Hub',

--- a/Dashboard.html
+++ b/Dashboard.html
@@ -1,8 +1,9 @@
 <!-- OKR Dashboard -->
 
-<?!= include('layout', { 
-        baseUrl: baseUrl || '', 
-        user: user || {}, 
+<?!= include('layout', {
+        baseUrl: baseUrl || '',
+        scriptUrl: scriptUrl,
+        user: user || {},
         currentPage: currentPage || 'okr-dashboard',
         pageTitle: 'OKR Performance Dashboard',
         pageDescription: 'Multi-Campaign Analytics & Insights'

--- a/EODReport.html
+++ b/EODReport.html
@@ -1,5 +1,6 @@
 <?!= include('layout', {
   baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
   user: user,
   currentPage: currentPage
 }) ?>

--- a/GoalSetting.html
+++ b/GoalSetting.html
@@ -1,5 +1,5 @@
 <!-- OKR Goal Setting & Target Management Interface -->
-<?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <style>
   .goal-container {

--- a/ImportAttendance.html
+++ b/ImportAttendance.html
@@ -1,5 +1,5 @@
 <!-- File: ImportAttendance.html -->
-<?!= include('layout', { baseUrl: baseUrl, rawToken: rawToken, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, rawToken: rawToken, user: user, currentPage: currentPage }) ?>
 
 <style>
   /* Import-specific styles using the modern design system */

--- a/ImportCsv.html
+++ b/ImportCsv.html
@@ -1,5 +1,5 @@
 <!-- File: ImportCallReport.html -->
-<?!= include('layout', { baseUrl: baseUrl, rawToken: rawToken, user: user, currentPage: "Import Call Report" }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, rawToken: rawToken, user: user, currentPage: "Import Call Report" }) ?>
 
 <style>
   /* Call Report Import specific styles using the modern design system */

--- a/IndependenceCoachingDashboard.html
+++ b/IndependenceCoachingDashboard.html
@@ -1,5 +1,5 @@
     <!-- CoachingDashboard.html -->
-    <?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>

--- a/LuminaHQUserGuide.html
+++ b/LuminaHQUserGuide.html
@@ -1,4 +1,4 @@
-<?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: 'Admin Dashboard' }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: 'Admin Dashboard' }) ?>
 
 
     <style>

--- a/ManagerExecutiveExperience.html
+++ b/ManagerExecutiveExperience.html
@@ -1,6 +1,7 @@
 <!-- ManagerExecutiveExperience.html -->
 <?!= include('layout', {
   baseUrl: baseUrl || '',
+  scriptUrl: scriptUrl,
   user: user || {},
   currentPage: currentPage || 'manager-executive-experience',
   pageTitle: 'Manager & Executive Command Center',

--- a/Notifications.html
+++ b/Notifications.html
@@ -1,5 +1,6 @@
 <?!= include('layout', {
   baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
   user: user,
   currentPage: 'Notifications'
 }) ?>

--- a/QACollabList.html
+++ b/QACollabList.html
@@ -1,5 +1,5 @@
 <!-- QAList.html -->
-<?!= include('layout', { rawToken: rawToken, baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <div class="container my-4">
   <div class="card shadow-sm">

--- a/QADashboard.html
+++ b/QADashboard.html
@@ -2,6 +2,7 @@
 
 <?!= include('layout', {
       baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
       currentPage: currentPage,
       userList: userList,
       granularity: granularity,

--- a/QAList.html
+++ b/QAList.html
@@ -1,5 +1,6 @@
 <?!= include('layout', {
   baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
   user: user,
   currentPage: currentPage
 }) ?>

--- a/QualityForm.html
+++ b/QualityForm.html
@@ -1,6 +1,7 @@
 <!-- Quality Form -->
 <?!= include('layout', {    
       baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
       currentPage: currentPage,
       userList: userList,
       granularity: granularity,

--- a/Search.html
+++ b/Search.html
@@ -1,5 +1,5 @@
 <!-- Enhanced Search.html with Proxy Integration -->
-<?!= include('layout', {rawToken: rawToken, baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <!-- Google Font -->
 <link

--- a/SearchSecurityDashboard.html
+++ b/SearchSecurityDashboard.html
@@ -1,5 +1,5 @@
 <!-- Admin Dashboard for LuminaHQ Browsing System -->
-<?!= include('layout', { baseUrl: baseUrl, user: user, currentPage: 'Admin Dashboard' }) ?>
+<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: 'Admin Dashboard' }) ?>
 
 <!-- Chart.js for analytics -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>

--- a/SlotManagementInterface.html
+++ b/SlotManagementInterface.html
@@ -1,4 +1,4 @@
-<?!= include('layout', {rawToken: rawToken, baseUrl: baseUrl, user: user, currentPage: 'Shift Slot Management' }) ?>
+<?!= include('layout', {rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: 'Shift Slot Management' }) ?>
     
     <style>
         :root {

--- a/TakList.html
+++ b/TakList.html
@@ -1,8 +1,9 @@
-<?!= include('layout',{ 
-  rawToken: rawToken, 
-  baseUrl: baseUrl, 
-  user: user, 
-  recordId: recordId, 
+<?!= include('layout',{
+  rawToken: rawToken,
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  recordId: recordId,
   currentPage: currentPage 
 }) ?>
 

--- a/TaskForm.html
+++ b/TaskForm.html
@@ -1,6 +1,7 @@
 <?!= include('layout',{
      rawToken: rawToken,
      baseUrl: baseUrl,
+     scriptUrl: scriptUrl,
      currentPage: currentPage,
      user: user,
      recordId: recordId,

--- a/Users.html
+++ b/Users.html
@@ -1,7 +1,8 @@
 <!-- Include header and existing styles -->
 <?!= include('layout', {
-    currentPage: currentPage || 'Users', 
-    baseUrl: baseUrl,    
+    currentPage: currentPage || 'Users',
+    baseUrl: baseUrl,
+    scriptUrl: scriptUrl,
     user: user
 }) ?>
 

--- a/layout.html
+++ b/layout.html
@@ -20,6 +20,49 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.min.js"></script>
 
+  <?
+    function __layoutSlugify(value) {
+      if (!value) {
+        return '';
+      }
+
+      var source = String(value);
+      source = source.replace(/["'`]+/g, '');
+
+      try {
+        if (source.normalize) {
+          source = source.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+        }
+      } catch (slugErr) {
+        // Ignore normalization issues and continue with original value
+      }
+
+      return source
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80);
+    }
+
+    var __layoutPageSlugInput = (typeof pageSlug !== 'undefined' && pageSlug) ? pageSlug : '';
+    var __layoutCurrentPageName = (typeof currentPage !== 'undefined' && currentPage) ? currentPage : '';
+    var __layoutPageTitleText = (typeof pageTitle !== 'undefined' && pageTitle) ? pageTitle : '';
+
+    var __layoutSlugCandidate = __layoutSlugify(__layoutPageSlugInput) ||
+      __layoutSlugify(__layoutCurrentPageName) ||
+      __layoutSlugify(__layoutPageTitleText);
+
+    var __layoutSlugSources = [
+      __layoutPageSlugInput,
+      __layoutCurrentPageName,
+      __layoutPageTitleText,
+      __layoutSlugCandidate
+    ];
+
+    var __layoutRawReturnUrl = (typeof returnUrl !== 'undefined' && returnUrl) ? returnUrl : '';
+  ?>
+
   <style>
     /* Make sure notifications float above modals/menus */
     .notifyjs-corner {
@@ -31,6 +74,9 @@
     // Base URLs for navigation
     let BASE_URL = '<?= baseUrl ?>';
     let SCRIPT_URL = '<?= scriptUrl || baseUrl ?>';
+
+    const __PAGE_SLUG_SOURCES = <?!= JSON.stringify(__layoutSlugSources) ?>;
+    const __RAW_RETURN_URL = <?!= JSON.stringify(__layoutRawReturnUrl) ?>;
 
     const __invalidPanelPattern = /usercodeapppanel/i;
 
@@ -64,6 +110,57 @@
     BASE_URL = __BASE_URL || __SCRIPT_URL || BASE_URL;
     SCRIPT_URL = __SCRIPT_URL || __BASE_URL || SCRIPT_URL;
 
+    function createSlug(value, fallback) {
+      const queue = [];
+
+      const enqueue = (input) => {
+        if (typeof input === 'undefined' || input === null) {
+          return;
+        }
+
+        if (Array.isArray(input)) {
+          input.forEach(enqueue);
+          return;
+        }
+
+        queue.push(String(input));
+      };
+
+      enqueue(value);
+      enqueue(fallback);
+
+      while (queue.length) {
+        let candidate = queue.shift().trim();
+        if (!candidate) {
+          continue;
+        }
+
+        try {
+          if (candidate.normalize) {
+            candidate = candidate.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+          }
+        } catch (err) {
+          console.warn('Slug normalization failed:', err);
+        }
+
+        const slug = candidate
+          .replace(/["'`]+/g, '')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/-{2,}/g, '-')
+          .replace(/^-+|-+$/g, '')
+          .slice(0, 80);
+
+        if (slug) {
+          return slug;
+        }
+      }
+
+      return '';
+    }
+
+    const PAGE_SLUG = createSlug(__PAGE_SLUG_SOURCES);
+
     /**
      * Generate URLs for navigation
      */
@@ -95,9 +192,86 @@
       window.location.href = url;
     }
 
+    function deriveReturnUrl(rawUrl, slug) {
+      const sanitizedRaw = sanitizeNavigationUrl(rawUrl, '');
+      if (sanitizedRaw) {
+        return sanitizedRaw;
+      }
+
+      if (slug) {
+        return generateUrl(slug);
+      }
+
+      return BASE_URL || SCRIPT_URL || '';
+    }
+
+    const RETURN_URL = deriveReturnUrl(__RAW_RETURN_URL, PAGE_SLUG);
+
+    function buildReturnUrl(extraParams = {}, rawUrl = RETURN_URL) {
+      const base = deriveReturnUrl(rawUrl, PAGE_SLUG);
+      if (!extraParams || typeof extraParams !== 'object' || Array.isArray(extraParams)) {
+        return base;
+      }
+
+      try {
+        const url = new URL(base, window.location.origin);
+        const params = new URLSearchParams(url.search);
+
+        Object.entries(extraParams).forEach(([key, value]) => {
+          if (value === null || typeof value === 'undefined') {
+            params.delete(key);
+            return;
+          }
+
+          params.set(key, value);
+        });
+
+        url.search = params.toString();
+        return url.toString();
+      } catch (err) {
+        console.warn('Failed to build return URL, falling back to base value:', err);
+        return base;
+      }
+    }
+
+    const __applySlugMetadata = () => {
+      if (typeof document === 'undefined' || !document.body) {
+        return;
+      }
+
+      try {
+        document.body.dataset.pageSlug = PAGE_SLUG || '';
+        if (RETURN_URL) {
+          document.body.dataset.returnUrl = RETURN_URL;
+        } else {
+          delete document.body.dataset.returnUrl;
+        }
+      } catch (err) {
+        console.warn('Unable to apply slug/return data attributes:', err);
+      }
+    };
+
+    if (typeof document !== 'undefined') {
+      if (document.body) {
+        __applySlugMetadata();
+      } else {
+        try {
+          document.addEventListener('DOMContentLoaded', __applySlugMetadata, { once: true });
+        } catch (err) {
+          document.addEventListener('DOMContentLoaded', __applySlugMetadata, false);
+        }
+      }
+    }
+
     // Make utilities available globally
     window.generateUrl = generateUrl;
     window.navigateToPage = navigateToPage;
+    window.createSlug = createSlug;
+    window.pageSlug = PAGE_SLUG;
+    window.returnUrl = RETURN_URL;
+    window.deriveReturnUrl = (rawUrl, slug = PAGE_SLUG) => deriveReturnUrl(rawUrl, slug);
+    window.buildReturnUrl = buildReturnUrl;
+    window.getReturnUrl = buildReturnUrl;
   </script>
 
   <style>
@@ -981,7 +1155,10 @@
   </style>
 </head>
 
-<body>
+<body
+  data-page-slug="<?!= __layoutSlugCandidate ?>"
+  data-return-url="<?!= __layoutRawReturnUrl ?>"
+>
   <?
     // Shared layout context so navigation components can stay in sync
     var __layoutUser = (typeof safeUser !== 'undefined' && safeUser) ? safeUser : (typeof user !== 'undefined' ? user : {});


### PR DESCRIPTION
## Summary
- derive consistent page slug metadata from the layout inputs and expose it via globals and body data attributes
- add sanitized return URL generation helpers, including builders for downstream navigation logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadc2bae848326afa9cca7fa6da01e