### PR TITLE
Ensure navigation generates stable URLs for profile page

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -312,9 +312,35 @@
     /**
      * Generate URLs for navigation
      */
+    function resolveNavigationBaseUrl() {
+      const directBase = NAVIGATION_BASE_URL || BASE_URL || SCRIPT_URL;
+      if (directBase) {
+        return directBase;
+      }
+
+      if (typeof window !== 'undefined' && window.location) {
+        try {
+          const { origin, pathname, href } = window.location;
+          if (origin && pathname) {
+            return origin + pathname;
+          }
+          if (href) {
+            const parsed = new URL(href);
+            parsed.search = '';
+            parsed.hash = '';
+            return parsed.toString();
+          }
+        } catch (resolveErr) {
+          console.warn('Unable to derive navigation base URL from window.location', resolveErr);
+        }
+      }
+
+      return '';
+    }
+
     function generateUrl(page, _campaign = null, additionalParams = {}) {
       // _campaign is kept for backward compatibility but intentionally unused to avoid exposing it in URLs
-      let url = NAVIGATION_BASE_URL || BASE_URL || SCRIPT_URL;
+      let url = resolveNavigationBaseUrl();
       const params = new URLSearchParams();
 
       if (page) {
@@ -329,7 +355,13 @@
       });
       
       const queryString = params.toString();
-      return queryString ? `${url}?${queryString}` : url;
+
+      if (!url) {
+        return queryString ? `?${queryString}` : '';
+      }
+
+      const separator = url.includes('?') ? (/[?&]$/.test(url) ? '' : '&') : '?';
+      return queryString ? `${url}${separator}${queryString}` : url;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a helper that derives a reliable navigation base URL when server-provided values are missing
- ensure generated navigation links append query strings with the correct separator so page slugs remain visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e135f822648326a039979dc3cfa08c