### PR TITLE
Modernize profile banner and surface profile IDs

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -19,33 +19,280 @@
 
 <style>
   :root {
-    --profile-navy: #022b5b;
-    --profile-cyan: #00bcd4;
-    --profile-mint: #31d0aa;
-    --profile-lavender: #7e8dfb;
+    --profile-navy: #0b1f33;
+    --profile-cyan: #0ea5e9;
+    --profile-mint: #22c55e;
+    --profile-lavender: #6366f1;
     --profile-surface: #ffffff;
-    --profile-soft: #f6f7fb;
-    --profile-border: #dbe4f3;
+    --profile-soft: #f3f5fb;
+    --profile-border: #d7deed;
     --profile-text: #0f172a;
     --profile-text-secondary: #475569;
-    --profile-shadow: 0 18px 35px rgba(2, 43, 91, 0.12);
-    --profile-radius-lg: 22px;
+    --profile-shadow: 0 22px 45px rgba(11, 31, 51, 0.12);
+    --profile-radius-lg: 20px;
     --profile-radius-md: 18px;
     --profile-radius-sm: 12px;
-    --profile-transition: all 0.25s ease;
-    --chip-bg: rgba(2, 43, 91, 0.08);
+    --profile-transition: all 0.2s ease;
+    --chip-bg: rgba(14, 165, 233, 0.1);
   }
 
   body {
     font-family: 'Inter', sans-serif;
-    background: linear-gradient(180deg, #eef2ff 0%, #f9fbff 100%);
+    background: linear-gradient(180deg, #f5f7fb 0%, #ffffff 60%);
     color: var(--profile-text);
   }
 
+  .profile-page {
+    padding: clamp(1.5rem, 4vw, 3.5rem) 0 4rem;
+  }
+
   .profile-wrapper {
-    padding: clamp(1.5rem, 3vw, 3rem);
-    max-width: 1180px;
-    margin: 0 auto 4rem auto;
+    width: min(1280px, 100% - clamp(2rem, 7vw, 7.5rem));
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 2.5vw, 3rem);
+  }
+
+  .profile-essentials[hidden] {
+    display: none !important;
+  }
+
+  .profile-essentials {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+    background: var(--profile-surface);
+    border-radius: var(--profile-radius-lg);
+    padding: clamp(1.35rem, 2.2vw, 2rem) clamp(1.5rem, 3vw, 2.4rem);
+    box-shadow: var(--profile-shadow);
+    border: 1px solid rgba(11, 31, 51, 0.05);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .profile-essentials::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 60%);
+    opacity: 0.7;
+  }
+
+  .profile-essential {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.25rem 0;
+  }
+
+  .profile-essential__label {
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--profile-text-secondary);
+  }
+
+  .profile-essential__value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--profile-text);
+    word-break: break-word;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .profile-essential__value--code {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+    letter-spacing: 0.05em;
+  }
+
+  .profile-essential__value a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .profile-essential__value a:hover,
+  .profile-essential__value a:focus {
+    text-decoration: underline;
+  }
+
+  .profile-essential__meta {
+    font-size: 0.85rem;
+    color: var(--profile-text-secondary);
+  }
+
+  .profile-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.85fr) minmax(0, 1.15fr);
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    align-items: start;
+  }
+
+  .profile-column {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.35rem, 2.2vw, 2rem);
+  }
+
+  .profile-column--secondary {
+    position: relative;
+  }
+
+  .profile-banner__headline {
+    display: flex;
+    align-items: center;
+    gap: clamp(1rem, 2.5vw, 2rem);
+    flex-wrap: wrap;
+  }
+
+  .profile-banner__avatar {
+    width: clamp(72px, 8vw, 104px);
+    height: clamp(72px, 8vw, 104px);
+    border-radius: 28px;
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(99, 102, 241, 0.4));
+    border: 1px solid rgba(14, 165, 233, 0.28);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 700;
+    color: var(--profile-navy);
+    box-shadow: inset 0 18px 32px rgba(14, 165, 233, 0.12);
+  }
+
+  .profile-banner__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .profile-banner__name {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 700;
+    color: var(--profile-navy);
+  }
+
+  .profile-banner__role {
+    font-size: clamp(1rem, 1.5vw, 1.25rem);
+    color: var(--profile-text-secondary);
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .profile-banner__role i {
+    color: var(--profile-cyan);
+  }
+
+  .profile-banner__username {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgba(15, 23, 42, 0.65);
+  }
+
+  .profile-banner__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 0.25rem;
+  }
+
+  .profile-banner__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border-radius: 999px;
+    padding: 0.45rem 0.85rem;
+    background: rgba(14, 165, 233, 0.15);
+    color: var(--profile-navy);
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+
+  .profile-banner__chip i {
+    font-size: 0.85rem;
+  }
+
+  .profile-banner__meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.1rem;
+    padding-top: 0.6rem;
+  }
+
+  .profile-banner__meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 150px;
+  }
+
+  .profile-banner__meta-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--profile-text-secondary);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .profile-banner__meta-label i {
+    color: var(--profile-cyan);
+    font-size: 0.85rem;
+  }
+
+  .profile-banner__meta-value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--profile-text);
+    word-break: break-word;
+  }
+
+  .profile-banner__meta-value--code {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+    letter-spacing: 0.04em;
+  }
+
+  .profile-banner__contacts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-top: 0.75rem;
+  }
+
+  .profile-banner__contact {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.95rem;
+    border-radius: 14px;
+    background: rgba(14, 165, 233, 0.1);
+    color: var(--profile-navy);
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .profile-banner__contact i {
+    color: var(--profile-cyan);
+  }
+
+  .profile-banner__contact a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .profile-banner__contact a:hover,
+  .profile-banner__contact a:focus-visible {
+    text-decoration: underline;
   }
 
   .profile-hero {
@@ -75,111 +322,23 @@
     flex-wrap: wrap;
   }
 
-  .profile-avatar {
-    width: clamp(92px, 10vw, 120px);
-    height: clamp(92px, 10vw, 120px);
-    border-radius: 28px;
-    background: rgba(255, 255, 255, 0.18);
-    border: 1px solid rgba(255, 255, 255, 0.35);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: clamp(2.5rem, 4vw, 3.5rem);
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.95);
-    box-shadow: inset 0 8px 24px rgba(2, 43, 91, 0.35);
-  }
-
-  .profile-identity h1 {
-    font-size: clamp(2rem, 3.2vw, 2.8rem);
-    margin-bottom: 0.35rem;
-    font-weight: 700;
-  }
-
-  .profile-identity p {
-    margin: 0;
-    font-size: clamp(1rem, 1.4vw, 1.2rem);
-    color: rgba(255, 255, 255, 0.85);
-  }
-
-  .profile-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-top: 1.35rem;
-  }
-
-  .profile-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    background: rgba(255, 255, 255, 0.16);
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
-    font-size: 0.9rem;
-    letter-spacing: 0.01em;
-    backdrop-filter: blur(6px);
-    border: 1px solid rgba(255, 255, 255, 0.35);
-  }
-
-  .profile-action {
-    position: relative;
-    margin-left: auto;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    justify-content: flex-end;
-  }
-
-  .profile-action a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.65rem 1.2rem;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-    font-weight: 600;
-    text-decoration: none;
-    transition: var(--profile-transition);
-    border: 1px solid rgba(255, 255, 255, 0.32);
-    backdrop-filter: blur(6px);
-  }
-
-  .profile-action a.secondary {
-    background: rgba(2, 43, 91, 0.15);
-    border-color: rgba(255, 255, 255, 0.28);
-  }
-
-  .profile-action a:hover {
-    transform: translateY(-2px);
-    background: rgba(255, 255, 255, 0.26);
-  }
-
-  .profile-action a.secondary:hover {
-    background: rgba(255, 255, 255, 0.2);
-  }
-
-  .profile-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.75rem;
-  }
-
   .profile-card {
     background: var(--profile-surface);
     border-radius: var(--profile-radius-md);
     padding: 1.75rem;
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
-    border: 1px solid rgba(2, 43, 91, 0.05);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+    border: 1px solid rgba(15, 23, 42, 0.05);
     position: relative;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
   }
 
   .profile-card h2 {
     font-size: 1.35rem;
     font-weight: 700;
-    margin-bottom: 1.25rem;
+    margin: 0;
     display: flex;
     align-items: center;
     gap: 0.65rem;
@@ -188,6 +347,49 @@
 
   .profile-card h2 i {
     color: var(--profile-navy);
+  }
+
+  .profile-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .profile-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .collapsible-card .profile-card-body[hidden] {
+    display: none;
+  }
+
+  .collapsible-toggle {
+    border: none;
+    background: rgba(14, 165, 233, 0.08);
+    color: var(--profile-navy);
+    border-radius: 999px;
+    padding: 0.45rem 0.9rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    cursor: pointer;
+    transition: var(--profile-transition);
+  }
+
+  .collapsible-toggle:hover {
+    background: rgba(14, 165, 233, 0.16);
+  }
+
+  .collapsible-toggle i {
+    transition: transform 0.2s ease;
+  }
+
+  .collapsible-toggle[aria-expanded="true"] i {
+    transform: rotate(180deg);
   }
 
   .info-grid {
@@ -257,7 +459,7 @@
     font-size: 0.95rem;
     color: var(--profile-text-secondary);
     background: var(--profile-soft);
-    border: 1px dashed rgba(2, 43, 91, 0.2);
+    border: 1px dashed rgba(14, 165, 233, 0.25);
     border-radius: var(--profile-radius-sm);
     padding: 1rem;
     text-align: center;
@@ -275,7 +477,7 @@
     padding: 0.9rem 1rem;
     border-radius: var(--profile-radius-sm);
     background: var(--profile-soft);
-    border: 1px solid rgba(2, 43, 91, 0.08);
+    border: 1px solid rgba(14, 165, 233, 0.18);
     display: grid;
     gap: 0.25rem;
   }
@@ -306,7 +508,6 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1.5rem;
   }
 
   .manager-chip {
@@ -315,7 +516,7 @@
     gap: 0.45rem;
     padding: 0.45rem 0.9rem;
     border-radius: 999px;
-    background: rgba(2, 43, 91, 0.08);
+    background: rgba(14, 165, 233, 0.12);
     color: var(--profile-navy);
     font-weight: 600;
     font-size: 0.85rem;
@@ -331,7 +532,7 @@
   .manager-stat {
     background: var(--profile-soft);
     border-radius: var(--profile-radius-sm);
-    border: 1px solid rgba(2, 43, 91, 0.08);
+    border: 1px solid rgba(14, 165, 233, 0.18);
     padding: 0.9rem 1rem;
     display: flex;
     flex-direction: column;
@@ -348,7 +549,7 @@
   .manager-stat .value {
     font-size: 1.1rem;
     font-weight: 700;
-    color: var(--profile-text);
+    color: var(--profile-navy);
   }
 
   .manager-list {
@@ -363,10 +564,10 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: 1rem 1.1rem;
+    padding: 1rem 1.15rem;
     border-radius: var(--profile-radius-sm);
-    border: 1px solid rgba(2, 43, 91, 0.08);
-    background: var(--profile-soft);
+    border: 1px solid rgba(14, 165, 233, 0.18);
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.05), rgba(99, 102, 241, 0.05));
   }
 
   .manager-row .info {
@@ -408,7 +609,7 @@
   .manager-row .metric .value {
     font-weight: 700;
     font-size: 1.05rem;
-    color: var(--profile-text);
+    color: var(--profile-navy);
   }
 
   .manager-row .metric small {
@@ -418,6 +619,50 @@
 
   .manager-summary-empty {
     margin-top: 0.5rem;
+  }
+
+  .manager-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .manager-pagination.hidden {
+    display: none !important;
+  }
+
+  .manager-pagination__range {
+    font-size: 0.9rem;
+    color: var(--profile-text-secondary);
+  }
+
+  .manager-pagination__controls {
+    display: inline-flex;
+    gap: 0.5rem;
+  }
+
+  .manager-pagination__button {
+    border: 1px solid rgba(14, 165, 233, 0.35);
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--profile-navy);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition: var(--profile-transition);
+  }
+
+  .manager-pagination__button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .manager-pagination__button:not(:disabled):hover {
+    background: rgba(14, 165, 233, 0.18);
   }
 
   .loader {
@@ -436,7 +681,7 @@
   .loader .spinner {
     width: 18px;
     height: 18px;
-    border: 3px solid rgba(2, 43, 91, 0.15);
+    border: 3px solid rgba(14, 165, 233, 0.18);
     border-top-color: var(--profile-cyan);
     border-radius: 50%;
     animation: spin 0.75s linear infinite;
@@ -446,22 +691,30 @@
     to { transform: rotate(360deg); }
   }
 
+  @media (max-width: 1200px) {
+    .profile-wrapper {
+      width: min(1200px, 100% - clamp(1.5rem, 6vw, 6rem));
+    }
+
+    .profile-layout {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 900px) {
+    .profile-essentials {
+      padding: 1.25rem 1.5rem;
+    }
+
+    .profile-banner__headline {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+
   @media (max-width: 768px) {
-    .profile-hero-content {
-      justify-content: center;
-      text-align: center;
-    }
-
-    .profile-action {
-      width: 100%;
-      margin: 1.5rem 0 0 0;
-      justify-content: center;
-      text-align: center;
-    }
-
-    .profile-action a {
-      width: 100%;
-      justify-content: center;
+    .profile-wrapper {
+      width: min(100%, 100% - 2rem);
     }
 
     .profile-card {
@@ -472,92 +725,88 @@
       grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     }
 
-    .manager-row {
+    .profile-banner__contacts {
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
     }
 
-    .manager-row .metrics {
-      width: 100%;
-      justify-content: space-between;
+    .profile-banner__contact {
+      justify-content: center;
     }
   }
 </style>
 
-<div class="profile-wrapper">
-  <section class="profile-hero">
-    <div class="profile-hero-content">
-      <div class="profile-avatar" id="profileAvatar">U</div>
-      <div class="profile-identity">
-        <h1 id="profileName">User</h1>
-        <p id="profileRole">Loading role…</p>
-      <div class="profile-chips" id="profileChips"></div>
+<main class="profile-page">
+  <div class="profile-wrapper">
+    <section class="profile-essentials" id="profileEssentials" aria-label="Profile essentials" hidden></section>
+
+    <div class="profile-layout">
+      <div class="profile-column profile-column--primary">
+        <section class="profile-card">
+          <h2><i class="fa-solid fa-id-card"></i> Personal Information</h2>
+          <div class="info-grid" id="personalDetails"></div>
+        </section>
+
+        <section class="profile-card">
+          <h2><i class="fa-solid fa-briefcase"></i> Employment</h2>
+          <div class="info-grid" id="employmentDetails"></div>
+        </section>
+
+        <section class="profile-card collapsible-card">
+          <div class="profile-card-header">
+            <h2><i class="fa-solid fa-user-shield"></i> Access &amp; Permissions</h2>
+            <button class="collapsible-toggle" type="button" data-target="accessPermissionsPanel"
+              data-collapsed-text="Show access" data-expanded-text="Hide access" aria-expanded="false">
+              <span class="collapsible-toggle__label">Show access</span>
+              <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div class="profile-card-body" id="accessPermissionsPanel" hidden>
+            <div class="chip-row" id="roleChips"></div>
+            <div class="chip-row" id="pageChips"></div>
+            <div class="info-grid" id="accessDetails"></div>
+          </div>
+        </section>
       </div>
-      <div class="profile-action">
-        <a id="agentExperienceLink" href="#" target="_top">
-          <i class="fa-solid fa-compass"></i>
-          Open Agent Experience
-        </a>
-        <a id="agentScheduleLink" class="secondary" href="#" target="_top">
-          <i class="fa-solid fa-calendar-check"></i>
-          View My Schedule
-        </a>
+
+      <div class="profile-column profile-column--secondary">
+        <section class="profile-card">
+          <h2><i class="fa-solid fa-lock"></i> Security</h2>
+          <div class="info-grid" id="securityDetails"></div>
+        </section>
+
+        <section class="profile-card">
+          <h2><i class="fa-solid fa-laptop"></i> Equipment &amp; Resources</h2>
+          <ul class="equipment-list" id="equipmentList"></ul>
+          <div class="loader" id="equipmentLoader">
+            <div class="spinner"></div>
+            Fetching equipment…
+          </div>
+        </section>
+
+        <section class="profile-card manager-card hidden" id="managerSummaryCard">
+          <div class="manager-card-header">
+            <h2><i class="fa-solid fa-people-group"></i> Managed Team Overview</h2>
+            <span class="manager-chip" id="managerSummaryManagedCount">
+              <i class="fa-solid fa-user-group"></i>
+              0 Managed
+            </span>
+          </div>
+          <div class="manager-stats" id="managerSummaryStats"></div>
+          <div class="manager-list" id="managerSummaryList"></div>
+          <div class="manager-pagination hidden" id="managerSummaryPagination"></div>
+          <div class="empty-state manager-summary-empty hidden" id="managerSummaryEmpty">
+            No managed team members are assigned to you yet.
+          </div>
+          <div class="loader" id="managerSummaryLoader">
+            <div class="spinner"></div>
+            Compiling team performance…
+          </div>
+        </section>
       </div>
     </div>
-  </section>
-
-  <div class="profile-grid">
-    <section class="profile-card">
-      <h2><i class="fa-solid fa-id-card"></i> Personal Information</h2>
-      <div class="info-grid" id="personalDetails"></div>
-    </section>
-
-    <section class="profile-card">
-      <h2><i class="fa-solid fa-briefcase"></i> Employment</h2>
-      <div class="info-grid" id="employmentDetails"></div>
-    </section>
-
-    <section class="profile-card">
-      <h2><i class="fa-solid fa-user-shield"></i> Access &amp; Permissions</h2>
-      <div class="chip-row" id="roleChips"></div>
-      <div class="chip-row" id="pageChips"></div>
-      <div class="info-grid" id="accessDetails"></div>
-    </section>
-
-    <section class="profile-card">
-      <h2><i class="fa-solid fa-lock"></i> Security</h2>
-      <div class="info-grid" id="securityDetails"></div>
-    </section>
-
-    <section class="profile-card">
-      <h2><i class="fa-solid fa-laptop"></i> Equipment &amp; Resources</h2>
-      <ul class="equipment-list" id="equipmentList"></ul>
-      <div class="loader" id="equipmentLoader">
-        <div class="spinner"></div>
-        Fetching equipment…
-      </div>
-    </section>
-
-    <section class="profile-card manager-card hidden" id="managerSummaryCard">
-      <div class="manager-card-header">
-        <h2><i class="fa-solid fa-people-group"></i> Managed Team Overview</h2>
-        <span class="manager-chip" id="managerSummaryManagedCount">
-          <i class="fa-solid fa-user-group"></i>
-          0 Managed
-        </span>
-      </div>
-      <div class="manager-stats" id="managerSummaryStats"></div>
-      <div class="manager-list" id="managerSummaryList"></div>
-      <div class="empty-state manager-summary-empty hidden" id="managerSummaryEmpty">
-        No managed team members are assigned to you yet.
-      </div>
-      <div class="loader" id="managerSummaryLoader">
-        <div class="spinner"></div>
-        Compiling team performance…
-      </div>
-    </section>
   </div>
-</div>
+</main>
 
 <script>
   const CURRENT_USER = <?!= currentUserJson || '{}' ?>;
@@ -572,15 +821,11 @@
     campaignId: PROFILE_BOOTSTRAP.campaignId || (CURRENT_USER ? CURRENT_USER.CampaignID || CURRENT_USER.campaignId || '' : ''),
     managerSummary: PROFILE_BOOTSTRAP.managerSummary || null,
     loadingEquipment: false,
-    loadingManagerSummary: false
+    loadingManagerSummary: false,
+    managerPagination: { page: 1, pageSize: 6 },
+    profileId: safeString(PROFILE_BOOTSTRAP.profileId) || '',
+    profileSummary: null
   };
-
-  function setText(id, value, fallback = '') {
-    const el = document.getElementById(id);
-    if (!el) return;
-    const text = value === null || typeof value === 'undefined' ? fallback : String(value);
-    el.textContent = text || fallback;
-  }
 
   function safeString(value) {
     if (value === null || typeof value === 'undefined') return '';
@@ -678,6 +923,76 @@
       } catch (_) { /* ignore */ }
     }
     return text.split(/[,;|]+/).map(part => safeString(part)).filter(Boolean);
+  }
+
+  function slugifyProfileBase(value) {
+    const base = safeString(value).toLowerCase();
+    if (!base) {
+      return 'user';
+    }
+    const normalized = base.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return normalized || 'user';
+  }
+
+  function computeProfileId(userRecord, detailRecord) {
+    const record = detailRecord && detailRecord.record ? detailRecord.record : detailRecord || {};
+    const usernameCandidate =
+      getField(userRecord, ['UserName', 'userName', 'username']) ||
+      getField(record, ['UserName', 'userName', 'username']) ||
+      getField(userRecord, ['Email', 'email']) ||
+      getField(record, ['Email', 'email']) ||
+      'user';
+    const username = safeString(usernameCandidate) || 'user';
+
+    const identifierCandidate =
+      getField(userRecord, ['ID', 'Id', 'id', 'EmployeeID', 'employeeId', 'ProfileID', 'profileId']) ||
+      getField(record, ['ID', 'Id', 'id', 'EmployeeID', 'employeeId', 'ProfileID', 'profileId']) ||
+      username;
+    const identifier = safeString(identifierCandidate) || username;
+
+    const seed = `${username}|${identifier}`;
+    let hash = 0;
+    for (let i = 0; i < seed.length; i++) {
+      hash = ((hash << 5) - hash) + seed.charCodeAt(i);
+      hash |= 0;
+    }
+
+    const modulo = Math.abs(hash % 1000000);
+    let digits = String(modulo);
+    while (digits.length < 6) {
+      digits = `0${digits}`;
+    }
+
+    const base = slugifyProfileBase(username);
+    return `${base}-${digits}`;
+  }
+
+  function ensureProfileIdInUrl(profileId) {
+    if (!profileId || typeof window === 'undefined' || !window.location || !window.history) {
+      return;
+    }
+
+    try {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('profileId') === profileId) {
+        return;
+      }
+      url.searchParams.set('profileId', profileId);
+      window.history.replaceState({}, document.title, url.toString());
+    } catch (err) {
+      const href = String(window.location.href || '');
+      if (!href) {
+        return;
+      }
+      const hasParam = /([?&])profileId=/i.test(href);
+      if (hasParam) {
+        const updated = href.replace(/([?&]profileId=)[^&#]*/i, `$1${encodeURIComponent(profileId)}`);
+        window.history.replaceState({}, document.title, updated);
+      } else {
+        const separator = href.indexOf('?') === -1 ? '?' : '&';
+        window.history.replaceState({}, document.title, `${href}${separator}profileId=${encodeURIComponent(profileId)}`);
+      }
+    }
   }
 
   function formatDate(value) {
@@ -841,6 +1156,80 @@
     nodes.forEach(node => container.appendChild(node));
   }
 
+  function renderProfileEssentials(summary) {
+    const container = document.getElementById('profileEssentials');
+    if (!container) {
+      return;
+    }
+
+    const items = [];
+    const pushItem = (label, value, options = {}) => {
+      const text = safeString(value);
+      if (!text) {
+        return;
+      }
+      items.push(Object.assign({ label, value: text }, options));
+    };
+
+    summary = summary || {};
+
+    pushItem('Profile ID', summary.profileId, { code: true });
+    pushItem('Work Email', summary.email, { isLink: true, href: summary.email ? `mailto:${summary.email}` : '' });
+    pushItem('Manager', summary.manager);
+    pushItem('Location', summary.location);
+    pushItem('Employment Status', summary.status);
+    pushItem('Tenure', summary.tenure, {
+      meta: summary.startDate ? `Started ${summary.startDate}` : ''
+    });
+
+    if (!items.length) {
+      container.hidden = true;
+      container.innerHTML = '';
+      return;
+    }
+
+    container.hidden = false;
+    container.innerHTML = '';
+
+    items.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'profile-essential';
+
+      const labelEl = document.createElement('span');
+      labelEl.className = 'profile-essential__label';
+      labelEl.textContent = item.label;
+      card.appendChild(labelEl);
+
+      const valueEl = document.createElement('div');
+      valueEl.className = 'profile-essential__value';
+      if (item.code) {
+        valueEl.classList.add('profile-essential__value--code');
+      }
+
+      if (item.isLink && item.value) {
+        const link = document.createElement('a');
+        link.href = item.href || item.value;
+        link.target = '_top';
+        link.rel = 'noopener';
+        link.textContent = item.value;
+        valueEl.appendChild(link);
+      } else {
+        valueEl.textContent = item.value;
+      }
+
+      card.appendChild(valueEl);
+
+      if (item.meta) {
+        const metaEl = document.createElement('div');
+        metaEl.className = 'profile-essential__meta';
+        metaEl.textContent = item.meta;
+        card.appendChild(metaEl);
+      }
+
+      container.appendChild(card);
+    });
+  }
+
   function renderChips(containerId, values, icon) {
     const container = document.getElementById(containerId);
     if (!container) return;
@@ -851,6 +1240,7 @@
       container.classList.add('empty');
       return;
     }
+    container.classList.remove('empty');
 
     list.forEach(value => {
       const chip = document.createElement('span');
@@ -968,6 +1358,7 @@
     const listEl = document.getElementById('managerSummaryList');
     const emptyEl = document.getElementById('managerSummaryEmpty');
     const countEl = document.getElementById('managerSummaryManagedCount');
+    const paginationEl = document.getElementById('managerSummaryPagination');
 
     if (emptyEl && state.loadingManagerSummary) {
       emptyEl.classList.add('hidden');
@@ -978,6 +1369,10 @@
     }
     if (statsEl) statsEl.innerHTML = '';
     if (listEl) listEl.innerHTML = '';
+    if (paginationEl) {
+      paginationEl.innerHTML = '';
+      paginationEl.classList.add('hidden');
+    }
 
     if (!summary) {
       if (emptyEl && !state.loadingManagerSummary) {
@@ -1055,6 +1450,10 @@
         emptyEl.textContent = 'No managed team members are assigned to you yet.';
         emptyEl.classList.remove('hidden');
       }
+      if (paginationEl) {
+        paginationEl.classList.add('hidden');
+      }
+      state.managerPagination.page = 1;
       return;
     }
 
@@ -1075,7 +1474,50 @@
       return aName.localeCompare(bName);
     });
 
-    users.forEach(user => {
+    const pageSize = state.managerPagination.pageSize || 6;
+    let currentPage = state.managerPagination.page || 1;
+    const totalPages = Math.max(1, Math.ceil(users.length / pageSize));
+    if (currentPage > totalPages) currentPage = totalPages;
+    if (currentPage < 1) currentPage = 1;
+    state.managerPagination.page = currentPage;
+
+    const startIndex = (currentPage - 1) * pageSize;
+    const pagedUsers = users.slice(startIndex, startIndex + pageSize);
+
+    if (paginationEl) {
+      paginationEl.innerHTML = '';
+      if (users.length) {
+        const range = document.createElement('span');
+        range.className = 'manager-pagination__range';
+        const start = startIndex + 1;
+        const end = Math.min(startIndex + pageSize, users.length);
+        range.textContent = `Showing ${start}–${end} of ${users.length}`;
+        paginationEl.appendChild(range);
+
+        if (totalPages > 1) {
+          const controls = document.createElement('div');
+          controls.className = 'manager-pagination__controls';
+
+          const createButton = (action, label, icon, disabled) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'manager-pagination__button';
+            button.dataset.pageAction = action;
+            button.disabled = disabled;
+            button.innerHTML = `<i class="${icon}"></i><span>${label}</span>`;
+            controls.appendChild(button);
+          };
+
+          createButton('prev', 'Previous', 'fa-solid fa-arrow-left', currentPage === 1);
+          createButton('next', 'Next', 'fa-solid fa-arrow-right', currentPage === totalPages);
+          paginationEl.appendChild(controls);
+        }
+
+        paginationEl.classList.remove('hidden');
+      }
+    }
+
+    pagedUsers.forEach(user => {
       const row = document.createElement('div');
       row.className = 'manager-row';
 
@@ -1117,6 +1559,53 @@
       if (listEl) {
         listEl.appendChild(row);
       }
+    });
+  }
+
+  function handleManagerPaginationClick(event) {
+    const button = event.target && event.target.closest ? event.target.closest('[data-page-action]') : null;
+    if (!button || button.disabled) {
+      return;
+    }
+
+    const action = button.getAttribute('data-page-action');
+    const currentPage = state.managerPagination.page || 1;
+    if (action === 'prev') {
+      state.managerPagination.page = Math.max(1, currentPage - 1);
+    } else if (action === 'next') {
+      state.managerPagination.page = currentPage + 1;
+    }
+
+    renderManagerSummary(state.managerSummary);
+  }
+
+  function setupCollapsibleCards() {
+    const toggles = document.querySelectorAll('.collapsible-toggle');
+    toggles.forEach(toggle => {
+      const targetId = toggle.getAttribute('data-target');
+      const panel = targetId ? document.getElementById(targetId) : null;
+      if (!panel) {
+        return;
+      }
+
+      const label = toggle.querySelector('.collapsible-toggle__label');
+      const collapsedText = toggle.getAttribute('data-collapsed-text') || 'Show';
+      const expandedText = toggle.getAttribute('data-expanded-text') || 'Hide';
+
+      const setState = expanded => {
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        panel.hidden = !expanded;
+        if (label) {
+          label.textContent = expanded ? expandedText : collapsedText;
+        }
+      };
+
+      setState(false);
+
+      toggle.addEventListener('click', () => {
+        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        setState(!isExpanded);
+      });
     });
   }
 
@@ -1163,61 +1652,264 @@
     return false;
   }
 
-  function hydrateHero(userRecord, detailRecord) {
+  function updateGlobalBannerFromProfile(summary) {
+    if (typeof initializeGlobalBanner !== 'function') {
+      return;
+    }
+
+    summary = summary || {};
+
+    const name = summary.name || 'My Profile';
+    const primaryRole = summary.primaryRole || 'Team Member';
+    const campaign = summary.campaign || '';
+    const status = summary.status || '';
+    const startDate = summary.startDate || '';
+    const tenure = summary.tenure || '';
+    const profileId = summary.profileId || '';
+    const username = safeString(summary.username);
+    const location = summary.location || '';
+    const manager = summary.manager || '';
+    const email = summary.email || '';
+    const phone = summary.phone || '';
+
+    const headline = document.createElement('div');
+    headline.className = 'profile-banner__headline';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'profile-banner__avatar';
+    avatar.textContent = safeString(name).charAt(0).toUpperCase() || 'U';
+    headline.appendChild(avatar);
+
+    const textWrap = document.createElement('div');
+    textWrap.className = 'profile-banner__text';
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'profile-banner__name';
+    nameEl.textContent = name;
+    textWrap.appendChild(nameEl);
+
+    if (primaryRole) {
+      const roleEl = document.createElement('div');
+      roleEl.className = 'profile-banner__role';
+      const icon = document.createElement('i');
+      icon.className = 'fa-solid fa-shield-halved';
+      roleEl.appendChild(icon);
+      const roleText = document.createElement('span');
+      roleText.textContent = primaryRole;
+      roleEl.appendChild(roleText);
+      textWrap.appendChild(roleEl);
+    }
+
+    if (username) {
+      const usernameEl = document.createElement('div');
+      usernameEl.className = 'profile-banner__username';
+      usernameEl.textContent = username.indexOf('@') === -1 ? `@${username}` : username;
+      textWrap.appendChild(usernameEl);
+    }
+
+    headline.appendChild(textWrap);
+
+    const chipsRow = document.createElement('div');
+    chipsRow.className = 'profile-banner__chips';
+
+    const appendChip = (icon, label) => {
+      if (!label) {
+        return;
+      }
+      const chip = document.createElement('span');
+      chip.className = 'profile-banner__chip';
+      if (icon) {
+        const iconEl = document.createElement('i');
+        iconEl.className = icon;
+        chip.appendChild(iconEl);
+      }
+      const text = document.createElement('span');
+      text.textContent = label;
+      chip.appendChild(text);
+      chipsRow.appendChild(chip);
+    };
+
+    appendChip('fa-solid fa-circle-check', status);
+    appendChip('fa-solid fa-calendar-day', startDate ? `Joined ${startDate}` : '');
+    appendChip('fa-solid fa-hourglass-half', tenure);
+    appendChip('fa-solid fa-diagram-project', campaign);
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'profile-banner__meta-row';
+
+    const appendMeta = (icon, label, value, options = {}) => {
+      const textValue = safeString(value);
+      if (!textValue) {
+        return;
+      }
+      const item = document.createElement('div');
+      item.className = 'profile-banner__meta-item';
+
+      const labelEl = document.createElement('div');
+      labelEl.className = 'profile-banner__meta-label';
+      if (icon) {
+        const iconEl = document.createElement('i');
+        iconEl.className = icon;
+        labelEl.appendChild(iconEl);
+      }
+      const labelText = document.createElement('span');
+      labelText.textContent = label;
+      labelEl.appendChild(labelText);
+      item.appendChild(labelEl);
+
+      const valueEl = document.createElement('div');
+      valueEl.className = 'profile-banner__meta-value';
+      if (options.code) {
+        valueEl.classList.add('profile-banner__meta-value--code');
+      }
+      valueEl.textContent = textValue;
+      item.appendChild(valueEl);
+
+      metaRow.appendChild(item);
+    };
+
+    appendMeta('fa-solid fa-id-badge', 'Profile ID', profileId, { code: true });
+    appendMeta('fa-solid fa-user-tie', 'Manager', manager);
+    appendMeta('fa-solid fa-location-dot', 'Location', location);
+
+    const contactsRow = document.createElement('div');
+    contactsRow.className = 'profile-banner__contacts';
+
+    const appendContact = (icon, label, value, href) => {
+      const textValue = safeString(value);
+      if (!textValue) {
+        return;
+      }
+      const contact = document.createElement('div');
+      contact.className = 'profile-banner__contact';
+      if (icon) {
+        const iconEl = document.createElement('i');
+        iconEl.className = icon;
+        contact.appendChild(iconEl);
+      }
+      const content = document.createElement(href ? 'a' : 'span');
+      if (href) {
+        content.href = href;
+        content.target = '_top';
+        content.rel = 'noopener';
+      }
+      content.textContent = textValue;
+      if (label) {
+        content.setAttribute('aria-label', `${label}: ${textValue}`);
+      }
+      contact.appendChild(content);
+      contactsRow.appendChild(contact);
+    };
+
+    appendContact('fa-solid fa-envelope', 'Email', email, email ? `mailto:${email}` : '');
+    if (phone) {
+      const tel = phone.replace(/[^0-9+]/g, '');
+      appendContact('fa-solid fa-phone', 'Phone', phone, tel ? `tel:${tel}` : '');
+    }
+
+    const descriptionElements = [];
+    if (chipsRow.childNodes.length) descriptionElements.push(chipsRow);
+    if (metaRow.childNodes.length) descriptionElements.push(metaRow);
+    if (contactsRow.childNodes.length) descriptionElements.push(contactsRow);
+
+    const actions = [];
+    const addAction = (href, label, icon, variant) => {
+      if (!href) {
+        return;
+      }
+      const action = document.createElement('a');
+      action.href = href;
+      action.target = '_top';
+      action.textContent = label;
+      action.setAttribute('data-banner-icon', icon);
+      action.setAttribute('data-banner-variant', variant);
+      action.setAttribute('data-banner-label', label);
+      actions.push(action);
+    };
+
+    try {
+      addAction(buildPageLink('agent-experience'), 'Agent Experience', 'fa-solid fa-user-gear', 'primary');
+      addAction(buildPageLink('agentschedule'), 'View Schedule', 'fa-solid fa-calendar-days', 'secondary');
+    } catch (err) {
+      console.warn('Unable to build banner actions', err);
+    }
+
+    initializeGlobalBanner({
+      eyebrow: 'Profile Overview',
+      titleFragments: [headline],
+      description: '',
+      descriptionElements,
+      campaignName: campaign,
+      actions
+    });
+  }
+
+  function hydrateProfileSummary(userRecord, detailRecord) {
     const record = detailRecord && detailRecord.record ? detailRecord.record : detailRecord || {};
     const name = resolveDisplayName(userRecord) || resolveDisplayName(record) || 'Your profile';
     const primaryRole = resolvePrimaryRole(userRecord, record) || 'Team Member';
     const campaign = safeString(userRecord.campaignName || userRecord.CampaignName || record.CampaignName || record.campaignName || state.campaignId);
     const status = safeString(record.EmploymentStatus || record.Status || userRecord.Status || userRecord.status);
-    const startDate = formatDate(record.StartDate || record.HireDate || record.DateHired || record.OnboardDate || record.CreatedAt || record.createdAt);
+    const startDateRaw = record.StartDate || record.HireDate || record.DateHired || record.OnboardDate || record.CreatedAt || record.createdAt;
+    const startDate = formatDate(startDateRaw);
+    const tenure = formatTenure(startDateRaw);
+    const username = safeString(
+      getField(userRecord, ['UserName', 'userName', 'username']) ||
+      getField(record, ['UserName', 'userName', 'username'])
+    );
+    const manager = safeString(
+      getField(record, ['Manager', 'manager', 'ManagerName', 'managerName', 'Supervisor', 'supervisor'])
+    );
+    const location = safeString(
+      getField(record, ['Location', 'location', 'City', 'city', 'Country', 'country']) ||
+      getField(userRecord, ['Location', 'location', 'City', 'city', 'Country', 'country'])
+    );
+    const email = safeString(
+      getField(record, ['WorkEmail', 'Email', 'email']) ||
+      getField(userRecord, ['WorkEmail', 'Email', 'email'])
+    );
+    const phone = safeString(
+      getField(record, ['Phone', 'phone', 'Mobile', 'mobile', 'WorkPhone', 'workPhone']) ||
+      getField(userRecord, ['Phone', 'phone', 'Mobile', 'mobile'])
+    );
 
-    const chips = document.getElementById('profileChips');
-    if (chips) {
-      chips.innerHTML = '';
-      if (status) {
-        const statusChip = document.createElement('span');
-        statusChip.className = 'profile-chip';
-        statusChip.innerHTML = '<i class="fa-solid fa-circle-check"></i>' + status;
-        chips.appendChild(statusChip);
-      }
-      if (startDate) {
-        const startChip = document.createElement('span');
-        startChip.className = 'profile-chip';
-        startChip.innerHTML = '<i class="fa-solid fa-calendar"></i> Joined ' + startDate;
-        chips.appendChild(startChip);
-      }
-      if (campaign) {
-        const campaignChip = document.createElement('span');
-        campaignChip.className = 'profile-chip';
-        campaignChip.innerHTML = '<i class="fa-solid fa-diagram-project"></i> ' + campaign;
-        chips.appendChild(campaignChip);
-      }
+    const computedProfileId = computeProfileId(userRecord, detailRecord);
+    if (computedProfileId && computedProfileId !== state.profileId) {
+      state.profileId = computedProfileId;
+    }
+    ensureProfileIdInUrl(state.profileId);
+
+    const sidebarPanel = document.getElementById('userPanel');
+    if (sidebarPanel && state.profileId) {
+      sidebarPanel.setAttribute('data-profile-id', state.profileId);
     }
 
-    setText('profileName', name, 'Your profile');
-    setText('profileRole', primaryRole || 'Team Member');
+    const summary = {
+      name,
+      primaryRole,
+      campaign,
+      status,
+      startDate,
+      tenure,
+      username,
+      profileId: state.profileId,
+      manager,
+      location,
+      email,
+      phone
+    };
 
-    const avatar = document.getElementById('profileAvatar');
-    if (avatar) {
-      const initial = safeString(name).charAt(0).toUpperCase() || 'U';
-      avatar.textContent = initial;
-    }
+    state.profileSummary = summary;
 
-    const agentLink = document.getElementById('agentExperienceLink');
-    if (agentLink) {
-      agentLink.href = buildPageLink('agent-experience');
-    }
-
-    const scheduleLink = document.getElementById('agentScheduleLink');
-    if (scheduleLink) {
-      scheduleLink.href = buildPageLink('agentschedule');
-    }
+    updateGlobalBannerFromProfile(summary);
+    renderProfileEssentials(summary);
   }
 
   function refreshSections() {
     const detailRecord = state.detail && state.detail.record ? state.detail.record : state.detail || {};
+    const combinedRecord = Object.assign({}, state.user, detailRecord);
 
-    hydrateHero(state.user, state.detail);
+    hydrateProfileSummary(state.user, state.detail);
 
     renderInfoGrid('personalDetails', [
       { label: 'Full Name', keys: ['FullName', 'fullName', 'DisplayName', 'displayName'] },
@@ -1226,7 +1918,7 @@
       { label: 'Phone', keys: ['Phone', 'phone', 'Mobile', 'mobile'] },
       { label: 'Username', keys: ['UserName', 'userName', 'username', 'Email'] },
       { label: 'Location', keys: ['Location', 'location', 'City', 'city', 'Country', 'country'] }
-    ], detailRecord);
+    ], combinedRecord);
 
     renderInfoGrid('employmentDetails', [
       { label: 'Employee ID', keys: ['EmployeeID', 'employeeId', 'ID', 'id'] },
@@ -1244,9 +1936,9 @@
         keys: ['StartDate', 'HireDate', 'DateHired', 'AnniversaryDate'],
         transform: (value) => formatTenure(value)
       }
-    ], detailRecord);
+    ], combinedRecord);
 
-    const roles = normalizeList(state.user.roleNames || detailRecord.roleNames || detailRecord.RoleNames || detailRecord.Roles || detailRecord.Role);
+    const roles = normalizeList(state.user.roleNames || combinedRecord.roleNames || combinedRecord.RoleNames || combinedRecord.Roles || combinedRecord.Role);
     renderChips('roleChips', roles, 'fa-solid fa-badge-check');
 
     renderChips('pageChips', state.pages, 'fa-solid fa-layer-group');
@@ -1259,8 +1951,17 @@
       } },
       { label: 'Manage Users', keys: ['canManageUsers'], transform: () => formatBoolean(state.permissions && state.permissions.canManageUsers) },
       { label: 'Manage Pages', keys: ['canManagePages'], transform: () => formatBoolean(state.permissions && state.permissions.canManagePages) },
