### PR TITLE
Add dark mode toggle and theme-aware styling

### DIFF
--- a/ResponsiveStyles.html
+++ b/ResponsiveStyles.html
@@ -10,6 +10,20 @@
     --lumina-primary: #0ea5e9;
     --lumina-primary-dark: #0369a1;
     --lumina-accent: #22d3ee;
+    --lumina-control-bg: #ffffff;
+    --lumina-control-text: #0f172a;
+    --lumina-button-text: #ffffff;
+    --lumina-tab-active-bg: #ffffff;
+    --lumina-tab-active-text: var(--lumina-primary-dark);
+    --lumina-stat-gradient: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(14, 165, 233, 0.04));
+    --lumina-stat-border: rgba(14, 165, 233, 0.25);
+    --lumina-stat-label: rgba(15, 23, 42, 0.55);
+    --lumina-pill-bg: rgba(15, 23, 42, 0.08);
+    --lumina-pill-text: rgba(15, 23, 42, 0.72);
+    --lumina-sticky-bg: rgba(248, 250, 252, 0.85);
+    --lumina-sticky-border: rgba(148, 163, 184, 0.25);
+    --lumina-body-overlay: radial-gradient(circle at top right, rgba(34, 211, 238, 0.08), transparent 45%),
+                radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.06), transparent 40%);
     --lumina-radius-sm: 0.5rem;
     --lumina-radius: 0.75rem;
     --lumina-radius-lg: 1.25rem;
@@ -21,6 +35,30 @@
     --lumina-spacing-lg: 2rem;
     --lumina-spacing-xl: 3rem;
     --lumina-container-max: 1200px;
+  }
+
+  :root[data-theme="dark"] {
+    --lumina-text-color: #e2e8f0;
+    --lumina-muted-text: #94a3b8;
+    --lumina-surface: #1f2937;
+    --lumina-surface-alt: #0b1120;
+    --lumina-border-color: rgba(148, 163, 184, 0.2);
+    --lumina-border-strong: rgba(148, 163, 184, 0.35);
+    --lumina-shadow-sm: 0 12px 30px rgba(2, 6, 23, 0.35);
+    --lumina-shadow-md: 0 24px 60px rgba(2, 6, 23, 0.45);
+    --lumina-control-bg: rgba(15, 23, 42, 0.65);
+    --lumina-control-text: #e2e8f0;
+    --lumina-tab-active-bg: rgba(14, 165, 233, 0.18);
+    --lumina-tab-active-text: #e0f2fe;
+    --lumina-stat-gradient: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(8, 47, 73, 0.65));
+    --lumina-stat-border: rgba(14, 165, 233, 0.35);
+    --lumina-stat-label: rgba(226, 232, 240, 0.72);
+    --lumina-pill-bg: rgba(148, 163, 184, 0.12);
+    --lumina-pill-text: rgba(226, 232, 240, 0.78);
+    --lumina-sticky-bg: rgba(15, 23, 42, 0.85);
+    --lumina-sticky-border: rgba(148, 163, 184, 0.25);
+    --lumina-body-overlay: radial-gradient(circle at top right, rgba(56, 189, 248, 0.14), transparent 45%),
+                radial-gradient(circle at bottom left, rgba(2, 132, 199, 0.18), transparent 40%);
   }
 
   *, *::before, *::after {
@@ -60,8 +98,7 @@
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(circle at top right, rgba(34, 211, 238, 0.08), transparent 45%),
-                radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.06), transparent 40%);
+    background: var(--lumina-body-overlay);
     z-index: -2;
   }
 
@@ -178,7 +215,8 @@
     padding: 0.75rem 0.9rem;
     border-radius: var(--lumina-radius-sm);
     border: 1px solid var(--lumina-border-color);
-    background: #fff;
+    background: var(--lumina-control-bg);
+    color: var(--lumina-control-text);
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
     font: inherit;
   }
@@ -202,7 +240,7 @@
     border: none;
     font-weight: 600;
     background: var(--lumina-primary);
-    color: #fff;
+    color: var(--lumina-button-text);
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   }
 
@@ -371,8 +409,8 @@
     top: 0;
     z-index: 20;
     backdrop-filter: blur(16px);
-    background: rgba(248, 250, 252, 0.85);
-    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    background: var(--lumina-sticky-bg);
+    border-bottom: 1px solid var(--lumina-sticky-border);
   }
 
   .sidebar,
@@ -440,8 +478,8 @@
     gap: 0.5rem;
     padding: clamp(1rem, 2vw, 1.5rem);
     border-radius: var(--lumina-radius);
