### PR TITLE
Fix QA Dashboard illegal return error

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -2835,27 +2835,13 @@ const rawQA = JSON.parse('<?= qaRecords ?>');
 
       syncPeriodInputs(currentGran, currentPeriod);
 
-        const avgForecast = clampPercent(avgReg.intercept + avgReg.slope * avgPoints.length);
-        const passForecast = clampPercent(passReg.intercept + passReg.slope * passPoints.length);
-
-        const summary = `${summaryParts.join(', ')}.`;
-
-        return {
-          summary,
-          points,
-          health,
-          forecast: { avg: avgForecast, pass: passForecast },
-          nextLabel: `next ${lowerGran}`
-        };
-      }
-
       function safeToDate(value) {
         return coerceDateValue(value);
       }
 
       function safeToISOString(dateValue) {
-          const date = safeToDate(dateValue);
-          return date ? date.toISOString() : null;
+        const date = safeToDate(dateValue);
+        return date ? date.toISOString() : null;
       }
 
       function normalizeKeyName(key) {


### PR DESCRIPTION
## Summary
- remove a stray top-level return block from the QA Dashboard client script that triggered an "Illegal return" parse error
- tidy the surrounding helper declarations after removing the errant block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d8bb3504832690f6525118a326f2