### PR TITLE
Ensure navigation links use sanitized web app URL

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1298,6 +1298,7 @@
 
   <?!= include('navigationSidebar', {
         baseUrl: (typeof baseUrl !== 'undefined') ? baseUrl : '',
+        scriptUrl: (typeof scriptUrl !== 'undefined') ? scriptUrl : ((typeof baseUrl !== 'undefined') ? baseUrl : ''),
         currentPage: typeof currentPage !== 'undefined' ? currentPage : '',
         user: __layoutUser || {},
         isAdmin: __layoutIsAdmin,
@@ -1310,6 +1311,7 @@
 
   <?!= include('navigationTopbar', {
         baseUrl: (typeof baseUrl !== 'undefined') ? baseUrl : '',
+        scriptUrl: (typeof scriptUrl !== 'undefined') ? scriptUrl : ((typeof baseUrl !== 'undefined') ? baseUrl : ''),
         currentPage: typeof currentPage !== 'undefined' ? currentPage : '',
         campaignName: __layoutCampaignName,
         isAdmin: __layoutIsAdmin

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -1,5 +1,49 @@
 <?
-  var baseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+  var __navInvalidPanelPattern = /usercodeapppanel/i;
+
+  function __navNormalizeUrlValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return '';
+    }
+
+    var trimmed = String(value).trim();
+    if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+      return '';
+    }
+
+    return trimmed;
+  }
+
+  function __navFixPanelUrl(value) {
+    var normalized = __navNormalizeUrlValue(value);
+    if (!normalized) {
+      return '';
+    }
+
+    if (!__navInvalidPanelPattern.test(normalized)) {
+      return normalized;
+    }
+
+    return normalized.replace(/\/userCodeAppPanel.*$/i, '/exec');
+  }
+
+  function __navSanitizeNavigationUrl(url, fallback) {
+    var primary = __navFixPanelUrl(url);
+    if (primary) {
+      return primary;
+    }
+
+    return __navFixPanelUrl(fallback);
+  }
+
+  var __navRawBaseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+  var __navRawScriptUrl = (typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : __navRawBaseUrl;
+
+  var __navSanitizedBaseUrl = __navSanitizeNavigationUrl(__navRawBaseUrl, __navRawScriptUrl);
+  var __navSanitizedScriptUrl = __navSanitizeNavigationUrl(__navRawScriptUrl, __navRawBaseUrl);
+
+  var baseUrl = __navSanitizedBaseUrl || __navSanitizedScriptUrl || __navRawBaseUrl;
+  var __navLinkBase = baseUrl || __navSanitizedScriptUrl || '';
   var currentPage = (typeof currentPage !== 'undefined' && currentPage) ? currentPage : '';
   var sidebarUser = (typeof user !== 'undefined' && user) ? user : {};
   var isAdminUser = Boolean(isAdmin);
@@ -73,7 +117,14 @@
   }
 
   function generateLink(page) {
-    return baseUrl + '?page=' + encodeURIComponent(page);
+    var target = __navLinkBase;
+    if (!target) {
+      return '?page=' + encodeURIComponent(page);
+    }
+
+    var hasQuery = target.indexOf('?') !== -1;
+    var separator = hasQuery ? (/[?&]$/.test(target) ? '' : '&') : '?';
+    return target + separator + 'page=' + encodeURIComponent(page);
   }
 ?>
 

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -1,11 +1,62 @@
 <?
-  var baseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+  var __topbarInvalidPanelPattern = /usercodeapppanel/i;
+
+  function __topbarNormalizeUrlValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return '';
+    }
+
+    var trimmed = String(value).trim();
+    if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+      return '';
+    }
+
+    return trimmed;
+  }
+
+  function __topbarFixPanelUrl(value) {
+    var normalized = __topbarNormalizeUrlValue(value);
+    if (!normalized) {
+      return '';
+    }
+
+    if (!__topbarInvalidPanelPattern.test(normalized)) {
+      return normalized;
+    }
+
+    return normalized.replace(/\/userCodeAppPanel.*$/i, '/exec');
+  }
+
+  function __topbarSanitizeNavigationUrl(url, fallback) {
+    var primary = __topbarFixPanelUrl(url);
+    if (primary) {
+      return primary;
+    }
+
+    return __topbarFixPanelUrl(fallback);
+  }
+
+  var __topbarRawBaseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+  var __topbarRawScriptUrl = (typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : __topbarRawBaseUrl;
+
+  var __topbarSanitizedBaseUrl = __topbarSanitizeNavigationUrl(__topbarRawBaseUrl, __topbarRawScriptUrl);
+  var __topbarSanitizedScriptUrl = __topbarSanitizeNavigationUrl(__topbarRawScriptUrl, __topbarRawBaseUrl);
+
+  var baseUrl = __topbarSanitizedBaseUrl || __topbarSanitizedScriptUrl || __topbarRawBaseUrl;
+  var __topbarLinkBase = baseUrl || __topbarSanitizedScriptUrl || '';
   var currentPageValue = (typeof currentPage !== 'undefined' && currentPage) ? currentPage : 'Home';
   var campaignNameValue = (typeof campaignName !== 'undefined' && campaignName) ? campaignName : '';
   var isAdminValue = Boolean(isAdmin);
 
   function generateLink(page) {
-    return baseUrl + '?page=' + encodeURIComponent(page);
+    var target = __topbarLinkBase;
+    if (!target) {
+      return '?page=' + encodeURIComponent(page);
+    }
+
+    var hasQuery = target.indexOf('?') !== -1;
+    var separator = hasQuery ? (/[?&]$/.test(target) ? '' : '&') : '?';
+    return target + separator + 'page=' + encodeURIComponent(page);
   }
 ?>
 


### PR DESCRIPTION
## Summary
- sanitize the sidebar and topbar navigation helpers to replace userCodeAppPanel URLs with the deployed /exec link
- pass the resolved script URL into the navigation partials so links always include the correct base

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db02ce792c832684122a8ddad627f4