### PR TITLE
Disable recurring keep-alive background pings

### DIFF
--- a/chatHeader.html
+++ b/chatHeader.html
@@ -440,32 +440,29 @@
         return;
       }
 
-      const ping = () => {
-        const tokenForPing = rawToken || readAuthCookie();
-        if (!tokenForPing) {
-          return;
-        }
+      const tokenForPing = rawToken || readAuthCookie();
+      if (!tokenForPing) {
+        return;
+      }
 
-        google.script.run
-          .withSuccessHandler(result => {
-            if (result && result.success) {
-              rawToken = result.sessionToken || tokenForPing;
-              persistAuthCookie(rawToken, result.sessionTtlSeconds);
-            } else if (result && result.expired) {
-              clearAuthCookie();
-              const loginUrl = new URL(location.origin + location.pathname);
-              loginUrl.searchParams.set('page', 'login');
-              window.location.href = loginUrl.toString();
-            }
-          })
-          .withFailureHandler(err => {
-            console.warn('Keep-alive failed:', err);
-          })
-          .keepAlive(tokenForPing);
-      };
-
-      ping();
-      setInterval(ping, 10 * 60 * 1000);
+      // Only perform a one-time keep-alive call so the chat header no longer
+      // schedules repeated background requests that slowed navigation.
+      google.script.run
+        .withSuccessHandler(result => {
+          if (result && result.success) {
+            rawToken = result.sessionToken || tokenForPing;
+            persistAuthCookie(rawToken, result.sessionTtlSeconds);
+          } else if (result && result.expired) {
+            clearAuthCookie();
+            const loginUrl = new URL(location.origin + location.pathname);
+            loginUrl.searchParams.set('page', 'login');
+            window.location.href = loginUrl.toString();
+          }
+        })
+        .withFailureHandler(err => {
+          console.warn('Keep-alive failed:', err);
+        })
+        .keepAlive(tokenForPing);
     }
 
     scheduleKeepAlive();

--- a/headerConf.html
+++ b/headerConf.html
@@ -516,32 +516,32 @@
         return;
       }
 
-      const ping = () => {
-        const tokenForPing = rawToken || readAuthCookie();
-        if (!tokenForPing) {
-          return;
-        }
+      const tokenForPing = rawToken || readAuthCookie();
+      if (!tokenForPing) {
+        return;
+      }
 
-        google.script.run
-          .withSuccessHandler(result => {
-            if (result && result.success) {
-              rawToken = result.sessionToken || tokenForPing;
-              persistAuthCookie(rawToken, result.sessionTtlSeconds);
-            } else if (result && result.expired) {
-              clearAuthCookie();
-              const loginUrl = new URL(location.origin + location.pathname);
-              loginUrl.searchParams.set('page', 'login');
-              window.location.href = loginUrl.toString();
-            }
-          })
-          .withFailureHandler(err => {
-            console.warn('Keep-alive failed:', err);
-          })
-          .keepAlive(tokenForPing);
-      };
-
-      ping();
-      setInterval(ping, 10 * 60 * 1000);
+      // Execute a single keep-alive request during page load without
+      // establishing any recurring timers. The previous implementation
+      // scheduled an interval that continued to ping the server in the
+      // background, which slowed navigation. Removing the interval keeps the
+      // session check lightweight and avoids background processing.
+      google.script.run
+        .withSuccessHandler(result => {
+          if (result && result.success) {
+            rawToken = result.sessionToken || tokenForPing;
+            persistAuthCookie(rawToken, result.sessionTtlSeconds);
+          } else if (result && result.expired) {
+            clearAuthCookie();
+            const loginUrl = new URL(location.origin + location.pathname);
+            loginUrl.searchParams.set('page', 'login');
+            window.location.href = loginUrl.toString();
+          }
+        })
+        .withFailureHandler(err => {
+          console.warn('Keep-alive failed:', err);
+        })
+        .keepAlive(tokenForPing);
     }
 
     scheduleKeepAlive();


### PR DESCRIPTION
## Summary
- remove the recurring keep-alive intervals from shared header templates so navigation no longer spawns background requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db15c68a18832694c329e8a0678866