### PR TITLE
Fix sidebar navigation link highlighting

### DIFF
--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -275,8 +275,24 @@
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
+  function removeExistingPageParam(url) {
+    if (!url) {
+      return '';
+    }
+
+    var cleaned = url.replace(/([?&])page=[^&#]*(&)?/gi, function (match, prefix, suffix) {
+      if (prefix === '?') {
+        return suffix ? '?' : '';
+      }
+
+      return suffix ? prefix : '';
+    });
+
+    return cleaned.replace(/[?&]$/, '');
+  }
+
   function generateLink(page) {
-    var target = __navLinkBase;
+    var target = removeExistingPageParam(__navLinkBase);
     if (!target) {
       return '?page=' + encodeURIComponent(page);
     }


### PR DESCRIPTION
## Summary
- remove existing page query parameters before generating sidebar links
- ensure the active page highlighting logic receives the correct page key

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df219166008326a536084e9f4da48c