### PR TITLE
Normalize layout currentPage fallbacks

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -3,7 +3,7 @@
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,
   user: user,
-  currentPage: currentPage,
+  currentPage: currentPage || 'attendancereports',
   userList: userList || [],
   granularity: granularity || 'Week',
   periodValue: periodValue || '',

--- a/BookmarkManager.html
+++ b/BookmarkManager.html
@@ -1,5 +1,10 @@
 <!-- BookmarkManager.html -->
-<?!= include('layout', {baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'bookmarks'
+}) ?>
 
 <link
   rel="stylesheet"

--- a/Calendar.html
+++ b/Calendar.html
@@ -1,4 +1,9 @@
-<?!= include('layout',{ baseUrl, scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout',{
+  baseUrl,
+  scriptUrl,
+  user: user,
+  currentPage: currentPage || 'calendar'
+}) ?>
 
 <!-- FullCalendar CSS -->
 <link

--- a/CallReports.html
+++ b/CallReports.html
@@ -1,4 +1,9 @@
-<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'callreports'
+}) ?>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"></script>
 

--- a/CampaignManagement.html
+++ b/CampaignManagement.html
@@ -629,7 +629,7 @@
         baseUrl: baseUrl,
         scriptUrl: scriptUrl,
         user: user,
-        currentPage: currentPage,
+        currentPage: currentPage || 'managecampaign',
         pageTitle: 'Campaign Management',
         pageDescription: 'Manage campaigns, organize pages, and control access permissions.'
       }) ?>

--- a/Chat.html
+++ b/Chat.html
@@ -1,7 +1,12 @@
 <!-- ====================================== -->
 <!-- ChatWindow.html - Enhanced Main Chat Interface -->
 <!-- ====================================== -->
-<?!= include('layout',{ baseUrl, scriptUrl, user, currentPage }) ?>
+<?!= include('layout',{
+  baseUrl,
+  scriptUrl,
+  user,
+  currentPage: currentPage || 'chat'
+}) ?>
 <? 
   const adminRoles = ['CEO','CTO','COO','CFO','Director','Account Manager'];
   const isAdmin = (user.roleNames||[]).some(r => adminRoles.includes(r));

--- a/CoachingAckForm.html
+++ b/CoachingAckForm.html
@@ -1,6 +1,10 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingAckForm.html -->
-<?!= include("headerConf", { baseUrl: baseUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("headerConf", {
+  baseUrl: baseUrl,
+  user: user,
+  currentPage: currentPage || 'ackform'
+}) ?>
 
 <script>
   // Injected by doGet:

--- a/CoachingDashboard.html
+++ b/CoachingDashboard.html
@@ -1,5 +1,10 @@
 <!-- CoachingDashboard.html -->
-<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'coachingdashboard'
+}) ?>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <style>

--- a/CoachingForm.html
+++ b/CoachingForm.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingForm.html -->
-<?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'coachingsheet'
+}) ?>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/CoachingList.html
+++ b/CoachingList.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- CoachingList.html -->
-<?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'coachinglist'
+}) ?>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <style>

--- a/CoachingView.html
+++ b/CoachingView.html
@@ -4,7 +4,7 @@
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,
   user: user,
-  currentPage: currentPage,
+  currentPage: currentPage || 'coachingview',
   pageTitle: 'Coaching Session Details',
   pageDescription: 'Review coaching insights, topics covered, and send acknowledgement links to agents.'
 }) ?>

--- a/CollaborationReporting.html
+++ b/CollaborationReporting.html
@@ -3,7 +3,7 @@
   baseUrl: baseUrl || '',
   scriptUrl: scriptUrl,
   user: user || {},
-  currentPage: currentPage || 'Collaboration Reporting',
+  currentPage: currentPage || 'collaboration-reporting',
   pageTitle: 'Collaboration & Reporting Hub',
   pageDescription: 'Unify quality, attendance, executive intelligence, and collaboration workflows in one command center.'
 }) ?>

--- a/CreditSuiteQAForm.html
+++ b/CreditSuiteQAForm.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Credit Suite QA Form - Enhanced Client-Side Integration -->
-<?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'creditsuiteqa'
+}) ?>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!-- Quill CSS -->

--- a/Dashboard.html
+++ b/Dashboard.html
@@ -4,7 +4,7 @@
         baseUrl: baseUrl || '',
         scriptUrl: scriptUrl,
         user: user || {},