-    background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(14, 165, 233, 0.04));
-    border: 1px solid rgba(14, 165, 233, 0.25);
+    background: var(--lumina-stat-gradient);
+    border: 1px solid var(--lumina-stat-border);
   }
 
   .stat-block .label,
@@ -450,7 +488,7 @@
     font-size: 0.85rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: rgba(15, 23, 42, 0.55);
+    color: var(--lumina-stat-label);
   }
 
   .stat-block .value,
@@ -494,8 +532,8 @@
   .tab-nav button.active,
   .nav-tabs .nav-link.active,
   .tabstrip button.active {
-    background: #fff;
-    color: var(--lumina-primary-dark);
+    background: var(--lumina-tab-active-bg);
+    color: var(--lumina-tab-active-text);
     box-shadow: 0 10px 25px rgba(14, 165, 233, 0.18);
   }
 
@@ -526,8 +564,8 @@
   .pill {
     padding: 0.3rem 0.85rem;
     border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    color: rgba(15, 23, 42, 0.72);
+    background: var(--lumina-pill-bg);
+    color: var(--lumina-pill-text);
     font-weight: 500;
   }
 
@@ -552,7 +590,7 @@
   .modal .modal-content,
   .dialog .dialog-content {
     border-radius: var(--lumina-radius-lg);
-    background: #fff;
+    background: var(--lumina-surface);
     padding: clamp(1.25rem, 3vw, 2rem);
     box-shadow: var(--lumina-shadow-md);
   }

--- a/layout.html
+++ b/layout.html
@@ -118,6 +118,141 @@
   <?!= includeOnce('ResponsiveStyles') ?>
 
   <script>
+    (function initializeLuminaTheme() {
+      const STORAGE_KEY = 'lumina-theme';
+      const docEl = document.documentElement;
+
+      const readStoredTheme = () => {
+        try {
+          return window.localStorage.getItem(STORAGE_KEY);
+        } catch (err) {
+          console.warn('Lumina theme: unable to read stored theme', err);
+          return null;
+        }
+      };
+
+      const writeStoredTheme = (theme) => {
+        try {
+          window.localStorage.setItem(STORAGE_KEY, theme);
+        } catch (err) {
+          console.warn('Lumina theme: unable to persist theme', err);
+        }
+      };
+
+      const applyTheme = (theme) => {
+        const next = theme === 'dark' ? 'dark' : 'light';
+        docEl.setAttribute('data-theme', next);
+        if (document.body) {
+          document.body.setAttribute('data-theme', next);
+        }
+        return next;
+      };
+
+      const ensureBodySync = () => {
+        if (document.body) {
+          document.body.setAttribute('data-theme', docEl.getAttribute('data-theme') || 'light');
+        }
+      };
+
+      const stored = readStoredTheme();
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initial = stored || (prefersDark ? 'dark' : 'light');
+      applyTheme(initial);
+
+      if (document.readyState !== 'loading') {
+        ensureBodySync();
+      } else {
+        document.addEventListener('DOMContentLoaded', ensureBodySync, { once: true });
+      }
+
+      const notify = (theme, meta) => {
+        try {
+          const detail = Object.assign({ theme }, meta || {});
+          window.dispatchEvent(new CustomEvent('lumina:theme-changed', { detail }));
+        } catch (err) {
+          console.warn('Lumina theme: unable to dispatch theme change', err);
+        }
+      };
+
+      const setTheme = (theme, meta) => {
+        const options = Object.assign({}, meta || {});
+        const next = applyTheme(theme);
+        if (options.persist === false) {
+          // Respect caller request to skip persistence (used for system preference follow).
+        } else {
+          writeStoredTheme(next);
+        }
+        notify(next, options);
+        return next;
+      };
+
+      const themeApi = {
+        get() {
+          return docEl.getAttribute('data-theme') || 'light';
+        },
+        set(theme, meta) {
+          const options = Object.assign({ source: 'manual' }, meta || {});
+          return setTheme(theme, options);
+        },
+        toggle() {
+          const current = themeApi.get();
+          const next = current === 'dark' ? 'light' : 'dark';
+          return setTheme(next, { source: 'toggle' });
+        },
+        apply: applyTheme
+      };
+
+      window.__luminaTheme = themeApi;
+
+      const mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+      if (mediaQuery && typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', (event) => {
+          if (readStoredTheme()) {
+            return;
+          }
+          setTheme(event.matches ? 'dark' : 'light', { source: 'system', persist: false });
+        });
+      }
+
+      const updateToggleButtons = () => {
+        const isDark = themeApi.get() === 'dark';
+        const title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+        const state = isDark ? 'dark' : 'light';
+        document.querySelectorAll('[data-action="toggle-theme"]').forEach((button) => {
+          button.setAttribute('aria-pressed', String(isDark));
+          button.setAttribute('title', title);
+          button.setAttribute('aria-label', title);
+          button.setAttribute('data-theme-state', state);
+          button.setAttribute('data-bs-original-title', title);
+          const icon = button.querySelector('i');
+          if (icon) {
+            icon.classList.toggle('fa-moon', !isDark);
+            icon.classList.toggle('fa-sun', isDark);
+          }
+          if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip) {
+            const tooltip = bootstrap.Tooltip.getInstance(button);
+            if (tooltip && typeof tooltip.setContent === 'function') {
+              tooltip.setContent({ '.tooltip-inner': title });
+            }
+          }
+        });
+      };
+
+      document.addEventListener('DOMContentLoaded', () => {
+        updateToggleButtons();
+        document.querySelectorAll('[data-action="toggle-theme"]').forEach((button) => {
+          button.addEventListener('click', (event) => {
+            event.preventDefault();
+            themeApi.toggle();
+          });
+        });
+      });
+
+      window.addEventListener('lumina:theme-changed', updateToggleButtons);
+    })();
+  </script>
+
+  <script>
     // Base URLs for navigation
     let BASE_URL = '<?= baseUrl ?>';
     let SCRIPT_URL = '<?= scriptUrl || baseUrl ?>';
