### PR TITLE
Improve login redirects and logout handling

### DIFF
--- a/IdentityService.js
+++ b/IdentityService.js
@@ -1,73 +1,18 @@
 /**
  * IdentityService.js
  * -----------------------------------------------------------------------------
- * High level identity management service that mirrors the core workflow of
- * ASP.NET Core Identity (registration, login, logout, email verification,
- * password reset, and two-factor authentication) using Google Apps Script
- * primitives.
- *
- * The service builds on top of the existing AuthenticationService module while
- * ensuring users follow a centralized set of authentication rules across every
- * entry point in the Lumina Sheets solution.
+ * Simplified identity management helpers that build on top of the existing
+ * AuthenticationService and UserService modules.  The goal of this implementation
+ * is to keep all authentication state inside the legacy user schema without
+ * introducing any new headers or auxiliary sheets.  Only the columns that already
+ * exist in the Users sheet are touched, and every operation gracefully skips
+ * fields that are not present.
  */
 
 var IdentityService = (function () {
   const USERS_SHEET_NAME = (typeof USERS_SHEET === 'string' && USERS_SHEET)
     ? USERS_SHEET
     : 'Users';
-
-  const LEGACY_USER_HEADERS = [
-    'ID', 'UserName', 'FullName', 'Email', 'CampaignID', 'PasswordHash', 'ResetRequired',
-    'EmailConfirmation', 'EmailConfirmed', 'PhoneNumber', 'EmploymentStatus', 'HireDate', 'Country',
-    'LockoutEnd', 'TwoFactorEnabled', 'CanLogin', 'Roles', 'Pages', 'CreatedAt', 'UpdatedAt', 'IsAdmin'
-  ];
-
-  const IDENTITY_REQUIRED_HEADERS = [
-    'NormalizedUserName',
-    'NormalizedEmail',
-    'PhoneNumberConfirmed',
-    'LockoutEnabled',
-    'AccessFailedCount',
-    'TwoFactorDelivery',
-    'TwoFactorSecret',
-    'TwoFactorRecoveryCodes',
-    'SecurityStamp',
-    'ConcurrencyStamp',
-    'EmailConfirmationTokenHash',
-    'EmailConfirmationSentAt',
-    'EmailConfirmationExpiresAt',
-    'ResetPasswordToken',
-    'ResetPasswordTokenHash',
-    'ResetPasswordSentAt',
-    'ResetPasswordExpiresAt',
-    'LastLoginAt',
-    'LastLoginIp',
-    'LastLoginUserAgent'
-  ];
-
-  const USER_HEADERS = (function buildUserHeaders() {
-    const base = (typeof USERS_HEADERS !== 'undefined'
-      && Array.isArray(USERS_HEADERS)
-      && USERS_HEADERS.length)
-      ? USERS_HEADERS.slice()
-      : LEGACY_USER_HEADERS.slice();
-
-    const seen = {};
-    base.forEach(function (header) {
-      if (header) {
-        seen[header] = true;
-      }
-    });
-
-    IDENTITY_REQUIRED_HEADERS.forEach(function (header) {
-      if (header && !seen[header]) {
-        base.push(header);
-        seen[header] = true;
-      }
-    });
-
-    return base;
-  })();
 
   const EMAIL_CONFIRMATION_TTL_MINUTES = 60;
   const PASSWORD_RESET_TTL_MINUTES = 60;
@@ -76,46 +21,15 @@ var IdentityService = (function () {
     return new Date();
   }
 
-  function toIsoString(date) {
-    if (!date) return '';
-    if (date instanceof Date) {
-      return date.toISOString();
-    }
-    try {
-      const parsed = new Date(date);
-      return isNaN(parsed.getTime()) ? '' : parsed.toISOString();
-    } catch (err) {
-      return '';
-    }
-  }
-
   function toSheetBoolean(value) {
     return value ? 'TRUE' : 'FALSE';
   }
 
-  function fromSheetBoolean(value) {
-    if (value === true) return true;
-    if (value === false) return false;
-    if (value == null) return false;
-    const normalized = String(value).trim().toLowerCase();
-    return normalized === 'true'
-      || normalized === '1'
-      || normalized === 'y'
-      || normalized === 'yes';
-  }
-
   function normalizeEmail(email) {
-    if (!email && email !== 0) return '';
+    if (email === null || typeof email === 'undefined') {
+      return '';
+    }
     return String(email).trim().toLowerCase();
-  }
-
-  function normalizeUserName(userName) {
-    if (!userName && userName !== 0) return '';
-    return String(userName).trim();
-  }
-
-  function normalizedForLookup(value) {
-    return normalizeUserName(value).toUpperCase();
   }
 
   function hashToken(token) {
@@ -129,14 +43,56 @@ var IdentityService = (function () {
       .join('');
   }
 
-  function generateSecurityStamp() {
+  function generateToken() {
     return Utilities.getUuid();
   }
 
-  function generateToken() {
-    const raw = Utilities.getUuid() + Utilities.getUuid();
-    return Utilities.base64EncodeWebSafe(raw, Utilities.Charset.UTF_8)
-      .replace(/=+$/g, '');
+  function sanitizeLoginReturnUrl(url) {
+    if (!url && url !== 0) {
+      return '';
+    }
+
+    try {
+      var raw = String(url).trim();
+      if (!raw) {
+        return '';
+      }
+
+      if (/^javascript:/i.test(raw)) {
+        return '';
+      }
+
+      if (/^https?:/i.test(raw)) {
+        try {
+          var base = '';
+          if (typeof getBaseUrl === 'function') {
+            base = String(getBaseUrl() || '');
+          }
+          if (!base && typeof SCRIPT_URL === 'string') {
+            base = SCRIPT_URL;
+          }
+
+          if (base) {
+            var baseMatch = /^https?:\/\/[^/]+/i.exec(base);
+            var targetMatch = /^https?:\/\/[^/]+/i.exec(raw);
+            if (baseMatch && targetMatch && baseMatch[0].toLowerCase() !== targetMatch[0].toLowerCase()) {
+              return '';
+            }
+          }
+        } catch (originError) {
+          console.warn('sanitizeLoginReturnUrl: origin comparison failed', originError);
+        }
+      }
+
+      if (raw.length > 500) {
+        raw = raw.slice(0, 500);
+      }
+
+      return raw;
+    } catch (err) {
+      console.warn('sanitizeLoginReturnUrl: unable to sanitize return URL', err);
+      return '';
+    }
   }
 
   function getPasswordUtils() {
@@ -146,151 +102,50 @@ var IdentityService = (function () {
     if (typeof PasswordUtilities !== 'undefined' && PasswordUtilities) {
       return PasswordUtilities;
     }
-    throw new Error('Password utilities are not available');
+    throw new Error('Password utilities unavailable');
   }
 
-  function ensureAuthenticationService() {
-    if (typeof AuthenticationService === 'undefined' || !AuthenticationService) {
-      throw new Error('AuthenticationService unavailable');
-    }
-    return AuthenticationService;
-  }
-
-  function getUserSheet() {
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
-    let sheet = ss.getSheetByName(USERS_SHEET_NAME);
-    if (!sheet) {
-      sheet = ss.insertSheet(USERS_SHEET_NAME);
-    }
-    return sheet;
-  }
-
-  function ensureHeaders(sheet, requiredHeaders) {
-    const required = (requiredHeaders && requiredHeaders.length)
-      ? requiredHeaders.slice()
-      : USER_HEADERS.slice();
-    const lastRow = sheet.getLastRow();
-    const lastColumn = sheet.getLastColumn();
-
-    if (lastRow === 0 || lastColumn === 0) {
-      sheet.clear();
-      if (sheet.getMaxColumns() < required.length) {
-        sheet.insertColumns(1, required.length - sheet.getMaxColumns());
+  function invalidateUsersCache() {
+    try {
+      if (typeof invalidateCache === 'function') {
+        invalidateCache(USERS_SHEET_NAME);
       }
-      sheet.getRange(1, 1, 1, required.length).setValues([required]);
-      sheet.setFrozenRows(1);
-      return required;
-    }
-
-    const headerRange = sheet.getRange(1, 1, 1, lastColumn);
-    let headers = headerRange.getValues()[0].map(function (value) {
-      return value ? String(value) : '';
-    });
-
-    if (!headers.length || (headers.length === 1 && !headers[0])) {
-      sheet.clear();
-      if (sheet.getMaxColumns() < required.length) {
-        sheet.insertColumns(1, required.length - sheet.getMaxColumns());
-      }
-      sheet.getRange(1, 1, 1, required.length).setValues([required]);
-      sheet.setFrozenRows(1);
-      return required;
-    }
-
-    const existing = headers.slice();
-    required.forEach(function (header) {
-      if (existing.indexOf(header) !== -1) {
-        return;
-      }
-
-      const blankIndex = existing.indexOf('');
-      if (blankIndex !== -1) {
-        existing[blankIndex] = header;
-        sheet.getRange(1, blankIndex + 1).setValue(header);
-        headers[blankIndex] = header;
-        return;
-      }
-
-      const lastExistingColumn = headers.length || 1;
-      sheet.insertColumnsAfter(lastExistingColumn, 1);
-      const targetColumn = lastExistingColumn + 1;
-      sheet.getRange(1, targetColumn).setValue(header);
-      headers.push(header);
-      existing.push(header);
-    });
-
-    return headers;
-  }
-
-  function buildIndexMap(headers) {
-    const map = {};
-    headers.forEach(function (header, index) {
-      if (header) {
-        map[header] = index;
-      }
-    });
-    return map;
-  }
-
-  function ensureSheetColumns(sheet, columnCount) {
-    const maxColumns = sheet.getMaxColumns();
-    if (maxColumns < columnCount) {
-      sheet.insertColumnsAfter(maxColumns, columnCount - maxColumns);
+    } catch (err) {
+      console.warn('IdentityService: unable to invalidate cache', err);
     }
   }
 
   function loadUserContext() {
-    let sheet = getUserSheet();
-    if (typeof ensureSheetWithHeaders === 'function') {
-      try {
-        sheet = ensureSheetWithHeaders(USERS_SHEET_NAME, USER_HEADERS.slice());
-      } catch (ensureError) {
-        console.warn('loadUserContext: ensureSheetWithHeaders failed', ensureError);
-      }
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.getSheetByName(USERS_SHEET_NAME);
+    if (!sheet) {
+      throw new Error('Users sheet not found');
     }
 
-    const headers = ensureHeaders(sheet, USER_HEADERS);
-    const index = buildIndexMap(headers);
-    if (!index.ID) {
-      throw new Error('Users sheet is missing the ID column');
+    const lastColumn = sheet.getLastColumn();
+    if (lastColumn < 1) {
+      return { sheet: sheet, headers: [], index: {} };
     }
+
+    const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0]
+      .map(function (header) { return String(header || '').trim(); });
+
+    const index = {};
+    headers.forEach(function (header, idx) {
+      if (header) {
+        index[header] = idx;
+      }
+    });
+
     return { sheet: sheet, headers: headers, index: index };
   }
 
-  function readRow(sheet, headers, rowIndex) {
-    const range = sheet.getRange(rowIndex, 1, 1, headers.length);
-    const values = range.getValues()[0];
+  function buildRecord(headers, row) {
     const record = {};
-    for (let i = 0; i < headers.length; i++) {
-      record[headers[i]] = values[i];
+    for (let i = 0; i < headers.length; i += 1) {
+      record[headers[i]] = row[i];
     }
     return record;
-  }
-
-  function writeRow(sheet, headers, rowIndex, record) {
-    const row = [];
-    for (let i = 0; i < headers.length; i++) {
-      const header = headers[i];
-      row[i] = (typeof record[header] !== 'undefined' && record[header] !== null)
-        ? record[header]
-        : '';
-    }
-    ensureSheetColumns(sheet, headers.length);
-    sheet.getRange(rowIndex, 1, 1, headers.length).setValues([row]);
-  }
-
-  function appendRow(sheet, headers, record) {
-    const row = [];
-    for (let i = 0; i < headers.length; i++) {
-      const header = headers[i];
-      row[i] = (typeof record[header] !== 'undefined' && record[header] !== null)
-        ? record[header]
-        : '';
-    }
-    const nextRow = sheet.getLastRow() + 1;
-    ensureSheetColumns(sheet, headers.length);
-    sheet.getRange(nextRow, 1, 1, headers.length).setValues([row]);
-    return nextRow;
   }
 
   function findUserRow(predicate) {
@@ -306,15 +161,13 @@ var IdentityService = (function () {
     const range = sheet.getRange(2, 1, lastRow - 1, headers.length);
     const values = range.getValues();
 
-    for (let i = 0; i < values.length; i++) {
-      const record = {};
-      for (let j = 0; j < headers.length; j++) {
-        record[headers[j]] = values[i][j];
-      }
+    for (let i = 0; i < values.length; i += 1) {
+      const record = buildRecord(headers, values[i]);
       if (predicate(record)) {
         return {
           context: context,
           rowIndex: i + 2,
+          rowValues: values[i].slice(),
           user: record
         };
       }
@@ -324,250 +177,114 @@ var IdentityService = (function () {
   }
 
   function findUserRowByEmail(email) {
-    const normalized = normalizedForLookup(email);
-    if (!normalized) return null;
+    const normalized = normalizeEmail(email);
+    if (!normalized) {
+      return null;
+    }
     return findUserRow(function (row) {
-      const stored = row.NormalizedEmail || normalizedForLookup(row.Email || '');
-      return stored === normalized;
+      return normalizeEmail(row.Email) === normalized;
     });
   }
 
-  function findUserRowById(userId) {
-    if (!userId) return null;
-    return findUserRow(function (row) {
-      return String(row.ID || '') === String(userId);
+  function hasColumn(rowContext, column) {
+    return rowContext && rowContext.context && Object.prototype.hasOwnProperty.call(rowContext.context.index, column);
+  }
+
+  function setColumnValue(rowContext, column, value) {
+    if (!hasColumn(rowContext, column)) {
+      return false;
+    }
+    const columnIndex = rowContext.context.index[column];
+    rowContext.rowValues[columnIndex] = value;
+    rowContext.context.sheet.getRange(rowContext.rowIndex, columnIndex + 1).setValue(value);
+    rowContext.user[column] = value;
+    return true;
+  }
+
+  function clearColumns(rowContext, columns) {
+    columns.forEach(function (column) {
+      setColumnValue(rowContext, column, '');
     });
   }
 
-  function sanitizeUser(row) {
-    if (!row) return null;
-    const safe = {
-      id: row.ID,
-      userName: row.UserName,
-      normalizedUserName: row.NormalizedUserName,
-      email: row.Email,
-      normalizedEmail: row.NormalizedEmail,
-      fullName: row.FullName,
-      phoneNumber: row.PhoneNumber,
-      twoFactorEnabled: fromSheetBoolean(row.TwoFactorEnabled),
-      twoFactorDelivery: row.TwoFactorDelivery || 'email',
-      accessFailedCount: parseInt(row.AccessFailedCount, 10) || 0,
-      lockoutEnabled: fromSheetBoolean(row.LockoutEnabled),
-      lockoutEnd: row.LockoutEnd || '',
-      emailConfirmed: fromSheetBoolean(row.EmailConfirmed),
-      lastLoginAt: row.LastLoginAt || '',
-      createdAt: row.CreatedAt || '',
-      updatedAt: row.UpdatedAt || ''
-    };
-    return safe;
+  function applyTimestamp(rowContext) {
+    if (hasColumn(rowContext, 'UpdatedAt')) {
+      setColumnValue(rowContext, 'UpdatedAt', now());
+    }
   }
 
-  function createEmailConfirmation(row, context, options) {
+  function createEmailConfirmation(rowContext, options) {
     const token = generateToken();
-    const tokenHash = hashToken(token);
-    const sentAt = toIsoString(now());
-    const expiresAt = toIsoString(new Date(now().getTime() + EMAIL_CONFIRMATION_TTL_MINUTES * 60000));
+    const issuedAt = now();
+    const ttlMinutes = (options && options.ttlMinutes) || EMAIL_CONFIRMATION_TTL_MINUTES;
+    const expiresAt = new Date(issuedAt.getTime() + ttlMinutes * 60000);
 
-    row.EmailConfirmationTokenHash = tokenHash;
-    row.EmailConfirmationSentAt = sentAt;
-    row.EmailConfirmationExpiresAt = expiresAt;
-    row.EmailConfirmation = token;
-    row.ResetRequired = toSheetBoolean(true);
-    row.ResetPasswordToken = token;
-    row.ResetPasswordTokenHash = tokenHash;
-    row.ResetPasswordSentAt = sentAt;
-    row.ResetPasswordExpiresAt = expiresAt;
-    if (!fromSheetBoolean(row.EmailConfirmed)) {
-      row.EmailConfirmed = toSheetBoolean(false);
+    setColumnValue(rowContext, 'EmailConfirmation', token);
+    if (hasColumn(rowContext, 'EmailConfirmationTokenHash')) {
+      setColumnValue(rowContext, 'EmailConfirmationTokenHash', hashToken(token));
     }
-    row.SecurityStamp = row.SecurityStamp || generateSecurityStamp();
-    row.UpdatedAt = sentAt;
-
-    writeRow(context.sheet, context.headers, context.rowIndex, row);
-
-    if (!options || options.sendEmail !== false) {
-      try {
-        if (typeof sendPasswordSetupEmail === 'function') {
-          sendPasswordSetupEmail(row.Email, {
-            userName: row.UserName,
-            fullName: row.FullName,
-            passwordSetupToken: token
-          });
-        }
-      } catch (emailError) {
-        console.warn('createEmailConfirmation: failed to send email', emailError);
-      }
+    if (hasColumn(rowContext, 'EmailConfirmationSentAt')) {
+      setColumnValue(rowContext, 'EmailConfirmationSentAt', issuedAt);
     }
+    if (hasColumn(rowContext, 'EmailConfirmationExpiresAt')) {
+      setColumnValue(rowContext, 'EmailConfirmationExpiresAt', expiresAt);
+    }
+    if (hasColumn(rowContext, 'EmailConfirmed')) {
+      setColumnValue(rowContext, 'EmailConfirmed', toSheetBoolean(false));
+    }
+    if (hasColumn(rowContext, 'SecurityStamp')) {
+      setColumnValue(rowContext, 'SecurityStamp', Utilities.getUuid());
+    }
+    applyTimestamp(rowContext);
 
-    return {
-      token: token,
-      expiresAt: expiresAt
-    };
+    return { token: token, issuedAt: issuedAt, expiresAt: expiresAt };
   }
 
-  function createPasswordReset(row, context, options) {
+  function createPasswordReset(rowContext, options) {
     const token = generateToken();
-    const tokenHash = hashToken(token);
-    const sentAt = toIsoString(now());
-    const expiresAt = toIsoString(new Date(now().getTime() + PASSWORD_RESET_TTL_MINUTES * 60000));
+    const issuedAt = now();
+    const ttlMinutes = (options && options.ttlMinutes) || PASSWORD_RESET_TTL_MINUTES;
+    const expiresAt = new Date(issuedAt.getTime() + ttlMinutes * 60000);
 
-    row.ResetPasswordToken = token;
-    row.ResetPasswordTokenHash = tokenHash;
-    row.ResetPasswordSentAt = sentAt;
-    row.ResetPasswordExpiresAt = expiresAt;
-    row.ResetRequired = toSheetBoolean(true);
-    row.UpdatedAt = sentAt;
-
-    writeRow(context.sheet, context.headers, context.rowIndex, row);
-
-    if (!options || options.sendEmail !== false) {
-      try {
-        if (options && options.useAdminTemplate && typeof sendAdminPasswordResetEmail === 'function') {
-          sendAdminPasswordResetEmail(row.Email, { resetToken: token });
-        } else if (typeof sendPasswordResetEmail === 'function') {
-          sendPasswordResetEmail(row.Email, token);
-        } else if (typeof sendAdminPasswordResetEmail === 'function') {
-          sendAdminPasswordResetEmail(row.Email, { resetToken: token });
-        }
-      } catch (emailError) {
-        console.warn('createPasswordReset: failed to send email', emailError);
-      }
+    if (!setColumnValue(rowContext, 'ResetPasswordToken', token)) {
+      setColumnValue(rowContext, 'EmailConfirmation', token);
     }
+    if (hasColumn(rowContext, 'ResetPasswordTokenHash')) {
+      setColumnValue(rowContext, 'ResetPasswordTokenHash', hashToken(token));
+    }
+    if (hasColumn(rowContext, 'ResetPasswordSentAt')) {
+      setColumnValue(rowContext, 'ResetPasswordSentAt', issuedAt);
+    }
+    if (hasColumn(rowContext, 'ResetPasswordExpiresAt')) {
+      setColumnValue(rowContext, 'ResetPasswordExpiresAt', expiresAt);
+    }
+    if (hasColumn(rowContext, 'ResetRequired')) {
+      setColumnValue(rowContext, 'ResetRequired', toSheetBoolean(true));
+    }
+    if (hasColumn(rowContext, 'SecurityStamp')) {
+      setColumnValue(rowContext, 'SecurityStamp', Utilities.getUuid());
+    }
+    applyTimestamp(rowContext);
 
-    return {
-      token: token,
-      expiresAt: expiresAt
-    };
+    return { token: token, issuedAt: issuedAt, expiresAt: expiresAt };
   }
 
-  function registerUser(payload) {
-    const data = payload || {};
-    const email = normalizeEmail(data.email);
-    const userName = normalizeUserName(data.userName || data.email);
-
-    if (!email) {
-      return { success: false, error: 'Email is required', errorCode: 'EMAIL_REQUIRED' };
+  function parseDate(value) {
+    if (!value) {
+      return null;
     }
-    if (!userName) {
-      return { success: false, error: 'Username is required', errorCode: 'USERNAME_REQUIRED' };
+    if (value instanceof Date) {
+      return value;
     }
-    if (!data.password) {
-      return { success: false, error: 'Password is required', errorCode: 'PASSWORD_REQUIRED' };
-    }
-
-    const lock = LockService.getScriptLock();
-    try {
-      lock.waitLock(20000);
-    } catch (err) {
-      return { success: false, error: 'System busy. Try again shortly.' };
-    }
-
-    try {
-      const existing = findUserRowByEmail(email);
-      if (existing) {
-        return {
-          success: false,
-          error: 'A user with this email already exists.',
-          errorCode: 'DUPLICATE_EMAIL',
-          userId: existing.user.ID
-        };
-      }
-
-      const context = loadUserContext();
-      const utils = getPasswordUtils();
-      const passwordHash = utils.createPasswordHash(data.password);
-      const createdAt = toIsoString(now());
-      const id = Utilities.getUuid();
-      const securityStamp = generateSecurityStamp();
-      const concurrencyStamp = generateSecurityStamp();
-
-      const record = {
-        ID: id,
-        UserName: userName,
-        NormalizedUserName: normalizedForLookup(userName),
-        Email: data.email,
-        NormalizedEmail: normalizedForLookup(email),
-        FullName: data.fullName || '',
-        CampaignID: data.campaignId || '',
-        PasswordHash: passwordHash,
-        ResetRequired: toSheetBoolean(
-          typeof data.resetRequired === 'boolean'
-            ? data.resetRequired
-            : data.canLogin !== false
-        ),
-        EmailConfirmation: '',
-        EmailConfirmed: toSheetBoolean(!!data.emailConfirmed),
-        PhoneNumber: data.phoneNumber || '',
-        PhoneNumberConfirmed: toSheetBoolean(!!data.phoneNumberConfirmed),
-        EmploymentStatus: data.employmentStatus || '',
-        HireDate: data.hireDate || '',
-        Country: data.country || '',
-        TwoFactorEnabled: toSheetBoolean(!!data.twoFactorEnabled),
-        TwoFactorDelivery: data.twoFactorDelivery || 'email',
-        TwoFactorSecret: data.twoFactorSecret || '',
-        TwoFactorRecoveryCodes: Array.isArray(data.twoFactorRecoveryCodes)
-          ? data.twoFactorRecoveryCodes.join(',')
-          : (data.twoFactorRecoveryCodes || ''),
-        AccessFailedCount: 0,
-        LockoutEnabled: toSheetBoolean(data.lockoutEnabled !== false),
-        LockoutEnd: '',
-        CanLogin: toSheetBoolean(data.canLogin !== false),
-        Roles: Array.isArray(data.roles) ? data.roles.join(',') : (data.roles || ''),
-        Pages: Array.isArray(data.pages) ? data.pages.join(',') : (data.pages || ''),
-        SecurityStamp: securityStamp,
-        ConcurrencyStamp: concurrencyStamp,
-        EmailConfirmationTokenHash: '',
-        EmailConfirmationSentAt: '',
-        EmailConfirmationExpiresAt: '',
-        ResetPasswordToken: '',
-        ResetPasswordTokenHash: '',
-        ResetPasswordSentAt: '',
-        ResetPasswordExpiresAt: '',
-        LastLoginAt: '',
-        LastLoginIp: '',
-        LastLoginUserAgent: '',
-        CreatedAt: createdAt,
-        UpdatedAt: createdAt,
-        IsAdmin: toSheetBoolean(!!data.isAdmin)
-      };
-
-      const rowIndex = appendRow(context.sheet, context.headers, record);
-      const rowContext = {
-        sheet: context.sheet,
-        headers: context.headers,
-        index: context.index,
-        rowIndex: rowIndex,
-        user: record
-      };
-
-      let confirmationToken = null;
-      if (!record.EmailConfirmed || !fromSheetBoolean(record.EmailConfirmed)) {
-        const confirmation = createEmailConfirmation(record, rowContext, {
-          sendEmail: data.sendEmail !== false
-        });
-        confirmationToken = confirmation.token;
-      }
-
-      return {
-        success: true,
-        userId: id,
-        email: data.email,
-        requiresEmailConfirmation: !fromSheetBoolean(record.EmailConfirmed),
-        emailConfirmationToken: data.returnTokens ? confirmationToken : null
-      };
-    } catch (error) {
-      console.error('IdentityService.registerUser error', error);
-      return { success: false, error: error.message || String(error) };
-    } finally {
-      try { lock.releaseLock(); } catch (releaseErr) { console.warn('registerUser: releaseLock failed', releaseErr); }
-    }
+    const parsed = new Date(value);
+    return isNaN(parsed.getTime()) ? null : parsed;
   }
 
   function confirmEmail(token) {
     if (!token) {
       return { success: false, error: 'Token is required', errorCode: 'TOKEN_REQUIRED' };
     }
-    const tokenHash = hashToken(token);
+
     const lock = LockService.getScriptLock();
     try {
       lock.waitLock(20000);
@@ -576,35 +293,43 @@ var IdentityService = (function () {
     }
 
     try {
-      let match = findUserRow(function (row) {
-        return row.EmailConfirmationTokenHash && row.EmailConfirmationTokenHash === tokenHash;
+      const tokenHash = hashToken(token);
+      const match = findUserRow(function (row) {
+        if (row.EmailConfirmationTokenHash && String(row.EmailConfirmationTokenHash).trim() === tokenHash) {
+          return true;
+        }
+        if (row.EmailConfirmation && String(row.EmailConfirmation).trim() === String(token)) {
+          return true;
+        }
+        return false;
       });
-      if (!match) {
-        match = findUserRow(function (row) {
-          return row.EmailConfirmation && String(row.EmailConfirmation).trim() === String(token);
-        });
-      }
+
       if (!match) {
         return { success: false, error: 'Invalid or expired token', errorCode: 'TOKEN_INVALID' };
       }
 
-      const expiresAt = match.user.EmailConfirmationExpiresAt;
-      if (expiresAt) {
-        const expiry = new Date(expiresAt);
-        if (!isNaN(expiry.getTime()) && expiry.getTime() < now().getTime()) {
-          return { success: false, error: 'Confirmation token has expired', errorCode: 'TOKEN_EXPIRED' };
+      if (hasColumn(match, 'EmailConfirmationExpiresAt')) {
+        const expiry = parseDate(match.user.EmailConfirmationExpiresAt);
+        if (expiry && expiry.getTime() < now().getTime()) {
+          return { success: false, error: 'Confirmation link has expired', errorCode: 'TOKEN_EXPIRED' };
         }
       }
 
-      match.user.EmailConfirmed = toSheetBoolean(true);
-      match.user.EmailConfirmationTokenHash = '';
-      match.user.EmailConfirmationSentAt = '';
-      match.user.EmailConfirmationExpiresAt = '';
-      match.user.EmailConfirmation = '';
-      match.user.SecurityStamp = generateSecurityStamp();
-      match.user.UpdatedAt = toIsoString(now());
-
-      writeRow(match.context.sheet, match.context.headers, match.rowIndex, match.user);
+      setColumnValue(match, 'EmailConfirmed', toSheetBoolean(true));
+      clearColumns(match, [
+        'EmailConfirmation',
+        'EmailConfirmationTokenHash',
+        'EmailConfirmationSentAt',
+        'EmailConfirmationExpiresAt'
+      ]);
+      if (hasColumn(match, 'ResetRequired')) {
+        setColumnValue(match, 'ResetRequired', toSheetBoolean(false));
+      }
+      if (hasColumn(match, 'SecurityStamp')) {
+        setColumnValue(match, 'SecurityStamp', Utilities.getUuid());
+      }
+      applyTimestamp(match);
+      invalidateUsersCache();
 
       return { success: true };
     } catch (error) {
@@ -616,34 +341,112 @@ var IdentityService = (function () {
   }
 
   function resendEmailConfirmation(email, options) {
-    const userRow = findUserRowByEmail(email);
-    if (!userRow) {
-      return { success: true, message: 'If an account exists, a confirmation email has been sent.' };
-    }
-    if (fromSheetBoolean(userRow.user.EmailConfirmed)) {
-      return { success: false, error: 'Email already confirmed', errorCode: 'EMAIL_CONFIRMED' };
+    const lock = LockService.getScriptLock();
+    try {
+      lock.waitLock(20000);
+    } catch (err) {
+      return { success: false, error: 'System busy. Try again shortly.' };
     }
 
-    const confirmation = createEmailConfirmation(userRow.user, userRow, options || {});
-    return {
-      success: true,
-      emailConfirmationToken: (options && options.returnTokens) ? confirmation.token : null,
-      expiresAt: confirmation.expiresAt
-    };
+    try {
+      const match = findUserRowByEmail(email);
+      if (!match) {
+        return { success: true, message: 'If an account exists, a confirmation email has been sent.' };
+      }
+
+      if (hasColumn(match, 'EmailConfirmed')) {
+        const confirmed = String(match.user.EmailConfirmed || '').toUpperCase() === 'TRUE';
+        if (confirmed) {
+          return { success: false, error: 'Email already confirmed', errorCode: 'EMAIL_CONFIRMED' };
+        }
+      }
+
+      const confirmation = createEmailConfirmation(match, options || {});
+      invalidateUsersCache();
+
+      if (!options || options.sendEmail !== false) {
+        try {
+          if (typeof sendPasswordSetupEmail === 'function') {
+            sendPasswordSetupEmail(match.user.Email, {
+              userName: match.user.UserName || '',
+              fullName: match.user.FullName || '',
+              passwordSetupToken: confirmation.token
+            });
+          } else if (typeof sendPasswordResetEmail === 'function') {
+            sendPasswordResetEmail(match.user.Email, confirmation.token);
+          }
+        } catch (mailErr) {
+          console.warn('resendEmailConfirmation: unable to send email', mailErr);
+        }
+      }
+
+      return {
+        success: true,
+        emailConfirmationToken: (options && options.returnTokens) ? confirmation.token : null,
+        expiresAt: confirmation.expiresAt
+      };
+    } catch (error) {
+      console.error('IdentityService.resendEmailConfirmation error', error);
+      return { success: false, error: error.message || String(error) };
+    } finally {
+      try { lock.releaseLock(); } catch (releaseErr) { console.warn('resendEmailConfirmation: releaseLock failed', releaseErr); }
+    }
   }
 
   function beginPasswordReset(email, options) {
-    const userRow = findUserRowByEmail(email);
-    if (!userRow) {
-      return { success: true, message: 'If an account exists, password reset instructions were sent.' };
+    const lock = LockService.getScriptLock();
+    try {
+      lock.waitLock(20000);
+    } catch (err) {
+      return { success: false, error: 'System busy. Try again shortly.' };
     }
 
-    const reset = createPasswordReset(userRow.user, userRow, options || {});
-    return {
-      success: true,
-      resetToken: (options && options.returnTokens) ? reset.token : null,
-      expiresAt: reset.expiresAt
-    };
+    try {
+      const match = findUserRowByEmail(email);
+      if (!match) {
+        return { success: true, message: 'If an account exists, password reset instructions were sent.' };
+      }
+
+      const reset = createPasswordReset(match, options || {});
+      invalidateUsersCache();
+
+      if (!options || options.sendEmail !== false) {
+        try {
+          if (typeof sendPasswordResetEmail === 'function') {
+            sendPasswordResetEmail(match.user.Email, reset.token);
+          }
+        } catch (mailErr) {
+          console.warn('beginPasswordReset: unable to send email', mailErr);
+        }
+      }
+
+      return {
+        success: true,
+        resetToken: (options && options.returnTokens) ? reset.token : null,
+        expiresAt: reset.expiresAt
+      };
+    } catch (error) {
+      console.error('IdentityService.beginPasswordReset error', error);
+      return { success: false, error: error.message || String(error) };
+    } finally {
+      try { lock.releaseLock(); } catch (releaseErr) { console.warn('beginPasswordReset: releaseLock failed', releaseErr); }
+    }
+  }
+
+  function findResetMatch(token) {
+    const tokenHash = hashToken(token);
+    return findUserRow(function (row) {
+      if (row.ResetPasswordTokenHash && String(row.ResetPasswordTokenHash).trim() === tokenHash) {
+        return true;
+      }
+      if (row.ResetPasswordToken && String(row.ResetPasswordToken).trim() === String(token)) {
+        return true;
+      }
+      if (!row.ResetPasswordToken && row.EmailConfirmation && String(row.EmailConfirmation).trim() === String(token)) {
+        return true;
+      }
+      return false;
+    });
   }
 
   function resetPassword(token, newPassword) {
@@ -654,7 +457,6 @@ var IdentityService = (function () {
       return { success: false, error: 'Password is required', errorCode: 'PASSWORD_REQUIRED' };
     }
 
-    const tokenHash = hashToken(token);
     const lock = LockService.getScriptLock();
     try {
       lock.waitLock(20000);
@@ -663,45 +465,39 @@ var IdentityService = (function () {
     }
 
     try {
-      let match = findUserRow(function (row) {
-        return row.ResetPasswordTokenHash && row.ResetPasswordTokenHash === tokenHash;
-      });
-      if (!match) {
-        match = findUserRow(function (row) {
-          return row.ResetPasswordToken && String(row.ResetPasswordToken).trim() === String(token);
-        });
-      }
-      if (!match) {
-        match = findUserRow(function (row) {
-          return row.EmailConfirmation && String(row.EmailConfirmation).trim() === String(token);
-        });
-      }
+      const match = findResetMatch(token);
       if (!match) {
         return { success: false, error: 'Invalid or expired token', errorCode: 'TOKEN_INVALID' };
       }
 
-      const expiresAt = match.user.ResetPasswordExpiresAt;
-      if (expiresAt) {
-        const expiry = new Date(expiresAt);
-        if (!isNaN(expiry.getTime()) && expiry.getTime() < now().getTime()) {
+      if (hasColumn(match, 'ResetPasswordExpiresAt')) {
+        const expiry = parseDate(match.user.ResetPasswordExpiresAt);
+        if (expiry && expiry.getTime() < now().getTime()) {
           return { success: false, error: 'Reset token has expired', errorCode: 'TOKEN_EXPIRED' };
         }
       }
 
       const utils = getPasswordUtils();
       const passwordHash = utils.createPasswordHash(newPassword);
+      setColumnValue(match, 'PasswordHash', passwordHash);
 
-      match.user.PasswordHash = passwordHash;
-      match.user.ResetPasswordToken = '';
-      match.user.ResetPasswordTokenHash = '';
-      match.user.ResetPasswordSentAt = '';
-      match.user.ResetPasswordExpiresAt = '';
-      match.user.EmailConfirmation = '';
-      match.user.ResetRequired = toSheetBoolean(false);
-      match.user.SecurityStamp = generateSecurityStamp();
-      match.user.UpdatedAt = toIsoString(now());
-
-      writeRow(match.context.sheet, match.context.headers, match.rowIndex, match.user);
+      clearColumns(match, [
+        'ResetPasswordToken',
+        'ResetPasswordTokenHash',
+        'ResetPasswordSentAt',
+        'ResetPasswordExpiresAt'
+      ]);
+      if (hasColumn(match, 'EmailConfirmation')) {
+        setColumnValue(match, 'EmailConfirmation', '');
+      }
+      if (hasColumn(match, 'ResetRequired')) {
+        setColumnValue(match, 'ResetRequired', toSheetBoolean(false));
+      }
+      if (hasColumn(match, 'SecurityStamp')) {
+        setColumnValue(match, 'SecurityStamp', Utilities.getUuid());
+      }
+      applyTimestamp(match);
+      invalidateUsersCache();
 
       return { success: true };
     } catch (error) {
@@ -710,19 +506,6 @@ var IdentityService = (function () {
     } finally {
       try { lock.releaseLock(); } catch (releaseErr) { console.warn('resetPassword: releaseLock failed', releaseErr); }
     }
-  }
-
-  function maskEmail(email) {
-    if (!email) return '';
-    const normalized = String(email).trim();
-    const parts = normalized.split('@');
-    if (parts.length !== 2) return normalized;
-    const local = parts[0];
-    const domain = parts[1];
-    const maskedLocal = local.length <= 2
-      ? local.charAt(0) + '*'
-      : local.charAt(0) + Array(local.length - 1).fill('*').join('') + local.charAt(local.length - 1);
-    return maskedLocal + '@' + domain;
   }
 
   function signIn(email, password, options) {
@@ -735,20 +518,34 @@ var IdentityService = (function () {
       return { success: false, error: 'Password is required', errorCode: 'PASSWORD_REQUIRED' };
     }
 
-    const rememberMe = !!options.rememberMe;
-    const ipAddress = options.ipAddress || (options.metadata && options.metadata.ipAddress) || '';
-    const userAgent = options.userAgent || (options.metadata && options.metadata.userAgent) || '';
-    const metadata = options.metadata ? Object.assign({}, options.metadata) : {};
-    if (ipAddress && !metadata.ipAddress) metadata.ipAddress = ipAddress;
-    if (userAgent && !metadata.userAgent) metadata.userAgent = userAgent;
-
-    if (options.campaignId && !metadata.requestedCampaignId) {
-      metadata.requestedCampaignId = options.campaignId;
-    }
-
     try {
-      const auth = ensureAuthenticationService();
-      return auth.login((email || '').trim(), password, rememberMe, metadata);
+      const auth = (typeof AuthenticationService !== 'undefined' && AuthenticationService)
+        ? AuthenticationService
+        : null;
+      if (!auth || typeof auth.login !== 'function') {
+        throw new Error('AuthenticationService.login unavailable');
+      }
+      const rememberMe = !!options.rememberMe;
+      const metadata = options.metadata ? Object.assign({}, options.metadata) : {};
+      if (options.ipAddress && !metadata.ipAddress) metadata.ipAddress = options.ipAddress;
+      if (options.userAgent && !metadata.userAgent) metadata.userAgent = options.userAgent;
+      if (options.campaignId && !metadata.requestedCampaignId) {
+        metadata.requestedCampaignId = options.campaignId;
+      }
+      if (options.returnUrl) {
+        const sanitizedReturn = sanitizeLoginReturnUrl(options.returnUrl);
+        if (sanitizedReturn) {
+          metadata.requestedReturnUrl = sanitizedReturn;
+        }
+      }
+      const result = auth.login(normalizedEmail, password, rememberMe, metadata);
+      if (result && result.success && options && options.returnUrl) {
+        const requestedReturn = sanitizeLoginReturnUrl(options.returnUrl);
+        if (requestedReturn) {
+          result.requestedReturnUrl = requestedReturn;
+        }
+      }
+      return result;
     } catch (error) {
       console.error('IdentityService.signIn error', error);
       return { success: false, error: error.message || String(error) };
@@ -756,18 +553,13 @@ var IdentityService = (function () {
   }
 
   function verifyTwoFactorCode(challengeId, code, options) {
-    if (!challengeId || !code) {
-      return { success: false, error: 'Challenge ID and code are required', errorCode: 'INVALID_REQUEST' };
-    }
-
-    const metadata = options && options.metadata ? Object.assign({}, options.metadata) : {};
-    if (options && options.campaignId && !metadata.requestedCampaignId) {
-      metadata.requestedCampaignId = options.campaignId;
-    }
-
     try {
-      const auth = ensureAuthenticationService();
-      return auth.verifyMfaCode(challengeId, code, metadata);
+      if (typeof AuthenticationService !== 'undefined'
+        && AuthenticationService
+        && typeof AuthenticationService.verifyMfaCode === 'function') {
+        return AuthenticationService.verifyMfaCode(challengeId, code, options || {});
+      }
+      return { success: false, error: 'Two-factor verification unavailable' };
     } catch (error) {
       console.error('IdentityService.verifyTwoFactorCode error', error);
       return { success: false, error: error.message || String(error) };
@@ -776,25 +568,19 @@ var IdentityService = (function () {
 
   function signOut(sessionToken) {
     try {
-      const auth = ensureAuthenticationService();
-      return auth.logout(sessionToken);
+      if (typeof AuthenticationService !== 'undefined'
+        && AuthenticationService
+        && typeof AuthenticationService.logout === 'function') {
+        return AuthenticationService.logout(sessionToken || '');
+      }
+      return { success: true };
     } catch (error) {
+      console.error('IdentityService.signOut error', error);
       return { success: false, error: error.message || String(error) };
     }
   }
 
-  function getUserByEmail(email) {
-    const userRow = findUserRowByEmail(email);
-    return userRow ? sanitizeUser(userRow.user) : null;
-  }
-
-  function getUserById(userId) {
-    const userRow = findUserRowById(userId);
-    return userRow ? sanitizeUser(userRow.user) : null;
-  }
-
   return {
-    registerUser: registerUser,
     confirmEmail: confirmEmail,
     resendEmailConfirmation: resendEmailConfirmation,
     beginPasswordReset: beginPasswordReset,
@@ -802,18 +588,9 @@ var IdentityService = (function () {
     signIn: signIn,
     verifyTwoFactorCode: verifyTwoFactorCode,
     signOut: signOut,
-    getUserByEmail: getUserByEmail,
-    getUserById: getUserById
+    sanitizeLoginReturnUrl: sanitizeLoginReturnUrl
   };
 })();
-
-function identityRegisterUser(payload) {
-  try {
-    return IdentityService.registerUser(payload);
-  } catch (error) {
-    return { success: false, error: error.message || String(error) };
-  }
-}
 
 function identityConfirmEmail(token) {
   try {

--- a/Login.html
+++ b/Login.html
@@ -1020,6 +1020,29 @@
     const LOGIN_REQUEST_TIMEOUT_MS = 20000; // Renew loading state after 20 seconds
     const SESSION_RESUME_LOADER_DELAY_MS = 500;
 
+    const LOGOUT_REASON_STORAGE_KEY = 'lumina.lastLogoutReason';
+
+    function getStoredLogoutReason() {
+      try {
+        if (window.sessionStorage) {
+          return window.sessionStorage.getItem(LOGOUT_REASON_STORAGE_KEY) || '';
+        }
+      } catch (err) {
+        console.warn('getStoredLogoutReason: unable to read logout reason', err);
+      }
+      return '';
+    }
+
+    function clearStoredLogoutReason() {
+      try {
+        if (window.sessionStorage) {
+          window.sessionStorage.removeItem(LOGOUT_REASON_STORAGE_KEY);
+        }
+      } catch (err) {
+        console.warn('clearStoredLogoutReason: unable to clear logout reason', err);
+      }
+    }
+
     function sanitizeBaseUrl(candidate, fallback) {
       const invalidPattern = /usercodeapppanel/i;
 
@@ -1144,7 +1167,9 @@
       sessionIdleTimeoutMinutes: null,
       sessionTtlSeconds: null,
       sessionExpiresAt: null,
-      lastRememberMe: false
+      lastRememberMe: false,
+      lastLogoutReason: getStoredLogoutReason(),
+      preferredReturnUrl: ''
     };
 
     // ───────────────────────────────────────────────────────────────────────────────
@@ -3417,7 +3442,24 @@
       );
 
       const redirectInput = response.redirectUrl || (response.redirectSlug ? `?page=${response.redirectSlug}` : '');
-      const destinationUrl = normalizeRedirectUrl(redirectInput);
+      let destinationUrl = normalizeRedirectUrl(redirectInput);
+
+      if (state.lastLogoutReason === 'auto' && state.preferredReturnUrl) {
+        const preferred = normalizeRedirectUrl(state.preferredReturnUrl);
+        if (preferred) {
+          destinationUrl = preferred;
+        }
+      } else if (response && response.requestedReturnUrl) {
+        const preferred = normalizeRedirectUrl(response.requestedReturnUrl);
+        if (preferred) {
+          destinationUrl = preferred;
+        }
+      }
+
+      clearStoredLogoutReason();
+      state.lastLogoutReason = '';
+      state.preferredReturnUrl = '';
+
       setupRedirect(destinationUrl);
       hideNextSteps();
     }
@@ -3429,6 +3471,14 @@
       console.log('Attempting login for:', email);
 
       monitorLoginRequest(email, rememberMe);
+
+      const clientMetadata = collectClientMetadata() || {};
+      if (state.lastLogoutReason) {
+        clientMetadata.logoutReason = state.lastLogoutReason;
+      }
+      if (state.lastLogoutReason === 'auto' && state.preferredReturnUrl) {
+        clientMetadata.requestedReturnUrl = state.preferredReturnUrl;
+      }
 
       google.script.run
         .withSuccessHandler(response => {
@@ -3498,7 +3548,7 @@
             ]
           });
         })
-        .loginUser(email, password, rememberMe, collectClientMetadata());
+        .loginUser(email, password, rememberMe, clientMetadata);
     }
 
     // ───────────────────────────────────────────────────────────────────────────────
@@ -3601,7 +3651,26 @@
         const newUrl = `${window.location.pathname}${newQuery ? `?${newQuery}` : ''}${window.location.hash || ''}`;
         window.history.replaceState({}, document.title, newUrl);
       }
-      
+
+      if (urlParams.has('returnUrl')) {
+        const rawReturnUrl = urlParams.get('returnUrl');
+        if (state.lastLogoutReason === 'auto') {
+          try {
+            const normalizedReturn = normalizeRedirectUrl(rawReturnUrl);
+            if (normalizedReturn && !/page=login/i.test(normalizedReturn)) {
+              state.preferredReturnUrl = normalizedReturn;
+            }
+          } catch (returnError) {
+            console.warn('Unable to normalize return URL parameter', returnError);
+          }
+        } else {
+          urlParams.delete('returnUrl');
+          const cleanedQuery = urlParams.toString();
+          const cleanUrl = `${window.location.pathname}${cleanedQuery ? `?${cleanedQuery}` : ''}${window.location.hash || ''}`;
+          window.history.replaceState({}, document.title, cleanUrl);
+        }
+      }
+
       if (error) {
         showAlert('error', decodeURIComponent(error));
       } else if (message) {

--- a/layout.html
+++ b/layout.html
@@ -452,6 +452,90 @@
     window.deriveReturnUrl = (rawUrl, slug = PAGE_SLUG) => deriveReturnUrl(rawUrl, slug);
     window.buildReturnUrl = buildReturnUrl;
     window.getReturnUrl = buildReturnUrl;
+
+    const LOGOUT_REASON_STORAGE_KEY = 'lumina.lastLogoutReason';
+
+    function setLogoutReason(reason) {
+      try {
+        if (!window.sessionStorage) {
+          return;
+        }
+        if (!reason) {
+          window.sessionStorage.removeItem(LOGOUT_REASON_STORAGE_KEY);
+        } else {
+          window.sessionStorage.setItem(LOGOUT_REASON_STORAGE_KEY, String(reason));
+        }
+      } catch (err) {
+        console.warn('setLogoutReason: unable to persist logout reason', err);
+      }
+    }
+
+    function getLogoutReason() {
+      try {
+        if (window.sessionStorage) {
+          return window.sessionStorage.getItem(LOGOUT_REASON_STORAGE_KEY) || '';
+        }
+      } catch (err) {
+        console.warn('getLogoutReason: unable to read logout reason', err);
+      }
+      return '';
+    }
+
+    function clearLogoutReason() {
+      setLogoutReason('');
+    }
+
+    function buildLoginUrl(options = {}) {
+      const baseTarget = window.__LUMINA_LOGIN_URL || LOGIN_URL || BASE_URL || SCRIPT_URL || '/';
+      const includeReturn = options.includeReturn === true;
+      const reason = (options.reason && String(options.reason)) || getLogoutReason();
+
+      if (!includeReturn || (reason && reason.toLowerCase() === 'manual')) {
+        return baseTarget;
+      }
+
+      let candidate = options.returnUrl || '';
+      if (!candidate && typeof window !== 'undefined' && window.location && window.location.href) {
+        candidate = window.location.href;
+      }
+      if (!candidate && RETURN_URL) {
+        candidate = RETURN_URL;
+      }
+
+      let sanitized = '';
+      try {
+        sanitized = buildReturnUrl({}, candidate);
+      } catch (err) {
+        console.warn('buildLoginUrl: unable to build return URL', err);
+      }
+
+      if (!sanitized || /page=login/i.test(sanitized)) {
+        sanitized = '';
+      }
+
+      if (!sanitized) {
+        return baseTarget;
+      }
+
+      try {
+        const loginUrl = new URL(baseTarget, window.location && window.location.href ? window.location.href : undefined);
+        loginUrl.searchParams.set('page', 'login');
+        loginUrl.searchParams.set('returnUrl', sanitized);
+        loginUrl.hash = '';
+        return loginUrl.toString();
+      } catch (err) {
+        console.warn('buildLoginUrl: falling back to manual concatenation', err);
+        const separator = baseTarget.indexOf('?') === -1
+          ? '?'
+          : (/[?&]$/.test(baseTarget) ? '' : '&');
+        return `${baseTarget}${separator}returnUrl=${encodeURIComponent(sanitized)}`;
+      }
+    }
+
+    window.buildLoginUrl = buildLoginUrl;
+    window.setLogoutReason = setLogoutReason;
+    window.getLogoutReason = getLogoutReason;
+    window.clearLogoutReason = clearLogoutReason;
   </script>
 
   <style>
@@ -2891,7 +2975,13 @@
             } catch (e) {
                 console.warn('⚠️ Could not clear storage:', e);
             }
-            
+
+            try {
+                setLogoutReason('manual');
+            } catch (reasonError) {
+                console.warn('handleLogout: unable to persist manual logout reason', reasonError);
+            }
+
             // Call server logout
             google.script.run
                 .withSuccessHandler(function(result) {
@@ -2918,12 +3008,18 @@
             } catch (e) {
                 console.warn('Could not clear storage:', e);
             }
-            
+
+            try {
+                setLogoutReason('manual');
+            } catch (reasonError) {
+                console.warn('performLogout: unable to persist manual logout reason', reasonError);
+            }
+
             // Show logout message and redirect
             showLogoutMessage();
 
             setTimeout(function() {
-                const target = window.__LUMINA_LOGIN_URL || LOGIN_URL || BASE_URL;
+                const target = buildLoginUrl({ includeReturn: false, reason: 'manual' });
                 window.location.href = target || BASE_URL;
             }, 2000);
         }
@@ -3051,10 +3147,36 @@
             } catch (sessionStorageError) {
                 console.warn('AuthGuard: unable to clear sessionStorage tokens', sessionStorageError);
             }
+
+            try {
+                const existingReason = getLogoutReason();
+                if (existingReason && existingReason.toLowerCase() === 'manual' && reason !== 'manual') {
+                    return;
+                }
+                setLogoutReason(reason === 'manual' ? 'manual' : 'auto');
+            } catch (reasonError) {
+                console.warn('AuthGuard: unable to persist logout reason', reasonError);
+            }
         }
 
-        function redirectToLogin() {
-            const target = window.__LUMINA_LOGIN_URL || LOGIN_URL || BASE_URL || '/';
+        function redirectToLogin(options) {
+            const opts = options || {};
+            if (opts.reason) {
+                try {
+                    const existingReason = getLogoutReason();
+                    if (!(existingReason && existingReason.toLowerCase() === 'manual' && opts.reason !== 'manual')) {
+                        setLogoutReason(opts.reason);
+                    }
+                } catch (reasonError) {
+                    console.warn('redirectToLogin: unable to persist logout reason', reasonError);
+                }
+            }
+
+            const target = buildLoginUrl({
+                includeReturn: opts.includeReturn === true,
+                returnUrl: opts.returnUrl,
+                reason: opts.reason
+            }) || '/';
             try {
                 if (window.location && typeof window.location.replace === 'function') {
                     window.location.replace(target);
@@ -3079,7 +3201,10 @@
 
             console.log('🔒 AuthGuard: missing auth token, enforcing logout redirect', context);
             clearClientAuthState(context || 'auth-guard');
-            redirectToLogin();
+            const currentLocation = (typeof window !== 'undefined' && window.location && window.location.href)
+                ? window.location.href
+                : '';
+            redirectToLogin({ includeReturn: true, reason: 'auto', returnUrl: currentLocation });
             return false;
         }
 
@@ -3614,7 +3739,22 @@
             }
 
             function redirectToLogin() {
-                const target = global.__LUMINA_LOGIN_URL || global.LOGIN_URL || global.BASE_URL || (global.location ? global.location.href : '/');
+                const current = (global.location && global.location.href) ? global.location.href : '';
+                if (global && typeof global.redirectToLogin === 'function') {
+                    try {
+                        global.redirectToLogin({ includeReturn: true, reason: 'auto', returnUrl: current });
+                        return;
+                    } catch (delegationError) {
+                        if (global.console && typeof global.console.warn === 'function') {
+                            console.warn('LuminaSessionHeartbeat: global redirectToLogin failed', delegationError);
+                        }
+                    }
+                }
+
+                const target = (typeof global.buildLoginUrl === 'function')
+                    ? global.buildLoginUrl({ includeReturn: true, reason: 'auto', returnUrl: current })
+                    : (global.__LUMINA_LOGIN_URL || global.LOGIN_URL || global.BASE_URL || (global.location ? global.location.href : '/'));
+
                 global.setTimeout(function () {
                     try {
                         global.location.href = target;
@@ -3655,7 +3795,7 @@
                 });
                 stop({ clearAuth: true, reason: reason, silent: true });
                 notifyExpired(result && result.message ? result.message : 'Your session has expired. Please sign in again.');
-                redirectToLogin();
+                redirectToLogin({ includeReturn: true, reason: 'auto', returnUrl: (global.location && global.location.href) || '' });
             }
 
             function handleSuccess(result) {
@@ -3741,7 +3881,7 @@
                     dispatchStatus('missing-token', { message: 'No session token available' });
                     stop({ clearAuth: true, reason: 'missing-token', silent: true });
                     notifyExpired('Your session has ended. Please sign in again.');
-                    redirectToLogin();
+                    redirectToLogin({ includeReturn: true, reason: 'auto', returnUrl: (global.location && global.location.href) || '' });
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- track logout reasons in the dashboard layout so manual logouts always return to the login page while auto-expired sessions keep a sanitized return URL
- sanitize and propagate requested return URLs through the identity and authentication services so successful logins can resume the correct page safely
- update the server logout handler to reuse the sanitized login URL builder for consistent redirects

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e1b4ce13248326af551c50b98d7411