-        currentPage: currentPage || 'okr-dashboard',
+        currentPage: currentPage || 'dashboard',
         pageTitle: 'OKR Performance Dashboard',
         pageDescription: 'Multi-Campaign Analytics & Insights'
       }) ?>

--- a/EODReport.html
+++ b/EODReport.html
@@ -2,7 +2,7 @@
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,
   user: user,
-  currentPage: currentPage
+  currentPage: currentPage || 'eodreport'
 }) ?>
 
 <style>

--- a/Escalations.html
+++ b/Escalations.html
@@ -1,5 +1,10 @@
     <?!= includeOnce('ResponsiveStyles') ?>
-<?!= include("layout",{ baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout",{
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'escalations'
+}) ?>
 
 <!-- Quill Snow theme CSS -->
 <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">

--- a/GoalSetting.html
+++ b/GoalSetting.html
@@ -1,5 +1,10 @@
 <!-- OKR Goal Setting & Target Management Interface -->
-<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'goalsetting'
+}) ?>
 
 <style>
   .goal-container {

--- a/GroundingQAForm.html
+++ b/GroundingQAForm.html
@@ -1,5 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
-<?!= include("layout", { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  rawToken: rawToken,
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'groundingqaform'
+}) ?>
 
 <!-- Quill -->
 <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet"/>

--- a/IdependenceCoachingForm.html
+++ b/IdependenceCoachingForm.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
     <!-- CoachingForm.html -->
-    <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include("layout", {
+      baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
+      user: user,
+      currentPage: currentPage || 'coachingsheet'
+    }) ?>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/ImportAttendance.html
+++ b/ImportAttendance.html
@@ -1,5 +1,10 @@
 <!-- File: ImportAttendance.html -->
-<?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'importattendance'
+}) ?>
 
 <style>
   /* Import-specific styles using the modern design system */

--- a/IndependenceCoachingDashboard.html
+++ b/IndependenceCoachingDashboard.html
@@ -1,5 +1,10 @@
     <!-- CoachingDashboard.html -->
-    <?!= include('layout', { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include('layout', {
+      baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
+      user: user,
+      currentPage: currentPage || 'coachingdashboard'
+    }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>

--- a/IndependenceCoachingList.html
+++ b/IndependenceCoachingList.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
     <!-- CoachingList.html -->
-    <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include("layout", {
+      baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
+      user: user,
+      currentPage: currentPage || 'coachinglist'
+    }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>

--- a/IndependenceCoachingView.html
+++ b/IndependenceCoachingView.html
@@ -5,7 +5,7 @@
         baseUrl: baseUrl,
         scriptUrl: scriptUrl,
         user: user,
-        currentPage: currentPage,
+        currentPage: currentPage || 'coachingview',
         pageTitle: 'Independence Coaching Session',
         pageDescription: 'Track independence coaching progress, share acknowledgement links, and print session summaries.'
     }) ?>

--- a/IndependenceQAForm.html
+++ b/IndependenceQAForm.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
     <!-- Independence Insurance QA Form - Enhanced Client-Side Integration -->
-    <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include("layout", {
+      baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
+      user: user,
+      currentPage: currentPage || 'independencequality'
+    }) ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Quill CSS -->
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">

--- a/IndependenceQAView.html
+++ b/IndependenceQAView.html
@@ -2,7 +2,12 @@
 <html>
 <head>
 <?!= includeOnce('ResponsiveStyles') ?>
-    <?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+    <?!= include("layout", {
+      baseUrl: baseUrl,
+      scriptUrl: scriptUrl,
+      user: user,
+      currentPage: currentPage || 'qualityview'
+    }) ?>
     
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Quill CSS -->

--- a/Notifications.html
+++ b/Notifications.html
@@ -2,7 +2,7 @@
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,
   user: user,
-  currentPage: 'Notifications'
+  currentPage: currentPage || 'notifications'
 }) ?>
 
 <style>

--- a/QACollabList.html
+++ b/QACollabList.html
@@ -1,5 +1,11 @@
 <!-- QAList.html -->
-<?!= include('layout', { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  rawToken: rawToken,
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'qacollablist'
+}) ?>
 
 <div class="container my-4">
   <div class="card shadow-sm">

--- a/QADashboard.html
+++ b/QADashboard.html
@@ -3,7 +3,7 @@
 <?!= include('layout', {
       baseUrl: baseUrl,
       scriptUrl: scriptUrl,
-      currentPage: currentPage,
+      currentPage: currentPage || 'qadashboard',
       userList: userList,
       granularity: granularity,
       periodValue: periodValue,

--- a/QAList.html
+++ b/QAList.html
@@ -2,7 +2,7 @@
   baseUrl: baseUrl,
   scriptUrl: scriptUrl,
   user: user,
-  currentPage: currentPage
+  currentPage: currentPage || 'qalist'
 }) ?>
 
 <style>

