### PR TITLE
Reimagine Lumina banner with immersive blue gradients

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1446,34 +1446,46 @@
     /* Unified global page banner */
     .lumina-banner {
       position: relative;
-      background: radial-gradient(140% 120% at 0% 0%, rgba(99, 102, 241, 0.45) 0%, rgba(14, 116, 144, 0) 55%),
-        radial-gradient(120% 140% at 100% 0%, rgba(45, 212, 191, 0.35) 0%, rgba(15, 23, 42, 0) 60%),
-        linear-gradient(135deg, rgba(2, 6, 23, 0.92) 0%, rgba(15, 23, 42, 0.92) 100%);
-      border: 1px solid rgba(148, 163, 184, 0.28);
-      border-radius: 32px;
-      padding: clamp(1.75rem, 3vw, 2.85rem);
+      background:
+        radial-gradient(140% 115% at -10% 15%, rgba(34, 197, 247, 0.35) 0%, rgba(2, 132, 199, 0) 55%),
+        radial-gradient(160% 140% at 110% 15%, rgba(6, 182, 212, 0.28) 0%, rgba(13, 71, 161, 0) 60%),
+        conic-gradient(from 210deg at 70% 75%, rgba(56, 189, 248, 0.2) 0deg, rgba(30, 64, 175, 0) 160deg),
+        linear-gradient(150deg, rgba(2, 6, 23, 0.96) 0%, rgba(12, 19, 41, 0.96) 42%, rgba(4, 47, 46, 0.92) 100%);
+      border: 1px solid rgba(125, 211, 252, 0.18);
+      border-radius: 34px;
+      padding: clamp(1.9rem, 3.5vw, 3.1rem);
       margin-bottom: 2.5rem;
-      box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.85);
+      box-shadow: 0 40px 80px -45px rgba(2, 6, 23, 0.85), 0 20px 40px -35px rgba(12, 74, 110, 0.5);
       color: #e2e8f0;
       overflow: hidden;
-      backdrop-filter: blur(8px);
+      backdrop-filter: blur(9px);
+      isolation: isolate;
     }
 
     .lumina-banner::before {
       content: '';
       position: absolute;
-      inset: 0;
-      background: linear-gradient(120deg, rgba(148, 163, 184, 0.18) 0%, rgba(59, 130, 246, 0.1) 45%, transparent 100%);
+      inset: -12% -8% -20% -8%;
+      background:
+        radial-gradient(50% 50% at 15% 25%, rgba(125, 211, 252, 0.45) 0%, rgba(125, 211, 252, 0) 62%),
+        radial-gradient(60% 60% at 85% 18%, rgba(191, 219, 254, 0.3) 0%, rgba(191, 219, 254, 0) 70%),
+        conic-gradient(from 140deg at 80% 65%, rgba(14, 165, 233, 0.5) 0deg, rgba(8, 145, 178, 0.05) 140deg, rgba(14, 165, 233, 0.4) 320deg, rgba(14, 165, 233, 0) 360deg),
+        linear-gradient(115deg, rgba(59, 130, 246, 0.25) 0%, rgba(13, 148, 136, 0) 40%);
       mix-blend-mode: screen;
       pointer-events: none;
+      opacity: 0.9;
+      filter: blur(0.5px);
     }
 
     .lumina-banner::after {
       content: '';
       position: absolute;
       inset: 1px;
-      border-radius: 30px;
-      border: 1px solid rgba(226, 232, 240, 0.18);
+      border-radius: 32px;
+      border: 1px solid rgba(148, 197, 255, 0.2);
+      background:
+        radial-gradient(120% 180% at 105% 105%, rgba(56, 189, 248, 0.16) 0%, rgba(56, 189, 248, 0) 60%),
+        linear-gradient(160deg, rgba(148, 163, 184, 0.08) 0%, rgba(14, 116, 144, 0.12) 45%, rgba(2, 6, 23, 0) 100%);
       pointer-events: none;
     }
 
@@ -1503,15 +1515,15 @@
       letter-spacing: 0.2em;
       text-transform: uppercase;
       font-weight: 700;
-      color: rgba(226, 232, 240, 0.78);
-      background: rgba(15, 23, 42, 0.45);
+      color: rgba(226, 240, 254, 0.88);
+      background: linear-gradient(120deg, rgba(15, 118, 110, 0.55) 0%, rgba(14, 165, 233, 0.5) 100%);
       padding: 0.45rem 0.95rem;
       border-radius: 999px;
