### PR TITLE
Expand role management to support scoped metadata

### DIFF
--- a/RoleManagement.html
+++ b/RoleManagement.html
@@ -152,6 +152,41 @@
             transition-duration: 0.01ms !important;
         }
     }
+
+    .norm-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        border-radius: 999px;
+        background: var(--surface-variant);
+        padding: 0.25rem 0.65rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--on-surface-variant);
+    }
+
+    .scope-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        border-radius: 999px;
+        padding: 0.3rem 0.7rem;
+        font-weight: 600;
+        font-size: 0.75rem;
+    }
+
+    .scope-badge.border {
+        border: 1px solid var(--outline);
+    }
+
+    .desc-cell {
+        max-width: 320px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--on-surface-variant);
+        font-size: 0.85rem;
+    }
 </style>
 
 
@@ -209,7 +244,9 @@
                 <thead>
                 <tr>
                     <th class="sortable" data-sort="name">Name <i class="fas fa-sort sort-ind"></i></th>
+                    <th class="sortable" data-sort="scope">Scope <i class="fas fa-sort sort-ind"></i></th>
                     <th>Normalized</th>
+                    <th>Description</th>
                     <th class="sortable" data-sort="createdAt">Created <i class="fas fa-sort sort-ind"></i></th>
                     <th class="sortable" data-sort="updatedAt">Updated <i class="fas fa-sort sort-ind"></i></th>
                     <th class="text-end">Actions</th>
@@ -218,12 +255,15 @@
                 <tbody id="rolesTableBody">
                 <!-- Enhanced skeleton loader -->
                 <tr>
-                    <td colspan="5">
+                    <td colspan="7">
                         <div class="row g-3">
-                            <div class="col-3">
+                            <div class="col-2">
                                 <div class="skeleton" style="height: 20px;"></div>
                             </div>
-                            <div class="col-3">
+                            <div class="col-2">
+                                <div class="skeleton" style="height: 20px;"></div>
+                            </div>
+                            <div class="col-2">
                                 <div class="skeleton" style="height: 20px;"></div>
                             </div>
                             <div class="col-3">
@@ -236,9 +276,12 @@
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="5">
+                    <td colspan="7">
                         <div class="row g-3">
-                            <div class="col-4">
+                            <div class="col-3">
+                                <div class="skeleton" style="height: 18px;"></div>
+                            </div>
+                            <div class="col-2">
                                 <div class="skeleton" style="height: 18px;"></div>
                             </div>
                             <div class="col-2">
@@ -247,7 +290,7 @@
                             <div class="col-3">
                                 <div class="skeleton" style="height: 18px;"></div>
                             </div>
-                            <div class="col-3">
+                            <div class="col-2">
                                 <div class="skeleton" style="height: 18px;"></div>
                             </div>
                         </div>
@@ -288,6 +331,16 @@
                     <input type="text" id="newRoleName" class="form-control" placeholder="e.g., Content Manager, System Admin" required>
                     <div class="form-text">Choose a descriptive name. The normalized identifier will be generated automatically.</div>
                 </div>
+                <div class="mb-3">
+                    <label for="newRoleScope" class="form-label">Scope</label>
+                    <input type="text" id="newRoleScope" class="form-control" placeholder="e.g., Global, Campaign, Department">
+                    <div class="form-text">Use scope to indicate where this role applies. Leave blank for global access.</div>
+                </div>
+                <div class="mb-3">
+                    <label for="newRoleDescription" class="form-label">Description</label>
+                    <textarea id="newRoleDescription" class="form-control" rows="3" placeholder="Summarize responsibilities and permissions"></textarea>
+                    <div class="form-text">Provide context to help admins understand this role's purpose.</div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-light" data-bs-dismiss="modal">
@@ -319,6 +372,16 @@
                     <label for="editRoleName" class="form-label">Role Name</label>
                     <input type="text" id="editRoleName" class="form-control" placeholder="e.g., Content Manager" required>
                     <div class="form-text">Update the role name. The normalized identifier will be updated automatically.</div>
