### PR TITLE
Add standalone about and capabilities landing pages

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -438,6 +438,63 @@
       line-height: 1.6;
     }
 
+    .section-cta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .section-cta a {
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.65rem 1.35rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: var(--transition);
+    }
+
+    .section-cta a.primary {
+      background: var(--lumina-blue);
+      color: #fff;
+      box-shadow: 0 12px 20px rgba(4, 120, 211, 0.18);
+      border: 1px solid transparent;
+    }
+
+    .section-cta a.ghost {
+      background: transparent;
+      color: var(--lumina-blue-dark);
+      border: 1px solid rgba(4, 120, 211, 0.28);
+    }
+
+    .section-cta a:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
+    }
+
+    .section-dark .section-cta a {
+      box-shadow: none;
+    }
+
+    .section-dark .section-cta a.primary {
+      background: rgba(255, 255, 255, 0.12);
+      color: var(--lumina-surface);
+      border: 1px solid rgba(255, 255, 255, 0.28);
+    }
+
+    .section-dark .section-cta a.ghost {
+      color: rgba(226, 232, 240, 0.9);
+      border: 1px solid rgba(226, 232, 240, 0.28);
+    }
+
+    .section-dark .section-cta a:hover {
+      background: rgba(255, 255, 255, 0.14);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+    }
+
     .about-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -562,7 +619,7 @@
           </div>
         </a>
         <div class="nav-actions">
-          <a class="btn-outline" href="#about"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a class="btn-outline" href="LandingAbout.html"><i class="fa-regular fa-circle-question"></i> About</a>
           <a class="btn-primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login</a>
         </div>
       </div>
@@ -579,7 +636,7 @@
                 <p class="hero-subtitle">LuminaHQ brings call center scheduling, performance, coaching, and collaboration into a single, secure control tower built for high-performing teams.</p>
                 <div class="hero-ctas">
                   <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
-                  <a class="ghost" href="#features"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+                  <a class="ghost" href="LandingCapabilities.html"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
                 </div>
               </div>
               <aside class="hero-showcase" aria-label="Platform highlights">
@@ -639,6 +696,10 @@
               <p>Deploy LuminaHQ directly on Google Workspace infrastructure so your team stays productive without new logins.</p>
             </article>
           </div>
+          <div class="section-cta">
+            <a class="primary" href="LandingCapabilities.html"><i class="fa-solid fa-diagram-project"></i> Explore full capabilities</a>
+            <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
+          </div>
         </div>
       </section>
 
@@ -664,6 +725,10 @@
               <h3>Kingston, Jamaica</h3>
               <p>Engineered by Lumina's product studio with a focus on modern, flat UI systems and a seamless Google Apps Script backbone.</p>
             </article>
+          </div>
+          <div class="section-cta">
+            <a class="primary" href="LandingAbout.html"><i class="fa-regular fa-circle-question"></i> Discover our story</a>
+            <a class="ghost" href="LandingCapabilities.html"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
           </div>
         </div>
       </section>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About LuminaHQ</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+  <style>
