### PR TITLE
Enforce 30-minute session timeout

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -14,7 +14,7 @@
 // AUTHENTICATION CONFIGURATION
 // ───────────────────────────────────────────────────────────────────────────────
 
-const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const REMEMBER_ME_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const DEFAULT_SESSION_COLUMNS = [
   'Token',
@@ -4268,7 +4268,7 @@ var AuthenticationService = (function () {
       if (!resolution || resolution.status !== 'active' || !resolution.entry) {
         const reason = resolution ? resolution.reason : 'NOT_FOUND';
         const message = reason === 'IDLE_TIMEOUT'
-          ? 'Session expired due to inactivity'
+          ? 'Session expired after 30 minutes of inactivity'
           : 'Session expired or invalid';
         return {
           success: false,

--- a/Login.html
+++ b/Login.html
@@ -1103,7 +1103,7 @@
 
     const SUPPORT_EMAIL = 'support@vlbpo.com';
     const REMEMBER_DURATION_MS = 24 * 60 * 60 * 1000;
-    const SESSION_COOKIE_MAX_AGE = 60 * 60; // 1 hour
+    const SESSION_COOKIE_MAX_AGE = 30 * 60; // 30 minutes
     const REMEMBER_COOKIE_MAX_AGE = 24 * 60 * 60; // 24 hours
     const STORAGE_KEYS = {
       rememberedEmail: 'lumina.auth.rememberedEmail',
@@ -2300,7 +2300,7 @@
       console.log('Session expired:', reason);
       clearAuthCookie();
       try {
-        showAlert('info', 'Your session has expired. Please sign in again.');
+        showAlert('info', 'Your session has expired after 30 minutes of inactivity. Please sign in again to continue.');
       } catch (err) {
         console.warn('handleSessionExpired: unable to show alert', err);
       }
@@ -3765,6 +3765,8 @@
       const urlParams = new URLSearchParams(window.location.search);
       const message = urlParams.get('message');
       const error = urlParams.get('error');
+      const logoutReason = (state.lastLogoutReason || '').toLowerCase();
+      const shouldShowAutoTimeout = !error && !message && logoutReason === 'auto';
 
       let shouldReplaceUrl = false;
 
@@ -3796,6 +3798,10 @@
       }
 
       const resumed = attemptSessionResume();
+
+      if (!resumed && shouldShowAutoTimeout) {
+        showAlert('info', 'Your session timed out after 30 minutes of inactivity. Please sign in again to continue.');
+      }
 
       // Auto-focus email field when not redirecting
       if (!resumed && elements.emailInput) {

--- a/layout.html
+++ b/layout.html
@@ -4229,7 +4229,7 @@
             }
 
             function notifyExpired(message) {
-                const text = message || 'Your session has expired. Please sign in again.';
+                const text = message || 'Your session has expired after 30 minutes of inactivity. Please sign in again to continue.';
 
                 try {
                     if (typeof global.showLuminaToast === 'function') {


### PR DESCRIPTION
## Summary
- reduce the server-side session TTL to 30 minutes and align inactivity messaging
- match client cookie persistence with the 30-minute timeout and inform users when they return after expiry
- update shared layout notifications to explain the inactivity timeout when redirecting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e40aa2ad508326b25fef9cc046e224