### PR TITLE
Add shared entity loader harness for quality form

### DIFF
--- a/EntityLoader.html
+++ b/EntityLoader.html
@@ -1,0 +1,436 @@
+<!-- Lumina Entity Loader partial -->
+<script>
+  (function () {
+    if (window.LuminaEntityLoader) {
+      return;
+    }
+
+    const skeletonRegistry = new Map();
+    const entityRegistry = new Map();
+    let autoId = 0;
+
+    function isGoogleScriptAvailable() {
+      return Boolean(window.google && google.script && google.script.run);
+    }
+
+    function runGoogleScript(methodName, ...args) {
+      return new Promise((resolve, reject) => {
+        if (!isGoogleScriptAvailable()) {
+          reject(new Error('google.script.run is not available.'));
+          return;
+        }
+
+        if (!methodName || typeof methodName !== 'string') {
+          reject(new Error('A google.script.run method name is required.'));
+          return;
+        }
+
+        const runner = google.script.run
+          .withSuccessHandler(resolve)
+          .withFailureHandler(reject);
+
+        if (typeof runner[methodName] !== 'function') {
+          reject(new Error(`google.script.run.${methodName} is not defined.`));
+          return;
+        }
+
+        runner[methodName](...args);
+      });
+    }
+
+    function ensureDocumentReady(callback) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => callback(), { once: true });
+      } else {
+        callback();
+      }
+    }
+
+    function toNodeList(value) {
+      if (!value) {
+        return [];
+      }
+
+      if (value instanceof DocumentFragment) {
+        return Array.from(value.childNodes);
+      }
+
+      if (value instanceof Node) {
+        return [value];
+      }
+
+      if (Array.isArray(value)) {
+        return value.reduce((acc, item) => acc.concat(toNodeList(item)), []);
+      }
+
+      const temp = document.createElement('div');
+      temp.innerHTML = String(value);
+      return Array.from(temp.childNodes);
+    }
+
+    function mountContent(target, content, options = {}) {
+      if (!target) {
+        return;
+      }
+
+      const opts = Object.assign({ append: false }, options);
+      if (!opts.append) {
+        target.innerHTML = '';
+      }
+
+      if (content === null || typeof content === 'undefined') {
+        return;
+      }
+
+      const nodes = toNodeList(content);
+      nodes.forEach(node => {
+        if (opts.append) {
+          target.appendChild(node);
+        } else {
+          target.appendChild(node);
+        }
+      });
+    }
+
+    function resolvePlaceholder(entry) {
+      if (entry.placeholder && entry.placeholder.isConnected) {
+        return entry.placeholder;
+      }
+
+      if (entry.placeholderSelector) {
+        const el = document.querySelector(entry.placeholderSelector);
+        if (el) {
+          entry.placeholder = el;
+          return el;
+        }
+      }
+
+      return null;
+    }
+
+    function normalizeSkeletonSpec(spec) {
+      if (!spec) {
+        return null;
+      }
+
+      if (typeof spec === 'string') {
+        return { id: spec, props: {} };
+      }
+
+      if (typeof spec === 'function') {
+        return { renderer: spec, props: {} };
+      }
+
+      if (spec instanceof HTMLTemplateElement) {
+        return {
+          renderer: () => spec.content.cloneNode(true),
+          props: {}
+        };
+      }
+
+      if (spec && typeof spec === 'object') {
+        const normalized = {
+          id: spec.id || null,
+          renderer: typeof spec.renderer === 'function' ? spec.renderer : null,
+          props: spec.props || {}
+        };
+
+        if (!normalized.renderer && typeof spec.markup === 'string') {
+          const markup = spec.markup;
+          normalized.renderer = () => markup;
+        }
+
+        if (!normalized.renderer && typeof spec.templateSelector === 'string') {
+          normalized.renderer = () => {
+            const tpl = document.querySelector(spec.templateSelector);
+            if (tpl && tpl.content) {
+              return tpl.content.cloneNode(true);
+            }
+            return null;
+          };
+        }
+
+        return normalized;
+      }
+
+      return null;
+    }
+
+    function renderSkeleton(entry, placeholder, overrideSpec) {
+      const spec = normalizeSkeletonSpec(overrideSpec || entry.skeleton);
+      if (!spec) {
+        return null;
+      }
+
+      let renderer = spec.renderer;
+      if (!renderer && spec.id && skeletonRegistry.has(spec.id)) {
+        renderer = skeletonRegistry.get(spec.id);
+      }
+
+      if (!renderer) {
+        return null;
+      }
+
+      placeholder.setAttribute('data-lumina-entity-loading', 'true');
+
+      const rendered = renderer({
+        id: entry.id,
+        placeholder,
+        props: spec.props || {},
+        mount: (content, opts) => mountContent(placeholder, content, opts)
+      });
+
+      placeholder.innerHTML = '';
+
+      if (rendered !== null && typeof rendered !== 'undefined') {
+        mountContent(placeholder, rendered, { append: true });
+      }
+
+      return () => {
+        placeholder.removeAttribute('data-lumina-entity-loading');
+        placeholder.innerHTML = '';
+      };
+    }
+
+    function registerSkeleton(id, renderer) {
+      if (!id) {
+        throw new Error('LuminaEntityLoader.attachSkeleton requires an id.');
+      }
+
+      let normalizedRenderer = renderer;
+      if (typeof renderer === 'string') {
+        const markup = renderer;
+        normalizedRenderer = () => markup;
+      } else if (renderer instanceof HTMLTemplateElement) {
+        normalizedRenderer = () => renderer.content.cloneNode(true);
+      } else if (renderer && typeof renderer === 'object' && typeof renderer.templateSelector === 'string') {
+        normalizedRenderer = () => {
+          const tpl = document.querySelector(renderer.templateSelector);
+          return tpl && tpl.content ? tpl.content.cloneNode(true) : null;
+        };
+      }
+
+      if (typeof normalizedRenderer !== 'function') {
+        throw new Error('Skeleton renderer must be a function, string, or template element.');
+      }
+
+      skeletonRegistry.set(id, normalizedRenderer);
+    }
+
+    function runEntityLoad(entry, overrideOptions = {}) {
+      const placeholder = resolvePlaceholder(entry);
+      if (!placeholder) {
+        console.warn(`LuminaEntityLoader: placeholder not found for entity "${entry.id}".`);
+        return Promise.resolve(null);
+      }
+
+      const options = Object.assign({ showSkeleton: true }, overrideOptions);
+      let cleanupSkeleton = null;
+
+      const context = {
+        id: entry.id,
+        placeholder,
+        run: runGoogleScript,
+        mount: (content, opts) => mountContent(placeholder, content, opts),
+        isGoogleScriptAvailable,
+        setLoadingState(isLoading) {
+          if (isLoading) {
+            placeholder.setAttribute('data-lumina-entity-loading', 'true');
+          } else {
+            placeholder.removeAttribute('data-lumina-entity-loading');
+          }
+        },
+        showSkeleton(spec) {
+          if (cleanupSkeleton) {
+            cleanupSkeleton();
+          }
+          cleanupSkeleton = renderSkeleton(entry, placeholder, spec);
+          return () => {
+            if (cleanupSkeleton) {
+              cleanupSkeleton();
+              cleanupSkeleton = null;
+            }
+          };
+        },
+        removeSkeleton() {
+          if (cleanupSkeleton) {
+            cleanupSkeleton();
+            cleanupSkeleton = null;
+          }
+        }
+      };
+
+      context.setLoadingState(true);
+
+      if (options.showSkeleton) {
+        cleanupSkeleton = renderSkeleton(entry, placeholder);
+      }
+
+      if (typeof entry.load !== 'function') {
+        console.warn(`LuminaEntityLoader: entity "${entry.id}" does not have a load() handler.`);
+        context.removeSkeleton();
+        context.setLoadingState(false);
+        return Promise.resolve(null);
+      }
+
+      return Promise.resolve()
+        .then(() => entry.load(context))
+        .then(result => {
+          if (typeof result !== 'undefined') {
+            context.mount(result);
+          }
+          return result;
+        })
+        .catch(error => {
+          console.error(`LuminaEntityLoader: failed to load entity "${entry.id}"`, error);
+          placeholder.setAttribute('data-lumina-entity-error', 'true');
+          throw error;
+        })
+        .finally(() => {
+          context.removeSkeleton();
+          context.setLoadingState(false);
+        });
+    }
+
+    function registerEntity(config) {
+      if (!config || typeof config !== 'object') {
+        throw new Error('LuminaEntityLoader.register requires a configuration object.');
+      }
+
+      const id = config.id || `luminaEntity${++autoId}`;
+
+      const entry = {
+        id,
+        placeholderSelector: config.placeholderSelector || null,
+        placeholder: config.placeholder || null,
+        load: config.load,
+        skeleton: config.skeleton || null,
+        autoStart: config.autoStart !== false
+      };
+
+      entityRegistry.set(id, entry);
+
+      const controller = {
+        id,
+        load(options) {
+          return runEntityLoad(entry, options);
+        },
+        refresh(options) {
+          return runEntityLoad(entry, options);
+        },
+        getPlaceholder() {
+          return resolvePlaceholder(entry);
+        },
+        setSkeleton(spec) {
+          entry.skeleton = spec;
+        }
+      };
+
+      if (entry.autoStart) {
+        ensureDocumentReady(() => runEntityLoad(entry));
+      }
+
+      return controller;
+    }
+
+    function loadEntityById(id, options) {
+      const entry = entityRegistry.get(id);
+      if (!entry) {
+        console.warn(`LuminaEntityLoader: entity "${id}" is not registered.`);
+        return Promise.resolve(null);
+      }
+      return runEntityLoad(entry, options);
+    }
+
+    function loadAllEntities() {
+      const promises = [];
+      entityRegistry.forEach(entry => {
+        promises.push(runEntityLoad(entry));
+      });
+      return Promise.all(promises);
+    }
+
+    function injectBaseStyles() {
+      if (document.getElementById('lumina-entity-loader-styles')) {
+        return;
+      }
+
+      const style = document.createElement('style');
+      style.id = 'lumina-entity-loader-styles';
+      style.textContent = `
+        @keyframes lumina-entity-spinner {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+
+        .lumina-entity-skeleton {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          font-size: 0.875rem;
+          color: var(--lumina-info, #0ea5e9);
+        }
+
+        .lumina-entity-skeleton--block {
+          display: flex;
+        }
+
+        .lumina-entity-skeleton__spinner {
+          width: 1rem;
+          height: 1rem;
+          border-radius: 50%;
+          border: 2px solid currentColor;
+          border-top-color: transparent;
+          animation: lumina-entity-spinner 0.75s linear infinite;
+        }
+
+        .lumina-entity-status {
+          font-size: 0.8125rem;
+          margin-top: 0.35rem;
+        }
+
+        .lumina-entity-status--warning {
+          color: var(--lumina-warning, #f59e0b);
+        }
+
+        .lumina-entity-status--error {
+          color: var(--lumina-danger, #dc2626);
+        }
+      `;
+
+      document.head.appendChild(style);
+    }
+
+    function registerDefaultSkeletons() {
+      if (skeletonRegistry.has('lumina-inline-spinner')) {
+        return;
+      }
+
+      registerSkeleton('lumina-inline-spinner', ({ props }) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'lumina-entity-skeleton';
+        const spinner = document.createElement('span');
+        spinner.className = 'lumina-entity-skeleton__spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+        const label = document.createElement('span');
+        label.className = 'lumina-entity-skeleton__label';
+        label.textContent = props && props.text ? props.text : 'Loading…';
+        wrapper.appendChild(spinner);
+        wrapper.appendChild(label);
+        return wrapper;
+      });
+    }
+
+    injectBaseStyles();
+    registerDefaultSkeletons();
+
+    window.LuminaEntityLoader = {
+      register: registerEntity,
+      attachSkeleton: registerSkeleton,
+      load: loadEntityById,
+      loadAll: loadAllEntities,
+      run: runGoogleScript,
+      isGoogleScriptAvailable
+    };
+  })();
+</script>

