### PR TITLE
Fix session token persistence across navigation

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2103,10 +2103,42 @@
         console.warn('Unable to clear auth token from sessionStorage', err);
       }
 
+      broadcastSessionTokenChange('');
+
       state.authToken = '';
       state.sessionIdleTimeoutMinutes = null;
       state.sessionTtlSeconds = null;
       state.sessionExpiresAt = null;
+    }
+
+    function broadcastSessionTokenChange(token) {
+      try {
+        if (typeof window === 'undefined') {
+          return;
+        }
+
+        window.__LUMINA_SESSION_TOKEN__ = token || '';
+
+        if (typeof window.dispatchEvent !== 'function') {
+          return;
+        }
+
+        const detail = { token: token || '' };
+        let event = null;
+
+        if (typeof CustomEvent === 'function') {
+          event = new CustomEvent('lumina:session-token', { detail });
+        } else if (window.document && typeof window.document.createEvent === 'function') {
+          event = window.document.createEvent('CustomEvent');
+          event.initCustomEvent('lumina:session-token', false, false, detail);
+        }
+
+        if (event) {
+          window.dispatchEvent(event);
+        }
+      } catch (err) {
+        console.warn('broadcastSessionTokenChange: Unable to notify listeners', err);
+      }
     }
 
     function persistSessionToken(token, rememberMe, expiresAtIso, ttlSeconds, idleTimeoutMinutes) {
@@ -2168,6 +2200,7 @@
         console.warn('Unable to persist auth token in sessionStorage', err);
       }
 
+      broadcastSessionTokenChange(token);
       restartSessionHeartbeat();
     }
 
@@ -2438,6 +2471,51 @@
       }
 
       return url;
+    }
+
+    function appendSessionTokenToUrl(url, providedToken) {
+      if (!url) {
+        return url;
+      }
+
+      const normalizedProvided = typeof providedToken === 'string' ? providedToken.trim() : '';
+      const tokenCandidate = normalizedProvided || state.authToken || readAuthCookie();
+      const token = tokenCandidate ? String(tokenCandidate).trim() : '';
+
+      if (!token) {
+        return url;
+      }
+
+      const raw = String(url).trim();
+      if (!raw || raw.startsWith('#')) {
+        return url;
+      }
+
+      if (/^(mailto:|tel:|javascript:)/i.test(raw)) {
+        return url;
+      }
+
+      try {
+        const base = window.location && window.location.href ? window.location.href : undefined;
+        const parsed = new URL(raw, base);
+
+        if (parsed.searchParams.get('token') !== token) {
+          parsed.searchParams.set('token', token);
+        }
+
+        if (raw.startsWith('?')) {
+          return (parsed.search || '') + (parsed.hash || '');
+        }
+
+        if (!/^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.startsWith('//')) {
+          return parsed.pathname + (parsed.search || '') + (parsed.hash || '');
+        }
+
+        return parsed.toString();
+      } catch (error) {
+        console.warn('appendSessionTokenToUrl: Unable to append token to redirect URL', error);
+        return url;
+      }
     }
 
     function buildPageUrl(page, params = {}) {
@@ -3376,7 +3454,9 @@
         return;
       }
 
