### PR TITLE
Normalize navigation URLs to Apps Script exec endpoint

### DIFF
--- a/headerConf.html
+++ b/headerConf.html
@@ -1,4 +1,54 @@
 <!-- File: header.html -->
+<?
+  var __headerInvalidPanelPattern = /usercodeapppanel/i;
+
+  function __headerNormalizeUrlValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return '';
+    }
+
+    var trimmed = String(value).trim();
+    if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+      return '';
+    }
+
+    return trimmed;
+  }
+
+  function __headerFixPanelUrl(value) {
+    var normalized = __headerNormalizeUrlValue(value);
+    if (!normalized) {
+      return '';
+    }
+
+    if (!__headerInvalidPanelPattern.test(normalized)) {
+      return normalized;
+    }
+
+    return normalized.replace(/\/userCodeAppPanel.*$/i, '/exec');
+  }
+
+  function __headerSanitizeNavigationUrl(url, fallback) {
+    var primary = __headerFixPanelUrl(url);
+    if (primary) {
+      return primary;
+    }
+
+    return __headerFixPanelUrl(fallback);
+  }
+
+  var __headerRawBaseUrl = (typeof baseUrl !== 'undefined') ? baseUrl : '';
+  var __headerRawScriptUrl = (typeof scriptUrl !== 'undefined') ? scriptUrl : __headerRawBaseUrl;
+
+  var __headerSanitizedBaseUrl = __headerSanitizeNavigationUrl(__headerRawBaseUrl, __headerRawScriptUrl);
+  var __headerSanitizedScriptUrl = __headerSanitizeNavigationUrl(__headerRawScriptUrl, __headerRawBaseUrl);
+
+  baseUrl = __headerSanitizedBaseUrl || __headerSanitizedScriptUrl || baseUrl;
+
+  if (typeof scriptUrl !== 'undefined') {
+    scriptUrl = __headerSanitizedScriptUrl || __headerSanitizedBaseUrl || scriptUrl;
+  }
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/layout.html
+++ b/layout.html
@@ -61,6 +61,55 @@
     ];
 
     var __layoutRawReturnUrl = (typeof returnUrl !== 'undefined' && returnUrl) ? returnUrl : '';
+
+    var __layoutInvalidPanelPattern = /usercodeapppanel/i;
+
+    function __layoutNormalizeUrlValue(value) {
+      if (value === null || typeof value === 'undefined') {
+        return '';
+      }
+
+      var trimmed = String(value).trim();
+      if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+        return '';
+      }
+
+      return trimmed;
+    }
+
+    function __layoutFixPanelUrl(value) {
+      var normalized = __layoutNormalizeUrlValue(value);
+      if (!normalized) {
+        return '';
+      }
+
+      if (!__layoutInvalidPanelPattern.test(normalized)) {
+        return normalized;
+      }
+
+      return normalized.replace(/\/userCodeAppPanel.*$/i, '/exec');
+    }
+
+    function __layoutSanitizeNavigationUrl(url, fallback) {
+      var primary = __layoutFixPanelUrl(url);
+      if (primary) {
+        return primary;
+      }
+
+      return __layoutFixPanelUrl(fallback);
+    }
+
+    var __layoutRawBaseUrl = (typeof baseUrl !== 'undefined') ? baseUrl : '';
+    var __layoutRawScriptUrl = (typeof scriptUrl !== 'undefined') ? scriptUrl : __layoutRawBaseUrl;
+
+    var __layoutSanitizedBaseUrl = __layoutSanitizeNavigationUrl(__layoutRawBaseUrl, __layoutRawScriptUrl);
+    var __layoutSanitizedScriptUrl = __layoutSanitizeNavigationUrl(__layoutRawScriptUrl, __layoutRawBaseUrl);
+
+    baseUrl = __layoutSanitizedBaseUrl || __layoutSanitizedScriptUrl || baseUrl;
+
+    if (typeof scriptUrl !== 'undefined') {
+      scriptUrl = __layoutSanitizedScriptUrl || __layoutSanitizedBaseUrl || scriptUrl;
+    }
   ?>
 
   <style>


### PR DESCRIPTION
## Summary
- sanitize the base and script URLs on the server before rendering navigational links
- replace userCodeAppPanel preview links with the production exec endpoint so navigation works correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daea2d1fd88326963ebe9ccec8e794