### PR TITLE
Fix banner title fragment extraction loop

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2206,7 +2206,13 @@
                     if (!bannerData.titleFragments.length) {
                         const fragments = [];
                         while (titleEl.firstChild) {
-                            fragments.push(titleEl.firstChild);
+                            const node = titleEl.firstChild;
+                            if (!node) {
+                                break;
+                            }
+
+                            fragments.push(node);
+                            titleEl.removeChild(node);
                         }
                         bannerData.titleFragments = fragments;
                     }


### PR DESCRIPTION
## Summary
- ensure banner title fragments are collected while removing nodes to avoid looping forever

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e113ac386083269237ef27638f108b