### PR TITLE
Ensure all modules use shared manager-scoped getUsers

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2599,7 +2599,9 @@ function _uiUserShape_(u, cmap) {
     ID: u.ID,
     UserName: u.UserName,
     FullName: u.FullName,
+    name: _normStr_(u.FullName || u.UserName || ''),
     Email: u.Email,
+    email: _normStr_(u.Email || ''),
     CampaignID: u.CampaignID,
     campaignName: cmap[cid] || _normStr_(u.CampaignName || ''),
     CanLogin: u.CanLogin,
@@ -2611,86 +2613,172 @@ function _uiUserShape_(u, cmap) {
   };
 }
 
+function _readUsersSheetSafe_() {
+  try {
+    return (typeof readSheet === 'function') ? (readSheet('Users') || []) : [];
+  } catch (err) {
+    console.warn('Unable to read Users sheet:', err);
+    return [];
+  }
+}
+
+function _readManagerUsersSheetSafe_() {
+  try {
+    return (typeof readSheet === 'function') ? (readSheet('MANAGER_USERS') || []) : [];
+  } catch (err) {
+    console.warn('Unable to read MANAGER_USERS sheet:', err);
+    return [];
+  }
+}
+
+function _dedupeAndSortUsers_(list) {
+  const seenIds = new Set();
+  const seenEmails = new Set();
+  const out = [];
+  for (let i = 0; i < list.length; i++) {
+    const user = list[i];
+    if (!user) continue;
+    const idKey = String(user.ID || '');
+    const emailKey = String(user.email || user.Email || '').trim().toLowerCase();
+    if (idKey && seenIds.has(idKey)) continue;
+    if (emailKey && seenEmails.has(emailKey)) continue;
+    if (idKey) seenIds.add(idKey);
+    if (emailKey) seenEmails.add(emailKey);
+    out.push(user);
+  }
+  out.sort(function (a, b) {
+    return String(a.name || a.FullName || '').localeCompare(String(b.name || b.FullName || '')) ||
+      String(a.UserName || '').localeCompare(String(b.UserName || ''));
+  });
+  return out;
+}
+
+function getUsersByManager(managerUserId, options) {
+  try {
+    const opts = Object.assign({
+      includeManager: true,
+      fallbackToCampaign: true,
+      fallbackToAll: false,
+      managerCampaignId: ''
+    }, options || {});
+
+    const allUsers = _readUsersSheetSafe_();
+    if (!allUsers.length) return [];
+
+    const cmap = _campaignNameMap_();
+    const byId = new Map(
+      allUsers
+        .filter(function (u) { return u && typeof u.ID !== 'undefined' && u.ID !== null && u.ID !== ''; })
+        .map(function (u) { return [String(u.ID), u]; })
+    );
+
+    const managerIdStr = managerUserId ? String(managerUserId) : '';
+    const manager = managerIdStr ? byId.get(managerIdStr) : null;
+    const visible = [];
+
+    const pushUser = function (rawUser) {
+      if (!rawUser) return;
+      visible.push(_uiUserShape_(rawUser, cmap));
+    };
+
+    if (opts.includeManager && manager) {
+      pushUser(manager);
+    }
+
+    const assignedIds = new Set();
+    if (managerIdStr) {
+      const relations = _readManagerUsersSheetSafe_();
+      for (let i = 0; i < relations.length; i++) {
+        const rel = relations[i];
+        if (!rel) continue;
+        if (String(rel.ManagerUserID) === managerIdStr && rel.UserID) {
+          assignedIds.add(String(rel.UserID));
+        }
+      }
+    }
+
+    assignedIds.forEach(function (id) {
+      const match = byId.get(id);
+      if (match) pushUser(match);
+    });
+
+    const hasAssigned = assignedIds.size > 0;
+
+    if ((!hasAssigned || visible.length === (opts.includeManager && manager ? 1 : 0)) && opts.fallbackToCampaign) {
+      const targetCampaign = opts.managerCampaignId || (manager && (manager.CampaignID || manager.campaignId)) || '';
+      if (targetCampaign) {
+        allUsers.forEach(function (u) {
+          if (String(u.CampaignID || u.campaignId) === String(targetCampaign)) {
+            pushUser(u);
+          }
+        });
+      }
+    }
+
+    if (!visible.length && opts.fallbackToAll) {
+      allUsers.forEach(pushUser);
+    }
+
+    return _dedupeAndSortUsers_(visible);
+
+  } catch (error) {
+    console.error('Error in getUsersByManager:', error);
+    writeError && writeError('getUsersByManager', error);
+    return [];
+  }
+}
+
+function getUser(managerUserId, options) {
+  try {
+    let mgrId = managerUserId;
+    let opts = options;
+
+    if (typeof mgrId === 'object' && mgrId !== null && !Array.isArray(mgrId) && typeof opts === 'undefined') {
+      opts = mgrId;
+      mgrId = undefined;
+    }
+
+    if (!mgrId) {
+      const current = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+      if (current && current.ID) {
+        mgrId = current.ID;
+        opts = Object.assign({ managerCampaignId: current.CampaignID || current.campaignId || '' }, opts || {});
+      }
+    }
+
+    const finalOpts = Object.assign({ includeManager: false, fallbackToCampaign: false, fallbackToAll: false }, opts || {});
+    return getUsersByManager(mgrId, finalOpts);
+
+  } catch (error) {
+    console.error('Error in getUser:', error);
+    writeError && writeError('getUser', error);
+    return [];
+  }
+}
+
 function getUsers() {
   try {
     console.log('getUsers() called');
 
-    const meEmail = _normEmail_((Session.getActiveUser() && Session.getActiveUser().getEmail()) || '');
-    console.log('Current user email:', meEmail);
+    const currentUser = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+    const managerId = currentUser && currentUser.ID ? currentUser.ID : null;
+    const managerCampaignId = currentUser ? (currentUser.CampaignID || currentUser.campaignId || '') : '';
 
-    if (!meEmail) {
-      console.warn('No current user email found');
-      return [];
-    }
-
-    const allUsers = (typeof readSheet === 'function') ? (readSheet('Users') || []) : [];
-    console.log('All users from sheet:', allUsers.length);
-
-    if (allUsers.length === 0) {
-      console.warn('No users found in Users sheet');
-      return [];
-    }
-
-    const me = allUsers.find(function (u) {
-      return _normEmail_(u.Email || u.email) === meEmail;
+    const users = getUsersByManager(managerId, {
+      includeManager: true,
+      fallbackToCampaign: true,
+      fallbackToAll: true,
+      managerCampaignId: managerCampaignId
     });
 
-    if (!me) {
-      console.warn('Current user not found in Users sheet');
-      return allUsers.map(u => _uiUserShape_(u, _campaignNameMap_()));
+    if (users.length) {
+      console.log('Final user list:', users.length, 'users');
+      return users;
     }
 
-    console.log('Found current user:', me.FullName || me.UserName);
-
-    let muRows = [];
-    try {
-      muRows = (typeof readSheet === 'function') ? (readSheet('MANAGER_USERS') || []) : [];
-      console.log('Manager-user relationships found:', muRows.length);
-    } catch (error) {
-      console.warn('Could not read manager-user relationships, will return all users:', error);
-      return allUsers.map(u => _uiUserShape_(u, _campaignNameMap_()));
-    }
-
-    const assignedIds = new Set(
-      muRows.filter(function (a) { return String(a.ManagerUserID) === String(me.ID); })
-        .map(function (a) { return String(a.UserID); })
-        .filter(Boolean)
-    );
-
-    console.log('Assigned user IDs:', Array.from(assignedIds));
-
-    if (assignedIds.size === 0) {
-      console.log('No assigned users found, using campaign-based filtering');
-      const sameCampaignUsers = allUsers.filter(u =>
-        (u.CampaignID || u.campaignId) === (me.CampaignID || me.campaignId)
-      );
-      return sameCampaignUsers.map(u => _uiUserShape_(u, _campaignNameMap_()));
-    }
-
-    const byId = new Map(allUsers.filter(function (u) { return u && u.ID; }).map(function (u) { return [String(u.ID), u]; }));
-    const cmap = _campaignNameMap_();
-
-    const out = [_uiUserShape_(me, cmap)];
-    assignedIds.forEach(function (id) {
-      const u = byId.get(id);
-      if (u) out.push(_uiUserShape_(u, cmap));
-    });
-
-    const seen = new Set();
-    const dedup = out.filter(function (u) {
-      const k = String(u.ID || '');
-      if (!k || seen.has(k)) return false;
-      seen.add(k);
-      return true;
-    });
-
-    dedup.sort(function (a, b) {
-      return String(a.FullName || '').localeCompare(String(b.FullName || '')) ||
-        String(a.UserName || '').localeCompare(String(b.UserName || ''));
-    });
-
-    console.log('Final user list:', dedup.length, 'users');
-    return dedup;
+    const fallback = currentUser ? [_uiUserShape_(currentUser, _campaignNameMap_())] : [];
+    console.warn('No users found by manager; returning fallback list of size', fallback.length);
+    return fallback;
 
   } catch (e) {
     console.error('Error in getUsers:', e);

--- a/CreditSuiteQAServices.js
+++ b/CreditSuiteQAServices.js
@@ -312,63 +312,6 @@ const CREDIT_SUITE_QA_CONFIG = {
     }
 };
 
-function getUsers() {
-  try {
-    // 1) Identify the logged-in manager by email
-    const mgrEmail = (Session.getActiveUser().getEmail() || '').trim().toLowerCase();
-    if (!mgrEmail) return [];
-
-    const users = readSheet(USERS_SHEET) || [];
-    const manager = users.find(u => String(u.Email || '').trim().toLowerCase() === mgrEmail);
-    if (!manager) return [];
-
-    // 2) Read manager→user assignments (sheet name helper if present, else default)
-    const muSheetName = (typeof getManagerUsersSheetName_ === 'function')
-      ? getManagerUsersSheetName_()
-      : 'MANAGER_USERS';
-
-    const assignments = readSheet(muSheetName) || [];
-    const assignedIds = new Set(
-      assignments
-        .filter(a => String(a.ManagerUserID) === String(manager.ID))
-        .map(a => String(a.UserID))
-    );
-
-    // 3) Build list: include the manager + all assigned users (no active filter)
-    const list = [];
-
-    if (manager.FullName && manager.Email) {
-      list.push({
-        name: String(manager.FullName).trim(),
-        email: String(manager.Email).trim()
-      });
-    }
-
-    users.forEach(u => {
-      if (assignedIds.has(String(u.ID)) && u.FullName && u.Email) {
-        list.push({
-          name: String(u.FullName).trim(),
-          email: String(u.Email).trim()
-        });
-      }
-    });
-
-    // 4) De-dupe by email and sort by name
-    const seen = new Set();
-    const out = list.filter(item => {
-      const key = (item.email || '').toLowerCase();
-      if (!key || seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    }).sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
-
-    return out;
-  } catch (e) {
-    Logger.log('getUsers error: ' + e);
-    return [];
-  }
-}
-
 /**
  * Client-accessible: return the Credit Suite user list
  * (wraps the existing getUsers() function)

--- a/IndependenceQAServices.js
+++ b/IndependenceQAServices.js
@@ -909,63 +909,6 @@ function clientPreviewIndependenceQAScore(formData) {
     }
 }
 
-function getUsers() {
-  try {
-    // 1) Identify the logged-in manager by email
-    const mgrEmail = (Session.getActiveUser().getEmail() || '').trim().toLowerCase();
-    if (!mgrEmail) return [];
-
-    const users = readSheet(USERS_SHEET) || [];
-    const manager = users.find(u => String(u.Email || '').trim().toLowerCase() === mgrEmail);
-    if (!manager) return [];
-
-    // 2) Read manager→user assignments (sheet name helper if present, else default)
-    const muSheetName = (typeof getManagerUsersSheetName_ === 'function')
-      ? getManagerUsersSheetName_()
-      : 'MANAGER_USERS';
-
-    const assignments = readSheet(muSheetName) || [];
-    const assignedIds = new Set(
-      assignments
-        .filter(a => String(a.ManagerUserID) === String(manager.ID))
-        .map(a => String(a.UserID))
-    );
-
-    // 3) Build list: include the manager + all assigned users (no active filter)
-    const list = [];
-
-    if (manager.FullName && manager.Email) {
-      list.push({
-        name: String(manager.FullName).trim(),
-        email: String(manager.Email).trim()
-      });
-    }
-
-    users.forEach(u => {
-      if (assignedIds.has(String(u.ID)) && u.FullName && u.Email) {
-        list.push({
-          name: String(u.FullName).trim(),
-          email: String(u.Email).trim()
-        });
-      }
-    });
-
-    // 4) De-dupe by email and sort by name
-    const seen = new Set();
-    const out = list.filter(item => {
-      const key = (item.email || '').toLowerCase();
-      if (!key || seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    }).sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }));
-
-    return out;
-  } catch (e) {
-    Logger.log('getUsers error: ' + e);
-    return [];
-  }
-}
-
 function clientGetIndependenceQAConfig() {
     try {
         return JSON.parse(JSON.stringify(INDEPENDENCE_QA_CONFIG));


### PR DESCRIPTION
## Summary
- add name/email aliases and stronger deduping to the shared manager-scoped user shape
- remove duplicate service-local getUsers implementations so Credit Suite and Independence QA rely on the global helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dce4d0986c83269b9210ead59e6577