### PR TITLE
Ensure legal hero sections populate global banner

### DIFF
--- a/LuminaHQUserGuide.html
+++ b/LuminaHQUserGuide.html
@@ -372,10 +372,10 @@
 
     <div class="container">
         <!-- Header -->
-        <div class="header">
+        <header class="header" data-banner-source="page-hero">
             <h1>🌟 LuminaHQ User Guide</h1>
             <p>Your complete reference for navigating the LuminaHQ secure browsing workspace</p>
-        </div>
+        </header>
         
         <!-- Navigation -->
         <nav class="nav">

--- a/PrivacyPolicy.html
+++ b/PrivacyPolicy.html
@@ -136,7 +136,7 @@
 </style>
 
 <main class="policy-wrapper">
-  <header class="policy-header">
+  <header class="policy-header" data-banner-source="page-hero">
     <h1>Lumina HQ Privacy Policy</h1>
     <p>
       Lumina HQ empowers business process outsourcing (BPO) leaders, quality assurance coaches, and client stakeholders with shared visibility into workforce performance. This Privacy Policy explains how we handle personal and operational data when clients and internal teams use the platform for call, chat, and digital engagement transparency.

--- a/TermsOfService.html
+++ b/TermsOfService.html
@@ -140,7 +140,7 @@
 </style>
 
 <main class="tos-wrapper">
-  <section class="tos-hero">
+  <section class="tos-hero" data-banner-source="page-hero">
     <h1>Lumina HQ Terms of Service</h1>
     <p>
       These Terms govern your access to the Lumina HQ workforce transparency platform operated by our organization for the benefit of contracted call center and BPO clients. By using the service, you agree to uphold the accountability and confidentiality standards described here.

--- a/layout.html
+++ b/layout.html
@@ -2023,7 +2023,8 @@
                 '.eod-header',
                 '.global-page-header',
                 '.hero-header',
-                '.page-hero'
+                '.page-hero',
+                '[data-banner-source="page-hero"]'
             ];
 
             const bannerData = {


### PR DESCRIPTION
## Summary
- add a shared data attribute selector so page-specific heroes can be absorbed into the global banner
- mark the Terms of Service, Privacy Policy, and Lumina HQ User Guide hero sections with the shared banner source attribute

## Testing
- not run (manual verification requires the Google Apps Script runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e119d1fd6c8326b3dfffb48cd76f45