--- a/QualityForm.html
+++ b/QualityForm.html
@@ -166,16 +166,26 @@
     gap: 0.5rem;
   }
 
-  .status-text i {
-    color: #10b981;
-    font-size: 1.1rem;
-  }
+    .status-text i {
+      color: #10b981;
+      font-size: 1.1rem;
+    }
 
-  @keyframes pulse-live {
+    .lumina-entity-placeholder {
+      margin-top: 0.5rem;
+      min-height: 1.25rem;
+    }
 
-    0%,
-    100% {
-      opacity: 1;
+    .lumina-entity-placeholder:empty {
+      margin-top: 0;
+      min-height: 0;
+    }
+
+    @keyframes pulse-live {
+
+      0%,
+      100% {
+        opacity: 1;
       transform: scale(1);
       box-shadow: 0 0 15px rgba(16, 185, 129, 0.6);
     }
@@ -1473,6 +1483,7 @@
                   <option value="<?= name ?>" <?= recObj.AgentName===name?'selected':'' ?>><?= name ?></option>
                 <? } ?>
               </select>
+              <div id="agentLoaderHost" class="lumina-entity-placeholder" aria-live="polite"></div>
             </div>
             <div class="form-group">
               <label for="agentEmail">Agent Email</label>
@@ -2362,7 +2373,6 @@
     const sel = document.getElementById('agentName');
     if (!sel) return;
 
-    // Preserve the placeholder option
     const placeholder = sel.querySelector('option[disabled]');
     sel.innerHTML = '';
     if (placeholder) sel.appendChild(placeholder);
@@ -2373,7 +2383,6 @@
       const email = (typeof u === 'object') ? (u?.email || u?.mail || u?.emailAddress || '') : '';
       if (!name) return;
 
-      // Keep userMap in sync
       if (!(name in userMap)) userMap[name] = email || '';
 
       const opt = document.createElement('option');
@@ -2383,7 +2392,6 @@
     });
     sel.appendChild(frag);
 