-      { label: 'Assigned Campaign', keys: ['CampaignID', 'campaignId'], transform: (value) => safeString(value || state.campaignId) }
-    ], Object.assign({}, detailRecord, { permissions: state.permissions }));
+      {
+        label: 'Assigned Campaign',
+        keys: ['CampaignName', 'campaignName', 'CampaignID', 'campaignId'],
+        transform: (value, record, userData) => {
+          const name = safeString(record && (record.CampaignName || record.campaignName)) ||
+            safeString(userData && (userData.CampaignName || userData.campaignName));
+          const id = safeString(record && (record.CampaignID || record.campaignId)) || safeString(state.campaignId);
+          return name || id;
+        }
+      }
+    ], Object.assign({}, state.user, detailRecord, { permissions: state.permissions }));
 
     renderInfoGrid('securityDetails', [
       { label: 'Email Confirmed', keys: ['EmailConfirmed', 'emailConfirmed'], transform: (value) => formatBoolean(value) },
@@ -1268,7 +1969,7 @@
       { label: 'Last Login', keys: ['LastLoginAt', 'LastLogin', 'lastLoginAt', 'lastLogin'], transform: (value) => formatDate(value) },
       { label: 'Last Activity', keys: ['LastActivityAt', 'lastActivityAt'], transform: (value) => formatDate(value) },
       { label: 'Password Reset Required', keys: ['ResetRequired', 'resetRequired'], transform: (value) => formatBoolean(value, { positive: 'Required', negative: 'Not Required' }) }
-    ], Object.assign({}, state.user, detailRecord));
+    ], combinedRecord);
 
     renderEquipment(state.equipment);
     renderManagerSummary(state.managerSummary);
