### PR TITLE
Add detailed logging for user save flow

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -1988,18 +1988,76 @@
 
 <script>
   // ---------- Promise wrapper for Apps Script ----------
+  const LOG_MAX_DEPTH = 4;
+  const LOG_MAX_KEYS = 40;
+  let googleScriptCallSeq = 0;
+
+  function safeForLog(value, depth = 0, seen = new WeakSet()) {
+    if (value === null || value === undefined) return value;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === 'function') return `[Function ${value.name || 'anonymous'}]`;
+    if (depth >= LOG_MAX_DEPTH) {
+      return Array.isArray(value) ? `[Array(${value.length})]` : '[Object]';
+    }
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      return value.slice(0, LOG_MAX_KEYS).map(item => safeForLog(item, depth + 1, seen));
+    }
+
+    const out = {};
+    Object.keys(value).slice(0, LOG_MAX_KEYS).forEach(key => {
+      try {
+        out[key] = safeForLog(value[key], depth + 1, seen);
+      } catch (err) {
+        out[key] = `[Unserializable: ${err.message || err}]`;
+      }
+    });
+    return out;
+  }
+
+  function logGroup(label, payload, level = 'log') {
+    try {
+      console.groupCollapsed(label);
+      if (level === 'error') {
+        console.error(payload);
+      } else if (level === 'warn') {
+        console.warn(payload);
+      } else {
+        console.log(payload);
+      }
+      console.groupEnd();
+    } catch (err) {
+      console.warn('logGroup failed', { label, payload, err });
+    }
+  }
+
   function callGoogleScript(fnName, ...args) {
+    const callId = ++googleScriptCallSeq;
+    logGroup(`[callGoogleScript #${callId}] ${fnName} :: args`, safeForLog(args));
+
     return new Promise((resolve, reject) => {
       if (!google || !google.script || !google.script.run) {
-        // Why: allow local preview without Apps Script runtime
-        return reject(new Error('google.script.run unavailable'));
+        const error = new Error('google.script.run unavailable');
+        logGroup(`[callGoogleScript #${callId}] ${fnName} :: failure`, safeForLog({ error: error.message }), 'error');
+        return reject(error);
       }
       try {
         google.script.run
-          .withSuccessHandler(resolve)
-          .withFailureHandler(err => reject(new Error(err && err.message ? err.message : String(err))))
+          .withSuccessHandler(result => {
+            logGroup(`[callGoogleScript #${callId}] ${fnName} :: success`, safeForLog(result));
+            resolve(result);
+          })
+          .withFailureHandler(err => {
+            const normalized = err && err.message ? err.message : String(err);
+            logGroup(`[callGoogleScript #${callId}] ${fnName} :: failure`, safeForLog({ error: normalized }), 'error');
+            reject(new Error(normalized));
+          })
           [fnName](...args);
       } catch (e) {
+        logGroup(`[callGoogleScript #${callId}] ${fnName} :: exception`, safeForLog({ error: e.message || String(e) }), 'error');
         reject(e);
       }
     });
@@ -3482,6 +3540,11 @@
     }
 
     form.classList.add('was-validated');
+    logGroup('saveUserWithPages: form validation triggered', safeForLog({
+      isEditing: !!currentEditingUserId,
+      currentEditingUserId,
+      timestamp: new Date().toISOString()
+    }));
 
     const userNameField = document.getElementById('userName');
     const emailField = document.getElementById('email');
@@ -3507,6 +3570,7 @@
     console.log('Username value:', userName);
     console.log('Email value:', email);
     console.groupEnd();
+    logGroup('saveUserWithPages: identity snapshot', safeForLog({ userName, email }));
 
     if (!userName) {
       showAlert('error', 'Username is required and cannot be empty');
@@ -3560,7 +3624,8 @@
       showAlert('error', 'Unable to process selected campaigns. Please refresh and try again.');
       return;
     }
-    
+    logGroup('saveUserWithPages: campaign selection', safeForLog({ selectedCampaigns }));
+
     if (!selectedCampaigns.length) {
       showAlert('error', 'Please select at least one campaign');
       const campaignTabEl = document.getElementById('campaigns-tab');
@@ -3580,6 +3645,7 @@
       showAlert('error', 'Unable to process selected pages. Please refresh and try again.');
       return;
     }
