### PR TITLE
Wrap profile banner summary block

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -3015,23 +3015,30 @@
     }
 
     const descriptionElements = [];
-    if (chipsRow.childNodes.length) descriptionElements.push(chipsRow);
-    if (metaRow.childNodes.length) descriptionElements.push(metaRow);
-    if (contactsRow.childNodes.length) descriptionElements.push(contactsRow);
+    const bannerBlock = document.createElement('div');
+    bannerBlock.className = 'lumina-banner__rich-block';
+    if (chipsRow.childNodes.length) bannerBlock.appendChild(chipsRow);
+    if (metaRow.childNodes.length) bannerBlock.appendChild(metaRow);
+    if (contactsRow.childNodes.length) bannerBlock.appendChild(contactsRow);
+    if (bannerBlock.childNodes.length) {
+      descriptionElements.push(bannerBlock);
+    }
 
     const actions = [];
     const addAction = (href, label, icon, variant) => {
-      if (!href) {
+      const safeHref = safeString(href);
+      const safeLabel = safeString(label);
+      if (!safeHref || !safeLabel) {
         return;
       }
-      const action = document.createElement('a');
-      action.href = href;
-      action.target = '_top';
-      action.textContent = label;
-      action.setAttribute('data-banner-icon', icon);
-      action.setAttribute('data-banner-variant', variant);
-      action.setAttribute('data-banner-label', label);
-      actions.push(action);
+      actions.push({
+        href: safeHref,
+        label: safeLabel,
+        icon,
+        variant: variant || 'primary',
+        target: '_top',
+        rel: 'noopener'
+      });
     };
 
     try {


### PR DESCRIPTION
## Summary
- wrap the banner summary content in a lumina banner rich block so the global header keeps profile metadata grouped without stretching horizontally
- supply sanitized action descriptors to the layout banner helper instead of raw anchor elements so the buttons render with the correct labels

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e14773708083269ea0440bd3980ba0