### PR TITLE
Restore live status utilities on QA dashboard

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -146,6 +146,46 @@
     font-size: 1.1rem;
   }
 
+  .data-refresh-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.15);
+    color: #e2e8f0;
+    box-shadow: 0 4px 15px rgba(15, 23, 42, 0.08);
+    transition: var(--transition-smooth);
+  }
+
+  .data-refresh-status i {
+    font-size: 0.95rem;
+  }
+
+  .data-refresh-status.success {
+    color: #10b981;
+    border-color: rgba(16, 185, 129, 0.4);
+    background: rgba(16, 185, 129, 0.15);
+  }
+
+  .data-refresh-status.updating {
+    color: #f59e0b;
+    border-color: rgba(245, 158, 11, 0.35);
+    background: rgba(245, 158, 11, 0.12);
+  }
+
+  .data-refresh-status.error {
+    color: #ef4444;
+    border-color: rgba(239, 68, 68, 0.4);
+    background: rgba(239, 68, 68, 0.12);
+  }
+
+  .data-refresh-status .status-label {
+    white-space: nowrap;
+  }
+
   @keyframes pulse-live {
     0%, 100% {
       opacity: 1;
@@ -2634,7 +2674,16 @@
   <div class="live-header">
     <div class="live-status">
       <div class="live-indicator"></div>
+      <div class="status-text">
+        <i class="fas fa-wifi"></i>
+        <span>Dashboard Live</span>
+      </div>
     </div>
+    <div class="data-refresh-status updating" id="dataRefreshStatus">
+      <i class="fas fa-sync-alt fa-spin"></i>
+      <span class="status-label">Initializing…</span>
+    </div>
+    <div class="datetime-display" id="liveDatetime">Loading...</div>
   </div>
 </div>
 
@@ -2802,6 +2851,9 @@
         Year: []
       };
 
+      const PASS_MARK = 0.95;
+      const PASS_SCORE_THRESHOLD = Math.round(PASS_MARK * 100);
+
       const QA_MONITOR = (() => {
         const startTimes = new Map();
         const makeTimestamp = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
@@ -2892,6 +2944,87 @@
           end
         };
       })();
+
+      function updateLiveDatetime() {
+        const datetimeDisplay = document.getElementById('liveDatetime');
+        if (!datetimeDisplay) {
+          QA_MONITOR.warn('liveDatetime element missing');
+          return;
+        }
+
+        try {
+          const now = new Date();
+          const options = {
+            weekday: 'short',
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: true,
+            timeZoneName: 'short'
+          };
+
+          const formatted = typeof now.toLocaleString === 'function'
+            ? now.toLocaleString('en-US', options)
+            : now.toISOString();
+
+          datetimeDisplay.textContent = formatted;
+        } catch (error) {
+          QA_MONITOR.warn('updateLiveDatetime failed', { message: error?.message });
+          datetimeDisplay.textContent = new Date().toISOString();
+        }
+      }
+
+      function updateDataRefreshStatus(state, message) {
+        const statusEl = document.getElementById('dataRefreshStatus');
+        if (!statusEl) {
+          QA_MONITOR.warn('dataRefreshStatus element missing');
+          return;
+        }
+
+        const normalized = typeof state === 'string' ? state.toLowerCase() : 'success';
+        const configs = {
+          success: {
+            className: 'success',
+            icon: 'fa-check-circle',
+            text: message || 'Data Current'
+          },
+          updating: {
+            className: 'updating',
+            icon: 'fa-sync-alt fa-spin',
+            text: message || 'Refreshing…'
+          },
+          loading: {
+            className: 'updating',
+            icon: 'fa-sync-alt fa-spin',
+            text: message || 'Loading…'
+          },
+          error: {
+            className: 'error',
+            icon: 'fa-exclamation-triangle',
+            text: message || 'Attention Required'
+          }
+        };
+
+        const config = configs[normalized] || configs.success;
+
+        statusEl.classList.remove('success', 'updating', 'error');
+        statusEl.classList.add(config.className);
+
+        const iconEl = statusEl.querySelector('i');
+        if (iconEl) {
+          iconEl.className = `fas ${config.icon}`;
+        }
+
+        const labelEl = statusEl.querySelector('.status-label') || statusEl.querySelector('span');
+        if (labelEl) {
+          labelEl.textContent = config.text;
+        } else {
+          statusEl.textContent = config.text;
+        }
+      }
 
       window.addEventListener('error', event => {
         QA_MONITOR.error('Global error captured', {
@@ -5786,6 +5919,8 @@
         'normalizeClientQaRecord',
         'isValidDate',
         'showLoader',
+        'updateLiveDatetime',
+        'updateDataRefreshStatus',
         'updateAITrendPanel',
         'computeCategoryMetrics',
         'formatPeriodLabel',


### PR DESCRIPTION
## Summary
- add dedicated styling and markup for the QA dashboard live header, including live time and refresh status badges
- define reusable pass mark constants and implement helper utilities for updating the live datetime and refresh status
- register the new helpers with the dashboard instrumentation for consistent monitoring

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e431de2290832696b1240b2df3b73f