### PR TITLE
Fix sidebar user panel role and full name display

### DIFF
--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -98,6 +98,16 @@
   var displayFullNameValue = userFullNameValue || firstLastDisplayName || userNameValue;
   var displayPrimaryNameValue = firstLastDisplayName || displayFullNameValue || userNameValue || 'Unknown User';
 
+  var primaryRoleNameValue = getUserFieldValue(sidebarUser, [
+    'RoleName', 'roleName', 'PrimaryRole', 'primaryRole',
+    'Role', 'role', 'Title', 'title',
+    'JobTitle', 'jobTitle'
+  ]);
+
+  if (!primaryRoleNameValue && userRoleNames && userRoleNames.length) {
+    primaryRoleNameValue = userRoleNames[0];
+  }
+
   if (!displayFullNameValue) {
     displayFullNameValue = displayPrimaryNameValue;
   }
@@ -363,10 +373,8 @@
     </div>
     <div class="user-info">
       <div class="names" id="userName">
-        <? if (firstLastDisplayName) { ?>
-        <div class="name-line first-last" id="userFirstLast"><?= firstLastDisplayName ?></div>
-        <? } else { ?>
-        <div class="name-line first-last" id="userFirstLast"><?= displayPrimaryNameValue ?></div>
+        <? if (primaryRoleNameValue) { ?>
+        <div class="name-line role-name" id="userRoleNameDisplay"><?= primaryRoleNameValue ?></div>
         <? } ?>
         <div class="name-line full-name" id="userFullName"><?= displayFullNameValue ?></div>
       </div>


### PR DESCRIPTION
## Summary
- derive the primary role name from available user fields for the sidebar header
- show the primary role name above the full name to eliminate duplicate full-name rows

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dbfc7127e083268a950ce36ce2da09