### PR TITLE
Fix QA Dashboard script markup parsing

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -2835,27 +2835,13 @@ const rawQA = JSON.parse('<?= qaRecords ?>');
 
       syncPeriodInputs(currentGran, currentPeriod);
 
-        const avgForecast = clampPercent(avgReg.intercept + avgReg.slope * avgPoints.length);
-        const passForecast = clampPercent(passReg.intercept + passReg.slope * passPoints.length);
-
-        const summary = `${summaryParts.join(', ')}.`;
-
-        return {
-          summary,
-          points,
-          health,
-          forecast: { avg: avgForecast, pass: passForecast },
-          nextLabel: `next ${lowerGran}`
-        };
-      }
-
       function safeToDate(value) {
         return coerceDateValue(value);
       }
 
       function safeToISOString(dateValue) {
-          const date = safeToDate(dateValue);
-          return date ? date.toISOString() : null;
+        const date = safeToDate(dateValue);
+        return date ? date.toISOString() : null;
       }
 
       function normalizeKeyName(key) {
@@ -2916,65 +2902,14 @@ const rawQA = JSON.parse('<?= qaRecords ?>');
         return clamp01(normalized);
       }
 
-<!-- Category KPIs -->
-<div class="category-kpis-grid stagger-animation" id="categoryKpis">
-  <!-- Dynamically populated by JavaScript -->
-</div>
+      function excelSerialToDate(serial) {
+        if (typeof serial !== 'number' || !isFinite(serial)) {
+          return null;
+        }
 
-<!-- AI Intelligence Layer -->
-<div class="ai-intel-grid fade-in">
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-robot"></i>
-      <span>Lumina QA Copilot</span>
-      <div class="ai-header-meta">
-        <span class="ai-source-chip client" id="aiInsightSource" title="Intelligence generated in-browser">Local AI</span>
-        <span class="ai-confidence-badge" id="aiConfidenceBadge">Confidence 0%</span>
-      </div>
-    </div>
-    <p class="ai-insights-summary" id="aiInsightsSummary">AI insights will appear once data loads.</p>
-    <ul class="ai-insights-list" id="aiInsightsList"></ul>
-  </div>
-
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-bolt"></i>
-      <span>Automation Playbook</span>
-      <span class="ai-automation-state" id="aiAutomationState">Monitoring</span>
-    </div>
-    <p class="ai-automation-summary" id="aiAutomationSummary">AI recommendations will populate after analysis.</p>
-    <ul class="ai-actions-list" id="aiRecommendationsList"></ul>
-    <div class="ai-next-best-action" id="aiNextBestAction" style="display: none;">
-      <i class="fas fa-magic"></i>
-      <div>
-        <strong>Next best automation</strong>
-        <span id="aiNextBestActionText"></span>
-      </div>
-    </div>
-  </div>
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-chart-line"></i>
-      <span>AI Trend Radar</span>
-      <span class="ai-trend-health" id="aiTrendHealth">Monitoring</span>
-    </div>
-    <p class="ai-trend-summary" id="aiTrendSummary">Trend intelligence will populate after analysis.</p>
-    <div class="ai-trend-visual" id="aiTrendVisual" style="display: none;">
-      <canvas id="aiTrendSparkline"></canvas>
-      <div class="ai-trend-forecast" id="aiTrendForecast"></div>
-    </div>
-    <ul class="ai-insights-list" id="aiTrendList"></ul>
-  </div>
-</div>
-
-<!-- Modern Charts -->
-<div class="modern-chart-grid stagger-animation">
-  <div class="modern-chart-card">
-    <h6><i class="fas fa-calendar-day me-2"></i>Daily Performance</h6>
-    <div class="chart-container">
-      <canvas id="dailyChart"></canvas>
-    </div>
-  </div>
+        if (serial <= 60) {
+          return null;
+        }
 
         const utcDays = Math.floor(serial - 25569);
         const utcMilliseconds = utcDays * 86400000;
@@ -5890,7 +5825,8 @@ const rawQA = JSON.parse('<?= qaRecords ?>');
 
         console.log('Quality Dashboard initialization completed');
       });
-</script><!-- Category KPIs -->
+</script>
+<!-- Category KPIs -->
 <div class="category-kpis-grid stagger-animation" id="categoryKpis">
   <!-- Dynamically populated by JavaScript -->
 </div>


### PR DESCRIPTION
## Summary
- remove the duplicated Category/AI/Chart markup that was embedded inside the QA Dashboard script block and triggering browser syntax errors
- separate the script close tag from the dashboard markup so the HTML renders only once outside the JavaScript bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d8bb3504832690f6525118a326f2