### PR TITLE
Improve schedule load error handling

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2529,16 +2529,27 @@
 
                     const result = await this.callServerFunction('clientGetAllSchedules', filters);
 
-                    if (result && result.success) {
-                        this.displaySchedules(result.schedules);
-                        document.getElementById('totalSchedules').textContent = result.schedules.length;
-                    } else {
-                        throw new Error(result?.error || 'Failed to load schedules');
+                    const { schedules, total, error, errorSeverity } = this.parseSchedulesResponse(result);
+
+                    const safeSchedules = Array.isArray(schedules) ? schedules : [];
+
+                    if (error) {
+                        console.warn('⚠️ Schedule response warning:', error);
+                        this.showToast(`Failed to load some schedules: ${error}`, errorSeverity || 'warning');
+                    }
+
+                    this.displaySchedules(safeSchedules);
+
+                    const totalElement = document.getElementById('totalSchedules');
+                    if (totalElement) {
+                        const safeTotal = Number.isFinite(total) ? total : safeSchedules.length;
+                        totalElement.textContent = safeTotal;
                     }
 
                 } catch (error) {
                     console.error('❌ Error loading schedules:', error);
                     this.displaySchedules([]);
+                    this.showToast('Failed to load schedules: ' + (error.message || 'Unexpected error'), 'danger');
                 }
             }
 
@@ -2592,6 +2603,96 @@
                             </td>
                         </tr>
                     `).join('');
+            }
+
+            parseSchedulesResponse(result) {
+                const baseResponse = {
+                    schedules: [],
+                    total: 0,
+                    error: null,
+                    errorSeverity: 'warning'
+                };
+
+                if (result == null) {
+                    return {
+                        ...baseResponse,
+                        error: 'No response was returned from the server.',
+                        errorSeverity: 'danger'
+                    };
+                }
+
+                if (Array.isArray(result)) {
+                    return {
+                        ...baseResponse,
+                        schedules: result,
+                        total: result.length
+                    };
+                }
+
+                if (typeof result === 'string') {
+                    try {
+                        return this.parseSchedulesResponse(JSON.parse(result));
+                    } catch (parseError) {
+                        return {
+                            ...baseResponse,
+                            error: result,
+                            errorSeverity: 'danger'
+                        };
+                    }
+                }
+
+                if (typeof result === 'object') {
+                    const nestedDataSources = [
+                        result.schedules,
+                        result.data?.schedules,
+                        result.data,
+                        result.items,
+                        result.records
+                    ];
+
+                    const scheduleArray = nestedDataSources.find(Array.isArray);
+
+                    if (scheduleArray) {
+                        const totalCandidates = [
+                            result.total,
+                            result.count,
+                            result.data?.total,
+                            scheduleArray.length
+                        ];
+
+                        const resolvedTotal = totalCandidates.find(value => Number.isFinite(value));
+
+                        const severity = result.success === false ? 'danger' : 'warning';
+
+                        return {
+                            ...baseResponse,
+                            schedules: scheduleArray,
+                            total: Number.isFinite(resolvedTotal) ? resolvedTotal : scheduleArray.length,
+                            error: result.success === false ? (result.error || result.message || 'Server returned a failure response.') : null,
+                            errorSeverity: severity
+                        };
+                    }
+
+                    if (result.success === false) {
+                        return {
+                            ...baseResponse,
+                            error: result.error || result.message || 'Server returned a failure response.',
+                            errorSeverity: 'danger'
+                        };
+                    }
+
+                    if (result.success === true) {
+                        return {
+                            ...baseResponse,
+                            error: 'The server reported success but did not return any schedule data.'
+                        };
+                    }
+                }
+
+                return {
+                    ...baseResponse,
+                    error: 'Unexpected response format received while loading schedules.'
+                };
             }
 
             async loadAttendanceCalendar() {


### PR DESCRIPTION
## Summary
- prevent schedule loading from throwing when backend responses omit array data by defaulting to safe empty collections
- surface toast notifications when the backend reports warnings or failures during schedule retrieval
- expand the schedule response parser to understand additional response shapes and capture severity metadata for UI messaging

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e06a721f388326a0edad2bb809f8a2