-    // If the record had an agent preselected, reapply it
     if (recordId && record && record !== '{}') {
       try {
         const rec = JSON.parse(record);
@@ -2394,134 +2402,125 @@
     }
   }
 
-  function hydrateAgentList() {
-    console.log('Starting agent list hydration...');
-    
-    // Check if Google Apps Script is available
-    if (!(window.google && google.script && google.script.run)) {
-      console.warn('google.script.run not available, using fallback');
-      fallbackToStaticUsers();
-      return;
-    }
-
-    // Get campaign ID if available (for campaign-specific agents)
-    const cid = (typeof campaignId !== 'undefined' && campaignId) ? campaignId : '';
-    console.log('Using campaign ID:', cid || 'none');
-
-    // Primary method: Try to get campaign-assigned agents
-    google.script.run
-      .withSuccessHandler(names => {
-        console.log('Received agent names from clientGetAssignedAgentNames:', names);
-        if (!Array.isArray(names) || names.length === 0) { 
-          console.warn('Empty or invalid names payload, falling back to getUsers');
-          fallbackToGetUsers(); 
-          return; 
-        }
-        userList = names;
-        populateAgentSelect(names);
-        console.log('Updated userList from campaign agents:', userList.length, 'agents');
-      })
-      .withFailureHandler(err => {
-        console.warn('clientGetAssignedAgentNames failed:', err);
-        fallbackToGetUsers();
-      })
-      .clientGetAssignedAgentNames(cid);
-
-    function fallbackToGetUsers() {
-      console.log('Falling back to general user list...');
-      google.script.run
-        .withSuccessHandler(users => {
-          console.log('Received users from getUsers:', users);
-          const names = (users || [])
-            .map(u => u.FullName || u.UserName || u.Email || u.name || u.fullName)
-            .filter(Boolean)
-            .sort((a, b) => a.localeCompare(b));
-          
-          if (names.length === 0) {
-            console.warn('No users found from getUsers, trying QA data fallback');
-            fallbackToQAData();
-          } else {
-            userList = names;
-            populateAgentSelect(names);
-            console.log('Updated userList from general users:', userList.length, 'agents');
-          }
-        })
-        .withFailureHandler(err => {
-          console.error('getUsers failed:', err);
-          fallbackToQAData();
-        })
-        .getUsers();
-    }
-
-    function fallbackToQAData() {
-      console.log('Falling back to QA data extraction...');
-      try {
-        // Try to get agents from existing QA data if available
-        if (typeof rawQA !== 'undefined' && Array.isArray(rawQA)) {
-          const qaAgents = Array.from(new Set(rawQA.map(r => r.AgentName).filter(Boolean))).sort();
-          if (qaAgents.length > 0) {
-            userList = qaAgents;
-            populateAgentSelect(qaAgents);
-            console.log('Updated userList from QA data:', userList.length, 'agents');
-            return;
-          }
-        }
-        
-        // Try alternative QA data source
-        google.script.run
-          .withSuccessHandler(qaData => {
-            console.log('Received QA data for agent extraction');
-            if (Array.isArray(qaData) && qaData.length > 0) {
-              const qaAgents = Array.from(new Set(qaData.map(r => r.AgentName || r.agentName).filter(Boolean))).sort();
-              if (qaAgents.length > 0) {
-                userList = qaAgents;
-                populateAgentSelect(qaAgents);
-                console.log('Updated userList from server QA data:', userList.length, 'agents');
-                return;
-              }
-            }
-            fallbackToStaticUsers();
-          })
-          .withFailureHandler(err => {
-            console.warn('QA data fallback failed:', err);
-            fallbackToStaticUsers();
-          })
-          .getAllQA();
-          
-      } catch (e) {
-        console.warn('QA data fallback exception:', e);
-        fallbackToStaticUsers();
-      }
-    }
-
-    function fallbackToStaticUsers() {
-      console.log('Using static/template users as final fallback...');
-      // Use the template-injected users as absolute fallback
-      if (Array.isArray(USERS) && USERS.length > 0) {
-        userList = USERS.slice(); // Make a copy
-        populateAgentSelect(USERS);
-        console.log('Updated userList from template users:', userList.length, 'agents');
-      } else {
-        console.error('No users available from any source');
-        userList = [];
-        populateAgentSelect([]);
-        showToast('Unable to load agent list. Please contact support.', true);
-      }
+  function fallbackToStaticUsers() {
+    console.log('Using static/template users as final fallback...');
+    if (Array.isArray(USERS) && USERS.length > 0) {
+      userList = USERS.slice();
+      populateAgentSelect(USERS);
+      console.log('Updated userList from template users:', userList.length, 'agents');
+    } else {
+      console.error('No users available from any source');
+      userList = [];
+      populateAgentSelect([]);
+      showToast('Unable to load agent list. Please contact support.', true);
     }
   }
 
-  function loadAgentsFromServerIfNeeded() {
+  function extractAgentNamesFromQAData(data) {
+    if (!Array.isArray(data) || data.length === 0) {
+      return [];
+    }
+
+    return Array.from(new Set(
+      data
+        .map(r => (r && (r.AgentName || r.agentName)) || null)
+        .filter(Boolean)
+    )).sort((a, b) => a.localeCompare(b));
+  }
+
+  async function hydrateAgentList(run) {
+    console.log('Starting agent list hydration...');
+
+    const hasRunHelper = typeof run === 'function';
+    const cid = (typeof campaignId !== 'undefined' && campaignId) ? campaignId : '';
+
+    if (!hasRunHelper) {
+      console.warn('google.script.run helper unavailable, using fallback data');
+      const fallback = Array.isArray(USERS) && USERS.length > 0
+        ? USERS.slice()
+        : extractAgentNamesFromQAData(typeof rawQA !== 'undefined' ? rawQA : []);
+
+      if (fallback.length > 0) {
+        userList = fallback;
+        populateAgentSelect(fallback);
+        console.log('Hydrated agent list from fallback data:', userList.length, 'agents');
+        return true;
+      }
+
+      fallbackToStaticUsers();
+      return false;
+    }
+
+    console.log('Using campaign ID:', cid || 'none');
+
+    try {
+      const names = await run('clientGetAssignedAgentNames', cid);
+      if (Array.isArray(names) && names.length > 0) {
+        userList = names;
+        populateAgentSelect(names);
+        console.log('Updated userList from campaign agents:', userList.length, 'agents');
+        return true;
+      }
+      console.warn('Empty campaign agent response, falling back to getUsers');
+    } catch (error) {
+      console.warn('clientGetAssignedAgentNames failed:', error);
+    }
+
+    try {
+      const users = await run('getUsers');
+      const names = (users || [])
+        .map(u => u.FullName || u.UserName || u.Email || u.name || u.fullName)
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b));
+
+      if (names.length > 0) {
+        userList = names;
+        populateAgentSelect(names);
+        console.log('Updated userList from general users:', userList.length, 'agents');
+        return true;
+      }
+      console.warn('No users returned from getUsers, falling back to QA data');
+    } catch (error) {
+      console.error('getUsers failed:', error);
+    }
+
+    const qaTemplateAgents = extractAgentNamesFromQAData(typeof rawQA !== 'undefined' ? rawQA : []);
+    if (qaTemplateAgents.length > 0) {
+      userList = qaTemplateAgents;
+      populateAgentSelect(qaTemplateAgents);
+      console.log('Updated userList from embedded QA data:', userList.length, 'agents');
+      return true;
+    }
+
+    try {
+      const qaData = await run('getAllQA');
+      const qaAgents = extractAgentNamesFromQAData(qaData);
+      if (qaAgents.length > 0) {
+        userList = qaAgents;
+        populateAgentSelect(qaAgents);
+        console.log('Updated userList from server QA data:', userList.length, 'agents');
+        return true;
+      }
+      console.warn('QA data fallback returned no agents');
+    } catch (error) {
+      console.warn('QA data fallback failed:', error);
+    }
+
+    fallbackToStaticUsers();
+    return userList.length > 0;
+  }
+
+  async function loadAgentsFromServerIfNeeded(run) {
     console.log('=== AGENT LOADING PROCESS STARTED ===');
-    
-    // Check if we already have users from server template
+
     if (Array.isArray(USERS) && USERS.length > 0) {
       console.log('Using pre-loaded template users:', USERS.length, 'agents');
+      userList = USERS.slice();
       populateAgentSelect(USERS);
-      return;
+      return true;
     }
-    
-    // Otherwise, use the enhanced hydration method
-    hydrateAgentList();
+
+    return hydrateAgentList(run);
   }
 
   // ============================================================================
@@ -3391,8 +3390,10 @@
 
   function fallbackToBasicAgentList() {
     console.log('Using basic agent list fallback');
-    // Your existing fallback logic
-    hydrateAgentList();
+    const runHelper = (window.LuminaEntityLoader && typeof LuminaEntityLoader.run === 'function' && LuminaEntityLoader.isGoogleScriptAvailable())
+      ? LuminaEntityLoader.run
+      : undefined;
+    hydrateAgentList(runHelper);
   }
 
   function loadAgentsWithEmails() {
@@ -3601,10 +3602,67 @@
       // Setup event listeners
       setupEventListeners();
       
-      // Load agents with enhanced method
-      loadAgentsFromServerIfNeeded();
-      
-      loadAgentsWithEmails
+      const agentLoaderHost = document.getElementById('agentLoaderHost');
+      if (window.LuminaEntityLoader && typeof LuminaEntityLoader.register === 'function' && agentLoaderHost) {
+        LuminaEntityLoader.register({
+          id: 'qualityForm.agentRoster',
+          placeholder: agentLoaderHost,
+          skeleton: { id: 'lumina-inline-spinner', props: { text: 'Loading agent roster…' } },
+          load: async ({ run, mount, removeSkeleton, placeholder }) => {
+            const agentSelect = document.getElementById('agentName');
+            if (!agentSelect) {
+              mount('');
+              return;
+            }
+
+            agentSelect.disabled = true;
+
+            try {
+              const loaded = await loadAgentsFromServerIfNeeded(run);
+              removeSkeleton();
+              placeholder.removeAttribute('data-lumina-entity-error');
+              if (loaded) {
+                mount('');
+              } else {
+                mount('<div class="lumina-entity-status lumina-entity-status--warning">Showing fallback agent roster.</div>');
+              }
+              loadAgentsWithEmails();
+            } catch (error) {
+              console.error('Agent roster load failed:', error);
+              placeholder.setAttribute('data-lumina-entity-error', 'true');
+              fallbackToStaticUsers();
+              mount('<div class="lumina-entity-status lumina-entity-status--error">Unable to reach the server. Using offline roster.</div>');
+              showToast('Unable to load the latest agent roster. Showing fallback list.', true);
+              loadAgentsWithEmails();
+            } finally {
+              agentSelect.disabled = false;
+            }
+          }
+        });
+      } else {
+        const inlineRun = (methodName, ...args) => new Promise((resolve, reject) => {
+          if (!(window.google && google.script && google.script.run)) {
+            reject(new Error('google.script.run is not available.'));
+            return;
+          }
+
+          const runner = google.script.run
+            .withSuccessHandler(resolve)
+            .withFailureHandler(reject);
+
+          if (typeof runner[methodName] !== 'function') {
+            reject(new Error(`google.script.run.${methodName} is not defined.`));
+            return;
+          }
+
+          runner[methodName](...args);
+        });
+
+        loadAgentsFromServerIfNeeded(window.google && google.script && google.script.run ? inlineRun : undefined)
+          .finally(() => {
+            loadAgentsWithEmails();
+          });
+      }
       // Prefill form if record exists
       if (record && record !== '{}') {
         try {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Call center management system built on Google Apps Script + Google Sheets.
 
+## Frontend lazy-loading harness
+
+- Every layout now includes `EntityLoader.html`, which exposes a global
+  `LuminaEntityLoader` helper for registering async entities with shared
+  skeletons and a promise-based `google.script.run` wrapper.
+- Pilot implementation lives in `QualityForm.html`; additional feature pages can
+  follow the same pattern to hydrate UI fragments once data returns.
+- Refer to [`docs/lazy-loading.md`](docs/lazy-loading.md) for usage examples,
+  skeleton registration, and helper APIs.
+
 ## Trigger maintenance
 
 - `checkRealtimeUpdatesJob()` now self-throttles by default, limiting each run to

--- a/docs/lazy-loading.md
+++ b/docs/lazy-loading.md
@@ -1,0 +1,98 @@
+# Lazy loading harness
+
+The Lumina layout now exposes a shared entity loader that coordinates DOM skeletons
+and asynchronous `google.script.run` calls. The harness is delivered by the new
+`EntityLoader.html` partial and is included automatically for every view via
+`layout.html`.
+
+## Core concepts
+
+- `LuminaEntityLoader.register(options)` registers a unit of work (an entity) and
+  starts loading it once the DOM is ready. Every entity keeps a reference to the
+  placeholder element, renders an optional skeleton, and runs your custom
+  `load(context)` callback.
+- `context.run(methodName, ...args)` is a promise wrapper around
+  `google.script.run`. It rejects automatically when Apps Script is unavailable or
+  when the requested server method is missing.
+- Skeletons can be reused across pages by calling
+  `LuminaEntityLoader.attachSkeleton(id, renderer)`. The renderer receives
+  `{ id, placeholder, props, mount }` and should return HTML, a DOM node, or a
+  fragment to display while the entity is loading.
+- The loader ships with a default inline spinner skeleton registered as
+  `lumina-inline-spinner`.
+
+## Quick start
+
+1. Make sure your page has a placeholder element inside the area that should show
+   loading status and results. For example:
+
+   ```html
+   <div class="form-group">
+     <select id="agentName"></select>
+     <div id="agentLoaderHost" class="lumina-entity-placeholder" aria-live="polite"></div>
+   </div>
+   ```
+
+2. Register the entity inside your DOM-ready handler:
+
+   ```javascript
+   LuminaEntityLoader.register({
+     id: 'qualityForm.agentRoster',
+     placeholder: document.getElementById('agentLoaderHost'),
+     skeleton: { id: 'lumina-inline-spinner', props: { text: 'Loading agent roster…' } },
+     load: async ({ run, mount, removeSkeleton }) => {
+       try {
+         const agents = await run('getUsers');
+         mount(renderAgentOptions(agents));
+       } finally {
+         removeSkeleton();
+       }
+     }
+   });
+   ```
+
+   The loader automatically clears the skeleton and mounts returned content. If
+   your `load` callback returns a value (string, node, or fragment) the loader
+   injects it into the placeholder. You can also call `mount()` manually and
+   return `undefined` when you want full control.
+
+3. When you need bespoke skeletons, register them once (anywhere after the
+   partial loads):
+
+   ```javascript
+   LuminaEntityLoader.attachSkeleton('agents-pill', ({ props }) => {
+     const wrapper = document.createElement('div');
+     wrapper.className = 'pill-skeleton';
+     wrapper.textContent = props.text || 'Fetching…';
+     return wrapper;
+   });
+   ```
+
+   Then point your entity at `skeleton: { id: 'agents-pill', props: { text: 'Loading…' } }`.
+
+## Quality form example
+
+`QualityForm.html` now registers `qualityForm.agentRoster` to hydrate the agent
+selector. The loader handles:
+
+- Showing the inline spinner placeholder
+- Orchestrating the multi-step `google.script.run` fallbacks (`clientGetAssignedAgentNames`, `getUsers`, `getAllQA`)
+- Surface-level messaging when the server is offline (the placeholder displays a
+  warning/error status instead of an empty gap)
+
+Review the script near the bottom of `QualityForm.html` for a full example of
+mounting skeletons, calling `context.run`, and handling fallbacks.
+
+## Additional helpers
+
+The global loader also exposes:
+
+- `LuminaEntityLoader.load(id)` – re-run a specific entity on demand
+- `LuminaEntityLoader.loadAll()` – refresh every registered entity
+- `LuminaEntityLoader.isGoogleScriptAvailable()` – feature detection for Apps
+  Script availability
+- `LuminaEntityLoader.run()` – direct access to the promise-wrapped
+  `google.script.run` helper when you need it outside of an entity callback
+
+These utilities make it easy to migrate existing feature pages to the shared
+harness incrementally while reusing the same data access patterns.

--- a/layout.html
+++ b/layout.html
@@ -1822,7 +1822,8 @@
       }
     }
   </style>
-<?!= include('layoutLoader') ?>
+  <?!= include('layoutLoader') ?>
+  <?!= include('EntityLoader') ?>
 </head>
 
 <body


### PR DESCRIPTION
## Summary
- add a reusable `LuminaEntityLoader` partial that manages skeletons and wraps `google.script.run`
- include the loader from `layout.html` and migrate `QualityForm.html` to register its agent roster hydration through the shared harness
- document the lazy-loading workflow for other pages in the README and the new `docs/lazy-loading.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf15dfaac8326b3a380e64648aeea