### PR TITLE
Secure session storage with idle cleanup and keep-alives

### DIFF
--- a/CallCenterWorkflowService.js
+++ b/CallCenterWorkflowService.js
@@ -140,7 +140,7 @@
       { key: 'roles', name: global.ROLES_SHEET || 'Roles', headerVar: 'ROLES_HEADER', idColumn: 'ID', cacheTTL: 3600 },
       { key: 'userRoles', name: global.USER_ROLES_SHEET || 'UserRoles', headerVar: 'USER_ROLES_HEADER', idColumn: null, cacheTTL: 1800 },
       { key: 'userClaims', name: global.USER_CLAIMS_SHEET || 'UserClaims', headerVar: 'CLAIMS_HEADERS', idColumn: 'ID', cacheTTL: 1800 },
-      { key: 'sessions', name: global.SESSIONS_SHEET || 'Sessions', headerVar: 'SESSIONS_HEADERS', idColumn: 'Token' },
+      { key: 'sessions', name: global.SESSIONS_SHEET || 'Sessions', headerVar: 'SESSIONS_HEADERS', idColumn: 'TokenHash' },
       { key: 'campaigns', name: global.CAMPAIGNS_SHEET || 'Campaigns', headerVar: 'CAMPAIGNS_HEADERS', idColumn: 'ID', requireTenant: false, cacheTTL: 3600 },
       { key: 'campaignPermissions', name: global.CAMPAIGN_USER_PERMISSIONS_SHEET || 'CampaignUserPermissions', headerVar: 'CAMPAIGN_USER_PERMISSIONS_HEADERS', idColumn: 'ID', preferTenantColumns: ['CampaignID', 'CampaignId'], requireTenant: true, cacheTTL: 2700 },
       { key: 'userCampaigns', name: global.USER_CAMPAIGNS_SHEET || 'UserCampaigns', headerVar: 'USER_CAMPAIGNS_HEADERS', idColumn: 'ID', preferTenantColumns: ['CampaignId', 'CampaignID'], requireTenant: true, cacheTTL: 1800 },

--- a/DatabaseBindings.js
+++ b/DatabaseBindings.js
@@ -55,7 +55,7 @@
     registerIfDefined(global.ROLES_SHEET || 'Roles', global.ROLES_HEADER, 'ID', { cacheTTL: 3600 });
     registerIfDefined(global.USER_ROLES_SHEET || 'UserRoles', global.USER_ROLES_HEADER, 'UserId', { cacheTTL: 1800 });
     registerIfDefined(global.USER_CLAIMS_SHEET || 'UserClaims', global.CLAIMS_HEADERS, 'ID', { cacheTTL: 1800 });
-    registerIfDefined(global.SESSIONS_SHEET || 'Sessions', global.SESSIONS_HEADERS, 'Token');
+    registerIfDefined(global.SESSIONS_SHEET || 'Sessions', global.SESSIONS_HEADERS, 'TokenHash');
     registerIfDefined(global.CAMPAIGNS_SHEET || 'Campaigns', global.CAMPAIGNS_HEADERS, 'ID', { cacheTTL: 3600 });
     registerIfDefined(global.PAGES_SHEET || 'Pages', global.PAGES_HEADERS, 'PageKey', { cacheTTL: 3600 });
     registerIfDefined(global.CAMPAIGN_PAGES_SHEET || 'CampaignPages', global.CAMPAIGN_PAGES_HEADERS, 'ID', { tenantColumn: 'CampaignID', requireTenant: true, cacheTTL: 2700 });

--- a/Login.html
+++ b/Login.html
@@ -1108,7 +1108,13 @@
       mfaCountdownTimer: null,
       mfaBaseMessage: '',
       pendingDeviceVerification: null,
-      deviceVerificationInFlight: false
+      deviceVerificationInFlight: false,
+      keepAliveTimer: null,
+      keepAliveIntervalMs: null,
+      sessionIdleTimeoutMinutes: null,
+      sessionTtlSeconds: null,
+      sessionExpiresAt: null,
+      lastRememberMe: false
     };
 
     // ───────────────────────────────────────────────────────────────────────────────