+    :root {
+      --lumina-navy: #0b1b3f;
+      --lumina-blue: #0478d3;
+      --lumina-blue-dark: #035799;
+      --lumina-cyan: #38bdf8;
+      --lumina-surface: #f5f8ff;
+      --lumina-card: #ffffff;
+      --lumina-muted: #475467;
+      --lumina-border: rgba(15, 23, 42, 0.08);
+      --lumina-gradient: linear-gradient(135deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.9));
+      --shadow-card: 0 30px 60px rgba(11, 27, 63, 0.12);
+      --radius-lg: 26px;
+      --radius-md: 18px;
+      --transition: all 0.28s ease;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--lumina-navy);
+      background: radial-gradient(circle at 20% 20%, rgba(4, 120, 211, 0.08), transparent 55%),
+        radial-gradient(circle at 80% 0, rgba(56, 189, 248, 0.1), transparent 45%),
+        var(--lumina-surface);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page-shell {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      backdrop-filter: blur(16px);
+      background: rgba(255, 255, 255, 0.82);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+      z-index: 20;
+    }
+
+    .nav-container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .brand img {
+      width: 46px;
+      height: 46px;
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .brand span {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--lumina-muted);
+    }
+
+    .nav-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .nav-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.6rem 1.2rem;
+      border-radius: 999px;
+      transition: var(--transition);
+      color: var(--lumina-blue-dark);
+      border: 1px solid rgba(4, 120, 211, 0.32);
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .nav-actions a.primary {
+      color: #fff;
+      background: var(--lumina-blue);
+      border-color: transparent;
+      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
+    }
+
+    .nav-actions a:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 22px rgba(4, 120, 211, 0.15);
+    }
+
+    main {
+      flex: 1;
+    }
+
+    .hero {
+      position: relative;
+      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
+      color: rgba(241, 247, 255, 0.96);
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 0 0 48px 48px;
+      background: var(--lumina-gradient);
+      z-index: 0;
+    }
+
+    .hero-inner {
+      position: relative;
+      z-index: 1;
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.5rem;
+      align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .hero-copy h2 {
+      font-size: clamp(2.4rem, 4vw, 3.2rem);
+      margin-bottom: 1.2rem;
+      line-height: 1.1;
+    }
+
+    .hero-copy p {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      max-width: 520px;
+      margin-bottom: 1.5rem;
+    }
+
+    .hero-meta {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .meta-card {
+      background: rgba(255, 255, 255, 0.14);
+      padding: 1.25rem 1.4rem;
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      border: 1px solid rgba(255, 255, 255, 0.22);
+    }
+
+    .meta-card span {
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-weight: 600;
+      font-size: 0.72rem;
+      color: rgba(248, 250, 252, 0.72);
+    }
+
+    .meta-card strong {
+      font-size: 1.4rem;
+      font-weight: 700;
+    }
+
+    .content-section {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: clamp(3rem, 5vw, 4.5rem) 1.5rem;
+      display: grid;
+      gap: 2.75rem;
+    }
+
+    .section-header {
+      max-width: 760px;
+    }
+
+    .section-header h3 {
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+      margin-bottom: 1rem;
+      color: var(--lumina-navy);
+    }
+
+    .section-header p {
+      font-size: 1.05rem;
+      line-height: 1.8;
+      color: var(--lumina-muted);
+    }
+
+    .value-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 1.75rem;
+    }
+
+    .value-card {
+      background: var(--lumina-card);
+      border-radius: var(--radius-md);
+      padding: 2rem 2.2rem;
+      border: 1px solid var(--lumina-border);
+      box-shadow: var(--shadow-card);
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .value-card i {
+      font-size: 1.5rem;
+      color: var(--lumina-blue);
+    }
+
+    .value-card h4 {
+      margin: 0;
+      font-size: 1.35rem;
+    }
+
+    .value-card p {
+      margin: 0;
+      line-height: 1.7;
+      color: var(--lumina-muted);
+    }
+
+    .story-timeline {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      position: relative;
+    }
+
+    .story-card {
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: var(--radius-md);
+      padding: 1.75rem 1.9rem;
+      border: 1px solid var(--lumina-border);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    }
+
+    .story-card strong {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--lumina-blue-dark);
+    }
+
+    .story-card h4 {
+      font-size: 1.35rem;
+      margin: 0.75rem 0;
+    }
+
+    .story-card p {
+      margin: 0;
+      line-height: 1.7;
+      color: var(--lumina-muted);
+    }
+
+    .culture-banner {
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(4, 120, 211, 0.18));
+      border-radius: var(--radius-lg);
+      padding: 3rem 2.5rem;
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      border: 1px solid rgba(4, 120, 211, 0.25);
+    }
+
+    .culture-banner h4 {
+      margin: 0;
+      font-size: 1.6rem;
+    }
+
+    .culture-banner ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.9rem;
+    }
+
+    .culture-banner li {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .culture-banner li i {
+      color: var(--lumina-blue);
+      margin-top: 0.2rem;
+    }
+
+    footer {
+      padding: 2.5rem 1.5rem 3rem;
+      background: #0b1b3f;
+      color: rgba(226, 232, 240, 0.85);
+      margin-top: auto;
+    }
+
+    .footer-shell {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .footer-shell a {
+      color: rgba(148, 163, 184, 0.85);
+      text-decoration: none;
+    }
+
+    .footer-shell a:hover {
+      color: #fff;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        position: static;
+      }
+
+      .nav-container {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-shell">
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="Landing.html">
+          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+          <div>
+            <span>LuminaHQ</span>
+            <h1>Command Center</h1>
+          </div>
+        </a>
+        <div class="nav-actions">
+          <a href="LandingCapabilities.html"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+          <a class="primary" href="Landing.html"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-inner">
+          <div class="hero-copy">
+            <h2>Built for teams who turn every customer moment into momentum.</h2>
+            <p>LuminaHQ started as a skunkworks experiment inside Lumina's Innovation Lab in Kingston, Jamaica. What began as a scheduling toolkit for a single campaign now orchestrates workforce intelligence across global BPO operations.</p>
+            <div class="hero-meta">
+              <div class="meta-card">
+                <span>Origins</span>
+                <strong>Kingston, Jamaica</strong>
+                <p>Where our product studio designs, prototypes, and ships every module.</p>
+              </div>
+              <div class="meta-card">
+                <span>Focus</span>
+                <strong>Workforce clarity</strong>
+                <p>Unifying scheduling, QA, coaching, and collaboration into one control tower.</p>
+              </div>
+            </div>
+          </div>
+          <div class="hero-visual" aria-hidden="true">
+            <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1710450011/vlbpo/lumina/about-grid_qws7ir.png" alt="LuminaHQ culture collage" style="width:100%;border-radius:24px;box-shadow:0 32px 60px rgba(8, 47, 73, 0.2);object-fit:cover;">
+          </div>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div class="section-header">
+          <h3>Why we exist</h3>
+          <p>Call center leaders are asked to coach, staff, report, and innovate without friction. LuminaHQ removes the swivel-chair work by giving teams an integrated workspace that adapts to each campaign, geography, and client requirement.</p>
+        </div>
+        <div class="value-grid">
+          <article class="value-card">
+            <i class="fa-solid fa-compass"></i>
+            <h4>Customer-first design</h4>
+            <p>Every workflow is tested with active operations teams to ensure the UI stays intuitive even for fast-scaling programs.</p>
+          </article>
+          <article class="value-card">
+            <i class="fa-solid fa-people-group"></i>
+            <h4>Human-centered automation</h4>
+            <p>Automation is only useful when it empowers analysts and supervisors. Our scripts reduce manual steps while keeping people in control.</p>
+          </article>
+          <article class="value-card">
+            <i class="fa-solid fa-shield-heart"></i>
+            <h4>Secure collaboration</h4>
+            <p>Multi-tenant controls, audit trails, and granular permissions protect customer data while keeping teams aligned.</p>
+          </article>
+          <article class="value-card">
+            <i class="fa-solid fa-globe"></i>
+            <h4>Global reach, local roots</h4>
+            <p>We support distributed teams across the Americas, yet maintain our product craft and culture in the Caribbean.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div class="section-header">
+          <h3>How LuminaHQ evolved</h3>
+          <p>A cross-functional team of engineers, data analysts, and operations specialists continues to expand LuminaHQ based on real-world call center use cases.</p>
+        </div>
+        <div class="story-timeline">
+          <article class="story-card">
+            <strong><i class="fa-solid fa-flag"></i> 2019</strong>
+            <h4>Scheduling foundations</h4>
+            <p>Introduced the first Google Workspace scripts to automate agent shift updates and broadcast daily coaching plans.</p>
+          </article>
+          <article class="story-card">
+            <strong><i class="fa-solid fa-rocket"></i> 2021</strong>
+            <h4>Unified coaching</h4>
+            <p>Expanded into coaching dashboards, QA data pipelines, and collaboration workflows for hybrid teams.</p>
+          </article>
+          <article class="story-card">
+            <strong><i class="fa-solid fa-shield"></i> 2023</strong>
+            <h4>Enterprise-ready security</h4>
+            <p>Shipped tenant-aware access controls, SSO alignment, and audit logging for compliance-driven partners.</p>
+          </article>
+          <article class="story-card">
+            <strong><i class="fa-solid fa-chart-line"></i> Today</strong>
+            <h4>Predictive intelligence</h4>
+            <p>Integrating forecasting, AI summarization, and proactive alerts so teams anticipate changes instead of reacting to them.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-section" style="padding-bottom:4.5rem;">
+        <div class="culture-banner">
+          <div>
+            <h4>Inside the LuminaHQ culture</h4>
+            <p style="color:var(--lumina-muted);line-height:1.7;margin-top:0.75rem;">We operate with curiosity, empathy, and a bias toward shipping. Our product rituals keep customer teams connected to the builders shaping their tools.</p>
+          </div>
+          <div>
+            <ul>
+              <li><i class="fa-solid fa-lightbulb"></i> Weekly design reviews align engineering, QA, and enablement on new feature experiments.</li>
+              <li><i class="fa-solid fa-person-chalkboard"></i> Immersive onboarding embeds our product team directly inside partner operations for live feedback.</li>
+              <li><i class="fa-solid fa-hands"></i> Community initiatives reinvest in Jamaican tech talent through mentorship, internships, and open-source learning.</li>
+            </ul>
+          </div>
+          <div>
+            <ul>
+              <li><i class="fa-solid fa-headset"></i> Dedicated customer pods pair product managers with operations leads for faster roadmap alignment.</li>
+              <li><i class="fa-solid fa-leaf"></i> We balance rapid delivery with sustainable workloads to maintain a resilient team.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <strong>Ready to explore the workspace?</strong>
+        <div>
+          <a href="LandingCapabilities.html">Discover LuminaHQ capabilities</a> &middot;
+          <a href="Landing.html#about">Back to landing overview</a>
+        </div>
+        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
+      </div>
+    </footer>
+  </div>
+</body>
+
+</html>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Explore LuminaHQ Capabilities</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+  <? var loginUrl = buildLoginPageUrl({}); ?>
+  <style>
+    :root {
+      --lumina-navy: #0b1b3f;
+      --lumina-blue: #0478d3;
+      --lumina-blue-dark: #035799;
+      --lumina-cyan: #38bdf8;
+      --lumina-surface: #f6f9ff;
+      --lumina-card: #ffffff;
+      --lumina-muted: #475467;
+      --lumina-border: rgba(15, 23, 42, 0.08);
+      --shadow-card: 0 28px 50px rgba(11, 27, 63, 0.12);
+      --radius-lg: 26px;
+      --radius-md: 18px;
+      --radius-sm: 14px;
+      --transition: all 0.28s ease;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--lumina-navy);
+      background: var(--lumina-surface);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page-shell {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      backdrop-filter: blur(16px);
+      background: rgba(255, 255, 255, 0.9);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+      z-index: 20;
+    }
+
+    .nav-container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .brand img {
+      width: 46px;
+      height: 46px;
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .brand span {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--lumina-muted);
+    }
+
+    .nav-actions {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .nav-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.6rem 1.2rem;
+      border-radius: 999px;
+      transition: var(--transition);
+      color: var(--lumina-blue-dark);
+      border: 1px solid rgba(4, 120, 211, 0.32);
+      background: rgba(255, 255, 255, 0.92);
+    }
+
+    .nav-actions a.primary {
+      color: #fff;
+      background: var(--lumina-blue);
+      border-color: transparent;
+      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
+    }
+
+    .nav-actions a:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
+    }
+
+    .hero {
+      position: relative;
+      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
+      color: rgba(241, 247, 255, 0.96);
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
+      z-index: 0;
+      border-radius: 0 0 48px 48px;
+    }
+
+    .hero::after {
+      content: '';
+      position: absolute;
+      top: -20%;
+      right: -20%;
+      width: 420px;
+      height: 420px;
+      background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 60%);
+      z-index: 0;
+    }
+
+    .hero-inner {
+      position: relative;
+      z-index: 1;
+      max-width: 1120px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .hero-copy h2 {
+      font-size: clamp(2.4rem, 4vw, 3.2rem);
+      margin-bottom: 1.2rem;
+      line-height: 1.1;
+    }
+
+    .hero-copy p {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      max-width: 520px;
+      margin-bottom: 1.6rem;
+    }
+
+    .hero-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      background: rgba(255, 255, 255, 0.18);
+      border-radius: 999px;
+      padding: 0.65rem 1.3rem;
+      font-weight: 600;
+      color: #fff;
+      text-decoration: none;
+      transition: var(--transition);
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      max-width: fit-content;
+    }
+
+    .hero-cta:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.24);
+    }
+
+    main {
+      flex: 1;
+    }
+
+    .section {
+      padding: clamp(3.2rem, 5vw, 4.5rem) 1.5rem;
+    }
+
+    .section-shell {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.75rem;
+    }
+
+    .section-header {
+      display: grid;
+      gap: 1rem;
+      max-width: 760px;
+    }
+
+    .section-header h3 {
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+      margin: 0;
+    }
+
+    .section-header p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--lumina-muted);
+      line-height: 1.8;
+    }
+
+    .module-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.75rem;
+    }
+
+    .module-card {
+      background: var(--lumina-card);
+      border-radius: var(--radius-md);
+      padding: 2rem 2.2rem;
+      border: 1px solid var(--lumina-border);
+      box-shadow: var(--shadow-card);
+      display: flex;
+      flex-direction: column;
+      gap: 0.7rem;
+      transition: var(--transition);
+    }
+
+    .module-card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 32px 70px rgba(11, 27, 63, 0.16);
+    }
+
+    .module-card span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--lumina-blue-dark);
+    }
+
+    .module-card h4 {
+      margin: 0;
+      font-size: 1.35rem;
+    }
+
+    .module-card p {
+      margin: 0;
+      line-height: 1.65;
+      color: var(--lumina-muted);
+    }
+
+    .module-card ul {
+      margin: 0.75rem 0 0;
+      padding-left: 1.1rem;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .capability-matrix {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .matrix-card {
+      background: linear-gradient(145deg, rgba(4, 120, 211, 0.1), rgba(56, 189, 248, 0.08));
+      border-radius: var(--radius-md);
+      padding: 2.1rem 2.3rem;
+      border: 1px solid rgba(4, 120, 211, 0.18);
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .matrix-card h4 {
+      margin: 0;
+      font-size: 1.35rem;
+    }
+
+    .matrix-card p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .matrix-points {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .matrix-points li {
+      display: flex;
+      gap: 0.55rem;
+      align-items: flex-start;
+      color: var(--lumina-muted);
+    }
+
+    .matrix-points li i {
+      color: var(--lumina-blue);
+      margin-top: 0.15rem;
+    }
+
+    .integration-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.4rem;
+    }
+
+    .integration-card {
+      background: var(--lumina-card);
+      border-radius: var(--radius-sm);
+      padding: 1.6rem 1.8rem;
+      border: 1px solid var(--lumina-border);
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
+    }
+
+    .integration-card strong {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--lumina-blue-dark);
+    }
+
+    .integration-card ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .cta-panel {
+      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
+      color: #fff;
+      border-radius: var(--radius-lg);
+      padding: 3rem 2.5rem;
+      display: grid;
+      gap: 1.5rem;
+      justify-items: start;
+      box-shadow: 0 38px 70px rgba(8, 30, 70, 0.22);
+      text-align: left;
+    }
+
+    .cta-panel h3 {
+      margin: 0;
+      font-size: clamp(2rem, 3.5vw, 2.5rem);
+    }
+
+    .cta-panel p {
+      margin: 0;
+      font-size: 1.05rem;
+      max-width: 520px;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.85);
+    }
+
+    .cta-panel a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      background: #fff;
+      color: var(--lumina-blue-dark);
+      text-decoration: none;
+      padding: 0.75rem 1.5rem;
+      border-radius: 999px;
+      font-weight: 600;
+      transition: var(--transition);
+    }
+
+    .cta-panel a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 30px rgba(255, 255, 255, 0.25);
+    }
+
+    footer {
+      padding: 2.5rem 1.5rem 3rem;
+      background: #0b1b3f;
+      color: rgba(226, 232, 240, 0.85);
+      margin-top: auto;
+    }
+
+    .footer-shell {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .footer-shell a {
+      color: rgba(148, 163, 184, 0.85);
+      text-decoration: none;
+    }
+
+    .footer-shell a:hover {
+      color: #fff;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        position: static;
+      }
+
+      .nav-container {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-shell">
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="Landing.html">
+          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+          <div>
+            <span>LuminaHQ</span>
+            <h1>Command Center</h1>
+          </div>
+        </a>
+        <div class="nav-actions">
+          <a href="LandingAbout.html"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a class="primary" href="Landing.html"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-inner">
+          <div class="hero-copy">
+            <h2>Every capability connects frontline execution to leadership insight.</h2>
+            <p>Explore the end-to-end modules that power LuminaHQ. From real-time scheduling to QA intelligence, each capability is engineered to help teams anticipate demand and act with confidence.</p>
+            <a class="hero-cta" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to experience LuminaHQ</a>
+          </div>
+          <div class="hero-visual" aria-hidden="true" style="display:grid;gap:1rem;">
+            <div style="background:rgba(255,255,255,0.12);border-radius:22px;padding:1.4rem 1.6rem;border:1px solid rgba(255,255,255,0.28);display:grid;gap:0.75rem;">
+              <div style="display:flex;align-items:center;justify-content:space-between;">
+                <strong style="font-size:0.95rem;letter-spacing:0.12em;text-transform:uppercase;">Live insights</strong>
+                <span style="display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;"><i class="fa-solid fa-signal"></i> Synced</span>
+              </div>
+              <div style="display:grid;gap:0.6rem;">
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <span>Schedule adherence</span>
+                  <strong>97.4%</strong>
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <span>QA coaching cycles</span>
+                  <strong>128</strong>
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                  <span>Campaign health</span>
+                  <strong>Green</strong>
+                </div>
+              </div>
+            </div>
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.75rem;">
+              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
+                <i class="fa-solid fa-calendar-check" style="font-size:1.4rem;"></i>
+                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Scheduling</p>
+              </div>
+              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
+                <i class="fa-solid fa-chalkboard-user" style="font-size:1.4rem;"></i>
+                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Coaching</p>
+              </div>
+              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
+                <i class="fa-solid fa-chart-line" style="font-size:1.4rem;"></i>
+                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Analytics</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="modules">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Core modules that power your operations</h3>
+            <p>Each LuminaHQ module is purpose-built for high-volume contact centers. They connect seamlessly, yet can be rolled out independently to match the maturity of each campaign.</p>
+          </div>
+          <div class="module-grid">
+            <article class="module-card">
+              <span><i class="fa-solid fa-calendar-check"></i> Scheduling</span>
+              <h4>Shift orchestration</h4>
+              <p>Broadcast real-time staffing updates, manage shift swaps, and automate exception handling directly in Google Workspace.</p>
+              <ul>
+                <li>Agent swap approvals with audit trails</li>
+                <li>Overtime forecasting and alerts</li>
+                <li>Work-from-home readiness checks</li>
+              </ul>
+            </article>
+            <article class="module-card">
+              <span><i class="fa-solid fa-user-graduate"></i> Coaching</span>
+              <h4>Enablement playbooks</h4>
+              <p>Give supervisors guided workflows to assign action plans, track completion, and celebrate wins in one place.</p>
+              <ul>
+                <li>Custom coaching templates &amp; sign-offs</li>
+                <li>Performance snapshots and heatmaps</li>
+                <li>Automated reminders for follow-ups</li>
+              </ul>
+            </article>
+            <article class="module-card">
+              <span><i class="fa-solid fa-shield-heart"></i> Quality</span>
+              <h4>QA intelligence hub</h4>
+              <p>Analyze evaluator feedback, calibrate teams, and surface QA performance trends with a modern reporting layer.</p>
+              <ul>
+                <li>Weighted scoring and variance tracking</li>
+                <li>Calibration dashboards with history</li>
+                <li>AI-ready form exports for deeper insights</li>
+              </ul>
+            </article>
+            <article class="module-card">
+              <span><i class="fa-solid fa-handshake"></i> Collaboration</span>
+              <h4>Campaign collaboration</h4>
+              <p>Coordinate cross-functional projects, document requirements, and drive accountability across partner teams.</p>
+              <ul>
+                <li>Project boards with owner visibility</li>
+                <li>Documented SLAs and knowledge sharing</li>
+                <li>Escalation routing with follow-through</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="intelligence">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Intelligence woven into every workflow</h3>
+            <p>LuminaHQ turns raw metrics into proactive insights. Supervisors and executives gain the same live picture, tailored to their priorities.</p>
+          </div>
+          <div class="capability-matrix">
+            <article class="matrix-card">
+              <h4>Operational awareness</h4>
+              <p>See how staffing, quality, and coaching interact in real-time.</p>
+              <ul class="matrix-points">
+                <li><i class="fa-solid fa-signal"></i> Color-coded adherence by site, line of business, or skill group.</li>
+                <li><i class="fa-solid fa-chart-area"></i> Trend analysis that blends historical performance with live data.</li>
+                <li><i class="fa-solid fa-bell"></i> Notifications when service levels or QA thresholds drift.</li>
+              </ul>
+            </article>
+            <article class="matrix-card">
+              <h4>Guided decisioning</h4>
+              <p>Surface the next best action for every role on the floor.</p>
+              <ul class="matrix-points">
+                <li><i class="fa-solid fa-route"></i> Prescriptive playbooks for coaching, staffing, and client communication.</li>
+                <li><i class="fa-solid fa-person-chalkboard"></i> Supervisor dashboards tuned for quick huddles.</li>
+                <li><i class="fa-solid fa-gears"></i> Automations triggered by thresholds, statuses, or campaign events.</li>
+              </ul>
+            </article>
+            <article class="matrix-card">
+              <h4>Executive visibility</h4>
+              <p>Translate frontline operations into boardroom clarity.</p>
+              <ul class="matrix-points">
+                <li><i class="fa-solid fa-chart-line"></i> Roll-up scorecards across programs with drill-downs to agent level.</li>
+                <li><i class="fa-solid fa-file-lines"></i> Auto-generated executive briefs summarizing wins and risks.</li>
+                <li><i class="fa-solid fa-globe"></i> Global dashboards that segment by client, region, or outsourcing partner.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="integrations">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Works seamlessly with your existing stack</h3>
+            <p>Built on Google Workspace and Apps Script, LuminaHQ plays nicely with your contact center ecosystem, ensuring data stays secure and in sync.</p>
+          </div>
+          <div class="integration-grid">
+            <article class="integration-card">
+              <strong><i class="fa-brands fa-google"></i> Google Workspace native</strong>
+              <ul>
+                <li>Single sign-on with your Google accounts</li>
+                <li>Drive, Sheets, and Docs automations included</li>
+                <li>Calendar sync for schedule updates</li>
+              </ul>
+            </article>
+            <article class="integration-card">
+              <strong><i class="fa-solid fa-cloud-arrow-up"></i> Data pipeline ready</strong>
+              <ul>
+                <li>Export-ready datasets for BI platforms</li>
+                <li>Webhook endpoints for real-time mirroring</li>
+                <li>Tenant-aware API keys and logging</li>
+              </ul>
+            </article>
+            <article class="integration-card">
+              <strong><i class="fa-solid fa-lock"></i> Security controls</strong>
+              <ul>
+                <li>Role-based permissions with audit history</li>
+                <li>Granular data residency and retention rules</li>
+                <li>Compliance alignment for SOC 2 readiness</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" style="padding-bottom:4.5rem;">
+        <div class="section-shell">
+          <div class="cta-panel">
+            <h3>See LuminaHQ in action</h3>
+            <p>Log in to your workspace or request a guided walkthrough to explore how LuminaHQ adapts to the rhythm of your operations.</p>
+            <a href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to LuminaHQ</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <strong>Looking for our story?</strong>
+        <div>
+          <a href="LandingAbout.html">Visit the LuminaHQ about page</a> &middot;
+          <a href="Landing.html#features">Return to landing highlights</a>
+        </div>
+        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</small>
+      </div>
+    </footer>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a rich About LuminaHQ page detailing mission, evolution, and culture for the landing experience
- add an Explore Capabilities page showcasing core modules, intelligence workflows, and integrations
- update the landing page navigation and calls-to-action to link to the new pages and provide shared CTA styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ba931c0883268628988c1cccb48e