@@ -563,6 +698,18 @@
       --shadow-hover: rgba(15, 23, 42, 0.2);
       --glass-bg: rgba(255, 255, 255, 0.1);
       --glass-border: rgba(255, 255, 255, 0.2);
+      --body-background: linear-gradient(135deg, var(--surface-variant) 0%, #ffffff 100%);
+      --body-text-color: #1e293b;
+      --topbar-bg: rgba(255, 255, 255, 0.95);
+      --topbar-border: var(--outline);
+      --topbar-icon-color: #64748b;
+      --topbar-icon-bg: rgba(248, 250, 252, 0.8);
+      --topbar-icon-border: rgba(226, 232, 240, 0.5);
+      --topbar-icon-hover-bg: rgba(14, 165, 233, 0.1);
+      --topbar-icon-hover-color: var(--primary);
+      --topbar-icon-hover-border: rgba(14, 165, 233, 0.3);
+      --topbar-text-muted: #64748b;
+      --topbar-text-strong: #1e293b;
 
       --sidebar-width: 320px;
       --sidebar-collapsed: 80px;
@@ -574,6 +721,28 @@
       --transition-fast: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
+    :root[data-theme="dark"] {
+      --surface: #111827;
+      --surface-variant: #0b1120;
+      --outline: rgba(148, 163, 184, 0.25);
+      --shadow: rgba(2, 6, 23, 0.45);
+      --shadow-hover: rgba(2, 6, 23, 0.6);
+      --glass-bg: rgba(15, 23, 42, 0.55);
+      --glass-border: rgba(148, 163, 184, 0.35);
+      --body-background: linear-gradient(135deg, #0f172a 0%, #111827 100%);
+      --body-text-color: #e2e8f0;
+      --topbar-bg: rgba(15, 23, 42, 0.92);
+      --topbar-border: rgba(148, 163, 184, 0.25);
+      --topbar-icon-color: #e2e8f0;
+      --topbar-icon-bg: rgba(30, 41, 59, 0.85);
+      --topbar-icon-border: rgba(71, 85, 105, 0.6);
+      --topbar-icon-hover-bg: rgba(14, 165, 233, 0.22);
+      --topbar-icon-hover-color: #38bdf8;
+      --topbar-icon-hover-border: rgba(56, 189, 248, 0.45);
+      --topbar-text-muted: #94a3b8;
+      --topbar-text-strong: #f8fafc;
+    }
+
     * {
       box-sizing: border-box;
     }
@@ -582,8 +751,8 @@
       margin: 0;
       padding: 0;
       font-family: 'Inter', "Google Sans", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
-      background: linear-gradient(135deg, var(--surface-variant) 0%, #ffffff 100%);
-      color: #1e293b;
+      background: var(--body-background);
+      color: var(--body-text-color);
       overflow-x: hidden;
       font-size: 14px;
       line-height: 1.6;
@@ -1323,9 +1492,9 @@
       left: var(--sidebar-width);
       right: 0;
       height: var(--topbar-height);
-      background: rgba(255, 255, 255, 0.95);
+      background: var(--topbar-bg);
       backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--outline);
+      border-bottom: 1px solid var(--topbar-border);
       z-index: 999;
       display: flex;
       align-items: center;
@@ -1342,7 +1511,7 @@
       background: none;
       border: none;
       font-size: 1.25rem;
-      color: #64748b;
+      color: var(--topbar-icon-color);
       padding: 0.75rem;
       border-radius: 50%;
       transition: var(--transition-smooth);
@@ -1355,8 +1524,8 @@
     }
 
     .topbar-toggle:hover {
-      background: rgba(100, 116, 139, 0.1);
-      color: var(--primary);
+      background: var(--topbar-icon-hover-bg);
+      color: var(--topbar-icon-hover-color);
       transform: scale(1.05);
     }
 
@@ -1364,13 +1533,13 @@
       display: flex;
       align-items: center;
       gap: 0.75rem;
-      color: #64748b;
+      color: var(--topbar-text-muted);
       font-size: 0.95rem;
       font-weight: 500;
     }
 
     .breadcrumb-nav .current-page {
-      color: #1e293b;
+      color: var(--topbar-text-strong);
       font-weight: 700;
       font-size: 1.125rem;
     }
