### PR TITLE
Make equipment form optional when saving users

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -1739,8 +1739,8 @@
                                                 <div class="row">
                                                     <div class="col-md-6">
                                                         <div class="mb-3">
-                                                            <label for="equipmentItemName" class="form-label fw-medium">Item Name <span class="text-danger">*</span></label>
-                                                            <input type="text" class="form-control" id="equipmentItemName" placeholder="e.g., Dell Laptop" maxlength="120" required>
+                                                            <label for="equipmentItemName" class="form-label fw-medium">Item Name</label>
+                                                            <input type="text" class="form-control" id="equipmentItemName" placeholder="e.g., Dell Laptop" maxlength="120">
                                                         </div>
                                                     </div>
                                                     <div class="col-md-6">


### PR DESCRIPTION
## Summary
- remove the required indicator from the equipment item name field so the equipment section is optional when saving a user
- leave the client-side equipment save validation untouched for when items are actually submitted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e032c4e9308326bf87204989c69e27