@@ -2001,6 +2007,7 @@
     }
 
     function clearAuthCookie() {
+      stopKeepAliveHeartbeat();
       try {
         if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
           CookieHandler.clearAuthToken();
@@ -2009,22 +2016,32 @@
         console.warn('Unable to clear auth cookie', err);
       }
       state.authToken = '';
+      state.sessionIdleTimeoutMinutes = null;
+      state.sessionTtlSeconds = null;
+      state.sessionExpiresAt = null;
     }
 
-    function persistSessionToken(token, rememberMe, expiresAtIso, ttlSeconds) {
+    function persistSessionToken(token, rememberMe, expiresAtIso, ttlSeconds, idleTimeoutMinutes) {
       if (!token) {
         clearAuthCookie();
         return;
       }
 
       state.authToken = token;
+      state.lastRememberMe = typeof rememberMe === 'boolean' ? rememberMe : state.lastRememberMe;
+      state.sessionExpiresAt = expiresAtIso || null;
+      state.sessionTtlSeconds = (typeof ttlSeconds === 'number' && ttlSeconds > 0) ? ttlSeconds : null;
 
-      let maxAgeSeconds = (typeof ttlSeconds === 'number' && ttlSeconds > 0)
-        ? Math.floor(ttlSeconds)
-        : (rememberMe ? REMEMBER_COOKIE_MAX_AGE : SESSION_COOKIE_MAX_AGE);
+      if (typeof idleTimeoutMinutes === 'number' && isFinite(idleTimeoutMinutes) && idleTimeoutMinutes > 0) {
+        state.sessionIdleTimeoutMinutes = Math.max(1, Math.round(idleTimeoutMinutes));
+      }
 
-      if (expiresAtIso) {
-        const expiryTime = Date.parse(expiresAtIso);
+      let maxAgeSeconds = state.sessionTtlSeconds
+        ? Math.floor(state.sessionTtlSeconds)
+        : (state.lastRememberMe ? REMEMBER_COOKIE_MAX_AGE : SESSION_COOKIE_MAX_AGE);
+
+      if (state.sessionExpiresAt) {
+        const expiryTime = Date.parse(state.sessionExpiresAt);
         if (!isNaN(expiryTime)) {
           const delta = Math.floor((expiryTime - Date.now()) / 1000);
           if (delta > 0) {
@@ -2033,7 +2050,7 @@
         }
       }
 
-      maxAgeSeconds = Math.max(300, maxAgeSeconds); // ensure at least 5 minutes
+      maxAgeSeconds = Math.max(300, maxAgeSeconds);
 
       try {
         if (window.CookieHandler && typeof CookieHandler.persistAuthToken === 'function') {
@@ -2041,6 +2058,110 @@
         }
       } catch (err) {
         console.warn('Unable to persist auth cookie', err);
+      }
+
+      restartSessionHeartbeat();
+    }
+
+    function stopKeepAliveHeartbeat() {
+      if (state.keepAliveTimer) {
+        clearTimeout(state.keepAliveTimer);
+        state.keepAliveTimer = null;
+      }
+    }
+
+    function scheduleKeepAliveHeartbeat(delayMs) {
+      stopKeepAliveHeartbeat();
+      if (!delayMs || !isFinite(delayMs) || delayMs <= 0) {
+        return;
+      }
+
+      state.keepAliveIntervalMs = delayMs;
+      state.keepAliveTimer = setTimeout(() => {
+        const tokenForPing = state.authToken || readAuthCookie();
+        if (!tokenForPing) {
+          stopKeepAliveHeartbeat();
+          return;
+        }
+
+        google.script.run
+          .withSuccessHandler(handleKeepAliveSuccess)
+          .withFailureHandler(handleKeepAliveFailure)
+          .keepAlive(tokenForPing);
+      }, delayMs);
+    }
+
+    function restartSessionHeartbeat() {
+      stopKeepAliveHeartbeat();
+
+      const tokenForPing = state.authToken || readAuthCookie();
+      if (!tokenForPing) {
+        return;
+      }
+
+      const idleMinutes = (state.sessionIdleTimeoutMinutes && state.sessionIdleTimeoutMinutes > 0)
+        ? state.sessionIdleTimeoutMinutes
+        : 30;
+      const idleMs = Math.max(1, idleMinutes) * 60 * 1000;
+
+      let ttlMs = null;
+      if (state.sessionTtlSeconds && state.sessionTtlSeconds > 0) {
+        ttlMs = state.sessionTtlSeconds * 1000;
+      } else if (state.sessionExpiresAt) {
+        const expiryTime = Date.parse(state.sessionExpiresAt);
+        if (!isNaN(expiryTime)) {
+          ttlMs = Math.max(0, expiryTime - Date.now());
+        }
+      }
+
+      let intervalMs = Math.max(60000, Math.floor(idleMs / 2));
+      if (ttlMs !== null && ttlMs > 0) {
+        intervalMs = Math.min(intervalMs, Math.max(60000, Math.floor(ttlMs / 2)));
+      }
+
+      const safetyWindow = Math.max(60000, Math.floor(idleMs * 0.2));
+      intervalMs = Math.min(intervalMs, Math.max(60000, idleMs - safetyWindow));
+
+      if (!isFinite(intervalMs) || intervalMs <= 0) {
+        intervalMs = 60000;
+      }
+
+      scheduleKeepAliveHeartbeat(intervalMs);
+    }
+
+    function handleKeepAliveSuccess(result) {
+      if (!result || !result.success) {
+        if (result && result.expired) {
+          handleSessionExpired(result.reason || 'SESSION_EXPIRED');
+        } else {
+          console.warn('Keep-alive returned unexpected response', result);
+          scheduleKeepAliveHeartbeat(Math.min(state.keepAliveIntervalMs || 300000, 300000));
+        }
+        return;
+      }
+
+      persistSessionToken(
+        result.sessionToken || state.authToken || readAuthCookie(),
+        state.lastRememberMe,
+        result.sessionExpiresAt,
+        result.sessionTtlSeconds,
+        result.idleTimeoutMinutes
+      );
+    }
+
+    function handleKeepAliveFailure(error) {
+      console.warn('Keep-alive failed:', error);
+      const retryDelay = Math.max(60000, Math.min((state.keepAliveIntervalMs || 300000) / 2, 300000));
+      scheduleKeepAliveHeartbeat(retryDelay);
+    }
+
+    function handleSessionExpired(reason) {
+      console.log('Session expired:', reason);
+      clearAuthCookie();
+      try {
+        showAlert('info', 'Your session has expired. Please sign in again.');
+      } catch (err) {
+        console.warn('handleSessionExpired: unable to show alert', err);
       }
     }
 
@@ -2078,7 +2199,7 @@
           const resolvedToken = result.sessionToken || cookieToken;
           const rememberFlag = result.rememberMe !== undefined ? !!result.rememberMe : true;
 
-          persistSessionToken(resolvedToken, rememberFlag, result.sessionExpiresAt, result.sessionTtlSeconds);
+          persistSessionToken(resolvedToken, rememberFlag, result.sessionExpiresAt, result.sessionTtlSeconds, result.idleTimeoutMinutes);
 
           const resumedUser = result.user || {};
           const resumedEmail = (resumedUser.Email || resumedUser.email || '').trim();
@@ -3283,7 +3404,8 @@
         response.sessionToken,
         response.rememberMe !== undefined ? !!response.rememberMe : !!rememberMeFallback,
         response.sessionExpiresAt,
-        response.sessionTtlSeconds
+        response.sessionTtlSeconds,
+        response.sessionIdleTimeoutMinutes
       );
 
       const destinationUrl = normalizeRedirectUrl(response.redirectUrl);

--- a/MainUtilities.js
+++ b/MainUtilities.js
@@ -82,13 +82,18 @@ if (typeof USER_ROLES_HEADER === 'undefined') var USER_ROLES_HEADER = [
 if (typeof CLAIMS_HEADERS === 'undefined') var CLAIMS_HEADERS = ["ID", "UserId", "ClaimType", "CreatedAt", "UpdatedAt"];
 if (typeof SESSIONS_HEADERS === 'undefined') var SESSIONS_HEADERS = [
   "Token",
+  "TokenHash",
+  "TokenSalt",
   "UserId",
   "CreatedAt",
+  "LastActivityAt",
   "ExpiresAt",
+  "IdleTimeoutMinutes",
   "RememberMe",
   "CampaignScope",
   "UserAgent",
-  "IpAddress"
+  "IpAddress",
+  "ServerIp"
 ];
 
 if (typeof CHAT_GROUPS_HEADERS === 'undefined') var CHAT_GROUPS_HEADERS = ['ID', 'Name', 'Description', 'CreatedBy', 'CreatedAt', 'UpdatedAt'];

--- a/chatHeader.html
+++ b/chatHeader.html
@@ -409,6 +409,7 @@
     }
 
     function clearAuthCookie() {
+      stopKeepAlive();
       try {
         if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
           CookieHandler.clearAuthToken();
@@ -416,6 +417,10 @@
       } catch (err) {
         console.warn('Unable to clear auth cookie', err);
       }
+      rawToken = '';
+      sessionIdleTimeoutMinutes = null;
+      sessionExpiresAt = null;
+      sessionTtlSeconds = null;
     }
 
     // collapse toggle
@@ -427,6 +432,12 @@
     const currentUrl = new URL(window.location.href);
     const urlToken = currentUrl.searchParams.get('token');
     let rawToken = readAuthCookie();
+    let keepAliveTimer = null;
+    let keepAliveIntervalMs = null;
+    let pendingKeepAliveToken = null;
+    let sessionIdleTimeoutMinutes = null;
+    let sessionExpiresAt = null;
+    let sessionTtlSeconds = null;
 
     if (urlToken) {
       rawToken = urlToken;
@@ -439,40 +450,115 @@
       persistAuthCookie(rawToken);
     }
 
-    function scheduleKeepAlive() {
-      if (!rawToken) {
+    function stopKeepAlive() {
+      if (keepAliveTimer) {
+        clearTimeout(keepAliveTimer);
+        keepAliveTimer = null;
+      }
+    }
+
+    function scheduleNextKeepAlive(delayMs) {
+      stopKeepAlive();
+      if (!delayMs || !isFinite(delayMs) || delayMs <= 0) {
         return;
       }
 
-      const ping = () => {
-        const tokenForPing = rawToken || readAuthCookie();
-        if (!tokenForPing) {
-          return;
-        }
-
-        google.script.run
-          .withSuccessHandler(result => {
-            if (result && result.success) {
-              rawToken = result.sessionToken || tokenForPing;
-              persistAuthCookie(rawToken, result.sessionTtlSeconds);
-            } else if (result && result.expired) {
-              clearAuthCookie();
-              const loginUrl = new URL(location.origin + location.pathname);
-              loginUrl.searchParams.set('page', 'login');
-              window.location.href = loginUrl.toString();
-            }
-          })
-          .withFailureHandler(err => {
-            console.warn('Keep-alive failed:', err);
-          })
-          .keepAlive(tokenForPing);
-      };
-
-      ping();
-      setInterval(ping, 10 * 60 * 1000);
+      keepAliveIntervalMs = delayMs;
+      keepAliveTimer = setTimeout(runKeepAlive, delayMs);
     }
 
-    scheduleKeepAlive();
+    function determineKeepAliveDelay() {
+      const idleMinutes = (sessionIdleTimeoutMinutes && sessionIdleTimeoutMinutes > 0)
+        ? sessionIdleTimeoutMinutes
+        : 30;
+      const idleMs = Math.max(1, idleMinutes) * 60 * 1000;
+
+      let ttlMs = null;
+      if (sessionTtlSeconds && sessionTtlSeconds > 0) {
+        ttlMs = sessionTtlSeconds * 1000;
+      } else if (sessionExpiresAt) {
+        const expiryTime = Date.parse(sessionExpiresAt);
+        if (!isNaN(expiryTime)) {
+          ttlMs = Math.max(0, expiryTime - Date.now());
+        }
+      }
+
+      let interval = Math.max(60000, Math.floor(idleMs / 2));
+      if (ttlMs !== null && ttlMs > 0) {
+        interval = Math.min(interval, Math.max(60000, Math.floor(ttlMs / 2)));
+      }
+
+      const safetyWindow = Math.max(60000, Math.floor(idleMs * 0.2));
+      interval = Math.min(interval, Math.max(60000, idleMs - safetyWindow));
+
+      if (!isFinite(interval) || interval <= 0) {
+        interval = 60000;
+      }
+
+      return interval;
+    }
+
+    function handleSessionExpired(reason) {
+      console.log('Session expired:', reason);
+      clearAuthCookie();
+      const loginUrl = new URL(location.origin + location.pathname);
+      loginUrl.searchParams.set('page', 'login');
+      window.location.href = loginUrl.toString();
+    }
+
+    function handleKeepAliveSuccess(result) {
+      if (!result || !result.success) {
+        if (result && result.expired) {
+          handleSessionExpired(result.reason || 'SESSION_EXPIRED');
+        } else {
+          console.warn('Keep-alive returned unexpected response', result);
+          scheduleNextKeepAlive(Math.min(keepAliveIntervalMs || 300000, 300000));
+        }
+        return;
+      }
+
+      rawToken = result.sessionToken || pendingKeepAliveToken || rawToken;
+      sessionIdleTimeoutMinutes = (typeof result.idleTimeoutMinutes === 'number' && result.idleTimeoutMinutes > 0)
+        ? Math.round(result.idleTimeoutMinutes)
+        : sessionIdleTimeoutMinutes;
+      sessionExpiresAt = result.sessionExpiresAt || sessionExpiresAt;
+      sessionTtlSeconds = (typeof result.sessionTtlSeconds === 'number' && result.sessionTtlSeconds > 0)
+        ? result.sessionTtlSeconds
+        : sessionTtlSeconds;
+
+      persistAuthCookie(rawToken, result.sessionTtlSeconds);
+      scheduleNextKeepAlive(determineKeepAliveDelay());
+    }
+
+    function handleKeepAliveFailure(error) {
+      console.warn('Keep-alive failed:', error);
+      const retryDelay = Math.max(60000, Math.min((keepAliveIntervalMs || 300000) / 2, 300000));
+      scheduleNextKeepAlive(retryDelay);
+    }
+
+    function runKeepAlive() {
+      const tokenForPing = rawToken || readAuthCookie();
+      if (!tokenForPing) {
+        stopKeepAlive();
+        return;
+      }
+
+      pendingKeepAliveToken = tokenForPing;
+      google.script.run
+        .withSuccessHandler(handleKeepAliveSuccess)
+        .withFailureHandler(handleKeepAliveFailure)
+        .keepAlive(tokenForPing);
+    }
+
+    function startKeepAlive() {
+      if (!rawToken) {
+        return;
+      }
+      stopKeepAlive();
+      runKeepAlive();
+    }
+
+    startKeepAlive();
 
     document.getElementById('logoutBtn').addEventListener('click', e => {
       e.preventDefault();

--- a/headerConf.html
+++ b/headerConf.html
@@ -485,6 +485,7 @@
     }
 
     function clearAuthCookie() {
+      stopKeepAlive();
       try {
         if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
           CookieHandler.clearAuthToken();
@@ -492,6 +493,10 @@
       } catch (err) {
         console.warn('Unable to clear auth cookie', err);
       }
+      rawToken = '';
+      sessionIdleTimeoutMinutes = null;
+      sessionExpiresAt = null;
+      sessionTtlSeconds = null;
     }
 
     // collapse toggle
@@ -503,6 +508,12 @@
     const currentUrl = new URL(window.location.href);
     const urlToken = currentUrl.searchParams.get('token');
     let rawToken = readAuthCookie();
+    let keepAliveTimer = null;
+    let keepAliveIntervalMs = null;
+    let pendingKeepAliveToken = null;
+    let sessionIdleTimeoutMinutes = null;
+    let sessionExpiresAt = null;
+    let sessionTtlSeconds = null;
 
     if (urlToken) {
       rawToken = urlToken;
@@ -515,40 +526,115 @@
       persistAuthCookie(rawToken);
     }
 
-    function scheduleKeepAlive() {
-      if (!rawToken) {
+    function stopKeepAlive() {
+      if (keepAliveTimer) {
+        clearTimeout(keepAliveTimer);
+        keepAliveTimer = null;
+      }
+    }
+
+    function scheduleNextKeepAlive(delayMs) {
+      stopKeepAlive();
+      if (!delayMs || !isFinite(delayMs) || delayMs <= 0) {
         return;
       }
 
-      const ping = () => {
-        const tokenForPing = rawToken || readAuthCookie();
-        if (!tokenForPing) {
-          return;
-        }
-
-        google.script.run
-          .withSuccessHandler(result => {
-            if (result && result.success) {
-              rawToken = result.sessionToken || tokenForPing;
-              persistAuthCookie(rawToken, result.sessionTtlSeconds);
-            } else if (result && result.expired) {
-              clearAuthCookie();
-              const loginUrl = new URL(location.origin + location.pathname);
-              loginUrl.searchParams.set('page', 'login');
-              window.location.href = loginUrl.toString();
-            }
-          })
-          .withFailureHandler(err => {
-            console.warn('Keep-alive failed:', err);
-          })
-          .keepAlive(tokenForPing);
-      };
-
-      ping();
-      setInterval(ping, 10 * 60 * 1000);
+      keepAliveIntervalMs = delayMs;
+      keepAliveTimer = setTimeout(runKeepAlive, delayMs);
     }
 
-    scheduleKeepAlive();
+    function determineKeepAliveDelay() {
+      const idleMinutes = (sessionIdleTimeoutMinutes && sessionIdleTimeoutMinutes > 0)
+        ? sessionIdleTimeoutMinutes
+        : 30;
+      const idleMs = Math.max(1, idleMinutes) * 60 * 1000;
+
+      let ttlMs = null;
+      if (sessionTtlSeconds && sessionTtlSeconds > 0) {
+        ttlMs = sessionTtlSeconds * 1000;
+      } else if (sessionExpiresAt) {
+        const expiryTime = Date.parse(sessionExpiresAt);
+        if (!isNaN(expiryTime)) {
+          ttlMs = Math.max(0, expiryTime - Date.now());
+        }
+      }
+
+      let interval = Math.max(60000, Math.floor(idleMs / 2));
+      if (ttlMs !== null && ttlMs > 0) {
+        interval = Math.min(interval, Math.max(60000, Math.floor(ttlMs / 2)));
+      }
+
+      const safetyWindow = Math.max(60000, Math.floor(idleMs * 0.2));
+      interval = Math.min(interval, Math.max(60000, idleMs - safetyWindow));
+
+      if (!isFinite(interval) || interval <= 0) {
+        interval = 60000;
+      }
+
+      return interval;
+    }
+
+    function handleSessionExpired(reason) {
+      console.log('Session expired:', reason);
+      clearAuthCookie();
+      const loginUrl = new URL(location.origin + location.pathname);
+      loginUrl.searchParams.set('page', 'login');
+      window.location.href = loginUrl.toString();
+    }
+
+    function handleKeepAliveSuccess(result) {
+      if (!result || !result.success) {
+        if (result && result.expired) {
+          handleSessionExpired(result.reason || 'SESSION_EXPIRED');
+        } else {
+          console.warn('Keep-alive returned unexpected response', result);
+          scheduleNextKeepAlive(Math.min(keepAliveIntervalMs || 300000, 300000));
+        }
+        return;
+      }
+
+      rawToken = result.sessionToken || pendingKeepAliveToken || rawToken;
+      sessionIdleTimeoutMinutes = (typeof result.idleTimeoutMinutes === 'number' && result.idleTimeoutMinutes > 0)
+        ? Math.round(result.idleTimeoutMinutes)
+        : sessionIdleTimeoutMinutes;
+      sessionExpiresAt = result.sessionExpiresAt || sessionExpiresAt;
+      sessionTtlSeconds = (typeof result.sessionTtlSeconds === 'number' && result.sessionTtlSeconds > 0)
+        ? result.sessionTtlSeconds
+        : sessionTtlSeconds;
+
+      persistAuthCookie(rawToken, result.sessionTtlSeconds);
+      scheduleNextKeepAlive(determineKeepAliveDelay());
+    }
+
+    function handleKeepAliveFailure(error) {
+      console.warn('Keep-alive failed:', error);
+      const retryDelay = Math.max(60000, Math.min((keepAliveIntervalMs || 300000) / 2, 300000));
+      scheduleNextKeepAlive(retryDelay);
+    }
+
+    function runKeepAlive() {
+      const tokenForPing = rawToken || readAuthCookie();
+      if (!tokenForPing) {
+        stopKeepAlive();
+        return;
+      }
+
+      pendingKeepAliveToken = tokenForPing;
+      google.script.run
+        .withSuccessHandler(handleKeepAliveSuccess)
+        .withFailureHandler(handleKeepAliveFailure)
+        .keepAlive(tokenForPing);
+    }
+
+    function startKeepAlive() {
+      if (!rawToken) {
+        return;
+      }
+      stopKeepAlive();
+      runKeepAlive();
+    }
+
+    startKeepAlive();
 
     document.getElementById('logoutBtn').addEventListener('click', e => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- hash session tokens with salts, track last activity/idle timeouts, and refresh sessions on keep-alive requests
- add scheduled cleanup function to purge expired or idle sessions and expose a job wrapper
- update client keep-alive heartbeats and cookie handling to respond to session expiration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a8d285c08326b9889a0946266476