### PR TITLE
Handle import CSV route aliases

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1646,6 +1646,8 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       case "agent-schedule":
         return serveAgentSchedulePage(e, baseUrl, e.parameter.token);
 
+      case 'importcsv':
+      case 'import-csv':
       case 'import':
         // Mirror Import Attendance authentication so managers and supervisors can import call reports
         if (isSystemAdmin(user) || hasManagerRole(user) || hasSupervisorRole(user)) {


### PR DESCRIPTION
## Summary
- route the `importcsv` and `import-csv` aliases to the existing ImportCsv admin page so alternate URLs load the CSV importer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b4ce0ca0832684bdaff4e431d4f8