-      console.log('Redirecting immediately to:', safeUrl);
+      const redirectUrl = appendSessionTokenToUrl(safeUrl);
+
+      console.log('Redirecting immediately to:', redirectUrl);
 
       if (elements.loginForm) {
         elements.loginForm.classList.add('form-slide-out');
@@ -3389,12 +3469,12 @@
           google.script.host &&
           typeof google.script.host.setLocation === 'function'
         ) {
-          google.script.host.setLocation(safeUrl);
+          google.script.host.setLocation(redirectUrl);
         } else {
-          window.location.href = safeUrl;
+          window.location.href = redirectUrl;
 
           setTimeout(() => {
-            window.location.assign(safeUrl);
+            window.location.assign(redirectUrl);
           }, 100);
         }
       } catch (error) {

--- a/layout.html
+++ b/layout.html
@@ -492,11 +492,13 @@
       const queryString = params.toString();
 
       if (!url) {
-        return queryString ? `?${queryString}` : '';
+        const relativeUrl = queryString ? `?${queryString}` : '';
+        return appendSessionTokenToUrl(relativeUrl);
       }
 
       const separator = url.includes('?') ? (/[?&]$/.test(url) ? '' : '&') : '?';
-      return queryString ? `${url}${separator}${queryString}` : url;
+      const builtUrl = queryString ? `${url}${separator}${queryString}` : url;
+      return appendSessionTokenToUrl(builtUrl);
     }
 
     /**
@@ -567,15 +569,27 @@
     };
 
     if (typeof document !== 'undefined') {
-      if (document.body) {
+      const handleDomReady = () => {
         __applySlugMetadata();
+        applySessionTokenToLinks();
+      };
+
+      if (document.body) {
+        handleDomReady();
       } else {
         try {
-          document.addEventListener('DOMContentLoaded', __applySlugMetadata, { once: true });
+          document.addEventListener('DOMContentLoaded', handleDomReady, { once: true });
         } catch (err) {
-          document.addEventListener('DOMContentLoaded', __applySlugMetadata, false);
+          document.addEventListener('DOMContentLoaded', handleDomReady, false);
         }
       }
+    }
+
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+      window.addEventListener('lumina:session-token', function(event) {
+        const detailToken = event && event.detail ? event.detail.token : '';
+        applySessionTokenToLinks(detailToken);
+      });
     }
 
     // Make utilities available globally
@@ -589,6 +603,12 @@
     window.getReturnUrl = buildReturnUrl;
 
     const LOGOUT_REASON_STORAGE_KEY = 'lumina.lastLogoutReason';
+    const SESSION_TOKEN_QUERY_PARAM = 'token';
+    const SESSION_TOKEN_STORAGE_KEYS = [
+      'lumina.session.token',
+      'lumina.auth.sessionToken',
+      'lumina.auth.fallbackToken'
+    ];
 
     function setLogoutReason(reason) {
       try {
@@ -618,6 +638,166 @@
 
     function clearLogoutReason() {
       setLogoutReason('');
+    }
+
+    function resolveClientSessionToken(providedToken) {
+      const normalizedProvided = typeof providedToken === 'string' ? providedToken.trim() : '';
+      if (normalizedProvided) {
+        return normalizedProvided;
+      }
+
+      try {
+        if (typeof window !== 'undefined' && window.__LUMINA_SESSION_TOKEN__) {
+          const globalToken = String(window.__LUMINA_SESSION_TOKEN__).trim();
+          if (globalToken) {
+            return globalToken;
+          }
+        }
+      } catch (_) {
+        // Ignore global token resolution errors
+      }
+
+      try {
+        if (typeof window !== 'undefined'
+          && window.CookieHandler
+          && typeof window.CookieHandler.readAuthToken === 'function') {
+          const cookieToken = window.CookieHandler.readAuthToken();
+          if (cookieToken) {
+            return cookieToken;
+          }
+        }
+      } catch (_) {
+        // Ignore cookie resolution errors
+      }
+
+      const storageKeys = Array.isArray(SESSION_TOKEN_STORAGE_KEYS) ? SESSION_TOKEN_STORAGE_KEYS : [];
+
+      for (let i = 0; i < storageKeys.length; i += 1) {
+        try {
+          if (typeof window !== 'undefined' && window.localStorage) {
+            const value = window.localStorage.getItem(storageKeys[i]);
+            if (value) {
+              return value;
+            }
+          }
+        } catch (_) {
+          // Ignore localStorage errors
+        }
+      }
+
+      for (let i = 0; i < storageKeys.length; i += 1) {
+        try {
+          if (typeof window !== 'undefined' && window.sessionStorage) {
+            const value = window.sessionStorage.getItem(storageKeys[i]);
+            if (value) {
+              return value;
+            }
+          }
+        } catch (_) {
+          // Ignore sessionStorage errors
+        }
+      }
+
+      return '';
+    }
+
+    function broadcastSessionTokenChange(token) {
+      try {
+        if (typeof window === 'undefined') {
+          return;
+        }
+
+        window.__LUMINA_SESSION_TOKEN__ = token || '';
+
+        if (typeof window.dispatchEvent !== 'function') {
+          return;
+        }
+
+        const detail = { token: token || '' };
+        let event = null;
+
+        if (typeof CustomEvent === 'function') {
+          event = new CustomEvent('lumina:session-token', { detail });
+        } else if (window.document && typeof window.document.createEvent === 'function') {
+          event = window.document.createEvent('CustomEvent');
+          event.initCustomEvent('lumina:session-token', false, false, detail);
+        }
+
+        if (event) {
+          window.dispatchEvent(event);
+        }
+      } catch (err) {
+        console.warn('broadcastSessionTokenChange: unable to notify listeners', err);
+      }
+    }
+
+    function appendSessionTokenToUrl(url, providedToken, options = {}) {
+      if (!url) {
+        return url;
+      }
+
+      const raw = String(url).trim();
+      if (!raw || raw.startsWith('#') || /^(mailto:|tel:|javascript:)/i.test(raw)) {
+        return url;
+      }
+
+      const token = resolveClientSessionToken(providedToken);
+      if (!token) {
+        return url;
+      }
+
+      try {
+        const base = (typeof window !== 'undefined' && window.location) ? window.location.href : undefined;
+        const parsed = new URL(raw, base);
+
+        if (options.sameOriginOnly !== false) {
+          const currentOrigin = (typeof window !== 'undefined' && window.location) ? window.location.origin : '';
+          if (currentOrigin && parsed.origin && parsed.origin !== currentOrigin) {
+            return url;
+          }
+        }
+
+        if (parsed.searchParams.get(SESSION_TOKEN_QUERY_PARAM) !== token) {
+          parsed.searchParams.set(SESSION_TOKEN_QUERY_PARAM, token);
+        }
+
+        if (raw.startsWith('?')) {
+          return (parsed.search || '') + (parsed.hash || '');
+        }
+
+        if (!/^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.startsWith('//')) {
+          return parsed.pathname + (parsed.search || '') + (parsed.hash || '');
+        }
+
+        return parsed.toString();
+      } catch (error) {
+        console.warn('appendSessionTokenToUrl: unable to append token', { url, error });
+        return url;
+      }
+    }
+
+    function applySessionTokenToLinks(explicitToken) {
+      if (typeof document === 'undefined') {
+        return;
+      }
+
+      const token = resolveClientSessionToken(explicitToken);
+      if (!token) {
+        return;
+      }
+
+      const anchors = document.querySelectorAll('a[href]');
+      anchors.forEach(anchor => {
+        const href = anchor.getAttribute('href');
+        if (!href) {
+          return;
+        }
+
+        const updated = appendSessionTokenToUrl(href, token, { sameOriginOnly: true });
+        if (updated && updated !== href) {
+          anchor.setAttribute('href', updated);
+        }
+      });
     }
 
     function buildLoginUrl(options = {}) {
@@ -3218,11 +3398,7 @@
         // ──────────────────────────────────────────────────────────────────────────────
         // AUTHENTICATION GUARD – PREVENT ACCESS AFTER LOGOUT
         // ──────────────────────────────────────────────────────────────────────────────
-        const AUTH_FALLBACK_STORAGE_KEYS = [
-            'lumina.session.token',
-            'lumina.auth.sessionToken',
-            'lumina.auth.fallbackToken'
-        ];
+        const AUTH_FALLBACK_STORAGE_KEYS = SESSION_TOKEN_STORAGE_KEYS;
 
         function shouldEnforceAuthGuard() {
             if (window.__LUMINA_DISABLE_AUTH_GUARD === true || window.disableLuminaAuthGuard === true) {
@@ -3326,6 +3502,8 @@
             } catch (sessionStorageError) {
                 console.warn('AuthGuard: unable to clear sessionStorage tokens', sessionStorageError);
             }
+
+            broadcastSessionTokenChange('');
 
             try {
                 const existingReason = getLogoutReason();
@@ -3815,6 +3993,13 @@
                 }
 
                 state.token = token;
+                try {
+                    broadcastSessionTokenChange(token);
+                } catch (broadcastError) {
+                    if (global.console && typeof global.console.warn === 'function') {
+                        console.warn('LuminaSessionHeartbeat: unable to broadcast persisted token', broadcastError);
+                    }
+                }
                 return token;
             }
 
@@ -3840,6 +4025,13 @@
                 }
 
                 state.token = '';
+                try {
+                    broadcastSessionTokenChange('');
+                } catch (broadcastError) {
+                    if (global.console && typeof global.console.warn === 'function') {
+                        console.warn('LuminaSessionHeartbeat: unable to broadcast cleared token', broadcastError);
+                    }
+                }
             }
 
             function clearTimer() {


### PR DESCRIPTION
## Summary
- ensure the login redirect reuses the freshly issued session token and broadcasts it to the client
- update the shared layout helpers to append the session token to generated URLs and existing navigation links
- synchronize token changes across storage, the auth guard, and the session heartbeat so navigation stays authenticated

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e274c516488326a9d8c7a25ab8dd64