@@ -1392,7 +1561,7 @@
       background: none;
       border: none;
       font-size: 1.25rem;
-      color: #64748b;
+      color: var(--topbar-icon-color);
       padding: 0.75rem;
       border-radius: 50%;
       transition: var(--transition-smooth);
@@ -1402,18 +1571,27 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(248, 250, 252, 0.8);
+      background: var(--topbar-icon-bg);
       backdrop-filter: blur(8px);
-      border: 1px solid rgba(226, 232, 240, 0.5);
+      border: 1px solid var(--topbar-icon-border);
     }
 
     .notification-btn:hover {
-      background: rgba(14, 165, 233, 0.1);
-      color: var(--primary);
+      background: var(--topbar-icon-hover-bg);
+      color: var(--topbar-icon-hover-color);
       text-decoration: none;
       transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(14, 165, 233, 0.2);
-      border-color: rgba(14, 165, 233, 0.3);
+      border-color: var(--topbar-icon-hover-border);
+    }
+
+    .theme-toggle-btn .fa-sun {
+      color: #facc15;
+      transition: color 0.3s ease;
+    }
+
+    :root[data-theme="dark"] .theme-toggle-btn .fa-sun {
+      color: #fde68a;
     }
 
     .notification-badge {
@@ -1424,7 +1602,7 @@
       height: 10px;
       background: linear-gradient(135deg, var(--danger), #dc2626);
       border-radius: 50%;
-      border: 2px solid var(--surface);
+      border: 2px solid var(--topbar-icon-bg);
       box-shadow: 0 2px 8px rgba(239, 68, 68, 0.4);
       animation: pulse 2s infinite;
     }
@@ -1446,11 +1624,11 @@
     /* Enhanced Topbar Logout Button */
     .logout-btn-topbar {
       position: relative;
-      background: rgba(248, 250, 252, 0.8);
+      background: var(--topbar-icon-bg);
       backdrop-filter: blur(8px);
-      border: 1px solid rgba(226, 232, 240, 0.5);
+      border: 1px solid var(--topbar-icon-border);
       font-size: 1.25rem;
-      color: #64748b;
+      color: var(--topbar-icon-color);
       padding: 0.75rem;
       border-radius: 50%;
       transition: var(--transition-smooth);
@@ -1463,7 +1641,7 @@
     }
 
     .logout-btn-topbar:hover {
-      background: rgba(239, 68, 68, 0.1);
+      background: rgba(239, 68, 68, 0.12);
       color: var(--danger);
       transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(239, 68, 68, 0.2);
@@ -1931,6 +2109,7 @@
 </head>
 
 <body
+  data-theme="light"
   data-page-slug="<?!= __layoutSlugCandidate ?>"
   data-return-url="<?!= __layoutRawReturnUrl ?>"
 >

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -91,6 +91,12 @@
     </a>
     <? } ?>
 
+    <button class="notification-btn theme-toggle-btn" data-action="toggle-theme" data-bs-toggle="tooltip"
+      title="Switch to dark mode" aria-label="Switch to dark mode">
+      <i class="fas fa-moon" aria-hidden="true"></i>
+      <span class="visually-hidden">Toggle color theme</span>
+    </button>
+
     <button class="logout-btn-topbar" onclick="handleLogout()" data-bs-toggle="tooltip" title="Logout" aria-label="Logout">
       <i class="fas fa-sign-out-alt"></i>
     </button>


### PR DESCRIPTION
## Summary
- introduce a global theme manager and button to toggle between light and dark mode
- extend shared style variables to support dark palettes across surface, form, and layout components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e260b1a7ec8326a55dd888b6ca08da