### PR TITLE
Ensure user profile routing is driven by user IDs

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -1305,6 +1305,7 @@
 
   const state = {
     user: (PROFILE_BOOTSTRAP.user && Object.keys(PROFILE_BOOTSTRAP.user).length ? PROFILE_BOOTSTRAP.user : CURRENT_USER) || {},
+    viewer: (PROFILE_BOOTSTRAP.viewer && Object.keys(PROFILE_BOOTSTRAP.viewer).length ? PROFILE_BOOTSTRAP.viewer : CURRENT_USER) || {},
     detail: PROFILE_BOOTSTRAP.detail || null,
     pages: PROFILE_BOOTSTRAP.pages || [],
     equipment: PROFILE_BOOTSTRAP.equipment || [],
@@ -1433,6 +1434,10 @@
 
   function computeProfileSlug(userRecord, detailRecord) {
     const record = detailRecord && detailRecord.record ? detailRecord.record : detailRecord || {};
+    const identifier = resolveProfileIdentifier(userRecord, detailRecord);
+    if (identifier) {
+      return identifier;
+    }
     const candidates = [];
 
     candidates.push(

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -141,6 +141,11 @@
       return 'user';
     }
 
+    var identifier = computeProfileIdentifierValue(user);
+    if (identifier) {
+      return identifier;
+    }
+
     var candidates = [];
     var pushCandidate = function (value) {
       var normalized = safeUserString(value);


### PR DESCRIPTION
## Summary
- honor the requested profileId when bootstrapping the user profile page so the viewed record and related resources load for that user
- default profile slugs and navigation metadata to use the resolved user identifier so the URL reflects the user ID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15337aed88326ada678a0f5ad82bd