-      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+      box-shadow: inset 0 0 0 1px rgba(165, 243, 252, 0.55), 0 10px 18px -15px rgba(59, 130, 246, 0.65);
     }
 
     .lumina-banner__eyebrow i {
-      color: #38bdf8;
+      color: #bef264;
     }
 
     .lumina-banner__title-row {
@@ -1534,7 +1546,7 @@
       margin: 0;
       font-size: 1.05rem;
       line-height: 1.65;
-      color: rgba(226, 232, 240, 0.82);
+      color: rgba(226, 240, 254, 0.86);
       max-width: 70ch;
       display: flex;
       flex-direction: column;
@@ -1598,7 +1610,7 @@
       border: 1px solid transparent;
       cursor: pointer;
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border 0.2s ease;
-      box-shadow: 0 14px 30px -22px rgba(99, 102, 241, 0.9);
+      box-shadow: 0 18px 34px -25px rgba(14, 165, 233, 0.85);
     }
 
     .lumina-banner__action i {
@@ -1606,27 +1618,27 @@
     }
 
     .lumina-banner__action--primary {
-      background: linear-gradient(120deg, #6366f1 0%, #22d3ee 100%);
-      color: #0f172a;
-      border-color: rgba(125, 211, 252, 0.55);
-      box-shadow: 0 18px 40px -22px rgba(34, 211, 238, 0.9);
+      background: linear-gradient(135deg, #1d4ed8 0%, #0891b2 35%, #22d3ee 100%);
+      color: #f8fafc;
+      border-color: rgba(94, 234, 212, 0.55);
+      box-shadow: 0 22px 48px -20px rgba(6, 182, 212, 0.85);
     }
 
     .lumina-banner__action--primary:hover,
     .lumina-banner__action--primary:focus-visible {
       transform: translateY(-1px);
-      box-shadow: 0 22px 50px -20px rgba(34, 211, 238, 0.95);
+      box-shadow: 0 26px 58px -18px rgba(6, 182, 212, 0.9);
     }
 
     .lumina-banner__action--secondary {
-      background: rgba(148, 163, 184, 0.14);
-      border-color: rgba(148, 163, 184, 0.4);
-      color: #e2e8f0;
+      background: rgba(148, 197, 255, 0.16);
+      border-color: rgba(125, 211, 252, 0.38);
+      color: rgba(226, 240, 254, 0.9);
     }
 
     .lumina-banner__action--secondary:hover,
     .lumina-banner__action--secondary:focus-visible {
-      background: rgba(148, 163, 184, 0.22);
+      background: rgba(148, 197, 255, 0.24);
       transform: translateY(-1px);
     }
 
@@ -1640,23 +1652,43 @@
       min-width: 240px;
       display: grid;
       gap: 1.1rem;
-      background: rgba(15, 23, 42, 0.55);
-      border-radius: 26px;
-      padding: 1.4rem 1.6rem;
-      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
-      backdrop-filter: blur(10px);
+      background:
+        radial-gradient(120% 90% at 0% 0%, rgba(59, 130, 246, 0.25) 0%, rgba(59, 130, 246, 0) 65%),
+        linear-gradient(160deg, rgba(15, 23, 42, 0.75) 0%, rgba(8, 47, 73, 0.85) 55%, rgba(15, 118, 110, 0.6) 100%);
+      border-radius: 28px;
+      padding: 1.5rem 1.7rem;
+      box-shadow: inset 0 0 0 1px rgba(165, 243, 252, 0.25), 0 18px 26px -28px rgba(2, 6, 23, 0.8);
+      backdrop-filter: blur(12px);
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+    }
+
+    .lumina-banner__meta::before {
+      content: '';
+      position: absolute;
+      inset: -35% -25% auto -25%;
+      height: 160%;
+      background: radial-gradient(55% 55% at 20% 20%, rgba(94, 234, 212, 0.3) 0%, rgba(94, 234, 212, 0) 70%),
+        linear-gradient(135deg, rgba(14, 165, 233, 0.12) 0%, rgba(148, 197, 255, 0) 60%);
+      mix-blend-mode: screen;
+      pointer-events: none;
+      opacity: 0.9;
+      z-index: 0;
     }
 
     .lumina-banner__meta-item {
       display: grid;
       gap: 0.45rem;
+      position: relative;
+      z-index: 1;
     }
 
     .lumina-banner__meta-label {
       font-size: 0.72rem;
       letter-spacing: 0.16em;
       text-transform: uppercase;
-      color: rgba(148, 163, 184, 0.78);
+      color: rgba(191, 219, 254, 0.75);
       font-weight: 700;
       display: inline-flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- build a multi-layered navy and cyan gradient system for the Lumina banner with energetic overlays and lighting effects
- refresh eyebrow, actions, and meta panel treatments to harmonize with the new palette while preserving contrast
- infuse the banner meta card with screen-blended highlights to add depth without sacrificing legibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e11f83dbc883268ea3568a00e224fa