### PR TITLE
Wire QA dashboard intelligence to backend service

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -516,6 +516,246 @@
     overflow: hidden;
   }
 
+  /* AI Intelligence Cards */
+  .ai-intel-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
+    margin: 2rem 0;
+  }
+
+  .ai-intel-card {
+    background: white;
+    border-radius: var(--border-radius-lg);
+    padding: 1.75rem;
+    box-shadow: var(--card-shadow);
+    border: 1px solid rgba(226, 232, 240, 0.6);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .ai-intel-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
+    opacity: 0.75;
+    pointer-events: none;
+  }
+
+  .ai-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 700;
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    position: relative;
+    z-index: 2;
+  }
+
+  .ai-card-header i {
+    color: #667eea;
+    font-size: 1.25rem;
+  }
+
+  .ai-confidence-badge,
+  .ai-automation-state {
+    margin-left: auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(102, 126, 234, 0.12);
+    color: #4338ca;
+  }
+
+  .ai-automation-state.active {
+    background: rgba(245, 158, 11, 0.15);
+    color: #b45309;
+  }
+
+  .ai-trend-health {
+    margin-left: auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+  }
+
+  .ai-trend-health.improving {
+    background: rgba(16, 185, 129, 0.18);
+    color: #047857;
+  }
+
+  .ai-trend-health.risk {
+    background: rgba(248, 113, 113, 0.18);
+    color: #b91c1c;
+  }
+
+  .ai-insights-summary,
+  .ai-automation-summary {
+    position: relative;
+    z-index: 2;
+    color: #475569;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin-bottom: 1.25rem;
+  }
+
+  .ai-insights-list,
+  .ai-actions-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    position: relative;
+    z-index: 2;
+  }
+
+  .ai-insight-item,
+  .ai-action-item {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    border-radius: 14px;
+    padding: 0.85rem 1rem;
+    background: rgba(102, 126, 234, 0.08);
+    border: 1px solid rgba(226, 232, 240, 0.6);
+    backdrop-filter: blur(6px);
+  }
+
+  .ai-insight-item.negative,
+  .ai-action-item.urgent {
+    background: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.3);
+  }
+
+  .ai-insight-item.positive {
+    background: rgba(16, 185, 129, 0.12);
+    border-color: rgba(16, 185, 129, 0.25);
+  }
+
+  .ai-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    background: white;
+    color: #4338ca;
+    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
+  }
+
+  .ai-insight-item.negative .ai-icon,
+  .ai-action-item.urgent .ai-icon {
+    color: #b91c1c;
+    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
+  }
+
+  .ai-insight-item.positive .ai-icon {
+    color: #059669;
+    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
+  }
+
+  .ai-insight-content strong,
+  .ai-action-content strong {
+    display: block;
+    font-size: 0.95rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .ai-insight-content span,
+  .ai-action-content span {
+    font-size: 0.9rem;
+    color: #475569;
+    line-height: 1.5;
+  }
+
+  .ai-next-best-action {
+    margin-top: 1.5rem;
+    padding: 1rem 1.2rem;
+    border-radius: 14px;
+    background: rgba(59, 130, 246, 0.1);
+    border: 1px dashed rgba(59, 130, 246, 0.3);
+    position: relative;
+    z-index: 2;
+    font-size: 0.9rem;
+    color: #1d4ed8;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .ai-next-best-action i {
+    font-size: 1.1rem;
+    margin-top: 0.1rem;
+  }
+
+  .ai-next-best-action strong {
+    display: block;
+    font-size: 0.95rem;
+  }
+
+  .ai-trend-summary {
+    position: relative;
+    z-index: 2;
+    color: #475569;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin-bottom: 1.25rem;
+  }
+
+  .ai-trend-visual {
+    position: relative;
+    z-index: 2;
+    background: rgba(102, 126, 234, 0.06);
+    border: 1px solid rgba(226, 232, 240, 0.6);
+    border-radius: 14px;
+    padding: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .ai-trend-visual canvas {
+    width: 100% !important;
+    height: 180px !important;
+  }
+
+  .ai-trend-forecast {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    color: #334155;
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .ai-trend-forecast span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(15, 118, 110, 0.12);
+    color: #0f766e;
+    font-weight: 600;
+  }
+
+  @media (max-width: 992px) {
+    .ai-intel-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
   .modern-table-card h6 {
     font-size: 1.1rem;
     font-weight: 700;
@@ -881,6 +1121,49 @@
   <!-- Dynamically populated by JavaScript -->
 </div>
 
+<!-- AI Intelligence Layer -->
+<div class="ai-intel-grid fade-in">
+  <div class="ai-intel-card">
+    <div class="ai-card-header">
+      <i class="fas fa-robot"></i>
+      <span>Lumina QA Copilot</span>
+      <span class="ai-confidence-badge" id="aiConfidenceBadge">Confidence 0%</span>
+    </div>
+    <p class="ai-insights-summary" id="aiInsightsSummary">AI insights will appear once data loads.</p>
+    <ul class="ai-insights-list" id="aiInsightsList"></ul>
+  </div>
+
+  <div class="ai-intel-card">
+    <div class="ai-card-header">
+      <i class="fas fa-bolt"></i>
+      <span>Automation Playbook</span>
+      <span class="ai-automation-state" id="aiAutomationState">Monitoring</span>
+    </div>
+    <p class="ai-automation-summary" id="aiAutomationSummary">AI recommendations will populate after analysis.</p>
+    <ul class="ai-actions-list" id="aiRecommendationsList"></ul>
+    <div class="ai-next-best-action" id="aiNextBestAction" style="display: none;">
+      <i class="fas fa-magic"></i>
+      <div>
+        <strong>Next best automation</strong>
+        <span id="aiNextBestActionText"></span>
+      </div>
+    </div>
+  </div>
+  <div class="ai-intel-card">
+    <div class="ai-card-header">
+      <i class="fas fa-chart-line"></i>
+      <span>AI Trend Radar</span>
+      <span class="ai-trend-health" id="aiTrendHealth">Monitoring</span>
+    </div>
+    <p class="ai-trend-summary" id="aiTrendSummary">Trend intelligence will populate after analysis.</p>
+    <div class="ai-trend-visual" id="aiTrendVisual" style="display: none;">
+      <canvas id="aiTrendSparkline"></canvas>
+      <div class="ai-trend-forecast" id="aiTrendForecast"></div>
+    </div>
+    <ul class="ai-insights-list" id="aiTrendList"></ul>
+  </div>
+</div>
+
 <!-- Modern Charts -->
 <div class="modern-chart-grid stagger-animation">
   <div class="modern-chart-card">
@@ -1018,7 +1301,7 @@
           return safeToDate(dateValue) !== null;
       }
       
-      let dailyChart, agentChart, categoryChart;
+      let dailyChart, agentChart, categoryChart, trendSparklineChart;
 
       function showLoader(detail = 'Loading QA metrics…') {
         const loaderApi = window.LuminaLoader;
@@ -1070,6 +1353,356 @@
           out[cat]={ avgScore, passPct };
         });
         return out;
+      }
+
+      function formatPeriodLabel(granularity, period) {
+        if (!period) return 'Period';
+        switch (granularity) {
+          case 'Week':
+            return period.replace(/^[0-9]{4}-/, '');
+          case 'Month': {
+            const [y, m] = period.split('-');
+            const date = new Date(Number(y), Number(m) - 1, 1);
+            return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+          }
+          case 'Quarter':
+            return period.replace('-', ' ');
+          case 'Year':
+            return period;
+          default:
+            return period;
+        }
+      }
+
+      function filterRecordsByPeriod(data, granularity, periodValue) {
+        if (!periodValue) return [];
+        return data.filter(record => {
+          const dt = record.callDateObj;
+          if (!dt) return false;
+          try {
+            switch (granularity) {
+              case 'Week':
+                return toISOWeek(dt) === periodValue;
+              case 'Month':
+                return dt.toISOString().slice(0, 7) === periodValue;
+              case 'Quarter':
+                return `${getQuarter(dt)}-${dt.getFullYear()}` === periodValue;
+              case 'Year':
+                return String(dt.getFullYear()) === periodValue;
+              default:
+                return true;
+            }
+          } catch (err) {
+            console.warn('filterRecordsByPeriod error', record, err);
+            return false;
+          }
+        });
+      }
+
+      function buildTrendSeries(granularity, currentPeriod, data, depth = 4) {
+        const series = [];
+        let cursor = currentPeriod;
+        let steps = 0;
+        const visited = new Set();
+
+        while (cursor && steps < depth && !visited.has(cursor)) {
+          visited.add(cursor);
+          const bucket = filterRecordsByPeriod(data, granularity, cursor);
+          const evalCount = bucket.length;
+          const agentCount = new Set(bucket.map(r => r.AgentName)).size;
+          const avgScore = evalCount ? Math.round(bucket.reduce((sum, r) => sum + (r.Percentage || 0), 0) / evalCount * 100) : 0;
+          const passRate = safePercentage(bucket.filter(r => r.Percentage >= PASS_MARK).length, evalCount);
+          const coverage = userList.length ? safePercentage(agentCount, userList.length) : (agentCount > 0 ? 100 : 0);
+
+          series.push({
+            period: cursor,
+            label: formatPeriodLabel(granularity, cursor),
+            avgScore,
+            passRate,
+            evalCount,
+            agentCount,
+            coverage
+          });
+
+          cursor = getPreviousPeriod(granularity, cursor);
+          steps += 1;
+        }
+
+        return series.reverse();
+      }
+
+      function linearRegression(points) {
+        if (!points || !points.length) {
+          return { slope: 0, intercept: 0 };
+        }
+
+        if (points.length === 1) {
+          return { slope: 0, intercept: points[0].y };
+        }
+
+        const n = points.length;
+        let sumX = 0;
+        let sumY = 0;
+        let sumXY = 0;
+        let sumXX = 0;
+
+        points.forEach(point => {
+          sumX += point.x;
+          sumY += point.y;
+          sumXY += point.x * point.y;
+          sumXX += point.x * point.x;
+        });
+
+        const denominator = (n * sumXX) - (sumX * sumX);
+        if (denominator === 0) {
+          return { slope: 0, intercept: sumY / n };
+        }
+
+        const slope = ((n * sumXY) - (sumX * sumY)) / denominator;
+        const intercept = (sumY - slope * sumX) / n;
+        return { slope, intercept };
+      }
+
+      function clampPercent(value) {
+        if (Number.isNaN(value)) return 0;
+        return Math.max(0, Math.min(100, Math.round(value)));
+      }
+
+      function analyzeTrendSeries(series, context = {}) {
+        const { granularity = 'Period' } = context;
+        const lowerGran = granularity.toLowerCase();
+
+        if (!series || !series.length) {
+          return {
+            summary: `Lumina AI is waiting for enough history to analyze ${lowerGran} trends.`,
+            points: [],
+            health: 'monitoring',
+            forecast: { avg: 0, pass: 0 },
+            nextLabel: `next ${lowerGran}`
+          };
+        }
+
+        const first = series[0];
+        const last = series[series.length - 1];
+
+        const avgPoints = series.map((point, index) => ({ x: index, y: point.avgScore }));
+        const passPoints = series.map((point, index) => ({ x: index, y: point.passRate }));
+        const avgReg = linearRegression(avgPoints);
+        const passReg = linearRegression(passPoints);
+
+        const avgDelta = last.avgScore - first.avgScore;
+        const passDelta = last.passRate - first.passRate;
+        const volumeDelta = last.evalCount - first.evalCount;
+
+        const slopeAvg = avgReg.slope;
+        const slopePass = passReg.slope;
+
+        const improving = slopeAvg > 0.5 || slopePass > 0.5;
+        const declining = slopeAvg < -0.5 || slopePass < -0.5;
+
+        let health = 'stable';
+        if (improving) health = 'improving';
+        if (declining) health = 'risk';
+
+        const summaryParts = [];
+        summaryParts.push(`Average quality is ${avgDelta >= 0 ? 'up' : 'down'} ${Math.abs(avgDelta).toFixed(1)} pts`);
+        summaryParts.push(`pass rate ${passDelta >= 0 ? 'gained' : 'slid'} ${Math.abs(passDelta).toFixed(1)} pts`);
+        summaryParts.push(`${last.evalCount} evaluations this ${lowerGran}`);
+
+        const points = [];
+
+        points.push({
+          icon: improving ? 'fa-arrow-up' : declining ? 'fa-arrow-down' : 'fa-arrows-alt-h',
+          tone: improving ? 'positive' : declining ? 'negative' : '',
+          title: `Average score ${improving ? 'rising' : declining ? 'dropping' : 'steady'}`,
+          text: `${first.avgScore}% → ${last.avgScore}% across the last ${series.length} ${series.length === 1 ? lowerGran : lowerGran + 's'}.`
+        });
+
+        points.push({
+          icon: passDelta >= 0 ? 'fa-shield-alt' : 'fa-exclamation-triangle',
+          tone: passDelta >= 0 ? 'positive' : 'negative',
+          title: `Pass rate ${passDelta >= 0 ? 'improving' : 'at risk'}`,
+          text: `${first.passRate}% → ${last.passRate}% (${passDelta >= 0 ? '+' : ''}${passDelta.toFixed(1)} pts).`
+        });
+
+        if (Math.abs(volumeDelta) > 0) {
+          points.push({
+            icon: volumeDelta >= 0 ? 'fa-users' : 'fa-user-slash',
+            tone: volumeDelta >= 0 ? 'positive' : 'negative',
+            title: `Evaluation volume ${volumeDelta >= 0 ? 'growing' : 'contracting'}`,
+            text: `${first.evalCount} → ${last.evalCount} evaluations (${volumeDelta >= 0 ? '+' : ''}${volumeDelta}).`
+          });
+        } else {
+          points.push({
+            icon: 'fa-stopwatch',
+            tone: '',
+            title: 'Volume steady',
+            text: `Evaluation count steady at ${last.evalCount} per ${lowerGran}.`
+          });
+        }
+
+        if (last.coverage < 80) {
+          points.push({
+            icon: 'fa-user-shield',
+            tone: 'negative',
+            title: 'Coverage gap detected',
+            text: `Only ${last.coverage}% of agents covered in the latest ${lowerGran}.`
+          });
+        }
+
+        const avgForecast = clampPercent(avgReg.intercept + avgReg.slope * avgPoints.length);
+        const passForecast = clampPercent(passReg.intercept + passReg.slope * passPoints.length);
+
+        const summary = `${summaryParts.join(', ')}.`;
+
+        return {
+          summary,
+          points,
+          health,
+          forecast: { avg: avgForecast, pass: passForecast },
+          nextLabel: `next ${lowerGran}`
+        };
+      }
+
+      function renderTrendSparkline(series, granularity) {
+        const visual = document.getElementById('aiTrendVisual');
+        const canvas = document.getElementById('aiTrendSparkline');
+
+        if (!visual || !canvas) {
+          return;
+        }
+
+        if (!series || !series.length) {
+          visual.style.display = 'none';
+          if (trendSparklineChart) {
+            trendSparklineChart.destroy();
+            trendSparklineChart = null;
+          }
+          return;
+        }
+
+        visual.style.display = '';
+
+        if (trendSparklineChart) {
+          trendSparklineChart.destroy();
+          trendSparklineChart = null;
+        }
+
+        const labels = series.map(point => point.label || formatPeriodLabel(granularity, point.period));
+        const avgData = series.map(point => point.avgScore);
+        const passData = series.map(point => point.passRate);
+
+        trendSparklineChart = new Chart(canvas, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [
+              {
+                label: 'Avg Score',
+                data: avgData,
+                borderColor: '#6366f1',
+                backgroundColor: 'rgba(99,102,241,0.15)',
+                tension: 0.4,
+                pointRadius: 4,
+                pointBackgroundColor: '#6366f1',
+                fill: true
+              },
+              {
+                label: 'Pass Rate',
+                data: passData,
+                borderColor: '#10b981',
+                backgroundColor: 'rgba(16,185,129,0.12)',
+                tension: 0.4,
+                pointRadius: 4,
+                pointBackgroundColor: '#10b981',
+                fill: true
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                display: true,
+                labels: {
+                  usePointStyle: true,
+                  font: {
+                    family: "'Google Sans', sans-serif",
+                    size: 11
+                  }
+                }
+              },
+              tooltip: {
+                backgroundColor: 'rgba(15,23,42,0.9)',
+                titleColor: '#fff',
+                bodyColor: '#e2e8f0',
+                cornerRadius: 10,
+                padding: 10
+              }
+            },
+            scales: {
+              y: {
+                beginAtZero: true,
+                max: 100,
+                grid: { color: 'rgba(15,23,42,0.05)' },
+                ticks: { font: { family: "'Google Sans', sans-serif" } }
+              },
+              x: {
+                grid: { display: false },
+                ticks: { font: { family: "'Google Sans', sans-serif" } }
+              }
+            }
+          }
+        });
+      }
+
+      function updateAITrendPanel({ series, granularity }, analysisOverride = null) {
+        const summaryEl = document.getElementById('aiTrendSummary');
+        const listEl = document.getElementById('aiTrendList');
+        const forecastEl = document.getElementById('aiTrendForecast');
+        const healthEl = document.getElementById('aiTrendHealth');
+
+        if (!summaryEl || !listEl) {
+          return;
+        }
+
+        const analysis = analysisOverride || analyzeTrendSeries(series, { granularity });
+
+        summaryEl.textContent = analysis.summary;
+        listEl.innerHTML = '';
+
+        if (analysis.points.length) {
+          listEl.innerHTML = analysis.points.map(point => {
+            const tone = point.tone ? ` ${point.tone}` : '';
+            return `<li class="ai-insight-item${tone}"><div class="ai-icon"><i class="fas ${point.icon}"></i></div><div class="ai-insight-content"><strong>${point.title}</strong><span>${point.text}</span></div></li>`;
+          }).join('');
+        } else {
+          listEl.innerHTML = '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>No trend data yet</strong><span>Capture a few periods of QA to unlock longitudinal intelligence.</span></div></li>';
+        }
+
+        if (forecastEl) {
+          if (analysis.forecast && (analysis.forecast.avg || analysis.forecast.pass)) {
+            forecastEl.innerHTML = `
+              <span><i class="fas fa-forward"></i>${analysis.nextLabel}: ${analysis.forecast.avg}% avg</span>
+              <span><i class="fas fa-shield-alt"></i>${analysis.forecast.pass}% pass</span>
+            `;
+          } else {
+            forecastEl.innerHTML = '';
+          }
+        }
+
+        if (healthEl) {
+          healthEl.textContent = analysis.health === 'improving' ? 'Improving' : analysis.health === 'risk' ? 'At Risk' : analysis.health === 'monitoring' ? 'Monitoring' : 'Stable';
+          healthEl.classList.remove('improving', 'risk');
+          if (analysis.health === 'improving') {
+            healthEl.classList.add('improving');
+          } else if (analysis.health === 'risk') {
+            healthEl.classList.add('risk');
+          }
+        }
+
+        renderTrendSparkline(series, granularity);
       }
 
       // CHANGED: uses PASS_SCORE_THRESHOLD / no undefined class access
