### PR TITLE
Handle benign google.script.run channel closure warnings

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2673,3 +2673,33 @@
 
         console.log('✨ Simplified header system loaded successfully');
     </script>
+    <script>
+        (function registerGlobalChannelClosedHandler() {
+            var CHANNEL_CLOSED_REGEX = /message channel closed/i;
+            var ASYNC_RESPONSE_REGEX = /listener indicated an asynchronous response/i;
+
+            function isGoogleChannelClosure(message) {
+                if (!message) {
+                    return false;
+                }
+                var normalized = String(message);
+                return CHANNEL_CLOSED_REGEX.test(normalized) || ASYNC_RESPONSE_REGEX.test(normalized);
+            }
+
+            window.addEventListener('unhandledrejection', function (event) {
+                if (!event || typeof event.preventDefault !== 'function') {
+                    return;
+                }
+
+                var reason = event.reason;
+                var message = (reason && reason.message) ? reason.message : String(reason || '');
+
+                if (isGoogleChannelClosure(message)) {
+                    if (window.console && typeof console.debug === 'function') {
+                        console.debug('Suppressed benign google.script.run channel closure:', message);
+                    }
+                    event.preventDefault();
+                }
+            });
+        })();
+    </script>


### PR DESCRIPTION
## Summary
- add a global unhandledrejection handler in the base layout to detect the "message channel closed"/"listener indicated an asynchronous response" errors produced by google.script.run
- prevent the default handling of those benign errors and log a debug message instead so they no longer surface on every page

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68deb69cd7bc8326ad9f406156b53236