### PR TITLE
Expose complete user sheet data in UI

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -931,6 +931,48 @@
         font-weight: 600;
         border: 1px solid var(--gray-200);
     }
+
+    /* User sheet data */
+    .user-sheet-details {
+        margin-top: 1.5rem;
+        background: rgba(248, 250, 252, 0.6);
+        border-radius: var(--border-radius-xs);
+        border: 1px solid rgba(203, 213, 225, 0.4);
+        padding: 0.75rem 1rem;
+    }
+
+    .user-sheet-details>summary {
+        cursor: pointer;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        list-style: none;
+    }
+
+    .user-sheet-details>summary::-webkit-details-marker {
+        display: none;
+    }
+
+    .sheet-data-table th {
+        width: 35%;
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        color: var(--gray-500);
+        background: rgba(226, 232, 240, 0.35);
+    }
+
+    .sheet-data-table td {
+        font-size: 0.8rem;
+        color: var(--gray-700);
+        word-break: break-word;
+        white-space: normal;
+    }
+
+    .user-sheet-data-empty {
+        font-style: italic;
+        color: var(--gray-500);
+    }
 </style>
 
 <!-- Loading Overlay -->
@@ -1381,6 +1423,18 @@
                                                 </label>
                                             </div>
                                         </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Sheet Snapshot -->
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <h6 class="mb-0 fw-bold"><i class="fas fa-database me-2"></i>User Sheet Snapshot</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div id="userSheetDataContent" class="user-sheet-data-empty">
+                                        Sheet data will appear here when editing an existing user.
                                     </div>
                                 </div>
                             </div>
@@ -2283,6 +2337,7 @@
           <div class="small text-muted mb-2 fw-medium"><i class="fas fa-robot me-1"></i>Auto-Discovered Page Access:</div>
           ${renderUserPagesBadges(user)}
         </div>
+        ${renderUserSheetDetails(user)}
       </div>
     </div>
   </div>`;
@@ -2348,6 +2403,71 @@
   function renderRolesBadges(user) {
     if (!user.roleNames || !user.roleNames.length) return '';
     return user.roleNames.map(r => `<span class="badge bg-secondary">${escapeHtml(r)}</span>`).join(' ');
+  }
+
+  function formatSheetFieldValue(value) {
+    if (value === null || value === undefined || value === '') return '—';
+    if (value instanceof Date) return value.toISOString().split('T')[0];
+    if (Array.isArray(value)) {
+      return value.map(item => formatSheetFieldValue(item)).join(', ');
+    }
+    if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value);
+      } catch (err) {
+        console.warn('Unable to stringify sheet field value', err, value);
+        return String(value);
+      }
+    }
+    return String(value);
+  }
+
+  function renderSheetFieldsTable(fields) {
+    if (!Array.isArray(fields) || !fields.length) {
+      return '<div class="user-sheet-data-empty"><i class="fas fa-info-circle me-1"></i>No sheet fields available.</div>';
+    }
+    const rows = fields.map(({ key, value }) => `
+      <tr>
+        <th scope="row">${escapeHtml(key)}</th>
+        <td>${escapeHtml(formatSheetFieldValue(value))}</td>
+      </tr>
+    `).join('');
+    return `
+      <div class="table-responsive">
+        <table class="table table-sm table-striped sheet-data-table align-middle mb-0">
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function renderUserSheetDetails(user) {
+    const fields = Array.isArray(user.sheetFields) ? user.sheetFields : [];
+    if (!fields.length) {
+      return '<div class="user-sheet-details user-sheet-data-empty"><i class="fas fa-info-circle me-1"></i>No sheet data found for this user.</div>';
+    }
+    const fieldCount = user.sheetFieldCount || fields.length;
+    return `
+      <details class="user-sheet-details">
+        <summary><i class="fas fa-table me-2"></i><span>Sheet data (${fieldCount})</span></summary>
+        <div class="mt-3">${renderSheetFieldsTable(fields)}</div>
+      </details>
+    `;
+  }
+
+  function updateUserSheetDataCard(user) {
+    const container = document.getElementById('userSheetDataContent');
+    if (!container) return;
+    if (!user || !Array.isArray(user.sheetFields) || !user.sheetFields.length) {
+      container.innerHTML = '<div class="user-sheet-data-empty"><i class="fas fa-info-circle me-1"></i>Select an existing user to view synced sheet data.</div>';
+      return;
+    }
+    const fieldCount = user.sheetFieldCount || user.sheetFields.length;
+    container.innerHTML = `
+      <div class="badge bg-primary text-white mb-3"><i class="fas fa-table me-1"></i>${fieldCount} field${fieldCount === 1 ? '' : 's'} from sheet</div>
+      ${renderSheetFieldsTable(user.sheetFields)}
+    `;
   }
 
   // ---------- Pagination control ----------
@@ -2492,6 +2612,7 @@
     // Reset UI elements
     updatePageStats();
     setEligibilityPill(false);
+    updateUserSheetDataCard(null);
 
     // Hide manager tab for new users
     document.getElementById('manage-users-tab').style.display = 'none';
@@ -2590,6 +2711,7 @@
         ? (new Date() >= new Date(document.getElementById('insuranceEligibleDate').value))
         : false);
     setEligibilityPill(qualified);
+    updateUserSheetDataCard(u);
 
     // Set roles
     const roleIds = u.roleIds || [];


### PR DESCRIPTION
## Summary
- normalize user records to retain every sheet column and expose them as sheetFields metadata
- display sheet data snapshots in the user modal and cards, including helpers to format values for review
- add styling and reset logic so administrators can inspect synced sheet information while adding or editing users

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dc4d7858d88326bec0e8a86bf76ef7