+    logGroup('saveUserWithPages: page selection', safeForLog({ selectedPages }));
 
     const insuranceEligibleDate = readInputValue('insuranceEligibleDate');
     const insuranceQualified = insuranceEligibleDate ? (new Date() >= new Date(insuranceEligibleDate)) : false;
@@ -3589,6 +3655,7 @@
     const sanitizedRoles = safeArray(rawRoles)
       .map(role => safeTrim(role))
       .filter(Boolean);
+    logGroup('saveUserWithPages: roles selection', safeForLog({ rawRoles, sanitizedRoles }));
 
     const payload = {
       userName: userName,
@@ -3619,11 +3686,13 @@
     console.groupCollapsed('saveUserWithPages: payload snapshot');
     console.log('Payload', payload);
     console.groupEnd();
+    logGroup('saveUserWithPages: payload (sanitized)', safeForLog(payload));
 
     showLoading(true);
 
     const isEditing = !!currentEditingUserId;
     let targetUserId = currentEditingUserId;
+    logGroup('saveUserWithPages: mode', safeForLog({ isEditing, targetUserId }));
 
     try {
       const normalizedUserKey = userName.toLowerCase();
@@ -3651,6 +3720,7 @@
       } catch (conflictErr) {
         console.warn('clientCheckUserConflicts failed:', conflictErr);
       }
+      logGroup('saveUserWithPages: conflict check response', safeForLog(conflictRes || {}), conflictRes && conflictRes.success === false ? 'warn' : 'log');
 
       if (conflictRes && conflictRes.success && conflictRes.hasConflicts) {
         const messages = [];
@@ -3687,6 +3757,7 @@
           targetUserId = saveResult.userId;
         }
       }
+      logGroup('saveUserWithPages: user save response', safeForLog({ saveResult, targetUserId }));
 
       if (!saveResult || !saveResult.success) {
         const message = saveResult?.error || saveResult?.message || 'Operation failed';
@@ -3705,15 +3776,24 @@
         if (!permResult || permResult.success === false) {
           throw new Error((permResult && (permResult.error || permResult.message)) || 'Failed to save campaign permissions');
         }
+        logGroup('saveUserWithPages: campaign permission response', safeForLog(permResult));
       }
 
       const pageResult = await callGoogleScript('clientAssignPagesToUser', targetUserId, selectedPages);
       if (!pageResult || pageResult.success === false) {
         throw new Error((pageResult && (pageResult.error || pageResult.message)) || 'Failed to assign pages');
       }
+      logGroup('saveUserWithPages: page assignment response', safeForLog(pageResult));
 
       const statusMsg = payload.employmentStatus ? ` (${payload.employmentStatus})` : '';
       showAlert('success', `User ${isEditing ? 'updated' : 'created'} successfully${statusMsg} with username "${payload.userName}"`);
+      logGroup('saveUserWithPages: success summary', safeForLog({
+        statusMsg,
+        targetUserId,
+        assignedPages: selectedPages,
+        assignedCampaigns: selectedCampaigns,
+        roles: sanitizedRoles
+      }));
 
       const userModalEl = document.getElementById('userModal');
       if (userModalEl && typeof bootstrap !== 'undefined' && typeof bootstrap.Modal !== 'undefined') {
@@ -3722,10 +3802,17 @@
       }
       loadAllData();
     } catch (err) {
-      console.error('Save error:', err);
+      console.error('saveUserWithPages: unexpected error', err);
+      logGroup('saveUserWithPages: unexpected error detail', safeForLog({
+        message: err?.message,
+        stack: err?.stack,
+        targetUserId,
+        payload: safeForLog(payload)
+      }), 'error');
       showAlert('error', 'Failed to save user: ' + (err.message || String(err)));
     } finally {
       showLoading(false);
+      logGroup('saveUserWithPages: loading overlay cleared', safeForLog({ timestamp: new Date().toISOString() }));
     }
   }
 


### PR DESCRIPTION
## Summary
- add reusable logging utilities to the Users page and instrument the save workflow to capture form state, selections, and service responses
- introduce sanitized logging helpers in UserService and log key phases of user registration and updates, including cache invalidation and role/page operations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd45829cbc83268e9ae6658d4bfc6a