### PR TITLE
Adjust Employee Trends modal width

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -352,8 +352,8 @@
     }
 
     .modal-trends .modal-dialog {
-      max-width: 1200px;
-      width: 95%;
+      max-width: 1440px;
+      width: 98%;
     }
 
     .modal-trends .modal-header {
@@ -368,7 +368,7 @@
     }
 
     .modal-trends .table {
-      min-width: 960px;
+      min-width: 1100px;
     }
 
     .modal-loading {


### PR DESCRIPTION
## Summary
- widen the Employee Trends modal dialog so more content is visible
- increase the minimum table width to better utilize the expanded modal space

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1dbb2bb0832680bd3586f9c4f706