### PR TITLE
Add role-aware landing redirects after authentication

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2385,7 +2385,9 @@
           }
 
           hideAllAlerts();
-          setupRedirect(buildPageUrl('dashboard'), resumedUser);
+          const resumeInput = result.redirectUrl || (result.redirectSlug ? `?page=${result.redirectSlug}` : '');
+          const resumeUrl = normalizeRedirectUrl(resumeInput);
+          setupRedirect(resumeUrl, resumedUser);
         })
         .withFailureHandler(error => {
           finalizeResumeAttempt();
@@ -3582,7 +3584,8 @@
         response.sessionIdleTimeoutMinutes
       );
 
-      const destinationUrl = normalizeRedirectUrl(response.redirectUrl);
+      const redirectInput = response.redirectUrl || (response.redirectSlug ? `?page=${response.redirectSlug}` : '');
+      const destinationUrl = normalizeRedirectUrl(redirectInput);
       setupRedirect(destinationUrl, response.user);
       hideNextSteps();
     }


### PR DESCRIPTION
## Summary
- add landing destination helpers to AuthenticationService and include role-aware redirect data in login, MFA, session creation, and keep-alive responses
- compute landing slugs in doGet and route the new userprofile alias through AgentExperience
- honor server-provided redirectUrl/redirectSlug in the login UI, including session resume

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e0ce5ac0ac83268da3d8b3636b4c14