+                </div>
+                <div class="mb-3">
+                    <label for="editRoleScope" class="form-label">Scope</label>
+                    <input type="text" id="editRoleScope" class="form-control" placeholder="e.g., Global, Campaign, Department">
+                    <div class="form-text">Refine where this role applies within LuminaHQ.</div>
+                </div>
+                <div class="mb-3">
+                    <label for="editRoleDescription" class="form-label">Description</label>
+                    <textarea id="editRoleDescription" class="form-control" rows="3" placeholder="Describe responsibilities and permissions"></textarea>
+                    <div class="form-text">Clarify what this role enables so future admins can manage it confidently.</div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -495,7 +558,9 @@
         if (q) {
             list = list.filter(r =>
                 (r.name || '').toLowerCase().includes(q) ||
-                (r.normalizedName || '').toLowerCase().includes(q)
+                (r.normalizedName || '').toLowerCase().includes(q) ||
+                (r.scope || '').toLowerCase().includes(q) ||
+                (r.description || '').toLowerCase().includes(q)
             );
         }
 
@@ -524,23 +589,33 @@
             const tr = document.createElement('tr');
             tr.innerHTML = `
         <td class="fw-bold">${escapeHtml(r.name || '')}</td>
+        <td>${renderScopeCell(r.scope)}</td>
         <td><span class="norm-chip"><i class="fa-solid fa-code"></i>${escapeHtml((r.normalizedName || '').toUpperCase())}</span></td>
+        <td>${renderDescriptionCell(r.description)}</td>
         <td>${renderDateCell(r.createdAt)}</td>
         <td>${renderDateCell(r.updatedAt)}</td>
         <td class="text-end">
-          <button class="btn btn-light btn-icon me-2"
-                  onclick="openEditRoleModal('${escapeAttr(r.id)}','${escapeAttr(r.name)}')"
+          <button class="btn btn-light btn-icon me-2 btn-edit-role"
+                  type="button"
                   data-bs-toggle="tooltip" title="Edit role">
             <i class="fas fa-edit"></i>
           </button>
-          <button class="btn btn-light btn-icon"
-                  onclick="deleteRole('${escapeAttr(r.id)}')"
+          <button class="btn btn-light btn-icon btn-delete-role" type="button"
                   data-bs-toggle="tooltip" title="Delete role">
             <i class="fas fa-trash text-danger"></i>
           </button>
         </td>
       `;
             tbody.appendChild(tr);
+
+            const editBtn = tr.querySelector('.btn-edit-role');
+            if (editBtn) {
+                editBtn.addEventListener('click', () => openEditRoleModal(r));
+            }
+            const deleteBtn = tr.querySelector('.btn-delete-role');
+            if (deleteBtn) {
+                deleteBtn.addEventListener('click', () => deleteRole(r.id || r.ID));
+            }
         }
 
         // 5) Result counter (range)
