### PR TITLE
Align global banner with Lumina brand colors

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2008,15 +2008,15 @@
     .lumina-banner {
       position: relative;
       background:
-        radial-gradient(140% 115% at -10% 15%, rgba(34, 197, 247, 0.35) 0%, rgba(2, 132, 199, 0) 55%),
-        radial-gradient(160% 140% at 110% 15%, rgba(6, 182, 212, 0.28) 0%, rgba(13, 71, 161, 0) 60%),
-        conic-gradient(from 210deg at 70% 75%, rgba(56, 189, 248, 0.2) 0deg, rgba(30, 64, 175, 0) 160deg),
-        linear-gradient(150deg, rgba(2, 6, 23, 0.96) 0%, rgba(12, 19, 41, 0.96) 42%, rgba(4, 47, 46, 0.92) 100%);
-      border: 1px solid rgba(125, 211, 252, 0.18);
+        radial-gradient(135% 120% at -15% 15%, rgba(56, 189, 248, 0.32) 0%, rgba(56, 189, 248, 0) 60%),
+        radial-gradient(150% 150% at 110% 5%, rgba(4, 120, 211, 0.35) 0%, rgba(4, 120, 211, 0) 65%),
+        conic-gradient(from 210deg at 70% 78%, rgba(3, 87, 153, 0.28) 0deg, rgba(11, 27, 63, 0) 165deg),
+        linear-gradient(160deg, rgba(11, 27, 63, 0.96) 0%, rgba(16, 48, 96, 0.95) 45%, rgba(3, 87, 153, 0.92) 100%);
+      border: 1px solid rgba(56, 189, 248, 0.22);
       border-radius: 34px;
       padding: clamp(1.9rem, 3.5vw, 3.1rem);
       margin-bottom: 2.5rem;
-      box-shadow: 0 40px 80px -45px rgba(2, 6, 23, 0.85), 0 20px 40px -35px rgba(12, 74, 110, 0.5);
+      box-shadow: 0 42px 90px -48px rgba(8, 23, 53, 0.9), 0 24px 55px -40px rgba(4, 120, 211, 0.4);
       color: #e2e8f0;
       overflow: hidden;
       backdrop-filter: blur(9px);
@@ -2028,13 +2028,13 @@
       position: absolute;
       inset: -12% -8% -20% -8%;
       background:
-        radial-gradient(50% 50% at 15% 25%, rgba(125, 211, 252, 0.45) 0%, rgba(125, 211, 252, 0) 62%),
-        radial-gradient(60% 60% at 85% 18%, rgba(191, 219, 254, 0.3) 0%, rgba(191, 219, 254, 0) 70%),
-        conic-gradient(from 140deg at 80% 65%, rgba(14, 165, 233, 0.5) 0deg, rgba(8, 145, 178, 0.05) 140deg, rgba(14, 165, 233, 0.4) 320deg, rgba(14, 165, 233, 0) 360deg),
-        linear-gradient(115deg, rgba(59, 130, 246, 0.25) 0%, rgba(13, 148, 136, 0) 40%);
+        radial-gradient(48% 55% at 16% 26%, rgba(148, 197, 255, 0.5) 0%, rgba(148, 197, 255, 0) 65%),
+        radial-gradient(58% 62% at 82% 15%, rgba(56, 189, 248, 0.4) 0%, rgba(56, 189, 248, 0) 72%),
+        conic-gradient(from 135deg at 78% 64%, rgba(4, 120, 211, 0.55) 0deg, rgba(3, 105, 161, 0.08) 150deg, rgba(4, 120, 211, 0.45) 320deg, rgba(4, 120, 211, 0) 360deg),
+        linear-gradient(112deg, rgba(3, 87, 153, 0.25) 0%, rgba(56, 189, 248, 0.08) 40%);
       mix-blend-mode: screen;
       pointer-events: none;
-      opacity: 0.9;
+      opacity: 0.92;
       filter: blur(0.5px);
     }
 
@@ -2043,10 +2043,10 @@
       position: absolute;
       inset: 1px;
       border-radius: 32px;
-      border: 1px solid rgba(148, 197, 255, 0.2);
+      border: 1px solid rgba(148, 197, 255, 0.22);
       background:
-        radial-gradient(120% 180% at 105% 105%, rgba(56, 189, 248, 0.16) 0%, rgba(56, 189, 248, 0) 60%),
-        linear-gradient(160deg, rgba(148, 163, 184, 0.08) 0%, rgba(14, 116, 144, 0.12) 45%, rgba(2, 6, 23, 0) 100%);
+        radial-gradient(120% 180% at 105% 105%, rgba(4, 120, 211, 0.18) 0%, rgba(4, 120, 211, 0) 60%),
+        linear-gradient(158deg, rgba(148, 197, 255, 0.12) 0%, rgba(11, 27, 63, 0.1) 55%, rgba(3, 87, 153, 0) 100%);
       pointer-events: none;
     }
 
@@ -2076,15 +2076,15 @@
       letter-spacing: 0.2em;
       text-transform: uppercase;
       font-weight: 700;
-      color: rgba(226, 240, 254, 0.88);
-      background: linear-gradient(120deg, rgba(15, 118, 110, 0.55) 0%, rgba(14, 165, 233, 0.5) 100%);
+      color: rgba(226, 240, 254, 0.9);
+      background: linear-gradient(125deg, rgba(4, 120, 211, 0.7) 0%, rgba(56, 189, 248, 0.6) 100%);
       padding: 0.45rem 0.95rem;
       border-radius: 999px;
-      box-shadow: inset 0 0 0 1px rgba(165, 243, 252, 0.55), 0 10px 18px -15px rgba(59, 130, 246, 0.65);
+      box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.55), 0 10px 18px -15px rgba(4, 120, 211, 0.65);
     }
 
     .lumina-banner__eyebrow i {
-      color: #bef264;
+      color: #38bdf8;
     }
 
     .lumina-banner__title-row {


### PR DESCRIPTION
## Summary
- update the global banner gradients and borders to use the Lumina logo navy and blue palette while keeping the glass effect
- refresh eyebrow pill styling to match the updated brand colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e44584fde88326a6fa1e70ef8eca68