@@ -1370,10 +2071,13 @@
         state.loadingManagerSummary = false;
         if (result && result.success) {
           state.managerSummary = result;
+          state.managerPagination.page = 1;
         } else if (result) {
           state.managerSummary = Object.assign({ success: false }, result);
+          state.managerPagination.page = 1;
         } else {
           state.managerSummary = { success: false, error: 'Unable to load team summary right now.' };
+          state.managerPagination.page = 1;
         }
         renderManagerSummary(state.managerSummary);
       })
@@ -1405,6 +2109,12 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
+    setupCollapsibleCards();
+    const paginationEl = document.getElementById('managerSummaryPagination');
+    if (paginationEl) {
+      paginationEl.addEventListener('click', handleManagerPaginationClick);
+    }
+
     refreshSections();
     fetchUserDetail();
     fetchUserPages();

--- a/layout.html
+++ b/layout.html
@@ -931,7 +931,7 @@
       align-items: center;
       width: 100%;
       text-align: left;
-      cursor: pointer;
+      cursor: default;
       color: inherit;
       font: inherit;
       border: none;
@@ -941,8 +941,6 @@
       transition: var(--transition-smooth);
       position: relative;
       z-index: 3;
-      appearance: none;
-      -webkit-appearance: none;
     }
 
     .user-panel:focus-visible {
@@ -998,6 +996,38 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .user-name-trigger {
+      border: none;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      padding: 0;
+      margin: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      cursor: pointer;
+    }
+
+    .user-name-trigger:hover i,
+    .user-name-trigger:focus i {
+      opacity: 0.9;
+    }
+
+    .user-name-trigger:focus-visible {
+      outline: 2px solid var(--sidebar-active);
+      outline-offset: 3px;
+      border-radius: 6px;
+    }
+
+    .user-name-trigger i {
+      font-size: 0.85rem;
+      opacity: 0.6;
     }
 
     .user-info .role {
@@ -1026,6 +1056,55 @@
       font-size: 0.7rem;
       opacity: 0.9;
       margin-right: 0.25rem;
+    }
+
+    .user-panel-menu {
+      position: absolute;
+      bottom: calc(100% - 0.5rem);
+      right: 1.5rem;
+      display: none;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.6rem;
+      border-radius: 12px;
+      background: rgba(15, 23, 42, 0.92);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
+      min-width: 180px;
+      z-index: 5;
+    }
+
+    .user-panel.menu-open .user-panel-menu {
+      display: flex;
+    }
+
+    .user-panel-menu[hidden] {
+      display: none !important;
+    }
+
+    .user-panel-menu__item {
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      border: none;
+      background: transparent;
+      color: rgba(255, 255, 255, 0.9);
+      font: inherit;
+      font-weight: 600;
+      padding: 0.55rem 0.7rem;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: var(--transition-smooth);
+    }
+
+    .user-panel-menu__item i {
+      font-size: 0.9rem;
+    }
+
+    .user-panel-menu__item:hover,
+    .user-panel-menu__item:focus {
+      background: rgba(99, 102, 241, 0.18);
+      color: #fff;
     }
 
     /* Enhanced Employment Status Colors */
@@ -3091,10 +3170,92 @@
             }
 
             console.log('✅ Lumina Dashboard initialized');