@@ -561,7 +636,7 @@
         // 8) Empty state
         if (!total) {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td colspan="5" class="empty-state">
+            tr.innerHTML = `<td colspan="7" class="empty-state">
         <i class="fas fa-shield-alt"></i>
         <h3>No roles found</h3>
         <p>${q ? 'Try adjusting your search terms' : 'Create your first role to get started'}</p>
@@ -715,6 +790,8 @@
             btnSpin.classList.remove('d-none');
 
             const name = document.getElementById('newRoleName').value.trim();
+            const scope = document.getElementById('newRoleScope').value.trim();
+            const description = document.getElementById('newRoleDescription').value.trim();
             if (!name) {
                 btnSpin.classList.add('d-none');
                 return;
@@ -731,7 +808,7 @@
                     btnSpin.classList.add('d-none');
                     showToast('Failed to create role. ' + (err?.message || ''), 'danger');
                 })
-                .addRole(name);
+                .addRole(name, scope, description);
         });
 
         document.getElementById('addRoleModal').addEventListener('hidden.bs.modal', () => {
@@ -743,12 +820,23 @@
     // ---------------- Edit Role modal ----------------
     let editRoleModal;
 
-    function openEditRoleModal(id, currentName) {
+    function openEditRoleModal(roleOrId, currentName, currentScope, currentDescription) {
         const modalEl = document.getElementById('editRoleModal');
         if (!editRoleModal) editRoleModal = new bootstrap.Modal(modalEl, {backdrop: 'static'});
 
-        document.getElementById('editRoleId').value = id || '';
-        document.getElementById('editRoleName').value = currentName || '';
+        const role = (roleOrId && typeof roleOrId === 'object' && !Array.isArray(roleOrId))
+            ? roleOrId
+            : {
+                id: roleOrId,
+                name: currentName,
+                scope: currentScope,
+                description: currentDescription
+            };
+
+        document.getElementById('editRoleId').value = role?.id || role?.ID || '';
+        document.getElementById('editRoleName').value = role?.name || role?.Name || '';
+        document.getElementById('editRoleScope').value = role?.scope || role?.Scope || '';
+        document.getElementById('editRoleDescription').value = role?.description || role?.Description || '';
 
         setEditSaving(false);
         editRoleModal.show();
@@ -761,6 +849,8 @@
             e.preventDefault();
             const id = document.getElementById('editRoleId').value.trim();
             const name = document.getElementById('editRoleName').value.trim();
+            const scope = document.getElementById('editRoleScope').value.trim();
+            const description = document.getElementById('editRoleDescription').value.trim();
             if (!id || !name) return;
 
             setEditSaving(true);
@@ -775,7 +865,7 @@
                     setEditSaving(false);
                     showToast('Failed to update role. ' + (err?.message || ''), 'danger');
                 })
-                .updateRole(id, name);
+                .updateRole(id, name, scope, description);
         });
 
         document.getElementById('editRoleModal').addEventListener('hidden.bs.modal', () => {
@@ -830,12 +920,23 @@
         toastEl.addEventListener('hidden.bs.toast', () => container.remove());
     }
 
-    function escapeHtml(s = '') {
-        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    function renderScopeCell(scope) {
+        const value = (scope || '').trim();
+        const label = value || 'Global';
+        const tone = value ? 'bg-info text-white' : 'bg-light text-muted border';
+        const icon = value ? 'fa-diagram-project' : 'fa-globe-americas';
+        return `<span class="badge scope-badge ${tone}"><i class="fas ${icon} me-1"></i>${escapeHtml(label)}</span>`;
     }
 
-    function escapeAttr(s = '') {
-        return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    function renderDescriptionCell(desc) {
+        const value = (desc || '').trim();
+        if (!value) return '<span class="text-muted">—</span>';
+        const short = value.length > 140 ? value.slice(0, 137) + '…' : value;
+        return `<div class="desc-cell" title="${escapeHtml(value)}">${escapeHtml(short)}</div>`;
+    }
+
+    function escapeHtml(s = '') {
+        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 </script>
 </body>

--- a/RolesService.js
+++ b/RolesService.js
@@ -2,96 +2,237 @@
 // Role & UserRole CRUD
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Returns [{ id, name, normalizedName }] */
+/** Returns [{ id, name, normalizedName, scope, description, createdAt, updatedAt, deletedAt }] */
 function getAllRoles() {
-  const rows = SpreadsheetApp
-    .getActive()
-    .getSheetByName(ROLES_SHEET)
-    .getDataRange()
-    .getValues()
-    .slice(1);
-  return rows.map(r => ({
-    id: r[0],
-    name: r[1],
-    normalizedName: r[2]
-  }));
+  try {
+    const rows = _readRolesSheet_();
+    return rows
+      .map(normalizeRoleRecord_)
+      .filter(Boolean);
+  } catch (error) {
+    console.error('Error getting all roles:', error);
+    return [];
+  }
 }
 
 /** Adds a new role */
-function addRole(name) {
-  const sheet = SpreadsheetApp.getActive().getSheetByName(ROLES_SHEET);
-  const id = Utilities.getUuid();
-  const now   = new Date();
-  sheet.appendRow([id, name, name.toUpperCase(), now, now]);
-  return id;
+function addRole(nameOrPayload, scopeOrPayload, description) {
+  try {
+    const payload = normalizeRoleInput_(nameOrPayload, scopeOrPayload, description);
+    if (!payload.name) throw new Error('Role name is required');
+
+    const sheet = _getOrCreateRolesSheet_();
+    const headers = _getSheetHeaders_(sheet, ROLES_HEADER);
+    const id = Utilities.getUuid();
+    const now = new Date();
+    const normalizedName = payload.normalizedName || payload.name.toUpperCase();
+
+    const rowMap = {
+      ID: id,
+      Name: payload.name,
+      NormalizedName: normalizedName,
+      Scope: payload.scope || '',
+      Description: payload.description || '',
+      CreatedAt: now,
+      UpdatedAt: now,
+      DeletedAt: ''
+    };
+
+    sheet.appendRow(_mapRowFromHeaders_(headers, rowMap));
+    if (typeof invalidateCache === 'function') invalidateCache(ROLES_SHEET);
+    return id;
+  } catch (error) {
+    console.error('Error adding role:', error);
+    throw error;
+  }
 }
 
 /** Updates an existing role */
-function updateRole(id, newName) {
-  const sheet = SpreadsheetApp.getActive().getSheetByName(ROLES_SHEET);
-  const data  = sheet.getDataRange().getValues();
-  const now   = new Date();
-  for (let i = 1; i < data.length; i++) {
-    if (data[i][0] === id) {
-      const row = i + 1;
-      sheet.getRange(row, 2).setValue(newName);
-      sheet.getRange(row, 3).setValue(newName.toUpperCase());
-      sheet.getRange(row, 5).setValue(now);
-      break;
+function updateRole(idOrPayload, name, scope, description) {
+  try {
+    const payload = normalizeRoleUpdate_(idOrPayload, name, scope, description);
+    if (!payload.id) throw new Error('Role ID is required');
+
+    const sheet = _getOrCreateRolesSheet_();
+    const data = sheet.getDataRange().getValues();
+    if (!data.length) return;
+
+    const headers = data[0].map(h => String(h || '').trim());
+    const idx = {
+      ID: headers.indexOf('ID'),
+      Name: headers.indexOf('Name'),
+      NormalizedName: headers.indexOf('NormalizedName'),
+      Scope: headers.indexOf('Scope'),
+      Description: headers.indexOf('Description'),
+      UpdatedAt: headers.indexOf('UpdatedAt')
+    };
+
+    const now = new Date();
+    for (let i = 1; i < data.length; i++) {
+      if (String(data[i][idx.ID]) === String(payload.id)) {
+        const row = i + 1;
+        if (idx.Name >= 0) sheet.getRange(row, idx.Name + 1).setValue(payload.name || '');
+        if (idx.NormalizedName >= 0) sheet.getRange(row, idx.NormalizedName + 1).setValue((payload.normalizedName || payload.name || '').toUpperCase());
+        if (idx.Scope >= 0) sheet.getRange(row, idx.Scope + 1).setValue(payload.scope || '');
+        if (idx.Description >= 0) sheet.getRange(row, idx.Description + 1).setValue(payload.description || '');
+        if (idx.UpdatedAt >= 0) sheet.getRange(row, idx.UpdatedAt + 1).setValue(now);
+        if (typeof invalidateCache === 'function') invalidateCache(ROLES_SHEET);
+        return;
+      }
     }
+  } catch (error) {
+    console.error('Error updating role:', error);
+    throw error;
   }
 }
 
 /** Deletes a role (and any user-role links) */
 function deleteRole(id) {
-  const ss = SpreadsheetApp.getActive();
-  // remove from Roles
-  const sh = ss.getSheetByName(ROLES_SHEET);
-  const data = sh.getDataRange().getValues();
-  for (let i = data.length - 1; i >= 1; i--) {
-    if (data[i][0] === id) sh.deleteRow(i+1);
-  }
-  // remove any UserRoles
-  const shUR = ss.getSheetByName(USER_ROLES_SHEET);
-  const urData = shUR.getDataRange().getValues();
-  for (let i = urData.length - 1; i >= 1; i--) {
-    if (urData[i][1] === id) shUR.deleteRow(i+1);
+  try {
+    const ss = SpreadsheetApp.getActive();
+    const rolesSheet = ss.getSheetByName(ROLES_SHEET);
+    if (rolesSheet) {
+      const data = rolesSheet.getDataRange().getValues();
+      if (data.length) {
+        const headers = data[0].map(h => String(h || '').trim());
+        const idCol = headers.indexOf('ID');
+        for (let i = data.length - 1; i >= 1; i--) {
+          if (idCol >= 0 && String(data[i][idCol]) === String(id)) {
+            rolesSheet.deleteRow(i + 1);
+          }
+        }
+      }
+    }
+
+    const userRolesSheet = ss.getSheetByName(USER_ROLES_SHEET);
+    if (userRolesSheet) {
+      const data = userRolesSheet.getDataRange().getValues();
+      if (data.length) {
+        const headers = data[0].map(h => String(h || '').trim());
+        const roleIdx = headers.indexOf('RoleId');
+        for (let i = data.length - 1; i >= 1; i--) {
+          if (roleIdx >= 0 && String(data[i][roleIdx]) === String(id)) {
+            userRolesSheet.deleteRow(i + 1);
+          }
+        }
+      }
+    }
+
+    if (typeof invalidateCache === 'function') {
+      invalidateCache(ROLES_SHEET);
+      invalidateCache(USER_ROLES_SHEET);
+    }
+  } catch (error) {
+    console.error('Error deleting role:', error);
+    throw error;
   }
 }
 
 /** Assigns a role to a user */
-function addUserRole(userId, roleId) {
-  const sheet = SpreadsheetApp.getActive().getSheetByName(USER_ROLES_SHEET);
-  const now   = new Date();
-  sheet.appendRow([userId, roleId, now, now]);
+function addUserRole(userId, roleId, scopeOrOptions, assignedBy) {
+  try {
+    if (!userId || !roleId) throw new Error('User ID and Role ID are required');
+
+    const sheet = SpreadsheetApp.getActive().getSheetByName(USER_ROLES_SHEET);
+    if (!sheet) throw new Error(`Sheet ${USER_ROLES_SHEET} not found`);
+
+    const headers = _getSheetHeaders_(sheet, USER_ROLES_HEADER);
+    const now = new Date();
+    const id = Utilities.getUuid();
+
+    let scope = '';
+    let assigned = '';
+    if (scopeOrOptions && typeof scopeOrOptions === 'object' && !Array.isArray(scopeOrOptions)) {
+      scope = scopeOrOptions.scope || scopeOrOptions.Scope || '';
+      assigned = scopeOrOptions.assignedBy || scopeOrOptions.AssignedBy || scopeOrOptions.assigned_by || '';
+    } else {
+      scope = scopeOrOptions || '';
+      assigned = assignedBy || '';
+    }
+
+    const rowMap = {
+      ID: id,
+      UserId: userId,
+      RoleId: roleId,
+      Scope: scope,
+      AssignedBy: assigned,
+      CreatedAt: now,
+      UpdatedAt: now,
+      DeletedAt: ''
+    };
+
+    sheet.appendRow(_mapRowFromHeaders_(headers, rowMap));
+    if (typeof invalidateCache === 'function') invalidateCache(USER_ROLES_SHEET);
+    return id;
+  } catch (error) {
+    console.error('Error assigning user role:', error);
+    throw error;
+  }
 }
 
-/** Removes all roles for a user (you can also add targeted removal) */
-function deleteUserRoles(userId) {
-  const sheet = SpreadsheetApp.getActive().getSheetByName(USER_ROLES_SHEET);
-  const data  = sheet.getDataRange().getValues();
-  for (let i = data.length - 1; i >= 1; i--) {
-    if (data[i][0] === userId) sheet.deleteRow(i+1);
+/** Removes roles for a user (optionally target a specific role) */
+function deleteUserRoles(userId, roleId) {
+  try {
+    const sheet = SpreadsheetApp.getActive().getSheetByName(USER_ROLES_SHEET);
+    if (!sheet) return;
+    const data = sheet.getDataRange().getValues();
+    if (!data.length) return;
+
+    const headers = data[0].map(h => String(h || '').trim());
+    const userIdx = headers.indexOf('UserId');
+    const roleIdx = headers.indexOf('RoleId');
+    if (userIdx < 0) return;
+
+    for (let i = data.length - 1; i >= 1; i--) {
+      const matchesUser = String(data[i][userIdx]) === String(userId);
+      const matchesRole = roleId ? String(data[i][roleIdx]) === String(roleId) : true;
+      if (matchesUser && matchesRole) {
+        sheet.deleteRow(i + 1);
+      }
+    }
+
+    if (typeof invalidateCache === 'function') invalidateCache(USER_ROLES_SHEET);
+  } catch (error) {
+    console.error('Error deleting user roles:', error);
+    throw error;
   }
 }
 
 /** Returns an array of roleIds for the given user */
 function getUserRoleIds(userId) {
-  const rows = SpreadsheetApp
-    .getActive()
-    .getSheetByName(USER_ROLES_SHEET)
-    .getDataRange()
-    .getValues()
-    .slice(1)
-    .filter(r => r[0] === userId);
-  return rows.map(r => r[1]);
+  try {
+    if (!userId) return [];
+    const sheet = SpreadsheetApp.getActive().getSheetByName(USER_ROLES_SHEET);
+    if (!sheet) return [];
+    const data = sheet.getDataRange().getValues();
+    if (data.length <= 1) return [];
+
+    const headers = data[0].map(h => String(h || '').trim());
+    const userIdx = headers.indexOf('UserId');
+    const roleIdx = headers.indexOf('RoleId');
+    if (userIdx < 0 || roleIdx < 0) return [];
+
+    return data
+      .slice(1)
+      .filter(row => String(row[userIdx]) === String(userId))
+      .map(row => row[roleIdx])
+      .filter(Boolean);
+  } catch (error) {
+    console.error('Error getting user role IDs:', error);
+    return [];
+  }
 }
 
 /** Returns full role objects for a user */
 function getUserRoles(userId) {
-  const allRoles = getAllRoles();
-  const assigned = getUserRoleIds(userId);
-  return allRoles.filter(r => assigned.indexOf(r.id) !== -1);
+  try {
+    const allRoles = getAllRoles();
+    const assigned = new Set(getUserRoleIds(userId).map(String));
+    return allRoles.filter(r => assigned.has(String(r.id || r.ID)));
+  } catch (error) {
+    console.error('Error getting user roles:', error);
+    return [];
+  }
 }
 
 /**
@@ -101,13 +242,13 @@ function getUserRoles(userId) {
  */
 function getRolesMapping() {
   try {
-    const roles = getAllRoles(); // This function exists in your system
+    const roles = getAllRoles();
     const mapping = {};
-
     roles.forEach(role => {
-      mapping[role.id] = role.name;
+      const id = role.id || role.ID;
+      const name = role.name || role.Name;
+      if (id) mapping[id] = name;
     });
-
     return mapping;
   } catch (error) {
     console.error('Error getting roles mapping:', error);
@@ -130,4 +271,145 @@ function getUserRoleNames(userRoleIds) {
     console.error('Error getting user role names:', error);
     return [];
   }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function _getOrCreateRolesSheet_() {
+  if (typeof ensureSheetWithHeaders === 'function') {
+    return ensureSheetWithHeaders(ROLES_SHEET, ROLES_HEADER);
+  }
+  const ss = SpreadsheetApp.getActive();
+  let sheet = ss.getSheetByName(ROLES_SHEET);
+  if (!sheet) {
+    sheet = ss.insertSheet(ROLES_SHEET);
+    sheet.getRange(1, 1, 1, ROLES_HEADER.length).setValues([ROLES_HEADER]).setFontWeight('bold');
+    sheet.setFrozenRows(1);
+  }
+  return sheet;
+}
+
+function _getSheetHeaders_(sheet, fallback) {
+  if (!sheet) return Array.isArray(fallback) ? fallback.slice() : [];
+  const lastColumn = sheet.getLastColumn();
+  if (lastColumn < 1) return Array.isArray(fallback) ? fallback.slice() : [];
+  const values = sheet.getRange(1, 1, 1, lastColumn).getValues();
+  if (!values.length) return Array.isArray(fallback) ? fallback.slice() : [];
+  return values[0].map(h => String(h || '').trim());
+}
+
+function _mapRowFromHeaders_(headers, valueMap) {
+  return headers.map(header => {
+    if (!header) return '';
+    return Object.prototype.hasOwnProperty.call(valueMap, header) ? valueMap[header] : '';
+  });
+}
+
+function _readRolesSheet_() {
+  if (typeof readSheet === 'function') {
+    const rows = readSheet(ROLES_SHEET) || [];
+    if (Array.isArray(rows)) return rows;
+  }
+
+  const sheet = SpreadsheetApp.getActive().getSheetByName(ROLES_SHEET);
+  if (!sheet) return [];
+  const range = sheet.getDataRange();
+  if (!range) return [];
+  const values = range.getValues();
+  if (!values.length) return [];
+  const headers = values.shift().map(h => String(h || '').trim());
+  return values
+    .map(row => {
+      const obj = {};
+      let hasData = false;
+      headers.forEach((header, idx) => {
+        if (!header) return;
+        const value = row[idx];
+        if (value !== '' && value != null) hasData = true;
+        obj[header] = value;
+      });
+      return hasData ? obj : null;
+    })
+    .filter(Boolean);
+}
+
+function normalizeRoleRecord_(record) {
+  if (!record || typeof record !== 'object') return null;
+  const base = Array.isArray(record) ? {} : Object.assign({}, record);
+
+  let id = base.ID || base.Id || base.id || '';
+  if (id != null) id = String(id).trim();
+  let name = base.Name || base.name || '';
+  if (name != null) name = String(name).trim();
+  const normalizedName = (base.NormalizedName || base.normalizedName || (name ? name.toUpperCase() : '') || '').toString();
+  const scope = base.Scope || base.scope || '';
+  const description = base.Description || base.description || '';
+
+  const createdValue = base.CreatedAt || base.createdAt || null;
+  const updatedValue = base.UpdatedAt || base.updatedAt || null;
+  const deletedValue = base.DeletedAt || base.deletedAt || null;
+
+  return Object.assign({}, base, {
+    ID: id || base.ID,
+    id: id,
+    Name: name || base.Name,
+    name: name,
+    NormalizedName: normalizedName,
+    normalizedName: normalizedName,
+    Scope: scope,
+    scope: scope,
+    Description: description,
+    description: description,
+    CreatedAt: createdValue,
+    createdAt: _toClientDate_(createdValue),
+    UpdatedAt: updatedValue,
+    updatedAt: _toClientDate_(updatedValue),
+    DeletedAt: deletedValue,
+    deletedAt: _toClientDate_(deletedValue)
+  });
+}
+
+function normalizeRoleInput_(nameOrPayload, scopeOrPayload, description) {
+  if (nameOrPayload && typeof nameOrPayload === 'object' && !Array.isArray(nameOrPayload)) {
+    return {
+      name: nameOrPayload.name || nameOrPayload.Name || '',
+      normalizedName: nameOrPayload.normalizedName || nameOrPayload.NormalizedName || '',
+      scope: nameOrPayload.scope || nameOrPayload.Scope || '',
+      description: nameOrPayload.description || nameOrPayload.Description || ''
+    };
+  }
+
+  return {
+    name: nameOrPayload || '',
+    scope: scopeOrPayload && typeof scopeOrPayload === 'string' ? scopeOrPayload : '',
+    description: description || ''
+  };
+}
+
+function normalizeRoleUpdate_(idOrPayload, name, scope, description) {
+  if (idOrPayload && typeof idOrPayload === 'object' && !Array.isArray(idOrPayload)) {
+    const payload = Object.assign({}, idOrPayload);
+    payload.id = idOrPayload.id || idOrPayload.ID || '';
+    payload.name = idOrPayload.name || idOrPayload.Name || payload.name || '';
+    payload.scope = idOrPayload.scope || idOrPayload.Scope || payload.scope || '';
+    payload.description = idOrPayload.description || idOrPayload.Description || payload.description || '';
+    payload.normalizedName = idOrPayload.normalizedName || idOrPayload.NormalizedName || payload.normalizedName || '';
+    return payload;
+  }
+
+  return {
+    id: idOrPayload,
+    name: name || '',
+    scope: scope || '',
+    description: description || '',
+    normalizedName: name ? name.toUpperCase() : ''
+  };
+}
+
+function _toClientDate_(value) {
+  if (!value && value !== 0) return null;
+  if (value instanceof Date) return value.toISOString();
+  return value;
 }


### PR DESCRIPTION
## Summary
- expose role scope and description fields in the role management table and modals, including enhanced filtering and rendering helpers
- align the Apps Script role service with the updated Roles and UserRoles sheet schema, including scope/description persistence and cache busting
- mirror the role metadata handling in UserService to ensure consistent fallbacks when managing user role assignments

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc13cddc148326b946120101ba45cc