### PR TITLE
Adjust modal content width for bootstrap modals

### DIFF
--- a/ResponsiveStyles.html
+++ b/ResponsiveStyles.html
@@ -551,11 +551,14 @@
 
   .modal .modal-content,
   .dialog .dialog-content {
-    width: min(720px, 100%);
     border-radius: var(--lumina-radius-lg);
     background: #fff;
     padding: clamp(1.25rem, 3vw, 2rem);
     box-shadow: var(--lumina-shadow-md);
+  }
+
+  .dialog .dialog-content {
+    width: min(720px, 100%);
   }
 
   .mobile-hidden {


### PR DESCRIPTION
## Summary
- remove the global width restriction from Bootstrap modal content in ResponsiveStyles.html
- scope the custom fixed width to the bespoke .dialog implementation so Bootstrap modals can respect their own sizing rules

## Testing
- manually verified the Users.html add/edit user modal renders with the wider layout

------
https://chatgpt.com/codex/tasks/task_e_68df99fdaf5c8326a12dac530d284e78