-            
+
+            const setupUserMenu = () => {
+                const panel = document.getElementById('userPanel');
+                const trigger = document.getElementById('userProfileTrigger');
+                const menu = document.getElementById('userPanelMenu');
+                if (!panel || !trigger || !menu) {
+                    return;
+                }
+
+                const closeMenu = () => {
+                    if (menu.hidden) {
+                        return;
+                    }
+                    menu.hidden = true;
+                    panel.classList.remove('menu-open');
+                    trigger.setAttribute('aria-expanded', 'false');
+                };
+
+                const openMenu = () => {
+                    menu.hidden = false;
+                    panel.classList.add('menu-open');
+                    trigger.setAttribute('aria-expanded', 'true');
+                };
+
+                const toggleMenu = () => {
+                    if (menu.hidden) {
+                        openMenu();
+                    } else {
+                        closeMenu();
+                    }
+                };
+
+                trigger.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    toggleMenu();
+                });
+
+                trigger.addEventListener('keydown', function(event) {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        toggleMenu();
+                    } else if (event.key === 'Escape') {
+                        event.preventDefault();
+                        closeMenu();
+                    }
+                });
+
+                menu.addEventListener('click', function(event) {
+                    const item = event.target && event.target.closest ? event.target.closest('.user-panel-menu__item') : null;
+                    if (!item) {
+                        return;
+                    }
+                    const action = item.getAttribute('data-menu-action');
+                    closeMenu();
+                    if (action === 'profile') {
+                        if (typeof navigateToPage === 'function') {
+                            const profileIdAttr = panel.getAttribute('data-profile-id') || '';
+                            const params = profileIdAttr ? { profileId: profileIdAttr } : {};
+                            navigateToPage('userprofile', null, params);
+                        }
+                    } else if (action === 'logout') {
+                        if (typeof handleLogout === 'function') {
+                            handleLogout();
+                        }
+                    }
+                });
+
+                document.addEventListener('click', function(event) {
+                    if (!menu.hidden && !panel.contains(event.target)) {
+                        closeMenu();
+                    }
+                });
+
+                document.addEventListener('keydown', function(event) {
+                    if (event.key === 'Escape') {
+                        closeMenu();
+                    }
+                });
+            };
+
+            setupUserMenu();
+
             // Mark as hydrated immediately to prevent any client updates
             window.__userHydrated = true;
