### PR TITLE
Add new feature pages to routing and discovery

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1258,6 +1258,14 @@ function canonicalizePageKey(k) {
     case 'campaigns':
       return 'admin.campaigns';
 
+    // Experience hubs
+    case 'agent-experience':
+      return 'workspace.agent';
+    case 'manager-executive-experience':
+      return 'workspace.executive';
+    case 'goalsetting':
+      return 'performance.goals';
+
     // Task Management (Default Pages)
     case 'tasklist':
     case 'task-list':
@@ -1289,6 +1297,8 @@ function canonicalizePageKey(k) {
     case 'schedule':
     case 'schedulemanagement':
       return 'global.schedule';
+    case 'agent-schedule':
+      return 'schedule.agent';
 
     // Other Global Pages
     case 'notifications':
@@ -1297,17 +1307,26 @@ function canonicalizePageKey(k) {
       return 'global.settings';
 
     // QA System Pages
+    case 'unifiedqadashboard':
     case 'qa-dashboard':
     case 'ibtrqualityreports':
       return 'qa.dashboard';
     case 'qualityform':
     case 'independencequality':
     case 'creditsuiteqa':
+    case 'groundingqaform':
       return 'qa.form';
+    case 'qualitycollabform':
+    case 'qacollabform':
+      return 'qa.collaboration.form';
     case 'qualityview':
       return 'qa.view';
     case 'qualitylist':
       return 'qa.list';
+    case 'qacollablist':
+      return 'qa.collaboration.list';
+    case 'qacollabview':
+      return 'qa.collaboration.view';
 
     // Report Pages
     case 'callreports':
@@ -1328,6 +1347,7 @@ function canonicalizePageKey(k) {
       return 'coaching.form';
 
     // Calendar and Schedule
+    case 'calendar':
     case 'attendancecalendar':
       return 'calendar.attendance';
     case 'slotmanagement':
@@ -1482,6 +1502,14 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
     // DEFAULT/GLOBAL PAGES (Always available, campaign-independent)
     // ═══════════════════════════════════════════════════════════════════════════
 
+    if (page === 'agent-experience') {
+      return serveGlobalPage('AgentExperience', e, baseUrl, user);
+    }
+
+    if (page === 'goalsetting') {
+      return serveGlobalPage('GoalSetting', e, baseUrl, user);
+    }
+
     // Task Management (Default Pages)
     if (page === "tasklist" || page === "task-list") {
       return serveGlobalPage('TaskList', e, baseUrl, user);
@@ -1513,6 +1541,14 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
     }
 
     // Administration (Default Pages)
+    if (page === 'manager-executive-experience') {
+      return serveAdminPage('ManagerExecutiveExperience', e, baseUrl, user, {
+        allowManagers: true,
+        allowSupervisors: true,
+        accessDeniedMessage: 'Manager or executive access required.'
+      });
+    }
+
     if (page === 'users' || page === 'manageuser') {
       return serveAdminPage('Users', e, baseUrl, user);
     }
@@ -1589,6 +1625,16 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       case 'qualitylist':
         return routeQAList(e, baseUrl, user, campaignIdFromCaller);
 
+      case 'qacollablist':
+        return serveCampaignPage('QACollabList', e, baseUrl, user, campaignIdFromCaller);
+
+      case 'qacollabview':
+        return serveCampaignPage('QualityCollabView', e, baseUrl, user, campaignIdFromCaller);
+
+      case 'qualitycollabform':
+      case 'qacollabform':
+        return serveCampaignPage('QualityCollabForm', e, baseUrl, user, campaignIdFromCaller);
+
       case "independencequality":
         return serveCampaignPage('IndependenceQAForm', e, baseUrl, user, campaignIdFromCaller);
 
@@ -1598,8 +1644,14 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       case "creditsuiteqa":
         return serveCampaignPage('CreditSuiteQAForm', e, baseUrl, user, campaignIdFromCaller);
 
+      case "groundingqaform":
+        return serveCampaignPage('GroundingQAForm', e, baseUrl, user, campaignIdFromCaller);
+
       case "qa-dashboard":
         return serveCampaignPage('CreditSuiteQADashboard', e, baseUrl, user, campaignIdFromCaller);
+
+      case "unifiedqadashboard":
+        return serveCampaignPage('UnifiedQADashboard', e, baseUrl, user, campaignIdFromCaller);
 
       case "callreports":
         return serveCampaignPage('CallReports', e, baseUrl, user, campaignIdFromCaller);
@@ -1628,6 +1680,7 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       case "collaborationreporting":
         return serveGlobalPage('CollaborationReporting', e, baseUrl, user);
 
+      case "calendar":
       case "attendancecalendar":
         return serveCampaignPage('Calendar', e, baseUrl, user, campaignIdFromCaller);
 

--- a/MainUtilities.js
+++ b/MainUtilities.js
@@ -1055,22 +1055,33 @@ function getAllPagesFromActualRouting() {
   const discoveredPages = [
     // DASHBOARD & ANALYTICS
     { key: 'dashboard', title: 'Dashboard', icon: 'fas fa-tachometer-alt', description: 'Main dashboard with OKR metrics and analytics', isSystem: true, requiresAdmin: false, category: 'Dashboard & Analytics', isMainPage: true },
+    { key: 'agent-experience', title: 'Agent Experience', icon: 'fas fa-user-headset', description: 'Personalized workspace for frontline specialists with schedules, tasks, and communications', isSystem: true, requiresAdmin: false, category: 'Dashboard & Analytics', isMainPage: true },
+    { key: 'goalsetting', title: 'Goal Setting', icon: 'fas fa-bullseye', description: 'Create, track, and update OKRs and performance targets', isSystem: true, requiresAdmin: false, category: 'Dashboard & Analytics' },
+
+    // LEADERSHIP & EXECUTIVE HUBS
+    { key: 'manager-executive-experience', title: 'Manager & Executive Experience', icon: 'fas fa-briefcase', description: 'Leadership analytics, coaching metrics, and cross-campaign oversight', isSystem: true, requiresAdmin: true, category: 'Dashboard & Analytics' },
 
     // QUALITY ASSURANCE
     { key: 'qualityform', title: 'Quality Form', icon: 'fas fa-clipboard-check', description: 'Quality assurance evaluation form (campaign-aware routing)', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
     { key: 'ibtrqualityreports', title: 'QA Dashboard', icon: 'fas fa-chart-pie', description: 'Quality assurance dashboard and reports (campaign-aware routing)', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
     { key: 'qualityview', title: 'Quality View', icon: 'fas fa-eye', description: 'View individual quality assurance records', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
     { key: 'qualitylist', title: 'Quality List', icon: 'fas fa-list-check', description: 'List all quality assurance records', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
+    { key: 'unifiedqadashboard', title: 'Unified QA Dashboard', icon: 'fas fa-layer-group', description: 'Cross-campaign QA dashboard for consolidated quality analytics', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
+    { key: 'qacollablist', title: 'QA Collaboration List', icon: 'fas fa-users-gear', description: 'Collaborative queue of QA audits and action items', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
+    { key: 'qacollabview', title: 'QA Collaboration View', icon: 'fas fa-users-viewfinder', description: 'Detailed view of collaborative QA audit items', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
+    { key: 'qualitycollabform', title: 'QA Collaboration Form', icon: 'fas fa-clipboard-list', description: 'Submit or update collaborative QA action plans', isSystem: true, requiresAdmin: false, category: 'Quality Assurance' },
 
     // CAMPAIGN-SPECIFIC QA
     { key: 'independencequality', title: 'Independence Insurance QA', icon: 'fas fa-shield-alt', description: 'Quality assurance form for Independence Insurance campaign', isSystem: true, requiresAdmin: false, category: 'Campaign QA' },
     { key: 'independenceqadashboard', title: 'Independence QA Dashboard', icon: 'fas fa-chart-line', description: 'Unified QA dashboard for Independence Insurance', isSystem: true, requiresAdmin: false, category: 'Campaign QA' },
     { key: 'creditsuiteqa', title: 'Credit Suite QA', icon: 'fas fa-credit-card', description: 'Quality assurance form for Credit Suite campaign', isSystem: true, requiresAdmin: false, category: 'Campaign QA' },
     { key: 'qa-dashboard', title: 'Credit Suite QA Dashboard', icon: 'fas fa-chart-area', description: 'QA dashboard for Credit Suite campaign', isSystem: true, requiresAdmin: false, category: 'Campaign QA' },
+    { key: 'groundingqaform', title: 'Grounding QA Form', icon: 'fas fa-seedling', description: 'Campaign-specific QA form for Grounding support teams', isSystem: true, requiresAdmin: false, category: 'Campaign QA' },
 
     // REPORTING
     { key: 'callreports', title: 'Call Reports', icon: 'fas fa-phone-volume', description: 'Call analytics and reporting dashboard with CSV export', isSystem: true, requiresAdmin: false, category: 'Reporting & Analytics' },
     { key: 'attendancereports', title: 'Attendance Reports', icon: 'fas fa-chart-bar', description: 'Attendance analytics and reports with CSV export', isSystem: true, requiresAdmin: false, category: 'Reporting & Analytics' },
+    { key: 'collaboration-reporting', title: 'Collaboration Reporting', icon: 'fas fa-people-arrows', description: 'Collaboration analytics, sentiment tracking, and engagement insights', isSystem: true, requiresAdmin: false, category: 'Reporting & Analytics' },
 
     // COACHING
     { key: 'coachingdashboard', title: 'Coaching Dashboard', icon: 'fas fa-chalkboard-teacher', description: 'Coaching metrics and management dashboard', isSystem: true, requiresAdmin: false, category: 'Coaching & Development' },
@@ -1088,6 +1099,7 @@ function getAllPagesFromActualRouting() {
     { key: 'schedulemanagement', title: 'Schedule Management', icon: 'fas fa-calendar-week', description: 'Manage work schedules and shifts', isSystem: true, requiresAdmin: false, category: 'Scheduling & Time' },
     { key: 'attendancecalendar', title: 'Attendance Calendar', icon: 'fas fa-calendar-check', description: 'Calendar view for attendance tracking', isSystem: true, requiresAdmin: false, category: 'Scheduling & Time' },
     { key: 'slotmanagement', title: 'Shift Slot Management', icon: 'fas fa-clock', description: 'Manage shift slots and time allocations', isSystem: true, requiresAdmin: false, category: 'Scheduling & Time' },
+    { key: 'agent-schedule', title: 'Agent Schedule', icon: 'fas fa-calendar-day', description: 'Personal schedule and shift details for agents', isSystem: true, requiresAdmin: false, category: 'Scheduling & Time' },
 
     // WORKFLOW
     { key: 'escalations', title: 'Escalations', icon: 'fas fa-exclamation-triangle', description: 'Issue escalation management and tracking', isSystem: true, requiresAdmin: false, category: 'Workflow & Operations' },
@@ -1252,16 +1264,27 @@ function suggestIconForPageKey(key) {
     const k = String(key || '').toLowerCase();
     const iconMap = {
       dashboard: 'fa-tachometer-alt',
+      'agent-experience': 'fa-user-headset',
+      goalsetting: 'fa-bullseye',
+      'manager-executive-experience': 'fa-briefcase',
       qualityform: 'fa-clipboard-check',
       ibtrqualityreports: 'fa-chart-pie',
       qualityview: 'fa-eye',
       qualitylist: 'fa-list-check',
+      unifiedqadashboard: 'fa-layer-group',
+      qacollablist: 'fa-users-gear',
+      qacollabview: 'fa-users-viewfinder',
+      qualitycollabform: 'fa-clipboard-list',
+      qacollabform: 'fa-clipboard-list',
       independencequality: 'fa-shield-alt',
       independenceqadashboard: 'fa-chart-line',
       creditsuiteqa: 'fa-credit-card',
       'qa-dashboard': 'fa-chart-area',
+      groundingqaform: 'fa-seedling',
       callreports: 'fa-phone-volume',
       attendancereports: 'fa-chart-bar',
+      'collaboration-reporting': 'fa-people-arrows',
+      collaborationreporting: 'fa-people-arrows',
       coachingdashboard: 'fa-chalkboard-teacher',
       coachingview: 'fa-search-plus',
       coachinglist: 'fa-list-ul',
@@ -1272,7 +1295,9 @@ function suggestIconForPageKey(key) {
       taskform: 'fa-plus-square',
       schedulemanagement: 'fa-calendar-week',
       attendancecalendar: 'fa-calendar-check',
+      calendar: 'fa-calendar-days',
       slotmanagement: 'fa-clock',
+      'agent-schedule': 'fa-calendar-day',
       escalations: 'fa-exclamation-triangle',
       eodreport: 'fa-clipboard-check',
       incentives: 'fa-trophy',


### PR DESCRIPTION
## Summary
- extend page auto-discovery metadata to include new experience hubs, QA collaboration tools, and agent schedule entries
- map the new slugs in the Apps Script router so agent, QA collaboration, and executive dashboards resolve correctly
- expand page icon suggestions for the new routes to keep navigation visuals consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0c6ba56c48326bd7fdd072e3c0d9e