### PR TITLE
Add shared responsive styles for Lumina Sheets UI

### DIFF
--- a/AccessDenied.html
+++ b/AccessDenied.html
@@ -6,6 +6,7 @@
     <title>Access Denied - VLBPO LuminaHQ</title>
     <?!= includeOnce('layoutLoader') ?>
     <?!= includeOnce('layoutAlerts') ?>
+    <?!= includeOnce('ResponsiveStyles') ?>
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png">
     <style>
         * {

--- a/AgentSchedule.html
+++ b/AgentSchedule.html
@@ -10,6 +10,7 @@
   <!-- Modern CSS Libraries -->
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"

--- a/AsyncInitializer.html
+++ b/AsyncInitializer.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <script>
   (function () {
     const START = Date.now();

--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?!= include("layout", {
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,

--- a/CampaignManagement.html
+++ b/CampaignManagement.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/ChangePassword.html
+++ b/ChangePassword.html
@@ -7,6 +7,7 @@
   <title>Set Your Password - Lumina</title>
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <!-- Bootstrap 5 & FontAwesome -->
   <link

--- a/ChatBubble.html
+++ b/ChatBubble.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <? 
   var allowed = (user.pages||[]).map(p => p.toLowerCase());
 if (!allowed.includes('chat')) return '';

--- a/CoachingAckForm.html
+++ b/CoachingAckForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingAckForm.html -->
 <?!= include("headerConf", { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
 

--- a/CoachingForm.html
+++ b/CoachingForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingForm.html -->
 <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <meta charset="utf-8">

--- a/CoachingList.html
+++ b/CoachingList.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingList.html -->
 <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/CoachingView.html
+++ b/CoachingView.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingView.html -->
 <?!= include("layout", {
   baseUrl: baseUrl,

--- a/CookieHandler.html
+++ b/CookieHandler.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <script>
   (function (global) {
     const COOKIE_NAME = 'authToken';

--- a/CreditSuiteQAForm.html
+++ b/CreditSuiteQAForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Credit Suite QA Form - Enhanced Client-Side Integration -->
 <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 

--- a/EmailConfirmed.html
+++ b/EmailConfirmed.html
@@ -7,6 +7,7 @@
   <title>Email Confirmation - VLBPO DataLog</title>
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/EntityLoader.html
+++ b/EntityLoader.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Lumina Entity Loader partial -->
 <script>
   (function () {

--- a/Escalations.html
+++ b/Escalations.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?!= include("layout",{ baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <!-- Quill Snow theme CSS -->

--- a/ForgotPassword.html
+++ b/ForgotPassword.html
@@ -7,6 +7,7 @@
   <title>Forgot Password - VLBPO DataLog</title>
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/GroundingQAForm.html
+++ b/GroundingQAForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?!= include("layout", { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 
 <!-- Quill -->

--- a/IdependenceCoachingForm.html
+++ b/IdependenceCoachingForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
     <!-- CoachingForm.html -->
     <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
     <meta charset="utf-8">

--- a/IndependenceCoachingList.html
+++ b/IndependenceCoachingList.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
     <!-- CoachingList.html -->
     <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/IndependenceCoachingView.html
+++ b/IndependenceCoachingView.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 
     <!-- CoachingView.html -->
     <?!= include("layout", {

--- a/IndependenceQAForm.html
+++ b/IndependenceQAForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
     <!-- Independence Insurance QA Form - Enhanced Client-Side Integration -->
     <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/IndependenceQAList.html
+++ b/IndependenceQAList.html
@@ -1,0 +1,1 @@
+    <?!= includeOnce('ResponsiveStyles') ?>

--- a/IndependenceQAView.html
+++ b/IndependenceQAView.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<?!= includeOnce('ResponsiveStyles') ?>
     <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
     
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/Login.html
+++ b/Login.html
@@ -10,6 +10,7 @@
   <?!= includeOnce('CookieHandler') ?>
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <!-- Bootstrap 5 & FontAwesome -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/QualityCollabForm.html
+++ b/QualityCollabForm.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Quality Form--->
 <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <?  

--- a/QualityCollabView.html
+++ b/QualityCollabView.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- QAView.html -->
 <?!= include("layout", { baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <meta charset="utf-8">

--- a/QualityView.html
+++ b/QualityView.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- QAView.html -->
 <?!= include("layout", { baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <meta charset="utf-8">

--- a/ResendVerification.html
+++ b/ResendVerification.html
@@ -7,6 +7,7 @@
   <title>Resend Email Verification - VLBPO DataLog</title>
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/ResponsiveStyles.html
+++ b/ResponsiveStyles.html
@@ -1,0 +1,670 @@
+<style id="lumina-responsive-styles">
+  :root {
+    --lumina-font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+    --lumina-text-color: #0f172a;
+    --lumina-muted-text: #64748b;
+    --lumina-surface: #ffffff;
+    --lumina-surface-alt: #f8fafc;
+    --lumina-border-color: rgba(15, 23, 42, 0.08);
+    --lumina-border-strong: rgba(15, 23, 42, 0.16);
+    --lumina-primary: #0ea5e9;
+    --lumina-primary-dark: #0369a1;
+    --lumina-accent: #22d3ee;
+    --lumina-radius-sm: 0.5rem;
+    --lumina-radius: 0.75rem;
+    --lumina-radius-lg: 1.25rem;
+    --lumina-shadow-sm: 0 10px 25px rgba(15, 23, 42, 0.05);
+    --lumina-shadow-md: 0 20px 50px rgba(15, 23, 42, 0.08);
+    --lumina-spacing-xs: 0.375rem;
+    --lumina-spacing-sm: 0.75rem;
+    --lumina-spacing-md: 1.25rem;
+    --lumina-spacing-lg: 2rem;
+    --lumina-spacing-xl: 3rem;
+    --lumina-container-max: 1200px;
+  }
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    font-size: 16px;
+    scroll-behavior: smooth;
+  }
+
+  @media (max-width: 768px) {
+    html {
+      font-size: 15px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    html {
+      font-size: 14px;
+    }
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+    background: var(--lumina-surface-alt);
+    color: var(--lumina-text-color);
+    font-family: var(--lumina-font-family);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, rgba(34, 211, 238, 0.08), transparent 45%),
+                radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.06), transparent 40%);
+    z-index: -2;
+  }
+
+  img, svg, canvas, video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  a {
+    color: var(--lumina-primary);
+    text-decoration: none;
+    transition: color 0.2s ease, opacity 0.2s ease;
+  }
+
+  a:hover, a:focus {
+    color: var(--lumina-primary-dark);
+    opacity: 0.9;
+  }
+
+  main,
+  .page-wrapper,
+  .app-wrapper,
+  .lumina-container,
+  .content-wrapper,
+  .dashboard-container {
+    width: min(100%, var(--lumina-container-max));
+    margin-inline: auto;
+    padding-inline: clamp(1rem, 3vw, 2.5rem);
+    padding-bottom: var(--lumina-spacing-xl);
+  }
+
+  header,
+  section,
+  footer,
+  .page-section {
+    width: 100%;
+    padding-block: clamp(1.5rem, 4vw, 3rem);
+  }
+
+  .card,
+  .panel,
+  .widget,
+  .module,
+  .app-card,
+  .data-card {
+    background: var(--lumina-surface);
+    border-radius: var(--lumina-radius);
+    border: 1px solid var(--lumina-border-color);
+    box-shadow: var(--lumina-shadow-sm);
+    padding: var(--lumina-spacing-md);
+    margin-bottom: var(--lumina-spacing-lg);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .card:hover,
+  .panel:hover,
+  .widget:hover,
+  .module:hover,
+  .app-card:hover,
+  .data-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--lumina-shadow-md);
+  }
+
+  .card-header,
+  .panel-header,
+  .widget-header,
+  .module-header,
+  .section-header,
+  .page-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--lumina-spacing-sm);
+    margin-bottom: var(--lumina-spacing-sm);
+  }
+
+  .card-title,
+  .section-title,
+  .page-title,
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+    color: var(--lumina-text-color);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  p,
+  .text-muted,
+  .description,
+  .help-text,
+  small {
+    color: var(--lumina-muted-text);
+    margin: 0;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--lumina-spacing-sm);
+  }
+
+  label {
+    font-weight: 500;
+    color: var(--lumina-text-color);
+    margin-bottom: 0.35rem;
+  }
+
+  input,
+  select,
+  textarea {
+    width: 100%;
+    padding: 0.75rem 0.9rem;
+    border-radius: var(--lumina-radius-sm);
+    border: 1px solid var(--lumina-border-color);
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    font: inherit;
+  }
+
+  input:focus,
+  select:focus,
+  textarea:focus {
+    border-color: var(--lumina-primary);
+    box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.15);
+    outline: none;
+  }
+
+  button,
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.15rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    background: var(--lumina-primary);
+    color: #fff;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  }
+
+  button:hover,
+  button:focus,
+  .btn:hover,
+  .btn:focus {
+    background: var(--lumina-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(14, 165, 233, 0.24);
+    outline: none;
+  }
+
+  .btn-outline,
+  .btn-secondary,
+  .btn-light {
+    background: transparent;
+    border: 1px solid var(--lumina-border-strong);
+    color: var(--lumina-text-color);
+  }
+
+  .btn-outline:hover,
+  .btn-secondary:hover,
+  .btn-light:hover {
+    background: rgba(14, 165, 233, 0.08);
+    color: var(--lumina-primary-dark);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  th,
+  td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--lumina-border-color);
+    text-align: left;
+  }
+
+  thead th {
+    background: rgba(148, 163, 184, 0.08);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+  }
+
+  .table-responsive,
+  .responsive-table,
+  .data-table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+    border-radius: var(--lumina-radius);
+    border: 1px solid var(--lumina-border-color);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  }
+
+  .table-responsive::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  .table-responsive::-webkit-scrollbar-thumb {
+    background: rgba(15, 23, 42, 0.25);
+    border-radius: 999px;
+  }
+
+  .chip,
+  .badge,
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.75rem;
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--lumina-primary-dark);
+  }
+
+  .flex-grid,
+  .responsive-grid,
+  .card-grid,
+  .widget-grid,
+  .panel-grid,
+  .lumina-grid {
+    display: grid;
+    gap: clamp(1rem, 2vw, 1.75rem);
+  }
+
+  .flex-grid.columns-2,
+  .responsive-grid.columns-2,
+  .card-grid.columns-2,
+  .widget-grid.columns-2,
+  .panel-grid.columns-2,
+  .lumina-grid.columns-2 {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .flex-grid.columns-3,
+  .responsive-grid.columns-3,
+  .card-grid.columns-3,
+  .widget-grid.columns-3,
+  .panel-grid.columns-3,
+  .lumina-grid.columns-3 {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .responsive-stack,
+  .stack,
+  .stacked,
+  .stack-on-mobile,
+  [data-stack] {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: var(--lumina-spacing-sm);
+  }
+
+  .responsive-stack > *,
+  .stack > *,
+  .stacked > *,
+  .stack-on-mobile > *,
+  [data-stack] > * {
+    flex: 1 1 260px;
+  }
+
+  .toolbar,
+  .actions,
+  .button-row,
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--lumina-spacing-xs);
+  }
+
+  .filters > *,
+  .toolbar > * {
+    flex: 1 1 auto;
+  }
+
+  .sticky-header,
+  .sticky-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    backdrop-filter: blur(16px);
+    background: rgba(248, 250, 252, 0.85);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
+  .sidebar,
+  .navigation,
+  .nav-pane {
+    width: 280px;
+    max-width: 100%;
+    background: var(--lumina-surface);
+    border-right: 1px solid var(--lumina-border-color);
+    padding: var(--lumina-spacing-md);
+  }
+
+  @media (max-width: 1024px) {
+    .sidebar,
+    .navigation,
+    .nav-pane {
+      position: fixed;
+      inset: 0 auto 0 0;
+      transform: translateX(-100%);
+      transition: transform 0.3s ease;
+      z-index: 1000;
+      height: 100vh;
+      overflow-y: auto;
+      max-width: min(320px, 80vw);
+      box-shadow: 0 25px 60px rgba(15, 23, 42, 0.22);
+    }
+
+    .sidebar.is-open,
+    .navigation.is-open,
+    .nav-pane.is-open {
+      transform: translateX(0);
+    }
+
+    .sidebar-backdrop,
+    .navigation-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.55);
+      backdrop-filter: blur(4px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      z-index: 999;
+    }
+
+    .sidebar-backdrop.is-visible,
+    .navigation-backdrop.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  .content-area,
+  .content,
+  .main-content {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: clamp(1.25rem, 3vw, 2.5rem);
+  }
+
+  .stat-block,
+  .metric-card,
+  .highlight-card {
+    display: grid;
+    gap: 0.5rem;
+    padding: clamp(1rem, 2vw, 1.5rem);
+    border-radius: var(--lumina-radius);
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(14, 165, 233, 0.04));
+    border: 1px solid rgba(14, 165, 233, 0.25);
+  }
+
+  .stat-block .label,
+  .metric-card .label,
+  .highlight-card .label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(15, 23, 42, 0.55);
+  }
+
+  .stat-block .value,
+  .metric-card .value,
+  .highlight-card .value {
+    font-size: clamp(1.5rem, 3vw, 2.4rem);
+    font-weight: 700;
+  }
+
+  .stat-block .trend,
+  .metric-card .trend,
+  .highlight-card .trend {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+
+  .tab-nav,
+  .nav-tabs,
+  .tabstrip {
+    display: flex;
+    overflow-x: auto;
+    gap: var(--lumina-spacing-xs);
+    padding: 0.25rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+  }
+
+  .tab-nav button,
+  .nav-tabs .nav-link,
+  .tabstrip button {
+    flex: 0 0 auto;
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    background: transparent;
+    color: var(--lumina-muted-text);
+    font-weight: 600;
+  }
+
+  .tab-nav button.active,
+  .nav-tabs .nav-link.active,
+  .tabstrip button.active {
+    background: #fff;
+    color: var(--lumina-primary-dark);
+    box-shadow: 0 10px 25px rgba(14, 165, 233, 0.18);
+  }
+
+  .table-actions,
+  .table-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--lumina-spacing-xs);
+    margin-bottom: var(--lumina-spacing-sm);
+  }
+
+  .filters .form-control,
+  .filters select,
+  .filters input[type="search"],
+  .filters input[type="text"] {
+    min-width: min(260px, 100%);
+  }
+
+  .chip-group,
+  .pill-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .pill {
+    padding: 0.3rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    color: rgba(15, 23, 42, 0.72);
+    font-weight: 500;
+  }
+
+  .modal,
+  .dialog {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(8px);
+  }
+
+  .modal.is-visible,
+  .dialog.is-visible {
+    display: flex;
+  }
+
+  .modal .modal-content,
+  .dialog .dialog-content {
+    width: min(720px, 100%);
+    border-radius: var(--lumina-radius-lg);
+    background: #fff;
+    padding: clamp(1.25rem, 3vw, 2rem);
+    box-shadow: var(--lumina-shadow-md);
+  }
+
+  .mobile-hidden {
+    display: block;
+  }
+
+  .desktop-hidden {
+    display: none !important;
+  }
+
+  @media (max-width: 992px) {
+    .page-header,
+    .section-header,
+    .card-header,
+    .table-actions,
+    .toolbar,
+    .filters {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .filters > *,
+    .toolbar > *,
+    .table-actions > * {
+      width: 100%;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .responsive-stack > *,
+    .stack > *,
+    .stacked > *,
+    .stack-on-mobile > *,
+    [data-stack] > * {
+      flex: 1 1 100%;
+    }
+
+    .card,
+    .panel,
+    .widget,
+    .module,
+    .app-card,
+    .data-card {
+      padding: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    .table-responsive,
+    .responsive-table,
+    .data-table-wrapper {
+      margin-inline: -1rem;
+      padding-inline: 1rem;
+    }
+
+    .tab-nav,
+    .nav-tabs,
+    .tabstrip {
+      border-radius: 1rem;
+    }
+
+    .mobile-hidden {
+      display: none !important;
+    }
+
+    .desktop-hidden {
+      display: block !important;
+    }
+  }
+
+  @media (max-width: 640px) {
+    header,
+    section,
+    footer,
+    .page-section {
+      padding-block: clamp(1.25rem, 6vw, 2rem);
+    }
+
+    th,
+    td {
+      padding: 0.65rem;
+    }
+
+    .table-actions,
+    .toolbar,
+    .filters {
+      gap: var(--lumina-spacing-xs);
+    }
+
+    .modal .modal-content,
+    .dialog .dialog-content {
+      padding: clamp(1rem, 5vw, 1.5rem);
+    }
+
+    button,
+    .btn {
+      width: 100%;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .card,
+    .panel,
+    .widget,
+    .module,
+    .app-card,
+    .data-card {
+      border-radius: calc(var(--lumina-radius) - 0.25rem);
+    }
+
+    .chip,
+    .badge,
+    .status-pill {
+      font-size: 0.7rem;
+      padding: 0.3rem 0.6rem;
+    }
+
+    .tab-nav,
+    .nav-tabs,
+    .tabstrip {
+      gap: 0.35rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+</style>

--- a/RoleManagement.html
+++ b/RoleManagement.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- RoleManagement.html -->
 <?!= include("layout", {
     baseUrl: baseUrl,

--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 <!-- Bootstrap CSS -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/UnifiedQADashboard.html
+++ b/UnifiedQADashboard.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- UnifiedQADashboard.html - Updated for Independence QA with Campaign Filtering -->
 <?!= include("layout", { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
 

--- a/chatHeader.html
+++ b/chatHeader.html
@@ -8,6 +8,7 @@
 
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <?!= includeOnce('CookieHandler') ?>
 

--- a/headerConf.html
+++ b/headerConf.html
@@ -58,6 +58,7 @@
 
   <?!= includeOnce('layoutLoader') ?>
   <?!= includeOnce('layoutAlerts') ?>
+<?!= includeOnce('ResponsiveStyles') ?>
 
   <?!= includeOnce('CookieHandler') ?>
  <link rel="icon" 

--- a/layout.html
+++ b/layout.html
@@ -114,6 +114,7 @@
   ?>
 
   <?!= includeOnce('layoutAlerts') ?>
+  <?!= includeOnce('ResponsiveStyles') ?>
 
   <script>
     // Base URLs for navigation

--- a/layoutAlerts.html
+++ b/layoutAlerts.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Shared Lumina alert and notification system -->
 <style id="lumina-alert-styles">
   .notifyjs-corner {

--- a/layoutLoader.html
+++ b/layoutLoader.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Shared Lumina loader system -->
 <style id="lumina-loader-styles">
   @keyframes lumina-spin {

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?
   var __navInvalidPanelPattern = /usercodeapppanel/i;
 

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -1,3 +1,4 @@
+    <?!= includeOnce('ResponsiveStyles') ?>
 <?
   var __topbarInvalidPanelPattern = /usercodeapppanel/i;
 


### PR DESCRIPTION
## Summary
- add a new ResponsiveStyles partial that defines mobile-first layout, typography, and component styles
- include the responsive partial across the layout and standalone HTML views so every page benefits from the shared responsive rules
- refresh navigation and partial templates to ensure the responsive theme loads consistently throughout the app

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68dee86e847c8326b321bf88555f41c5