-            
+
             // Check if user panel was properly rendered by server
             const userPanel = document.getElementById('userPanel');
             if (userPanel && userPanel.getAttribute('data-initialized') === 'true') {

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -128,6 +128,45 @@
 
   var userInitialValue = (displayPrimaryNameValue || 'U').charAt(0).toUpperCase();
 
+  function slugifyProfileIdBase(value) {
+    var text = safeUserString(value).toLowerCase();
+    if (!text) {
+      return 'user';
+    }
+    var normalized = text.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return normalized || 'user';
+  }
+
+  function computeProfileIdValue(user) {
+    if (!user) {
+      return 'user-000000';
+    }
+
+    var username = safeUserString(getUserFieldValue(user, ['UserName', 'userName', 'username', 'Email', 'email'])) || 'user';
+    var identifier = safeUserString(getUserFieldValue(user, ['ID', 'Id', 'id', 'EmployeeID', 'employeeId', 'ProfileID', 'profileId']));
+    if (!identifier) {
+      identifier = username;
+    }
+
+    var seed = username + '|' + identifier;
+    var hash = 0;
+    for (var idx = 0; idx < seed.length; idx++) {
+      hash = ((hash << 5) - hash) + seed.charCodeAt(idx);
+      hash |= 0;
+    }
+
+    var modulo = Math.abs(hash % 1000000);
+    var digits = String(modulo);
+    while (digits.length < 6) {
+      digits = '0' + digits;
+    }
+
+    var base = slugifyProfileIdBase(username);
+    return base + '-' + digits;
+  }
+
+  var profileIdValue = computeProfileIdValue(sidebarUser);
+
   function isLikelyRoleIdentifier(value) {
     var text = safeUserString(value);
     if (!text) {
@@ -492,14 +531,14 @@
     </div>
   </div>
 
-  <button type="button" class="user-panel" id="userPanel" data-initialized="true"
-    onclick="navigateToPage('userprofile')"
+  <div class="user-panel" id="userPanel" data-initialized="true"
     data-name="<?= displayPrimaryNameValue ?>"
     data-first-name="<?= firstNameValue ?>"
     data-last-name="<?= lastNameValue ?>"
     data-full-name="<?= displayFullNameValue ?>"
     data-roles="<?= (userRoleNames && userRoleNames.length) ? userRoleNames.join(', ') : (isAdminUser ? 'System Administrator' : 'User') ?>"
-    data-status="<?= sidebarUser.EmploymentStatus || '' ?>" data-country="<?= sidebarUser.Country || '' ?>">
+    data-status="<?= sidebarUser.EmploymentStatus || '' ?>" data-country="<?= sidebarUser.Country || '' ?>"
+    data-profile-id="<?= profileIdValue ?>">
     <div class="user-avatar-side" id="userAvatar">
       <?= userInitialValue ?>
     </div>
@@ -508,7 +547,10 @@
         <? if (primaryRoleNameValue) { ?>
         <div class="name-line role-name" id="userRoleNameDisplay"><?= primaryRoleNameValue ?></div>
         <? } ?>
-        <div class="name-line full-name" id="userFullName"><?= displayFullNameValue ?></div>
+        <button type="button" class="user-name-trigger" id="userProfileTrigger" aria-haspopup="true" aria-expanded="false">
+          <span class="name-line full-name" id="userFullName"><?= displayFullNameValue ?></span>
+          <i class="fa-solid fa-ellipsis-vertical" aria-hidden="true"></i>
+        </button>
       </div>
       <div class="role" id="userRole" title="<?= (userRoleNames && userRoleNames.length) ? userRoleNames.join(', ') : (isAdminUser ? 'System Administrator' : 'User') ?>">
         <div class="role-badges" id="userRoleBadges">
@@ -531,7 +573,17 @@
         <? } ?>
       </div>
     </div>
-  </button>
+    <div class="user-panel-menu" id="userPanelMenu" role="menu" aria-labelledby="userProfileTrigger" hidden>
+      <button type="button" class="user-panel-menu__item" data-menu-action="profile">
+        <i class="fa-solid fa-id-badge"></i>
+        View Profile
+      </button>
+      <button type="button" class="user-panel-menu__item" data-menu-action="logout">
+        <i class="fa-solid fa-arrow-right-from-bracket"></i>
+        Sign Out
+      </button>
+    </div>
+  </div>
 </nav>
 
 <script>


### PR DESCRIPTION
## Summary
- merge the profile summary into the global banner with avatar, chips, and contact meta while refreshing the page layout and styling
- add an essentials panel and reorganize profile sections into a wide two-column grid for a fuller, modern presentation
- generate deterministic profile IDs from usernames, append them to profile navigation, and keep the sidebar context menu in sync

## Testing
- Not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e10b277af483269154b0e387a47514