@@ -1143,47 +1776,20 @@
       }
 
       function renderAgentTable(data) {
-          const tbody = document.querySelector('#agentTable tbody'); 
+          const tbody = document.querySelector('#agentTable tbody');
+          if (!tbody) return;
           tbody.innerHTML = '';
-          const stats = {};
-          
-          data.forEach(r => {
-              const n = r.AgentName;
-              if (!stats[n]) stats[n] = { count: 0, sum: 0, passes: 0, recent: r.CallDate };
-              
-              const s = stats[n]; 
-              s.count++; 
-              s.sum += r.recordScore; 
-              if (r.Percentage >= PASS_MARK) s.passes++;
-              
-              // Safely compare dates
-              const currentDate = safeToDate(r.CallDate);
-              const recentDate = safeToDate(s.recent);
-              
-              if (currentDate && recentDate && currentDate > recentDate) {
-                  s.recent = r.CallDate;
-              }
-          });
-          
-          const tot = data.length;
-          Object.entries(stats).forEach(([name, s]) => {
-              const evalPct = tot ? Math.round(s.count / tot * 100) : 0;
-              const avgScore = s.count ? Math.round(s.sum / s.count) : 0;
-              const passPct = s.count ? Math.round(s.passes / s.count * 100) : 0;
-              
-              // Safely format the date
-              let recentDateFormatted = 'N/A';
-              const recentDate = safeToDate(s.recent);
-              if (recentDate) {
-                  recentDateFormatted = recentDate.toLocaleDateString();
-              }
-              
+
+          const { profiles } = calculateAgentProfiles(data);
+
+          profiles.forEach(profile => {
+              const recentDateFormatted = profile.recentDate ? profile.recentDate.toLocaleDateString() : 'N/A';
               const row = document.createElement('tr');
               row.innerHTML = `
-                  <td><strong>${name}</strong></td>
-                  <td>${evalPct}%</td>
-                  <td><span class="status-badge ${avgScore >= 95 ? 'excellent' : avgScore >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${avgScore}%</span></td>
-                  <td><span class="status-badge ${passPct >= 95 ? 'excellent' : passPct >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${passPct}%</span></td>
+                  <td><strong>${profile.name}</strong></td>
+                  <td>${profile.evaluationShare}%</td>
+                  <td><span class="status-badge ${profile.avgScore >= 95 ? 'excellent' : profile.avgScore >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${profile.avgScore}%</span></td>
+                  <td><span class="status-badge ${profile.passRate >= 95 ? 'excellent' : profile.passRate >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${profile.passRate}%</span></td>
                   <td>${recentDateFormatted}</td>`;
               tbody.appendChild(row);
           });
@@ -1213,15 +1819,11 @@
       }
 
       function renderAgentChart(data){
-        const aCnt={}, aPs={}, aSum={};
-        data.forEach(r=>{
-          const n=r.AgentName, score=r.recordScore, passed=r.Percentage>=PASS_MARK;
-          aCnt[n]=(aCnt[n]||0)+1; aPs[n]=(aPs[n]||0)+(passed?1:0); aSum[n]=(aSum[n]||0)+score;
-        });
-        const agents=Object.keys(aCnt); const tot=data.length;
-        const evalPct=agents.map(a=>tot?Math.round(aCnt[a]/tot*100):0);
-        const passPct=agents.map(a=>aCnt[a]?Math.round(aPs[a]/aCnt[a]*100):0);
-        const avgScore=agents.map(a=>aCnt[a]?Math.round(aSum[a]/aCnt[a]):0);
+        const { profiles } = calculateAgentProfiles(data);
+        const agents = profiles.map(p => p.name);
+        const evalPct = profiles.map(p => p.evaluationShare);
+        const avgScore = profiles.map(p => p.avgScore);
+        const passPct = profiles.map(p => p.passRate);
 
         if(agentChart){ agentChart.destroy(); agentChart=null; }
         const ctx=document.getElementById('agentChart'); if(!ctx) return;
@@ -1254,6 +1856,348 @@
         if (!denominator || denominator <= 0) return 0;
         const result = Math.round((numerator / denominator) * 100);
         return Math.min(result, maxCap);
+      }
+
+      function calculateAgentProfiles(data) {
+          const totalEvaluations = data.length;
+          const aggregates = {};
+
+          data.forEach(record => {
+              const agentName = record.AgentName || 'Unassigned';
+              if (!aggregates[agentName]) {
+                  aggregates[agentName] = {
+                      count: 0,
+                      scoreSum: 0,
+                      passCount: 0,
+                      recent: null
+                  };
+              }
+
+              const bucket = aggregates[agentName];
+              bucket.count += 1;
+              bucket.scoreSum += record.recordScore || 0;
+              if (record.Percentage >= PASS_MARK) {
+                  bucket.passCount += 1;
+              }
+
+              const callDate = safeToDate(record.CallDate);
+              if (callDate) {
+                  if (!bucket.recent || callDate > bucket.recent) {
+                      bucket.recent = callDate;
+                  }
+              }
+          });
+
+          const profiles = Object.entries(aggregates).map(([name, stats]) => {
+              const avgScore = stats.count ? Math.round(stats.scoreSum / stats.count) : 0;
+              const passRate = stats.count ? Math.round(stats.passCount / stats.count * 100) : 0;
+              const evaluationShare = totalEvaluations ? Math.round(stats.count / totalEvaluations * 100) : 0;
+
+              return {
+                  name,
+                  evaluations: stats.count,
+                  avgScore,
+                  passRate,
+                  evaluationShare,
+                  recentDate: stats.recent || null
+              };
+          }).sort((a, b) => b.avgScore - a.avgScore);
+
+          return { totalEvaluations, profiles };
+      }
+
+      function summarizeCategoryChange(currentMetrics, previousMetrics = {}) {
+          const details = Object.entries(currentMetrics).map(([category, metrics]) => {
+              const prev = previousMetrics[category];
+              const delta = prev ? Math.round((metrics.avgScore - prev.avgScore) * 10) / 10 : null;
+              return {
+                  category,
+                  avgScore: metrics.avgScore,
+                  passPct: metrics.passPct,
+                  delta
+              };
+          });
+
+          details.sort((a, b) => b.avgScore - a.avgScore);
+          return details;
+      }
+
+      function buildAIIntelligenceAnalysis({ filtered, prevFiltered, catMetrics, prevCatMetrics, kpis }) {
+          const { totalEvaluations, profiles } = calculateAgentProfiles(filtered || []);
+          const { profiles: prevProfiles } = calculateAgentProfiles(prevFiltered || []);
+          const categorySummary = summarizeCategoryChange(catMetrics || {}, prevCatMetrics || {});
+
+          const metrics = kpis || {};
+          const avgScore = Math.round(Math.min(metrics.avg ?? 0, 100));
+          const passRate = Math.round(Math.min(metrics.pass ?? 0, 100));
+          const coverage = Math.round(Math.min(metrics.coverage ?? 0, 100));
+          const completion = Math.round(Math.min(metrics.completion ?? 0, 100));
+          const confidenceScore = Math.max(5, Math.min(100, Math.round((coverage * 0.4) + (passRate * 0.3) + (avgScore * 0.3))));
+
+          const base = {
+              summary: '',
+              automationSummary: '',
+              confidence: confidenceScore,
+              automationState: 'Monitoring',
+              insights: [],
+              actions: [],
+              nextBest: null,
+              meta: {
+                  totalEvaluations,
+                  totalAgents: profiles.length,
+                  periodLabel: currentGran ? currentGran.toLowerCase() : 'period',
+                  source: 'local'
+              }
+          };
+
+          if (!totalEvaluations) {
+              base.summary = 'Lumina AI is monitoring for new evaluations. Adjust your filters or capture fresh QA reviews to generate insights.';
+              base.automationSummary = 'No automation required yet. Log additional evaluations to unlock targeted recommendations.';
+              return base;
+          }
+
+          const totalAgents = profiles.length;
+          const evaluationsWord = totalEvaluations === 1 ? 'evaluation' : 'evaluations';
+          const agentWord = totalAgents === 1 ? 'agent' : 'agents';
+          const periodLabel = base.meta.periodLabel;
+
+          base.summary = `AI reviewed ${totalEvaluations} ${evaluationsWord} across ${totalAgents} ${agentWord} for this ${periodLabel}, spotlighting performance opportunities instantly.`;
+          base.automationSummary = `Coverage at ${coverage}% and completion at ${completion}% give AI enough signal to trigger proactive workflows.`;
+
+          if (profiles.length) {
+              const topAgent = profiles[0];
+              base.insights.push({
+                  icon: 'fa-star',
+                  tone: 'positive',
+                  title: `${topAgent.name} is leading`,
+                  text: `${topAgent.name} is averaging ${topAgent.avgScore}% quality with a ${topAgent.passRate}% pass rate.`
+              });
+
+              const bottomAgent = profiles[profiles.length - 1];
+              if (bottomAgent && bottomAgent.avgScore < PASS_SCORE_THRESHOLD) {
+                  base.insights.push({
+                      icon: 'fa-life-ring',
+                      tone: 'negative',
+                      title: `${bottomAgent.name} needs attention`,
+                      text: `${bottomAgent.name} is trending at ${bottomAgent.avgScore}% with ${bottomAgent.passRate}% pass rate.`
+                  });
+                  base.actions.push({
+                      icon: 'fa-user-graduate',
+                      tone: 'urgent',
+                      title: `Launch coaching for ${bottomAgent.name}`,
+                      text: `Auto-create a coaching session to lift ${bottomAgent.name}'s quality score back above ${PASS_SCORE_THRESHOLD}%.`
+                  });
+              }
+
+              const prevProfileMap = Object.fromEntries(prevProfiles.map(p => [p.name, p]));
+              let strongestImprovement = null;
+              let largestRegression = null;
+
+              profiles.forEach(profile => {
+                  const prev = prevProfileMap[profile.name];
+                  if (!prev) return;
+                  const delta = profile.avgScore - prev.avgScore;
+                  if (strongestImprovement === null || delta > strongestImprovement.delta) {
+                      strongestImprovement = { ...profile, delta };
+                  }
+                  if (largestRegression === null || delta < largestRegression.delta) {
+                      largestRegression = { ...profile, delta };
+                  }
+              });
+
+              if (strongestImprovement && strongestImprovement.delta > 2) {
+                  base.insights.push({
+                      icon: 'fa-rocket',
+                      tone: 'positive',
+                      title: `${strongestImprovement.name} is improving`,
+                      text: `Up ${strongestImprovement.delta.toFixed(1)} pts vs last period.`
+                  });
+              }
+
+              if (largestRegression && largestRegression.delta < -2) {
+                  base.actions.push({
+                      icon: 'fa-reply',
+                      tone: 'urgent',
+                      title: `Check-in with ${largestRegression.name}`,
+                      text: `${largestRegression.name} dropped ${Math.abs(largestRegression.delta).toFixed(1)} pts period-over-period.`
+                  });
+              }
+          }
+
+          if (categorySummary.length) {
+              const bestCategory = categorySummary[0];
+              base.insights.push({
+                  icon: 'fa-thumbs-up',
+                  tone: 'positive',
+                  title: `${bestCategory.category} excels`,
+                  text: `${bestCategory.category} is averaging ${bestCategory.avgScore}% quality.`
+              });
+
+              const weakestCategory = categorySummary[categorySummary.length - 1];
+              if (weakestCategory && weakestCategory.avgScore < PASS_SCORE_THRESHOLD) {
+                  base.actions.push({
+                      icon: 'fa-sitemap',
+                      tone: 'urgent',
+                      title: `Reinforce ${weakestCategory.category}`,
+                      text: `Automate a calibration focused on ${weakestCategory.category} where scores average ${weakestCategory.avgScore}%.`
+                  });
+              }
+
+              const largestDelta = categorySummary.reduce((acc, entry) => {
+                  if (entry.delta === null) return acc;
+                  if (!acc || entry.delta < acc.delta) return entry;
+                  return acc;
+              }, null);
+
+              if (largestDelta && largestDelta.delta < -3) {
+                  base.actions.push({
+                      icon: 'fa-exclamation-circle',
+                      tone: 'urgent',
+                      title: `Reverse slide in ${largestDelta.category}`,
+                      text: `${largestDelta.category} fell ${Math.abs(largestDelta.delta).toFixed(1)} pts from the previous period.`
+                  });
+              }
+          }
+
+          if (passRate < 90) {
+              base.actions.push({
+                  icon: 'fa-headset',
+                  tone: 'urgent',
+                  title: 'Boost pass rate',
+                  text: `Configure an automated refresher for agents with pass rates below 90%. Current pass rate is ${passRate}%.`
+              });
+          }
+
+          if (coverage < 85) {
+              base.actions.push({
+                  icon: 'fa-user-check',
+                  tone: 'urgent',
+                  title: 'Increase agent coverage',
+                  text: `Auto-assign additional evaluations to reach at least 90% agent coverage. Currently at ${coverage}%.`
+              });
+          }
+
+          if (!base.insights.length) {
+              base.insights.push({
+                  icon: 'fa-lightbulb',
+                  tone: 'positive',
+                  title: 'All clear',
+                  text: 'No critical anomalies detected. AI will notify if trends change.'
+              });
+          }
+
+          base.automationState = base.actions.length ? 'Action Required' : 'Monitoring';
+          base.nextBest = base.actions.length ? base.actions[0] : null;
+          return base;
+      }
+
+      function renderAIIntelligence(analysis) {
+          const summaryEl = document.getElementById('aiInsightsSummary');
+          const automationSummaryEl = document.getElementById('aiAutomationSummary');
+          const confidenceEl = document.getElementById('aiConfidenceBadge');
+          const automationStateEl = document.getElementById('aiAutomationState');
+          const nextBestWrapper = document.getElementById('aiNextBestAction');
+          const nextBestText = document.getElementById('aiNextBestActionText');
+          const insightsList = document.getElementById('aiInsightsList');
+          const recommendationsList = document.getElementById('aiRecommendationsList');
+
+          if (!insightsList || !recommendationsList) {
+              return;
+          }
+
+          const {
+              summary = '',
+              automationSummary = '',
+              confidence = null,
+              automationState = 'Monitoring',
+              insights = [],
+              actions = [],
+              nextBest = null
+          } = analysis || {};
+
+          if (confidenceEl && confidence !== null) {
+              confidenceEl.textContent = `Confidence ${Math.round(confidence)}%`;
+          }
+
+          if (summaryEl) {
+              summaryEl.textContent = summary;
+          }
+
+          if (automationSummaryEl) {
+              automationSummaryEl.textContent = automationSummary;
+          }
+
+          insightsList.innerHTML = insights.length
+              ? insights.map(item => {
+                  const toneClass = item.tone ? ` ${item.tone}` : '';
+                  return `<li class="ai-insight-item${toneClass}"><div class="ai-icon"><i class="fas ${item.icon}"></i></div><div class="ai-insight-content"><strong>${item.title}</strong><span>${item.text}</span></div></li>`;
+              }).join('')
+              : '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>Insights pending</strong><span>Collect more QA evaluations to surface intelligence.</span></div></li>';
+
+          if (actions.length) {
+              recommendationsList.innerHTML = actions.map(action => {
+                  const toneClass = action.tone === 'urgent' ? ' urgent' : '';
+                  return `<li class="ai-action-item${toneClass}"><div class="ai-icon"><i class="fas ${action.icon}"></i></div><div class="ai-action-content"><strong>${action.title}</strong><span>${action.text}</span></div></li>`;
+              }).join('');
+          } else {
+              recommendationsList.innerHTML = `<li class="ai-action-item"><div class="ai-icon"><i class="fas fa-shield-alt"></i></div><div class="ai-action-content"><strong>Automations standing by</strong><span>All monitored metrics are stable. Lumina AI will trigger playbooks if trends shift.</span></div></li>`;
+          }
+
+          if (automationStateEl) {
+              automationStateEl.textContent = automationState;
+              if (automationState === 'Action Required') {
+                  automationStateEl.classList.add('active');
+              } else {
+                  automationStateEl.classList.remove('active');
+              }
+          }
+
+          if (nextBestWrapper) {
+              if (nextBest && nextBestText) {
+                  nextBestWrapper.style.display = '';
+                  nextBestText.textContent = nextBest.text || '';
+              } else {
+                  nextBestWrapper.style.display = 'none';
+                  if (nextBestText) {
+                      nextBestText.textContent = '';
+                  }
+              }
+          }
+      }
+
+      function updateAIIntelligencePanel(context, analysisOverride = null) {
+          if (analysisOverride) {
+              renderAIIntelligence(analysisOverride);
+              return;
+          }
+
+          if (!context) {
+              return;
+          }
+
+          const analysis = buildAIIntelligenceAnalysis(context);
+          renderAIIntelligence(analysis);
+      }
+
+      function fetchServerQAIntelligence(context = {}) {
+          if (!(window.google && google.script && google.script.run)) {
+              return Promise.resolve(null);
+          }
+
+          return new Promise(resolve => {
+              try {
+                  google.script.run
+                      .withSuccessHandler(result => resolve(result || null))
+                      .withFailureHandler(error => {
+                          console.warn('clientGetQAIntelligence failed:', error);
+                          resolve(null);
+                      })
+                      .clientGetQAIntelligence(context);
+              } catch (error) {
+                  console.warn('Unable to request QA intelligence from service:', error);
+                  resolve(null);
+              }
+          });
       }
 
       function applyFilters(){
@@ -1433,12 +2377,79 @@
 
               // Update charts and tables
               const catMetrics = computeCategoryMetrics(filtered);
+              const prevCatMetrics = computeCategoryMetrics(prevFiltered);
+              const trendSeries = buildTrendSeries(currentGran, currentPeriod, scored, 5);
               renderCategoryKpis(catMetrics);
               renderCategoryChart(catMetrics);
               renderCategoryTable(catMetrics);
               renderDailyChart(filtered);
               renderAgentChart(filtered);
               renderAgentTable(filtered);
+
+              const currentKpis = {
+                  avg: Math.min(avgPct, 100),
+                  pass: passPct,
+                  coverage: agentsEvalPct,
+                  completion: evalsCompletedPct
+              };
+
+              updateAIIntelligencePanel({
+                  filtered,
+                  prevFiltered,
+                  catMetrics,
+                  prevCatMetrics,
+                  kpis: currentKpis
+              });
+
+              updateAITrendPanel({
+                  series: trendSeries,
+                  granularity: currentGran || 'Period'
+              });
+
+              const serverContext = {
+                  granularity: currentGran || 'Week',
+                  period: currentPeriod,
+                  agent: currentAgent || '',
+                  campaignId: typeof campaignId !== 'undefined' ? campaignId : '',
+                  agentUniverse: Array.isArray(userList) ? userList.length : 0,
+                  depth: 6,
+                  timezone: (function() {
+                      try {
+                          if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+                              const opts = Intl.DateTimeFormat().resolvedOptions();
+                              return opts?.timeZone;
+                          }
+                      } catch (tzError) {
+                          console.warn('Timezone detection failed:', tzError);
+                      }
+                      return undefined;
+                  })(),
+                  passMark: PASS_MARK
+              };
+
+              fetchServerQAIntelligence(serverContext)
+                  .then(serverResult => {
+                      if (!serverResult) {
+                          return;
+                      }
+
+                      if (serverResult.intelligence) {
+                          updateAIIntelligencePanel(null, serverResult.intelligence);
+                      }
+
+                      if (serverResult.trend) {
+                          const serverSeries = Array.isArray(serverResult.trend.series) && serverResult.trend.series.length
+                              ? serverResult.trend.series
+                              : trendSeries;
+                          updateAITrendPanel({
+                              series: serverSeries,
+                              granularity: serverResult.trend.granularity || currentGran || 'Period'
+                          }, serverResult.trend.analysis || null);
+                      }
+                  })
+                  .catch(error => {
+                      console.warn('Server QA intelligence unavailable:', error);
+                  });
 
               window.LuminaLoader?.update({ detail: 'Dashboard refreshed!', progress: 100, tip: 'Latest QA metrics are ready.' });
               hideLoader();

--- a/QAService.js
+++ b/QAService.js
@@ -795,6 +795,780 @@ function getAllQA() {
   }
 }
 
+// ============================================================================
+// AI INTELLIGENCE PIPELINE FOR QA DASHBOARD
+// ============================================================================
+
+const QA_INTEL_PASS_MARK = 0.95;
+const QA_INTEL_PASS_SCORE_THRESHOLD = Math.round(QA_INTEL_PASS_MARK * 100);
+
+function clientGetQAIntelligence(request = {}) {
+  try {
+    const rawRecords = getAllQA();
+    const context = normalizeIntelligenceRequest_(request, rawRecords);
+    const normalizedRecords = rawRecords
+      .map(record => normalizeQaRecord_(record, context.timezone, context.passMark))
+      .filter(record => record.callDate instanceof Date);
+
+    const filtered = filterRecordsForIntelligence_(normalizedRecords, context);
+    const previousContext = { ...context, period: getPreviousPeriod_(context.granularity, context.period) };
+    const prevFiltered = previousContext.period
+      ? filterRecordsForIntelligence_(normalizedRecords, previousContext)
+      : [];
+
+    const categoryMetrics = computeCategoryMetrics_(filtered);
+    const prevCategoryMetrics = computeCategoryMetrics_(prevFiltered);
+
+    const kpis = computeKpiSummary_(filtered, {
+      previous: prevFiltered,
+      agentUniverse: context.agentUniverse,
+      allAgents: normalizedRecords.map(r => r.agent).filter(Boolean)
+    });
+
+    const trendSeries = buildTrendSeries_(context, normalizedRecords);
+    const trendAnalysis = analyzeTrendSeries_(trendSeries, { granularity: context.granularity });
+
+    const intelligence = buildAIIntelligenceAnalysis_({
+      filtered,
+      prevFiltered,
+      categoryMetrics,
+      prevCategoryMetrics,
+      kpis,
+      granularity: context.granularity
+    });
+
+    return {
+      generatedAt: new Date().toISOString(),
+      context,
+      kpis,
+      intelligence,
+      trend: {
+        granularity: context.granularity,
+        series: trendSeries,
+        analysis: trendAnalysis
+      }
+    };
+  } catch (error) {
+    console.error('clientGetQAIntelligence failed:', error);
+    writeError('clientGetQAIntelligence', error);
+    throw error;
+  }
+}
+
+function normalizeIntelligenceRequest_(request, rawRecords) {
+  const granularity = request && typeof request.granularity === 'string'
+    ? request.granularity
+    : 'Week';
+
+  const timezone = typeof request.timezone === 'string' && request.timezone
+    ? request.timezone
+    : Session.getScriptTimeZone();
+
+  const agentUniverse = Number(request.agentUniverse) > 0
+    ? Number(request.agentUniverse)
+    : null;
+
+  const filters = {
+    agent: (request.agent || '').toString().trim(),
+    campaignId: (request.campaignId || request.campaign || '').toString().trim(),
+    program: (request.program || '').toString().trim()
+  };
+
+  const depth = Number(request.depth) > 0 ? Math.min(Number(request.depth), 12) : 6;
+
+  const passMark = typeof request.passMark === 'number' ? request.passMark : QA_INTEL_PASS_MARK;
+
+  const normalizedRecords = (rawRecords || [])
+    .map(record => normalizeQaRecord_(record, timezone, passMark))
+    .filter(record => record.callDate instanceof Date);
+
+  let period = (request && request.period) ? String(request.period) : '';
+  if (!period) {
+    period = determineLatestPeriod_(granularity, normalizedRecords);
+  }
+
+  return {
+    granularity,
+    period,
+    timezone,
+    filters,
+    depth,
+    agentUniverse,
+    passMark
+  };
+}
+
+function normalizeQaRecord_(record, timezone, passMarkOverride) {
+  const entry = Object.assign({}, record);
+  const agent = String(entry.AgentName || entry.Agent || entry.AgentEmail || '').trim();
+  const campaign = String(entry.Campaign || entry.CampaignName || entry.Program || '').trim();
+
+  const dateValue = entry.CallDate || entry.CallTime || entry.EvaluationDate || entry.Date;
+  const callDate = safeToDate_(dateValue);
+
+  const percentageRaw = Number(entry.Percentage);
+  const percentage = isFinite(percentageRaw)
+    ? (percentageRaw > 1 ? percentageRaw / 100 : percentageRaw)
+    : 0;
+  const recordScore = Math.round(Math.max(0, Math.min(1, percentage)) * 100);
+
+  const passThreshold = typeof passMarkOverride === 'number' ? passMarkOverride : QA_INTEL_PASS_MARK;
+
+  const tz = timezone || Session.getScriptTimeZone();
+  const callDateIso = callDate instanceof Date
+    ? Utilities.formatDate(callDate, tz, "yyyy-MM-dd'T'HH:mm:ssXXX")
+    : '';
+
+  return {
+    raw: entry,
+    agent,
+    campaign,
+    callDate,
+    callDateIso,
+    percentage,
+    recordScore,
+    pass: percentage >= passThreshold,
+    week: callDate instanceof Date ? toISOWeek_(callDate) : '',
+    month: callDate instanceof Date ? formatMonthKey_(callDate) : '',
+    quarter: callDate instanceof Date ? `${getQuarter_(callDate)}-${callDate.getFullYear()}` : '',
+    year: callDate instanceof Date ? String(callDate.getFullYear()) : ''
+  };
+}
+
+function safeToDate_(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
+function determineLatestPeriod_(granularity, records) {
+  if (!records || !records.length) return '';
+  const sorted = records.slice().sort((a, b) => b.callDate - a.callDate);
+  const latest = sorted[0];
+  switch (granularity) {
+    case 'Week':
+      return latest.week;
+    case 'Month':
+      return latest.month;
+    case 'Quarter':
+      return latest.quarter;
+    case 'Year':
+      return latest.year;
+    default:
+      return latest.week;
+  }
+}
+
+function filterRecordsForIntelligence_(records, context) {
+  const { filters, granularity, period } = context;
+  return (records || []).filter(record => {
+    if (filters.agent && record.agent !== filters.agent) return false;
+    if (filters.campaignId && record.campaign !== filters.campaignId) return false;
+    if (filters.program && record.raw && record.raw.Program !== filters.program) return false;
+
+    if (!period) return true;
+
+    switch (granularity) {
+      case 'Week':
+        return record.week === period;
+      case 'Month':
+        return record.month === period;
+      case 'Quarter':
+        return record.quarter === period;
+      case 'Year':
+        return record.year === period;
+      default:
+        return true;
+    }
+  });
+}
+
+function computeKpiSummary_(records, options) {
+  const total = records.length;
+  const averageScore = total
+    ? Math.round((records.reduce((sum, record) => sum + record.percentage, 0) / total) * 100)
+    : 0;
+  const passCount = records.filter(record => record.pass).length;
+  const passRate = total ? Math.round((passCount / total) * 100) : 0;
+
+  const uniqueAgents = new Set(records.map(record => record.agent).filter(Boolean));
+  const agentUniverse = options && options.agentUniverse
+    ? Number(options.agentUniverse)
+    : new Set((options && options.allAgents) || []).size;
+
+  const coverage = agentUniverse
+    ? Math.min(Math.round((uniqueAgents.size / agentUniverse) * 100), 100)
+    : (uniqueAgents.size > 0 ? 100 : 0);
+
+  const completion = uniqueAgents.size
+    ? Math.min(Math.round((total / uniqueAgents.size) * 10), 100)
+    : 0;
+
+  return {
+    avg: averageScore,
+    pass: passRate,
+    coverage,
+    completion,
+    evaluations: total,
+    agents: uniqueAgents.size
+  };
+}
+
+function buildTrendSeries_(context, records) {
+  const { granularity, period, depth } = context;
+  const series = [];
+  const visited = new Set();
+  let cursor = period;
+  let steps = 0;
+
+  while (cursor && steps < depth && !visited.has(cursor)) {
+    visited.add(cursor);
+    const bucket = filterRecordsForIntelligence_(records, { ...context, period: cursor });
+    const evalCount = bucket.length;
+    const agentCount = new Set(bucket.map(r => r.agent).filter(Boolean)).size;
+    const avgScore = evalCount
+      ? Math.round((bucket.reduce((sum, r) => sum + r.percentage, 0) / evalCount) * 100)
+      : 0;
+    const passRate = evalCount
+      ? Math.round((bucket.filter(r => r.pass).length / evalCount) * 100)
+      : 0;
+    const coverage = context.agentUniverse
+      ? Math.min(Math.round((agentCount / context.agentUniverse) * 100), 100)
+      : (agentCount > 0 ? 100 : 0);
+
+    series.push({
+      period: cursor,
+      label: formatPeriodLabel_(granularity, cursor),
+      avgScore,
+      passRate,
+      evalCount,
+      agentCount,
+      coverage
+    });
+
+    cursor = getPreviousPeriod_(granularity, cursor);
+    steps += 1;
+  }
+
+  return series.reverse();
+}
+
+function linearRegression_(points) {
+  if (!points || !points.length) {
+    return { slope: 0, intercept: 0 };
+  }
+
+  if (points.length === 1) {
+    return { slope: 0, intercept: points[0].y };
+  }
+
+  const n = points.length;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+
+  points.forEach(point => {
+    sumX += point.x;
+    sumY += point.y;
+    sumXY += point.x * point.y;
+    sumXX += point.x * point.x;
+  });
+
+  const denominator = (n * sumXX) - (sumX * sumX);
+  if (denominator === 0) {
+    return { slope: 0, intercept: sumY / n };
+  }
+
+  const slope = ((n * sumXY) - (sumX * sumY)) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope, intercept };
+}
+
+function analyzeTrendSeries_(series, context) {
+  const granularity = context && context.granularity ? context.granularity : 'Period';
+  const lowerGran = granularity.toLowerCase();
+
+  if (!series || !series.length) {
+    return {
+      summary: `Lumina AI is waiting for enough history to analyze ${lowerGran} trends.`,
+      points: [],
+      health: 'monitoring',
+      forecast: { avg: 0, pass: 0 },
+      nextLabel: `next ${lowerGran}`
+    };
+  }
+
+  const first = series[0];
+  const last = series[series.length - 1];
+
+  const avgPoints = series.map((point, index) => ({ x: index, y: point.avgScore }));
+  const passPoints = series.map((point, index) => ({ x: index, y: point.passRate }));
+
+  const avgReg = linearRegression_(avgPoints);
+  const passReg = linearRegression_(passPoints);
+
+  const avgDelta = last.avgScore - first.avgScore;
+  const passDelta = last.passRate - first.passRate;
+  const volumeDelta = last.evalCount - first.evalCount;
+
+  const slopeAvg = avgReg.slope;
+  const slopePass = passReg.slope;
+
+  const improving = slopeAvg > 0.5 || slopePass > 0.5;
+  const declining = slopeAvg < -0.5 || slopePass < -0.5;
+
+  let health = 'stable';
+  if (improving) health = 'improving';
+  if (declining) health = 'risk';
+
+  const summaryParts = [];
+  summaryParts.push(`Average quality is ${avgDelta >= 0 ? 'up' : 'down'} ${Math.abs(avgDelta).toFixed(1)} pts`);
+  summaryParts.push(`pass rate ${passDelta >= 0 ? 'gained' : 'slid'} ${Math.abs(passDelta).toFixed(1)} pts`);
+  summaryParts.push(`${last.evalCount} evaluations this ${lowerGran}`);
+
+  const points = [];
+
+  points.push({
+    icon: improving ? 'fa-arrow-up' : declining ? 'fa-arrow-down' : 'fa-arrows-alt-h',
+    tone: improving ? 'positive' : declining ? 'negative' : '',
+    title: `Average score ${improving ? 'rising' : declining ? 'dropping' : 'steady'}`,
+    text: `${first.avgScore}% → ${last.avgScore}% across the last ${series.length} ${series.length === 1 ? lowerGran : lowerGran + 's'}.`
+  });
+
+  points.push({
+    icon: passDelta >= 0 ? 'fa-shield-alt' : 'fa-exclamation-triangle',
+    tone: passDelta >= 0 ? 'positive' : 'negative',
+    title: `Pass rate ${passDelta >= 0 ? 'improving' : 'at risk'}`,
+    text: `${first.passRate}% → ${last.passRate}% (${passDelta >= 0 ? '+' : ''}${passDelta.toFixed(1)} pts).`
+  });
+
+  if (Math.abs(volumeDelta) > 0) {
+    points.push({
+      icon: volumeDelta >= 0 ? 'fa-users' : 'fa-user-slash',
+      tone: volumeDelta >= 0 ? 'positive' : 'negative',
+      title: `Evaluation volume ${volumeDelta >= 0 ? 'growing' : 'contracting'}`,
+      text: `${first.evalCount} → ${last.evalCount} evaluations (${volumeDelta >= 0 ? '+' : ''}${volumeDelta}).`
+    });
+  } else {
+    points.push({
+      icon: 'fa-stopwatch',
+      tone: '',
+      title: 'Volume steady',
+      text: `Evaluation count steady at ${last.evalCount} per ${lowerGran}.`
+    });
+  }
+
+  if (last.coverage < 80) {
+    points.push({
+      icon: 'fa-user-shield',
+      tone: 'negative',
+      title: 'Coverage gap detected',
+      text: `Only ${last.coverage}% of agents covered in the latest ${lowerGran}.`
+    });
+  }
+
+  const forecastAvg = clampPercent_(avgReg.intercept + avgReg.slope * avgPoints.length);
+  const forecastPass = clampPercent_(passReg.intercept + passReg.slope * passPoints.length);
+
+  return {
+    summary: `${summaryParts.join(', ')}.`,
+    points,
+    health,
+    forecast: { avg: forecastAvg, pass: forecastPass },
+    nextLabel: `next ${lowerGran}`
+  };
+}
+
+function clampPercent_(value) {
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function buildAIIntelligenceAnalysis_(payload) {
+  const { filtered = [], prevFiltered = [], categoryMetrics = {}, prevCategoryMetrics = {}, kpis = {}, granularity } = payload;
+
+  const totalEvaluations = filtered.length;
+  const periodLabel = granularity ? granularity.toLowerCase() : 'period';
+
+  const confidenceScore = clampPercent_(
+    Math.round(
+      Math.max(5,
+        ((kpis.coverage || 0) * 0.4) +
+        ((kpis.pass || 0) * 0.3) +
+        ((kpis.avg || 0) * 0.3)
+      )
+    )
+  );
+
+  const base = {
+    summary: '',
+    automationSummary: '',
+    confidence: confidenceScore,
+    automationState: 'Monitoring',
+    insights: [],
+    actions: [],
+    nextBest: null,
+    meta: {
+      totalEvaluations,
+      periodLabel,
+      source: 'server'
+    }
+  };
+
+  if (!totalEvaluations) {
+    return {
+      ...base,
+      summary: 'Lumina AI is monitoring for new evaluations. Adjust your filters or capture fresh QA reviews to generate insights.',
+      automationSummary: 'No automation required yet. Log additional evaluations to unlock targeted recommendations.'
+    };
+  }
+
+  const { profiles } = calculateAgentProfiles_(filtered);
+  const { profiles: prevProfiles } = calculateAgentProfiles_(prevFiltered);
+  const categorySummary = summarizeCategoryChange_(categoryMetrics, prevCategoryMetrics);
+
+  const totalAgents = profiles.length;
+  base.meta.totalAgents = totalAgents;
+
+  base.summary = `AI reviewed ${totalEvaluations} ${totalEvaluations === 1 ? 'evaluation' : 'evaluations'} across ${totalAgents} ${totalAgents === 1 ? 'agent' : 'agents'} for this ${periodLabel}, spotlighting performance opportunities instantly.`;
+  base.automationSummary = `Coverage at ${clampPercent_(kpis.coverage || 0)}% and completion at ${clampPercent_(kpis.completion || 0)}% give AI enough signal to trigger proactive workflows.`;
+
+  if (profiles.length) {
+    const topAgent = profiles[0];
+    base.insights.push({
+      icon: 'fa-star',
+      tone: 'positive',
+      title: `${topAgent.name} is leading`,
+      text: `${topAgent.name} is averaging ${topAgent.avgScore}% quality with a ${topAgent.passRate}% pass rate.`
+    });
+
+    const bottomAgent = profiles[profiles.length - 1];
+    if (bottomAgent && bottomAgent.avgScore < QA_INTEL_PASS_SCORE_THRESHOLD) {
+      base.insights.push({
+        icon: 'fa-life-ring',
+        tone: 'negative',
+        title: `${bottomAgent.name} needs attention`,
+        text: `${bottomAgent.name} is trending at ${bottomAgent.avgScore}% with ${bottomAgent.passRate}% pass rate.`
+      });
+      base.actions.push({
+        icon: 'fa-user-graduate',
+        tone: 'urgent',
+        title: `Launch coaching for ${bottomAgent.name}`,
+        text: `Auto-create a coaching session to lift ${bottomAgent.name}'s quality score back above ${QA_INTEL_PASS_SCORE_THRESHOLD}%.`
+      });
+    }
+
+    const prevProfileMap = {};
+    prevProfiles.forEach(profile => {
+      prevProfileMap[profile.name] = profile;
+    });
+
+    let strongestImprovement = null;
+    let largestRegression = null;
+
+    profiles.forEach(profile => {
+      const prev = prevProfileMap[profile.name];
+      if (!prev) return;
+      const delta = profile.avgScore - prev.avgScore;
+      if (strongestImprovement === null || delta > strongestImprovement.delta) {
+        strongestImprovement = { ...profile, delta };
+      }
+      if (largestRegression === null || delta < largestRegression.delta) {
+        largestRegression = { ...profile, delta };
+      }
+    });
+
+    if (strongestImprovement && strongestImprovement.delta > 2) {
+      base.insights.push({
+        icon: 'fa-rocket',
+        tone: 'positive',
+        title: `${strongestImprovement.name} is improving`,
+        text: `Up ${strongestImprovement.delta.toFixed(1)} pts vs last period.`
+      });
+    }
+
+    if (largestRegression && largestRegression.delta < -2) {
+      base.actions.push({
+        icon: 'fa-reply',
+        tone: 'urgent',
+        title: `Check-in with ${largestRegression.name}`,
+        text: `${largestRegression.name} dropped ${Math.abs(largestRegression.delta).toFixed(1)} pts period-over-period.`
+      });
+    }
+  }
+
+  if (categorySummary.length) {
+    const bestCategory = categorySummary[0];
+    base.insights.push({
+      icon: 'fa-thumbs-up',
+      tone: 'positive',
+      title: `${bestCategory.category} excels`,
+      text: `${bestCategory.category} is averaging ${bestCategory.avgScore}% quality.`
+    });
+
+    const weakestCategory = categorySummary[categorySummary.length - 1];
+    if (weakestCategory && weakestCategory.avgScore < QA_INTEL_PASS_SCORE_THRESHOLD) {
+      base.actions.push({
+        icon: 'fa-sitemap',
+        tone: 'urgent',
+        title: `Reinforce ${weakestCategory.category}`,
+        text: `Automate a calibration focused on ${weakestCategory.category} where scores average ${weakestCategory.avgScore}%.`
+      });
+    }
+
+    const largestDelta = categorySummary.reduce((acc, entry) => {
+      if (entry.delta === null) return acc;
+      if (!acc || entry.delta < acc.delta) return entry;
+      return acc;
+    }, null);
+
+    if (largestDelta && largestDelta.delta < -3) {
+      base.actions.push({
+        icon: 'fa-exclamation-circle',
+        tone: 'urgent',
+        title: `Reverse slide in ${largestDelta.category}`,
+        text: `${largestDelta.category} fell ${Math.abs(largestDelta.delta).toFixed(1)} pts from the previous period.`
+      });
+    }
+  }
+
+  if ((kpis.pass || 0) < 90) {
+    base.actions.push({
+      icon: 'fa-headset',
+      tone: 'urgent',
+      title: 'Boost pass rate',
+      text: `Configure an automated refresher for agents with pass rates below 90%. Current pass rate is ${clampPercent_(kpis.pass || 0)}%.`
+    });
+  }
+
+  if ((kpis.coverage || 0) < 85) {
+    base.actions.push({
+      icon: 'fa-user-check',
+      tone: 'urgent',
+      title: 'Increase agent coverage',
+      text: `Auto-assign additional evaluations to reach at least 90% agent coverage. Currently at ${clampPercent_(kpis.coverage || 0)}%.`
+    });
+  }
+
+  if (!base.insights.length) {
+    base.insights.push({
+      icon: 'fa-lightbulb',
+      tone: 'positive',
+      title: 'All clear',
+      text: 'No critical anomalies detected. AI will notify if trends change.'
+    });
+  }
+
+  base.automationState = base.actions.length ? 'Action Required' : 'Monitoring';
+  base.nextBest = base.actions.length ? base.actions[0] : null;
+
+  return base;
+}
+
+function calculateAgentProfiles_(records) {
+  const totalEvaluations = records.length;
+  const aggregates = {};
+
+  records.forEach(record => {
+    const name = record.agent || 'Unassigned';
+    if (!aggregates[name]) {
+      aggregates[name] = {
+        count: 0,
+        scoreSum: 0,
+        passCount: 0,
+        recent: null
+      };
+    }
+
+    const bucket = aggregates[name];
+    bucket.count += 1;
+    bucket.scoreSum += record.recordScore;
+    if (record.pass) {
+      bucket.passCount += 1;
+    }
+
+    if (record.callDate instanceof Date) {
+      if (!bucket.recent || record.callDate > bucket.recent) {
+        bucket.recent = record.callDate;
+      }
+    }
+  });
+
+  const profiles = Object.keys(aggregates).map(name => {
+    const stats = aggregates[name];
+    const avgScore = stats.count ? Math.round(stats.scoreSum / stats.count) : 0;
+    const passRate = stats.count ? Math.round((stats.passCount / stats.count) * 100) : 0;
+    const evaluationShare = totalEvaluations ? Math.round((stats.count / totalEvaluations) * 100) : 0;
+
+    return {
+      name,
+      evaluations: stats.count,
+      avgScore,
+      passRate,
+      evaluationShare,
+      recentDate: stats.recent || null
+    };
+  }).sort((a, b) => b.avgScore - a.avgScore);
+
+  return { totalEvaluations, profiles };
+}
+
+function summarizeCategoryChange_(currentMetrics, previousMetrics) {
+  const details = Object.keys(currentMetrics || {}).map(category => {
+    const metrics = currentMetrics[category] || { avgScore: 0, passPct: 0 };
+    const prev = previousMetrics ? previousMetrics[category] : null;
+    const delta = prev ? Math.round((metrics.avgScore - prev.avgScore) * 10) / 10 : null;
+    return {
+      category,
+      avgScore: metrics.avgScore,
+      passPct: metrics.passPct,
+      delta
+    };
+  });
+
+  details.sort((a, b) => b.avgScore - a.avgScore);
+  return details;
+}
+
+function computeCategoryMetrics_(records) {
+  const categories = qaCategories_();
+  const weights = qaWeights_();
+  const metrics = {};
+
+  Object.keys(categories).forEach(category => {
+    const questionKeys = categories[category] || [];
+    const scores = [];
+    const passes = [];
+
+    records.forEach(record => {
+      const { raw } = record;
+      const answers = questionKeys.map(key => getAnswerValue_(raw, key));
+      const totalWeight = questionKeys.reduce((sum, key) => {
+        const normalizedKey = key.toLowerCase();
+        return sum + (weights[normalizedKey] || weights[key] || 0);
+      }, 0);
+
+      if (!totalWeight) {
+        return;
+      }
+
+      const earned = questionKeys.reduce((sum, key, index) => {
+        const normalizedKey = key.toLowerCase();
+        const weight = weights[normalizedKey] || weights[key] || 0;
+        const answer = String(answers[index] || '').toLowerCase();
+        if (answer === 'yes' || (normalizedKey === 'q17' && answer === 'no')) {
+          return sum + weight;
+        }
+        return sum;
+      }, 0);
+
+      const pct = totalWeight ? Math.round((earned / totalWeight) * 100) : 0;
+      const pass = answers.every(answer => String(answer || '').toLowerCase() === 'yes');
+
+      scores.push(pct);
+      passes.push(pass ? 1 : 0);
+    });
+
+    const avgScore = scores.length
+      ? Math.round(scores.reduce((sum, value) => sum + value, 0) / scores.length)
+      : 0;
+    const passPct = passes.length
+      ? Math.round((passes.reduce((sum, value) => sum + value, 0) / passes.length) * 100)
+      : 0;
+
+    metrics[category] = { avgScore, passPct };
+  });
+
+  return metrics;
+}
+
+function getAnswerValue_(record, key) {
+  if (!record) return '';
+  if (key in record) return record[key];
+  const upper = key.toUpperCase();
+  if (upper in record) return record[upper];
+  const lower = key.toLowerCase();
+  if (lower in record) return record[lower];
+  return '';
+}
+
+function toISOWeek_(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+function formatMonthKey_(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function getQuarter_(date) {
+  return 'Q' + (Math.floor(date.getMonth() / 3) + 1);
+}
+
+function getPreviousPeriod_(granularity, period) {
+  if (!period) return '';
+  switch (granularity) {
+    case 'Week': {
+      const parts = period.split('-W');
+      if (parts.length !== 2) return '';
+      const year = parseInt(parts[0], 10);
+      const week = parseInt(parts[1], 10);
+      if (week <= 1) {
+        return `${year - 1}-W52`;
+      }
+      return `${year}-W${String(week - 1).padStart(2, '0')}`;
+    }
+    case 'Month': {
+      const [y, m] = period.split('-').map(Number);
+      if (!y || !m) return '';
+      const date = new Date(y, m - 1, 1);
+      date.setMonth(date.getMonth() - 1);
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    }
+    case 'Quarter': {
+      const [q, y] = period.split('-');
+      if (!q || !y) return '';
+      const n = parseInt(q.replace('Q', ''), 10);
+      if (n <= 1) {
+        return `Q4-${parseInt(y, 10) - 1}`;
+      }
+      return `Q${n - 1}-${y}`;
+    }
+    case 'Year':
+      return String(parseInt(period, 10) - 1);
+    default:
+      return '';
+  }
+}
+
+function formatPeriodLabel_(granularity, period) {
+  if (!period) return 'Period';
+  switch (granularity) {
+    case 'Week':
+      return period.replace(/^[0-9]{4}-/, '');
+    case 'Month': {
+      const [y, m] = period.split('-');
+      if (!y || !m) return period;
+      const date = new Date(Number(y), Number(m) - 1, 1);
+      return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+    }
+    case 'Quarter':
+      return period.replace('-', ' ');
+    case 'Year':
+      return period;
+    default:
+      return period;
+  }
+}
+
 /**
  * Missing Helper Functions for QA PDF Service
  * Add these functions to your QAService.gs file


### PR DESCRIPTION
## Summary
- add a server-side `clientGetQAIntelligence` pipeline that normalizes QA records, builds KPI/trend analytics, and emits AI recommendations
- refactor the dashboard intelligence widgets to render from reusable analysis objects and accept backend overrides
- fetch AI intelligence from the QA service during filter refreshes while keeping the existing in-browser calculations as a fallback

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68e2c88524ec832685a83e36fd182c2c