### PR TITLE
Make session token helpers resilient to load order

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -469,6 +469,66 @@
       return '';
     })();
 
+    // Session token persistence helpers
+    const LOGOUT_REASON_STORAGE_KEY = 'lumina.lastLogoutReason';
+    var SESSION_TOKEN_QUERY_PARAM = (typeof SESSION_TOKEN_QUERY_PARAM === 'string'
+      && SESSION_TOKEN_QUERY_PARAM.trim())
+      ? SESSION_TOKEN_QUERY_PARAM.trim()
+      : 'token';
+    var SESSION_TOKEN_STORAGE_KEYS = (typeof SESSION_TOKEN_STORAGE_KEYS !== 'undefined'
+      && Array.isArray(SESSION_TOKEN_STORAGE_KEYS)
+      && SESSION_TOKEN_STORAGE_KEYS.length)
+      ? SESSION_TOKEN_STORAGE_KEYS.slice()
+      : [
+        'lumina.session.token',
+        'lumina.auth.sessionToken',
+        'lumina.auth.fallbackToken'
+      ];
+
+    if (typeof window !== 'undefined') {
+      if (Array.isArray(window.SESSION_TOKEN_STORAGE_KEYS) && window.SESSION_TOKEN_STORAGE_KEYS.length) {
+        SESSION_TOKEN_STORAGE_KEYS = window.SESSION_TOKEN_STORAGE_KEYS.slice();
+      } else {
+        window.SESSION_TOKEN_STORAGE_KEYS = SESSION_TOKEN_STORAGE_KEYS.slice();
+      }
+
+      if (typeof window.SESSION_TOKEN_QUERY_PARAM === 'string' && window.SESSION_TOKEN_QUERY_PARAM.trim()) {
+        SESSION_TOKEN_QUERY_PARAM = window.SESSION_TOKEN_QUERY_PARAM.trim();
+      } else {
+        window.SESSION_TOKEN_QUERY_PARAM = SESSION_TOKEN_QUERY_PARAM;
+      }
+    }
+
+    function setLogoutReason(reason) {
+      try {
+        if (!window.sessionStorage) {
+          return;
+        }
+        if (!reason) {
+          window.sessionStorage.removeItem(LOGOUT_REASON_STORAGE_KEY);
+        } else {
+          window.sessionStorage.setItem(LOGOUT_REASON_STORAGE_KEY, String(reason));
+        }
+      } catch (err) {
+        console.warn('setLogoutReason: unable to persist logout reason', err);
+      }
+    }
+
+    function getLogoutReason() {
+      try {
+        if (window.sessionStorage) {
+          return window.sessionStorage.getItem(LOGOUT_REASON_STORAGE_KEY) || '';
+        }
+      } catch (err) {
+        console.warn('getLogoutReason: unable to read logout reason', err);
+      }
+      return '';
+    }
+
+    function clearLogoutReason() {
+      setLogoutReason('');
+    }
+
     /**
      * Generate URLs for navigation
      */
@@ -626,44 +686,6 @@
     window.deriveReturnUrl = (rawUrl, slug = PAGE_SLUG) => deriveReturnUrl(rawUrl, slug);
     window.buildReturnUrl = buildReturnUrl;
     window.getReturnUrl = buildReturnUrl;
-
-    const LOGOUT_REASON_STORAGE_KEY = 'lumina.lastLogoutReason';
-    const SESSION_TOKEN_QUERY_PARAM = 'token';
-    const SESSION_TOKEN_STORAGE_KEYS = [
-      'lumina.session.token',
-      'lumina.auth.sessionToken',
-      'lumina.auth.fallbackToken'
-    ];
-
-    function setLogoutReason(reason) {
-      try {
-        if (!window.sessionStorage) {
-          return;
-        }
-        if (!reason) {
-          window.sessionStorage.removeItem(LOGOUT_REASON_STORAGE_KEY);
-        } else {
-          window.sessionStorage.setItem(LOGOUT_REASON_STORAGE_KEY, String(reason));
-        }
-      } catch (err) {
-        console.warn('setLogoutReason: unable to persist logout reason', err);
-      }
-    }
-
-    function getLogoutReason() {
-      try {
-        if (window.sessionStorage) {
-          return window.sessionStorage.getItem(LOGOUT_REASON_STORAGE_KEY) || '';
-        }
-      } catch (err) {
-        console.warn('getLogoutReason: unable to read logout reason', err);
-      }
-      return '';
-    }
-
-    function clearLogoutReason() {
-      setLogoutReason('');
-    }
 
     function resolveClientSessionToken(providedToken) {
       const normalizedProvided = typeof providedToken === 'string' ? providedToken.trim() : '';


### PR DESCRIPTION
## Summary
- guard the session token constants against load-order issues by promoting any existing globals and syncing them back to window
- default the token query parameter and storage key list when nothing has been initialised yet so downstream helpers can safely read them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3a54f26a48326a7b26e70bd595373