--- a/QualityCollabForm.html
+++ b/QualityCollabForm.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- Quality Form--->
-<?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'QualityCollabForm'
+}) ?>
 <?  
   // server‐side templating:
   // recordId   is a string ("" or your UUID)

--- a/QualityCollabView.html
+++ b/QualityCollabView.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- QAView.html -->
-<?!= include("layout", { baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'qacollabview'
+}) ?>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/QualityForm.html
+++ b/QualityForm.html
@@ -2,7 +2,7 @@
 <?!= include('layout', {    
       baseUrl: baseUrl,
       scriptUrl: scriptUrl,
-      currentPage: currentPage,
+      currentPage: currentPage || 'qualityform',
       userList: userList,
       granularity: granularity,
       periodValue: periodValue,

--- a/QualityView.html
+++ b/QualityView.html
@@ -1,6 +1,11 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- QAView.html -->
-<?!= include("layout", { baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'qualityview'
+}) ?>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/RoleManagement.html
+++ b/RoleManagement.html
@@ -4,7 +4,7 @@
     baseUrl: baseUrl,
     scriptUrl: scriptUrl,
     user: user,
-    currentPage: currentPage,
+    currentPage: currentPage || 'manageroles',
     pageTitle: 'Role Manager',
     pageDescription: 'Define permissions and access across LuminaHQ with precision and control.'
 }) ?>

--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1,5 +1,10 @@
     <?!= includeOnce('ResponsiveStyles') ?>
-<?!= include("layout", { baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'schedulemanagement'
+}) ?>
 <!-- Bootstrap CSS -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <!-- Font Awesome -->

--- a/Search.html
+++ b/Search.html
@@ -1,5 +1,11 @@
 <!-- Enhanced Search.html with Proxy Integration -->
-<?!= include('layout', {rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include('layout', {
+  rawToken: rawToken,
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'search'
+}) ?>
 
 <!-- Google Font -->
 <link

--- a/TakList.html
+++ b/TakList.html
@@ -4,7 +4,7 @@
   scriptUrl: scriptUrl,
   user: user,
   recordId: recordId,
-  currentPage: currentPage 
+  currentPage: currentPage || 'tasklist'
 }) ?>
 
 <style>

--- a/TaskBoard.html
+++ b/TaskBoard.html
@@ -3,7 +3,7 @@
   baseUrl: baseUrl,
   currentUser: user,
   user: user,
-  currentPage: currentPage,
+  currentPage: currentPage || 'taskboard',
   scriptUrl: scriptUrl
 }) ?>
 

--- a/TaskForm.html
+++ b/TaskForm.html
@@ -2,7 +2,7 @@
      rawToken: rawToken,
      baseUrl: baseUrl,
      scriptUrl: scriptUrl,
-     currentPage: currentPage,
+     currentPage: currentPage || 'taskform',
      user: user,
      recordId: recordId,
      record: record,

--- a/UnifiedQADashboard.html
+++ b/UnifiedQADashboard.html
@@ -1,6 +1,12 @@
     <?!= includeOnce('ResponsiveStyles') ?>
 <!-- UnifiedQADashboard.html - Updated for Independence QA with Campaign Filtering -->
-<?!= include("layout", { rawToken: rawToken, baseUrl: baseUrl, scriptUrl: scriptUrl, user: user, currentPage: currentPage }) ?>
+<?!= include("layout", {
+  rawToken: rawToken,
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'unifiedqadashboard'
+}) ?>
 
 <style>
     :root {

--- a/Users.html
+++ b/Users.html
@@ -1,6 +1,6 @@
 <!-- Include header and existing styles -->
 <?!= include('layout', {
-    currentPage: currentPage || 'Users',
+    currentPage: currentPage || 'manageuser',
     baseUrl: baseUrl,
     scriptUrl: scriptUrl,
     user: user,


### PR DESCRIPTION
## Summary
- ensure each layout/headerConf include defaults to its canonical navigation slug so the sidebar/topbar stay in sync when `page` is omitted
- align dashboard, notifications, and admin templates to the same slug-based convention for consistent highlighting and click handlers

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68df8f564dc08326823bed3931c3a0f6