### PR TITLE
Make sidebar user panel navigate to profile

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -929,12 +929,25 @@
       padding: 1.5rem;
       display: flex;
       align-items: center;
+      width: 100%;
+      text-align: left;
+      cursor: pointer;
+      color: inherit;
+      font: inherit;
+      border: none;
       border-top: 1px solid rgba(255, 255, 255, 0.1);
       background: rgba(255, 255, 255, 0.05);
       backdrop-filter: blur(15px);
       transition: var(--transition-smooth);
       position: relative;
       z-index: 3;
+      appearance: none;
+      -webkit-appearance: none;
+    }
+
+    .user-panel:focus-visible {
+      outline: 2px solid var(--sidebar-active);
+      outline-offset: 3px;
     }
 
     .user-panel::before {

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -492,7 +492,8 @@
     </div>
   </div>
 
-  <div class="user-panel" id="userPanel" data-initialized="true"
+  <button type="button" class="user-panel" id="userPanel" data-initialized="true"
+    onclick="navigateToPage('userprofile')"
     data-name="<?= displayPrimaryNameValue ?>"
     data-first-name="<?= firstNameValue ?>"
     data-last-name="<?= lastNameValue ?>"
@@ -530,7 +531,7 @@
         <? } ?>
       </div>
     </div>
-  </div>
+  </button>
 </nav>
 
 <script>


### PR DESCRIPTION
## Summary
- convert the sidebar user panel into a clickable button that routes to the user profile page
- preserve existing data attributes while adding accessible focus handling and keyboard support
- tweak sidebar styles so the interactive panel keeps its original visual design

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0fde8218883268d9f663de4413f0a