### PR TITLE
Add legal policy pages for Lumina HQ transparency platform

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -1087,13 +1087,13 @@
           </div>
 
           <p class="consent-text text-center">
-            By clicking <strong>Log in</strong>, you agree to our <a href="#">Terms &amp; Conditions</a> and acknowledge our <a href="#">Privacy Policy</a> on how we collect and handle data.
+            By clicking <strong>Log in</strong>, you agree to our <a href="<?= baseUrl ?>?page=terms-of-service" target="_blank" rel="noopener">Terms &amp; Conditions</a> and acknowledge our <a href="<?= baseUrl ?>?page=privacy-policy" target="_blank" rel="noopener">Privacy Policy</a> on how we collect and handle data.
           </p>
 
           <div class="footer-links text-center mt-4">
-            <a href="#" class="small">Privacy Policy</a>
+            <a href="<?= baseUrl ?>?page=privacy-policy" class="small" target="_blank" rel="noopener">Privacy Policy</a>
             <span class="small mx-2 text-muted">•</span>
-            <a href="#" class="small">Terms of Service</a>
+            <a href="<?= baseUrl ?>?page=terms-of-service" class="small" target="_blank" rel="noopener">Terms of Service</a>
           </div>
         </div>
       </div>

--- a/PrivacyPolicy.html
+++ b/PrivacyPolicy.html
@@ -1,0 +1,278 @@
+<!-- Privacy Policy -->
+<?!= include('layout', {
+  baseUrl: baseUrl || '',
+  scriptUrl: scriptUrl,
+  user: user || {},
+  currentPage: currentPage || 'privacy-policy',
+  pageTitle: 'Privacy Policy',
+  pageDescription: 'How Lumina HQ safeguards BPO workforce data and collaboration insights.'
+}) ?>
+
+<style>
+  :root {
+    --policy-bg: #f4f7fb;
+    --policy-card: #ffffff;
+    --policy-border: #e1e8f5;
+    --policy-primary: #003177;
+    --policy-accent: #00BFFF;
+    --policy-text: #1a2a4a;
+    --policy-muted: #64748b;
+  }
+
+  body {
+    background: var(--policy-bg);
+  }
+
+  .policy-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+    font-family: 'Inter', Arial, sans-serif;
+    color: var(--policy-text);
+  }
+
+  .policy-header {
+    background: linear-gradient(135deg, rgba(0, 49, 119, 0.95), rgba(0, 191, 255, 0.85));
+    color: #fff;
+    padding: 2.5rem;
+    border-radius: 24px;
+    box-shadow: 0 30px 50px rgba(0, 49, 119, 0.15);
+    margin-bottom: 2.5rem;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .policy-header::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.2), transparent 55%);
+    pointer-events: none;
+  }
+
+  .policy-header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .policy-header p {
+    max-width: 760px;
+    font-size: 1.05rem;
+    line-height: 1.7;
+  }
+
+  .policy-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 2.5rem;
+    margin-top: 1.5rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+  }
+
+  .policy-section {
+    background: var(--policy-card);
+    border-radius: 20px;
+    padding: 2rem 2.5rem;
+    margin-bottom: 1.75rem;
+    border: 1px solid var(--policy-border);
+    box-shadow: 0 10px 30px rgba(15, 35, 95, 0.06);
+  }
+
+  .policy-section h2 {
+    font-size: 1.6rem;
+    margin-bottom: 1rem;
+    color: var(--policy-primary);
+  }
+
+  .policy-section h3 {
+    font-size: 1.15rem;
+    margin-top: 1.5rem;
+    color: var(--policy-text);
+  }
+
+  .policy-section p,
+  .policy-section li {
+    color: var(--policy-muted);
+    line-height: 1.7;
+    font-size: 1rem;
+  }
+
+  .policy-section ul {
+    margin: 0.75rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .policy-callout {
+    background: linear-gradient(135deg, rgba(0, 191, 255, 0.15), rgba(0, 49, 119, 0.1));
+    border: 1px solid rgba(0, 191, 255, 0.35);
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-top: 1.25rem;
+  }
+
+  .contact-box {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+
+  @media (max-width: 768px) {
+    .policy-header {
+      padding: 2rem;
+    }
+
+    .policy-header h1 {
+      font-size: 2rem;
+    }
+
+    .policy-section {
+      padding: 1.75rem;
+    }
+  }
+</style>
+
+<main class="policy-wrapper">
+  <header class="policy-header">
+    <h1>Lumina HQ Privacy Policy</h1>
+    <p>
+      Lumina HQ empowers business process outsourcing (BPO) leaders, quality assurance coaches, and client stakeholders with shared visibility into workforce performance. This Privacy Policy explains how we handle personal and operational data when clients and internal teams use the platform for call, chat, and digital engagement transparency.
+    </p>
+    <div class="policy-meta">
+      <span>Applies to: Lumina HQ workforce transparency suite</span>
+      <span>Audience: Internal operations teams & contracted clients</span>
+      <span>Last Updated: <?= new Date().toISOString().slice(0, 10) ?></span>
+    </div>
+  </header>
+
+  <section class="policy-section" id="overview">
+    <h2>1. Scope & Responsibilities</h2>
+    <p>
+      Lumina HQ is deployed within our managed Google Workspace environment to support call center and BPO engagement. We act as the data controller for internal team member records and as a data processor for client-provided contact data or campaign information. Clients remain responsible for ensuring their own collection practices comply with applicable privacy laws and for providing any required notices to their workforce.
+    </p>
+    <div class="policy-callout">
+      <strong>Key principle:</strong> The platform is designed exclusively for operational transparency between our organization and contracted clients. No personal data is sold or shared outside of this relationship.
+    </div>
+  </section>
+
+  <section class="policy-section" id="data-collected">
+    <h2>2. Data We Collect</h2>
+    <p>We maintain only the information needed to coordinate service delivery, coaching, and quality outcomes:</p>
+    <h3>Workforce & Leadership Data</h3>
+    <ul>
+      <li>Employee and contractor profiles (name, work email, role assignments, tenant access).</li>
+      <li>Scheduling, attendance, and adherence metrics maintained in Google Sheets.</li>
+      <li>Performance coaching notes, QA scoring forms, and escalation records.</li>
+    </ul>
+    <h3>Client & Campaign Data</h3>
+    <ul>
+      <li>Campaign configuration, service level objectives, and authorized stakeholders.</li>
+      <li>Ticket, call, or chat identifiers required to measure outcomes—never the full recordings hosted in client telephony platforms.</li>
+      <li>Custom benchmarks or targets uploaded by clients to evaluate accountability.</li>
+    </ul>
+    <h3>Platform Telemetry</h3>
+    <ul>
+      <li>Authentication events, change history, and system audit trails.</li>
+      <li>Page navigation metadata and form submissions captured for troubleshooting and compliance.</li>
+      <li>API usage logs when synchronizing with Google Sheets or third-party services expressly authorized by the client.</li>
+    </ul>
+  </section>
+
+  <section class="policy-section" id="data-use">
+    <h2>3. How We Use Information</h2>
+    <ul>
+      <li>Deliver transparency dashboards and reports for leadership and client review.</li>
+      <li>Verify adherence to quality standards, compliance requirements, and contractual commitments.</li>
+      <li>Support coaching, escalation resolution, and corrective action workflows.</li>
+      <li>Maintain secure access controls, audit capabilities, and operational analytics.</li>
+      <li>Improve platform reliability and release new features aligned to client needs.</li>
+    </ul>
+    <p>
+      We do not use Lumina HQ data for marketing, sales prospecting, or unrelated analytics. Automated decision-making is limited to routing workflows defined by clients and internal leaders.
+    </p>
+  </section>
+
+  <section class="policy-section" id="lawful-basis">
+    <h2>4. Legal Bases & Compliance</h2>
+    <p>
+      Depending on the data relationship, processing is grounded in contractual necessity, legitimate interest in operating our managed services, or compliance with labor, tax, and safety obligations. We align our practices with applicable regulations such as GDPR, CCPA, and local labor laws. Clients may request data processing addendums or standard contractual clauses when international transfers are required.
+    </p>
+  </section>
+
+  <section class="policy-section" id="access-control">
+    <h2>5. Access & Transparency Controls</h2>
+    <p>
+      Only authorized team leads, QA coaches, managers, and approved client stakeholders receive role-based access within their tenant. Lumina HQ enforces segregation of campaigns, detailed audit logs, and approval workflows for elevated privileges. Clients may request read-only access profiles to validate scorecards or verify agent interactions.
+    </p>
+    <p>
+      Personnel are trained on confidentiality, secure handling of personal data, and responsible use of coaching insights. Access reviews are conducted at least quarterly and immediately upon role changes.
+    </p>
+  </section>
+
+  <section class="policy-section" id="data-sharing">
+    <h2>6. Sharing & Transfers</h2>
+    <ul>
+      <li><strong>Internal operations:</strong> Shared only with teams supporting the relevant campaign or quality initiative.</li>
+      <li><strong>Client stakeholders:</strong> Access provided through authenticated accounts with logging and expiration controls.</li>
+      <li><strong>Subprocessors:</strong> Limited to Google (Apps Script, Sheets, Drive) and approved infrastructure providers required to deliver the platform. Additional subprocessors are communicated before activation.</li>
+      <li><strong>Legal obligations:</strong> Disclosure occurs only when required by law, governmental request, or to enforce contractual rights.</li>
+    </ul>
+    <p>
+      International transfers rely on data protection addendums, regional hosting preferences, and encryption in transit and at rest.
+    </p>
+  </section>
+
+  <section class="policy-section" id="retention">
+    <h2>7. Data Retention & Deletion</h2>
+    <p>
+      Operational records are retained for the duration of the client engagement plus a standard audit window (typically 12–24 months) unless a longer period is mandated by contract or regulation. Clients may request accelerated deletion of campaign datasets upon termination, provided there are no unresolved disputes or outstanding legal holds. Audit logs may be preserved to demonstrate compliance with quality and employment obligations.
+    </p>
+  </section>
+
+  <section class="policy-section" id="security">
+    <h2>8. Security Practices</h2>
+    <ul>
+      <li>Google Workspace security baseline, including enforced multi-factor authentication and context-aware access.</li>
+      <li>Sheet- and script-level permission scopes aligned to least privilege.</li>
+      <li>Encryption in transit (HTTPS) and at rest through Google-managed keys.</li>
+      <li>Continuous monitoring, vulnerability management, and incident response protocols.</li>
+      <li>Change management and code review workflows to protect platform integrity.</li>
+    </ul>
+    <p>
+      Suspected incidents are escalated to our security response team and impacted clients within applicable notification timelines.
+    </p>
+  </section>
+
+  <section class="policy-section" id="rights">
+    <h2>9. Individual Rights & Requests</h2>
+    <p>
+      Eligible individuals may request access, correction, restriction, or deletion of their data by contacting our privacy office. We coordinate with clients to fulfill requests tied to their workforce. Identity verification is required, and response timelines follow relevant regulations. Certain operational data may be retained when necessary to comply with legal obligations or contractual commitments.
+    </p>
+  </section>
+
+  <section class="policy-section" id="updates">
+    <h2>10. Policy Updates</h2>
+    <p>
+      We review this Privacy Policy regularly to reflect product enhancements, regulatory updates, and client feedback. Material changes are communicated through platform notifications or direct client outreach at least 30 days prior to enforcement, unless a faster update is required by law.
+    </p>
+  </section>
+
+  <section class="policy-section" id="contact">
+    <h2>11. Contact & Escalations</h2>
+    <div class="contact-box">
+      <span>Privacy Office & Data Protection Contact</span>
+      <span>Email: privacy@lumina-hq.internal</span>
+      <span>Security Hotline: +1 (800) 000-0000 (24/7 incident reporting)</span>
+      <span>Address: Available upon request for client due diligence</span>
+    </div>
+    <p>
+      Clients may also request copies of our security certifications, subprocessors list, or data processing agreements through their account manager.
+    </p>
+  </section>
+</main>
+
+</body>
+</html>

--- a/TermsOfService.html
+++ b/TermsOfService.html
@@ -1,0 +1,294 @@
+<!-- Terms of Service -->
+<?!= include('layout', {
+  baseUrl: baseUrl || '',
+  scriptUrl: scriptUrl,
+  user: user || {},
+  currentPage: currentPage || 'terms-of-service',
+  pageTitle: 'Terms of Service',
+  pageDescription: 'Usage conditions for the Lumina HQ transparency platform.'
+}) ?>
+
+<style>
+  :root {
+    --tos-bg: #f6f8fb;
+    --tos-card: #ffffff;
+    --tos-border: #dde6f7;
+    --tos-primary: #003177;
+    --tos-accent: #00BFFF;
+    --tos-muted: #5f6d87;
+  }
+
+  body {
+    background: var(--tos-bg);
+  }
+
+  .tos-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+    font-family: 'Inter', Arial, sans-serif;
+    color: #1a2640;
+  }
+
+  .tos-hero {
+    background: linear-gradient(135deg, rgba(0, 49, 119, 0.92), rgba(0, 191, 255, 0.88));
+    color: #fff;
+    padding: 2.5rem;
+    border-radius: 24px;
+    box-shadow: 0 24px 48px rgba(0, 49, 119, 0.18);
+    margin-bottom: 2.5rem;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .tos-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.25), transparent 55%);
+  }
+
+  .tos-hero h1 {
+    font-size: 2.45rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .tos-hero p {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    max-width: 760px;
+  }
+
+  .tos-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 2.5rem;
+    margin-top: 1.5rem;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+
+  .tos-section {
+    background: var(--tos-card);
+    border-radius: 20px;
+    padding: 2rem 2.5rem;
+    margin-bottom: 1.75rem;
+    border: 1px solid var(--tos-border);
+    box-shadow: 0 10px 30px rgba(20, 40, 80, 0.06);
+  }
+
+  .tos-section h2 {
+    font-size: 1.55rem;
+    margin-bottom: 1rem;
+    color: var(--tos-primary);
+  }
+
+  .tos-section h3 {
+    font-size: 1.1rem;
+    margin-top: 1.5rem;
+    color: #1a2640;
+  }
+
+  .tos-section p,
+  .tos-section li {
+    color: var(--tos-muted);
+    line-height: 1.7;
+    font-size: 1rem;
+  }
+
+  .tos-section ul {
+    margin: 0.75rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .tos-highlight {
+    background: linear-gradient(135deg, rgba(0, 191, 255, 0.18), rgba(0, 49, 119, 0.12));
+    border: 1px solid rgba(0, 191, 255, 0.35);
+    border-radius: 16px;
+    padding: 1.35rem 1.5rem;
+    margin-top: 1.1rem;
+  }
+
+  .definition-list {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  .definition-item {
+    border-left: 4px solid var(--tos-accent);
+    padding-left: 1rem;
+  }
+
+  .definition-item h4 {
+    margin: 0 0 0.35rem;
+    color: #0b284d;
+    font-size: 1.05rem;
+  }
+
+  @media (max-width: 768px) {
+    .tos-hero {
+      padding: 2.2rem;
+    }
+
+    .tos-section {
+      padding: 1.75rem;
+    }
+  }
+</style>
+
+<main class="tos-wrapper">
+  <section class="tos-hero">
+    <h1>Lumina HQ Terms of Service</h1>
+    <p>
+      These Terms govern your access to the Lumina HQ workforce transparency platform operated by our organization for the benefit of contracted call center and BPO clients. By using the service, you agree to uphold the accountability and confidentiality standards described here.
+    </p>
+    <div class="tos-meta">
+      <span>Audience: Internal leaders, QA teams, and authorized client stakeholders</span>
+      <span>Effective Date: <?= new Date().toISOString().slice(0, 10) ?></span>
+    </div>
+  </section>
+
+  <section class="tos-section" id="definitions">
+    <h2>1. Definitions</h2>
+    <div class="definition-list">
+      <div class="definition-item">
+        <h4>"Company"</h4>
+        <p>The managed services provider operating Lumina HQ and responsible for delivering call, chat, and digital engagement solutions.</p>
+      </div>
+      <div class="definition-item">
+        <h4>"Client"</h4>
+        <p>A business or organization that contracts the Company to provide business process outsourcing support and receives Lumina HQ access for transparency.</p>
+      </div>
+      <div class="definition-item">
+        <h4>"Authorized User"</h4>
+        <p>Any employee, contractor, QA coach, leader, or client stakeholder granted credentials to access Lumina HQ within an approved tenant.</p>
+      </div>
+      <div class="definition-item">
+        <h4>"Platform Data"</h4>
+        <p>Operational metrics, schedules, quality evaluations, coaching notes, and supporting documentation collected or generated within Lumina HQ.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="tos-section" id="acceptance">
+    <h2>2. Acceptance of Terms</h2>
+    <p>
+      Accessing Lumina HQ signifies acceptance of these Terms, the Privacy Policy, and any supporting security standards communicated by the Company. Client administrators are responsible for ensuring that their Authorized Users review and comply with these requirements prior to receiving credentials.
+    </p>
+  </section>
+
+  <section class="tos-section" id="access">
+    <h2>3. Access & Account Management</h2>
+    <ul>
+      <li>Accounts are provisioned based on active campaigns and least-privilege roles.</li>
+      <li>Credentials are unique to each individual and may not be shared or transferred.</li>
+      <li>Authorized Users must use multi-factor authentication and secure workstations.</li>
+      <li>The Company may suspend access to protect platform integrity, address misuse, or comply with legal obligations.</li>
+      <li>Clients must notify the Company within one business day when a user’s role changes or no longer requires access.</li>
+    </ul>
+  </section>
+
+  <section class="tos-section" id="permitted-use">
+    <h2>4. Permitted Use & Restrictions</h2>
+    <p>
+      Lumina HQ may be used solely to coordinate, measure, and report on call center and BPO services delivered under signed statements of work. Users must not:
+    </p>
+    <ul>
+      <li>Export or redistribute Platform Data to unauthorized parties.</li>
+      <li>Attempt to access campaigns or data outside their assigned tenant.</li>
+      <li>Introduce malicious code, attempt to bypass security controls, or interfere with system stability.</li>
+      <li>Use the platform for unrelated marketing, personal projects, or competitive analysis.</li>
+    </ul>
+    <div class="tos-highlight">
+      <strong>Transparency commitment:</strong> Each coaching review, QA score, and escalation captured in Lumina HQ is visible to stakeholders with corresponding permissions. Altering or falsifying records violates these Terms and may trigger disciplinary action or contract remedies.
+    </div>
+  </section>
+
+  <section class="tos-section" id="data-ownership">
+    <h2>5. Data Ownership & Confidentiality</h2>
+    <ul>
+      <li>Clients retain ownership of campaign deliverables, scorecards, and any customer information they provide.</li>
+      <li>The Company retains ownership of platform architecture, templates, anonymized benchmarks, and internal process documentation.</li>
+      <li>All parties agree to maintain confidentiality of non-public information and apply equivalent safeguards when exporting reports.</li>
+      <li>Sharing Platform Data externally requires prior written consent except when mandated by law.</li>
+    </ul>
+  </section>
+
+  <section class="tos-section" id="compliance">
+    <h2>6. Regulatory & Contractual Compliance</h2>
+    <p>
+      The Company designs Lumina HQ to support industry obligations such as GDPR, CCPA, HIPAA (where applicable), PCI-DSS call handling standards, and local labor requirements. Clients remain responsible for determining whether the platform meets their specific regulatory expectations and for executing any required data processing agreements.
+    </p>
+    <p>
+      The Company will cooperate with audits or questionnaires reasonably necessary to validate compliance, subject to confidentiality and scheduling constraints.
+    </p>
+  </section>
+
+  <section class="tos-section" id="service-delivery">
+    <h2>7. Service Delivery & Availability</h2>
+    <ul>
+      <li>Standard availability targets align with Google Workspace service levels. Planned maintenance windows are communicated in advance when feasible.</li>
+      <li>Support is available through the operations command center and assigned account managers during agreed business hours.</li>
+      <li>The Company may enhance, modify, or deprecate features with reasonable notice. Material changes impacting contracted deliverables will be coordinated with clients.</li>
+      <li>Data backups leverage Google’s redundancy. Clients may request scheduled exports for archiving.</li>
+    </ul>
+  </section>
+
+  <section class="tos-section" id="auditing">
+    <h2>8. Auditing & Reporting</h2>
+    <p>
+      Lumina HQ logs sign-ins, configuration updates, and key coaching activities. The Company may review logs to uphold accountability, investigate incidents, or satisfy client audit requirements. Clients may request audit extracts related to their campaigns, subject to reasonable limits and security review.
+    </p>
+  </section>
+
+  <section class="tos-section" id="suspension">
+    <h2>9. Suspension & Termination</h2>
+    <ul>
+      <li>Either party may terminate platform access upon completion or termination of the underlying services agreement.</li>
+      <li>The Company may suspend or terminate individual accounts for breach of these Terms, suspected fraud, or security risk.</li>
+      <li>Upon termination, the Company will provide mutually agreed data exports and delete or anonymize remaining Platform Data per the Privacy Policy.</li>
+      <li>Sections concerning confidentiality, intellectual property, disclaimers, and limitation of liability survive termination.</li>
+    </ul>
+  </section>
+
+  <section class="tos-section" id="warranties">
+    <h2>10. Disclaimers & Limitation of Liability</h2>
+    <p>
+      Lumina HQ is provided “as is” for operational transparency. Except as expressly stated in the master services agreement, the Company disclaims warranties of merchantability, fitness for a particular purpose, and non-infringement. Liability for any claim arising from platform use is limited to direct damages and capped at the fees paid for the applicable services during the preceding twelve (12) months.
+    </p>
+  </section>
+
+  <section class="tos-section" id="indemnification">
+    <h2>11. Indemnification</h2>
+    <p>
+      Clients agree to indemnify and hold harmless the Company and its personnel against third-party claims arising from client instructions, unlawful data submissions, or misuse of the platform by the client’s Authorized Users. The Company will indemnify the client against third-party claims alleging that the platform infringes intellectual property rights, provided the client promptly notifies the Company and cooperates with the defense.
+    </p>
+  </section>
+
+  <section class="tos-section" id="modifications">
+    <h2>12. Changes to These Terms</h2>
+    <p>
+      The Company may update these Terms to reflect new features, regulatory requirements, or operational changes. Clients will receive at least 30 days’ notice for material updates. Continued use of the platform after the effective date constitutes acceptance of the revised Terms.
+    </p>
+  </section>
+
+  <section class="tos-section" id="governing-law">
+    <h2>13. Governing Law & Dispute Resolution</h2>
+    <p>
+      Unless otherwise specified in a master services agreement, these Terms are governed by the laws of the jurisdiction where the Company is headquartered, without regard to conflicts of law principles. Parties will first attempt to resolve disputes through executive escalation and mediation before initiating formal proceedings.
+    </p>
+  </section>
+
+  <section class="tos-section" id="contact">
+    <h2>14. Contact</h2>
+    <p>
+      Questions about these Terms should be directed to your account manager or to <a href="mailto:legal@lumina-hq.internal">legal@lumina-hq.internal</a>. Incident notifications should follow the security escalation process outlined in the Privacy Policy.
+    </p>
+  </section>
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a branded privacy policy page tailored to Lumina HQ's BPO transparency use case
- add a complementary terms of service page outlining responsibilities for internal leaders and clients
- document data handling, accountability, compliance, and contact information for both pages
- link the login screen to the privacy policy and terms of service pages for quick access

## Testing
- not run (HTML content only)

------
https://chatgpt.com/codex/tasks/task_e_68e0c8b1eb348326837f2fb45a1ff1b5