### PR TITLE
Segment landing sections with branded color blocks

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1757,7 +1757,11 @@ function doGet(e) {
     const rawPageParam = (typeof e.parameter.page === 'string') ? e.parameter.page : '';
     const page = rawPageParam.toLowerCase();
 
-    if (page === 'login' || !page) {
+    if (!page) {
+      return handlePublicPage('landing', e, baseUrl);
+    }
+
+    if (page === 'login') {
       try {
         const existingSession = authenticateUser(e);
         if (existingSession && existingSession.ID) {
@@ -1771,7 +1775,7 @@ function doGet(e) {
     }
 
     // Handle other public pages
-    const publicPages = ['setpassword', 'resetpassword', 'resend-verification', 'resendverification',
+    const publicPages = ['landing', 'setpassword', 'resetpassword', 'resend-verification', 'resendverification',
       'forgotpassword', 'forgot-password', 'emailconfirmed', 'email-confirmed'];
 
     if (publicPages.includes(page)) {
@@ -1795,11 +1799,6 @@ function doGet(e) {
         .setTitle('Change Password')
         .addMetaTag('viewport', 'width=device-width,initial-scale=1')
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
-    }
-
-    // Default route: redirect to persona-specific landing page
-    if (!page) {
-      return redirectToLanding(user);
     }
 
     const campaignId = e.parameter.campaign || user.CampaignID || '';
@@ -2294,6 +2293,16 @@ function handlePublicPage(page, e, baseUrl) {
   const scriptUrl = SCRIPT_URL;
 
   switch (page) {
+    case 'landing':
+      const landingTpl = HtmlService.createTemplateFromFile('Landing');
+      landingTpl.baseUrl = baseUrl;
+      landingTpl.scriptUrl = scriptUrl;
+
+      return landingTpl.evaluate()
+        .setTitle('LuminaHQ – Intelligent Workforce Command Center')
+        .addMetaTag('viewport', 'width=device-width,initial-scale=1')
+        .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+
     case 'setpassword':
     case 'resetpassword':
       const resetToken = e.parameter.token || '';

--- a/Landing.html
+++ b/Landing.html
@@ -1,0 +1,666 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <base target="_top">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LuminaHQ – Intelligent Workforce Command Center</title>
+
+  <?!= includeOnce('CookieHandler') ?>
+  <?!= includeOnce('layoutLoader') ?>
+  <?!= includeOnce('layoutAlerts') ?>
+  <?!= includeOnce('ResponsiveStyles') ?>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+
+  <style>
+    :root {
+      --lumina-navy: #0b1b3f;
+      --lumina-navy-alt: #103060;
+      --lumina-blue: #0478d3;
+      --lumina-blue-dark: #035799;
+      --lumina-cyan: #38bdf8;
+      --lumina-surface: #ffffff;
+      --lumina-muted: #f1f5fb;
+      --lumina-muted-dark: #d6e2f5;
+      --lumina-text: #101828;
+      --lumina-text-muted: #475467;
+      --shadow-primary: 0 12px 24px rgba(4, 120, 211, 0.18);
+      --shadow-card: 0 8px 18px rgba(15, 23, 42, 0.08);
+      --radius-lg: 24px;
+      --radius-md: 16px;
+      --radius-sm: 12px;
+      --transition: all 0.28s ease;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      margin: 0;
+      color: var(--lumina-text);
+      background: var(--lumina-surface);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .page-shell {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .hero {
+      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.25rem clamp(3rem, 5vw, 5rem);
+      width: 100%;
+      position: relative;
+      background: var(--lumina-navy-alt);
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    .hero-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .hero-surface {
+      background: transparent;
+      border-radius: var(--radius-lg);
+      border: none;
+      box-shadow: none;
+      padding: clamp(2.5rem, 5vw, 3.2rem);
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      backdrop-filter: blur(14px);
+      background: rgba(255, 255, 255, 0.85);
+      border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+    }
+
+    .nav-container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+    }
+
+    .brand-logo {
+      height: 46px;
+      width: auto;
+      display: block;
+    }
+
+    .brand h1 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--lumina-navy);
+      margin: 0;
+      letter-spacing: 0.01em;
+    }
+
+    .brand span {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      color: var(--lumina-text-muted);
+      letter-spacing: 0.14em;
+    }
+
+    .nav-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .nav-actions a {
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: var(--transition);
+    }
+
+    .nav-actions .btn-outline {
+      color: var(--lumina-blue-dark);
+      background: transparent;
+      border: 1px solid rgba(4, 120, 211, 0.36);
+    }
+
+    .nav-actions .btn-outline:hover {
+      background: rgba(4, 120, 211, 0.1);
+      transform: translateY(-1px);
+    }
+
+    .nav-actions .btn-primary {
+      color: white;
+      background: var(--lumina-blue);
+      box-shadow: none;
+    }
+
+    .nav-actions .btn-primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 10px 20px rgba(4, 120, 211, 0.24);
+    }
+
+    .hero-content {
+      position: relative;
+      display: grid;
+      gap: clamp(2.5rem, 5vw, 3.5rem);
+      align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      z-index: 1;
+    }
+
+    .hero-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 1.75rem;
+    }
+
+    .hero-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.55rem 1rem;
+      background: rgba(56, 189, 248, 0.16);
+      color: var(--lumina-surface);
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.85rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .hero-title {
+      font-size: clamp(2.4rem, 3.4vw + 1rem, 3.7rem);
+      line-height: 1.1;
+      margin: 0;
+      color: var(--lumina-surface);
+    }
+
+    .hero-subtitle {
+      margin: 0;
+      max-width: 520px;
+      font-size: 1.05rem;
+      color: rgba(226, 232, 240, 0.72);
+    }
+
+    .hero-ctas {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .hero-ctas a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 0.8rem 1.6rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: var(--transition);
+    }
+
+    .hero-ctas .primary {
+      background: var(--lumina-blue);
+      color: white;
+      box-shadow: none;
+    }
+
+    .hero-ctas .primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(4, 120, 211, 0.22);
+    }
+
+    .hero-ctas .ghost {
+      background: rgba(255, 255, 255, 0.12);
+      color: var(--lumina-surface);
+      border: 1px solid rgba(226, 232, 240, 0.28);
+    }
+
+    .hero-ctas .ghost:hover {
+      background: rgba(255, 255, 255, 0.18);
+      color: var(--lumina-surface);
+      border-color: rgba(226, 232, 240, 0.32);
+    }
+
+    .hero-showcase {
+      background: rgba(11, 27, 63, 0.55);
+      border-radius: var(--radius-md);
+      padding: clamp(1.5rem, 3vw, 2rem);
+      box-shadow: none;
+      border: 1px solid rgba(226, 232, 240, 0.15);
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .showcase-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .showcase-header h2 {
+      font-size: 1.1rem;
+      margin: 0;
+      color: var(--lumina-surface);
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.45rem 0.85rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.24);
+      color: var(--lumina-surface);
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .metric-card {
+      background: rgba(15, 23, 42, 0.45);
+      color: var(--lumina-surface);
+      padding: 1.4rem;
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(226, 232, 240, 0.12);
+      position: relative;
+    }
+
+    .metric-card strong {
+      display: block;
+      font-size: 2rem;
+      font-weight: 700;
+    }
+
+    .metric-card span {
+      font-size: 0.85rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.7);
+    }
+
+    .metric-card i {
+      font-size: 1.4rem;
+      opacity: 0.85;
+    }
+
+    .metric-card .icon-circle {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.14);
+      display: grid;
+      place-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .section {
+      padding: clamp(3rem, 5vw + 1rem, 4.5rem) 1.25rem;
+    }
+
+    .section-light {
+      background: var(--lumina-surface);
+    }
+
+    .section-dark {
+      background: var(--lumina-navy);
+      color: rgba(226, 232, 240, 0.9);
+    }
+
+    .section-shell {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.5rem;
+    }
+
+    .section-dark .section-shell {
+      max-width: 1100px;
+    }
+
+    .section-header {
+      display: grid;
+      gap: 0.75rem;
+      max-width: 720px;
+    }
+
+    .section-header h2 {
+      margin: 0;
+      font-size: clamp(2rem, 2vw + 1rem, 2.6rem);
+      color: var(--lumina-navy);
+    }
+
+    .section-header p {
+      margin: 0;
+      color: var(--lumina-text-muted);
+      font-size: 1.02rem;
+    }
+
+    .section-dark .section-header h2 {
+      color: var(--lumina-surface);
+    }
+
+    .section-dark .section-header p {
+      color: rgba(226, 232, 240, 0.75);
+    }
+
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.6rem;
+    }
+
+    .feature-card {
+      background: var(--lumina-surface);
+      border-radius: var(--radius-md);
+      padding: 1.8rem;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      display: grid;
+      gap: 1rem;
+      transition: var(--transition);
+    }
+
+    .feature-card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.1);
+    }
+
+    .feature-icon {
+      width: 54px;
+      height: 54px;
+      border-radius: 16px;
+      background: #e6f2ff;
+      display: grid;
+      place-items: center;
+      color: var(--lumina-blue-dark);
+      font-size: 1.35rem;
+    }
+
+    .feature-card h3 {
+      margin: 0;
+      font-size: 1.2rem;
+      color: var(--lumina-navy);
+    }
+
+    .feature-card p {
+      margin: 0;
+      color: var(--lumina-text-muted);
+      line-height: 1.6;
+    }
+
+    .about-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2rem;
+    }
+
+    .about-card {
+      background: var(--lumina-surface);
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      padding: 2rem;
+      display: grid;
+      gap: 0.75rem;
+      box-shadow: none;
+    }
+
+    .section-dark .feature-card {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(226, 232, 240, 0.18);
+    }
+
+    .section-dark .feature-card h3,
+    .section-dark .feature-card p {
+      color: var(--lumina-surface);
+    }
+
+    .section-dark .feature-card p {
+      color: rgba(226, 232, 240, 0.78);
+    }
+
+    .section-dark .feature-icon {
+      background: rgba(56, 189, 248, 0.18);
+      color: var(--lumina-surface);
+    }
+
+    .section-dark .feature-card:hover {
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+    }
+
+    .about-card small {
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--lumina-blue-dark);
+      font-weight: 600;
+    }
+
+    .about-card h3 {
+      margin: 0;
+      color: var(--lumina-navy);
+    }
+
+    .about-card p {
+      margin: 0;
+      color: var(--lumina-text-muted);
+      line-height: 1.6;
+    }
+
+    footer {
+      padding: 2.5rem 1.25rem 2rem;
+      background: var(--lumina-navy);
+      color: rgba(226, 232, 240, 0.9);
+      margin-top: auto;
+    }
+
+    .footer-shell {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .footer-shell a {
+      color: rgba(226, 232, 240, 0.85);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .footer-shell a:hover {
+      color: white;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        position: static;
+      }
+
+      .nav-container {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .hero {
+        padding-top: 3rem;
+      }
+
+      .hero-ctas {
+        width: 100%;
+      }
+
+      .hero-ctas a {
+        flex: 1;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-shell">
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="#top" aria-label="LuminaHQ home">
+          <img class="brand-logo" src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+          <div>
+            <span>LuminaHQ</span>
+            <h1>Command Center</h1>
+          </div>
+        </a>
+        <div class="nav-actions">
+          <a class="btn-outline" href="#about"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a class="btn-primary" href="Login.html"><i class="fa-solid fa-right-to-bracket"></i> Login</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" id="top">
+        <div class="hero-inner">
+          <div class="hero-surface">
+            <div class="hero-content">
+              <div class="hero-copy">
+                <span class="hero-tag"><i class="fa-solid fa-sparkles"></i> Modern Operations Platform</span>
+                <h2 class="hero-title">Unify your workforce intelligence from one elevated workspace.</h2>
+                <p class="hero-subtitle">LuminaHQ brings call center scheduling, performance, coaching, and collaboration into a single, secure control tower built for high-performing teams.</p>
+                <div class="hero-ctas">
+                  <a class="primary" href="Login.html"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
+                  <a class="ghost" href="#features"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+                </div>
+              </div>
+              <aside class="hero-showcase" aria-label="Platform highlights">
+                <div class="showcase-header">
+                  <h2>Live intelligence snapshot</h2>
+                  <span class="status-pill"><i class="fa-solid fa-signal"></i> Real-time sync</span>
+                </div>
+                <div class="metrics-grid">
+                  <div class="metric-card">
+                    <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
+                    <strong>2.8K</strong>
+                    <span>Active agents</span>
+                  </div>
+                  <div class="metric-card">
+                    <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
+                    <strong>98%</strong>
+                    <span>Service level</span>
+                  </div>
+                  <div class="metric-card">
+                    <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
+                    <strong>15m</strong>
+                    <span>Avg. onboarding</span>
+                  </div>
+                </div>
+                <p class="hero-subtitle" style="margin:0;">Designed for managers, analysts, and specialists who need actionable clarity every hour.</p>
+              </aside>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section-dark" id="features">
+        <div class="section-shell">
+          <div class="section-header">
+            <h2>Why teams trust LuminaHQ</h2>
+            <p>Built with a modern flat UI system, LuminaHQ keeps your workforce aligned while surfacing the KPIs that matter. Every module is orchestrated to boost operational clarity and coach teams at scale.</p>
+          </div>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <div class="feature-icon"><i class="fa-solid fa-headset"></i></div>
+              <h3>Unified agent visibility</h3>
+              <p>Track live schedules, skill coverage, and coaching plans without hopping between spreadsheets or dashboards.</p>
+            </article>
+            <article class="feature-card">
+              <div class="feature-icon"><i class="fa-solid fa-gauge-high"></i></div>
+              <h3>Performance intelligence</h3>
+              <p>Layer KPIs, QA feedback, and campaign health into interactive scorecards that spotlight opportunities faster.</p>
+            </article>
+            <article class="feature-card">
+              <div class="feature-icon"><i class="fa-solid fa-shield-halved"></i></div>
+              <h3>Secure, tenant-ready</h3>
+              <p>Multi-tenant architecture keeps each campaign isolated with granular access controls for admins and managers.</p>
+            </article>
+            <article class="feature-card">
+              <div class="feature-icon"><i class="fa-solid fa-rocket"></i></div>
+              <h3>Ready in minutes</h3>
+              <p>Deploy LuminaHQ directly on Google Workspace infrastructure so your team stays productive without new logins.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section-light" id="about">
+        <div class="section-shell">
+          <div class="section-header">
+            <h2>Where LuminaHQ was crafted</h2>
+            <p>Conceived inside Lumina's Innovation Lab in Austin, Texas, the platform blends contact center expertise with modern data engineering to streamline every customer interaction.</p>
+          </div>
+          <div class="about-grid">
+            <article class="about-card">
+              <small>Purpose</small>
+              <h3>Elevate every customer moment</h3>
+              <p>Give managers, analysts, and enablement leaders a cohesive view of scheduling, coaching, QA, and collaboration so they can focus on people instead of manual busywork.</p>
+            </article>
+            <article class="about-card">
+              <small>Built For</small>
+              <h3>Global call center teams</h3>
+              <p>From BPO networks to in-house support centers, LuminaHQ adapts to campaigns of every scale with tenant-aware governance baked in.</p>
+            </article>
+            <article class="about-card">
+              <small>Crafted In</small>
+              <h3>Austin, Texas</h3>
+              <p>Engineered by Lumina's product studio with a focus on modern, flat UI systems and a seamless Google Apps Script backbone.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <p>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</p>
+        <div>
+          <a href="PrivacyPolicy.html">Privacy</a> &middot;
+          <a href="TermsOfService.html">Terms</a> &middot;
+          <a href="Login.html">Login</a>
+        </div>
+      </div>
+    </footer>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- restyle the landing hero with a deep Lumina blue backdrop and updated contrast styling while keeping the provided logo untouched
- divide the feature and origin sections into distinct dark and white branded color blocks for a flat, segmented layout
- tune supporting elements such as buttons, metrics, and footer hues to keep light blue accents limited to calls to action

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e27b64d700832693a924d9b90068a5