### PR TITLE
Expand banner description coverage across the app

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -867,7 +867,7 @@
   })(typeof baseUrl !== 'undefined' ? baseUrl : '');
 ?>
 
-<div class="modern-page-header">
+<div class="modern-page-header" data-banner-source>
   <div class="d-flex gap-3 mb-4 flex-wrap">
     <button id="exportBtn" class="btn btn-light" onclick="showEnhancedExportModal()">
       <i class="fas fa-table me-2"></i>Export Matrix

--- a/CallReports.html
+++ b/CallReports.html
@@ -962,7 +962,7 @@
             </select>
         </div>
 
-        <div class="d-flex flex-wrap gap-2" role="group" aria-label="Call report actions">
+        <div class="d-flex flex-wrap gap-2" role="group" aria-label="Call report actions" data-banner-source>
             <button type="button" class="btn btn-ai btn-sm" id="aiAnalyzerBtn" aria-expanded="false">
                 <i class="fas fa-robot me-2"></i><span class="btn-label">AI Analyzer</span>
             </button>

--- a/CampaignManagement.html
+++ b/CampaignManagement.html
@@ -660,7 +660,7 @@
         <div class="card">
           <div class="card-header">
             <h2 class="card-title"><i class="fas fa-list"></i> Campaigns</h2>
-            <div>
+            <div data-banner-source>
               <button class="btn btn-primary" onclick="refreshData()"><i class="fas fa-sync-alt"></i> Refresh</button>
             </div>
           </div>
@@ -675,7 +675,7 @@
             <h2 class="card-title"><i class="fas fa-cogs"></i> Page Management -
               <span id="selectedCampaignName">Campaign</span>
             </h2>
-            <div>
+            <div data-banner-source>
               <button class="btn btn-success" onclick="autoFixCategories()"><i class="fas fa-magic"></i> Auto-Fix</button>
               <button class="btn btn-primary" onclick="closePageManagement()"><i class="fas fa-times"></i> Close</button>
             </div>
@@ -689,7 +689,9 @@
           <div id="categoriesTab" class="tab-content active">
             <div class="card-header">
               <h5>Navigation Categories</h5>
-              <button class="btn btn-sm btn-primary" onclick="showAddCategoryModal()"><i class="fas fa-plus"></i> Add Category</button>
+              <div data-banner-source>
+                <button class="btn btn-sm btn-primary" onclick="showAddCategoryModal()"><i class="fas fa-plus"></i> Add Category</button>
+              </div>
             </div>
             <div class="categories-grid" id="categoriesList"></div>
           </div>
@@ -697,7 +699,9 @@
           <div id="pagesTab" class="tab-content">
             <div class="card-header">
               <h5>Campaign Pages</h5>
-              <button class="btn btn-sm btn-primary" onclick="showAddPageModal()"><i class="fas fa-plus"></i> Add Page</button>
+              <div data-banner-source>
+                <button class="btn btn-sm btn-primary" onclick="showAddPageModal()"><i class="fas fa-plus"></i> Add Page</button>
+              </div>
             </div>
             <div id="pagesList"></div>
           </div>

--- a/QADashboard.html
+++ b/QADashboard.html
@@ -2755,7 +2755,7 @@
 </div>
 
 <!-- Modern Action Buttons -->
-<div class="modern-actions fade-in">
+<div class="modern-actions fade-in" data-banner-source>
   <? 
         // Build clean URLs without exposing campaign context
         function buildUrl(page) {

--- a/RoleManagement.html
+++ b/RoleManagement.html
@@ -136,6 +136,12 @@
         z-index: var(--bs-modal-zindex) !important;
     }
 
+    .toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
     /* Accessibility improvements */
     .btn:focus-visible,
     .form-control:focus-visible,
@@ -221,10 +227,11 @@
                     <option value="100">100</option>
                 </select>
             </div>
-
-            <button class="btn btn-primary" id="btnNewRole">
-                <i class="fas fa-plus-circle me-2"></i> New Role
-            </button>
+            <div class="toolbar-actions" data-banner-source>
+                <button class="btn btn-primary" id="btnNewRole">
+                    <i class="fas fa-plus-circle me-2"></i> New Role
+                </button>
+            </div>
         </div>
     </div>
 

--- a/Users.html
+++ b/Users.html
@@ -1186,7 +1186,7 @@
 <div class="content-header">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-md-center gap-3">
         <h2 class="mb-0 fw-bold fs-3">Users <span id="userCount" class="text-muted fw-normal">(0)</span></h2>
-        <div class="btn-group-responsive">
+        <div class="btn-group-responsive" data-banner-source>
             <button class="btn-modern btn-primary" onclick="showAddUserModal()">
                 <i class="fas fa-plus"></i>Add New User
             </button>

--- a/layout.html
+++ b/layout.html
@@ -61,6 +61,132 @@
       __layoutSlugCandidate
     ];
 
+    if (__layoutSlugCandidate) {
+      var __layoutCollapsedSlugCandidate = __layoutSlugCandidate.replace(/-/g, '');
+      if (__layoutCollapsedSlugCandidate && __layoutCollapsedSlugCandidate !== __layoutSlugCandidate) {
+        __layoutSlugSources.push(__layoutCollapsedSlugCandidate);
+      }
+    }
+
+    var __layoutPageDescriptionEntries = {
+      'ackform': 'Send coaching acknowledgement links and capture agent sign-off confirmations.',
+      'admin-dashboard': 'Reference security tools, governance policies, and documentation for LuminaHQ administrators.',
+      'agent-experience': 'Personalized workspace that surfaces coaching, quality, and productivity insights for agents.',
+      'attendancereports': 'Analyze attendance trends, compliance health, and time-off insights across the workforce.',
+      'bookmarks': 'Organize quick-access bookmarks to critical LuminaHQ dashboards and tools.',
+      'calendar': 'Visualize schedules, coverage, and operational events in a shared calendar view.',
+      'callreports': 'Review call performance analytics, AI insights, and exportable call summaries.',
+      'chat': 'Collaborate with teams in real-time chat rooms and announcement channels.',
+      'coachingdashboard': 'Monitor coaching programs, completion metrics, and follow-up priorities.',
+      'coachinglist': 'Track scheduled coaching sessions, ownership, and completion status.',
+      'coachingsheet': 'Document coaching conversations, commitments, and agreed action plans.',
+      'coachingview': 'Review coaching session details, notes, and acknowledgement history.',
+      'collaboration-reporting': 'Unify reporting for quality, attendance, and executive workflows in one hub.',
+      'creditsuiteqa': 'Evaluate Credit Suite cases with standardized QA scoring and compliance checks.',
+      'dashboard': 'View OKR performance, goal progress, and campaign-level analytics.',
+      'eodreport': 'Compile end-of-day summaries, escalations, and operational highlights.',
+      'escalations': 'Manage customer escalations, ownership, and resolution progress.',
+      'goalsetting': 'Set, track, and update operational goals with transparent accountability.',
+      'groundingqaform': 'Capture grounding QA results with agent feedback and compliance scoring.',
+      'home': 'Navigate primary LuminaHQ destinations and quick links.',
+      'importattendance': 'Upload attendance source files to refresh LuminaHQ workforce data.',
+      'import-call-report': 'Import call report CSV files to enrich analytics and dashboards.',
+      'independencequality': 'Complete independence QA evaluations with policy-aligned scoring.',
+      'managecampaign': 'Manage campaign records, navigation pages, and assignment permissions.',
+      'manager-executive-experience': 'Executive dashboards for cross-campaign coaching, quality, and outcomes.',
+      'manageroles': 'Administer roles, permissions, and access policies across LuminaHQ.',
+      'manageuser': 'Manage LuminaHQ users, profile access, and client assignments.',
+      'notifications': 'Configure and review LuminaHQ notification settings and alerts.',
+      'privacy-policy': 'Review how LuminaHQ protects workforce and client data.',
+      'qacollablist': 'Monitor collaborative QA submissions and workflow statuses.',
+      'qacollabview': 'Review collaborative QA details, commentary, and resolution steps.',
+      'qadashboard': 'Track quality assurance KPIs, agent performance, and review cadence.',
+      'qalist': 'Browse quality evaluations with filters, tags, and analyst insights.',
+      'qualitycollabform': 'Launch collaborative QA evaluations with shared reviewer inputs.',
+      'qualityform': 'Submit new quality assessments with rubric-driven scoring.',
+      'qualityview': 'Inspect detailed QA evaluation results, scoring, and trend history.',
+      'schedulemanagement': 'Coordinate schedules, shift swaps, and staffing coverage in LuminaHQ.',
+      'search': 'Search Lumina knowledge, dashboards, and operational resources.',
+      'shift-slot-management': 'Manage shift slots, staffing requests, and capacity planning.',
+      'taskboard': 'Plan and track operational work across kanban-style boards.',
+      'taskform': 'Create or edit LuminaHQ tasks with assignments and due dates.',
+      'tasklist': 'Review prioritized task lists and workflow statuses.',
+      'terms-of-service': 'Understand LuminaHQ platform terms and user responsibilities.',
+      'unifiedqadashboard': 'Blend QA insights across programs with unified analytics.',
+      'user-profile': 'Review and update your LuminaHQ profile, roles, and equipment.'
+    };
+
+    var __layoutPageDescriptionLookup = {};
+    for (var __layoutDescriptionKey in __layoutPageDescriptionEntries) {
+      if (!Object.prototype.hasOwnProperty.call(__layoutPageDescriptionEntries, __layoutDescriptionKey)) {
+        continue;
+      }
+
+      var __layoutDescriptionValue = __layoutPageDescriptionEntries[__layoutDescriptionKey];
+      if (!__layoutDescriptionValue) {
+        continue;
+      }
+
+      __layoutPageDescriptionLookup[__layoutDescriptionKey] = __layoutDescriptionValue;
+
+      var __layoutCollapsedKey = __layoutDescriptionKey.replace(/-/g, '');
+      if (
+        __layoutCollapsedKey &&
+        __layoutCollapsedKey !== __layoutDescriptionKey &&
+        !Object.prototype.hasOwnProperty.call(__layoutPageDescriptionEntries, __layoutCollapsedKey) &&
+        !Object.prototype.hasOwnProperty.call(__layoutPageDescriptionLookup, __layoutCollapsedKey)
+      ) {
+        __layoutPageDescriptionLookup[__layoutCollapsedKey] = __layoutDescriptionValue;
+      }
+    }
+
+    var __layoutPageDescriptionSource = '';
+    var __layoutResolvedDescriptionSlug = '';
+    var __layoutResolvedSlugCandidates = [];
+    var __layoutFallbackDescription = 'LuminaHQ operations workspace overview.';
+
+    function __layoutResolvePageDescription() {
+      if (__layoutPageDescriptionText) {
+        __layoutPageDescriptionSource = 'inline';
+        return __layoutPageDescriptionText;
+      }
+
+      for (var i = 0; i < __layoutSlugSources.length; i++) {
+        var candidateSlug = __layoutSlugify(__layoutSlugSources[i]);
+        if (!candidateSlug) {
+          continue;
+        }
+
+        __layoutResolvedSlugCandidates.push(candidateSlug);
+
+        if (Object.prototype.hasOwnProperty.call(__layoutPageDescriptionLookup, candidateSlug)) {
+          __layoutResolvedDescriptionSlug = candidateSlug;
+          __layoutPageDescriptionSource = 'lookup';
+          return __layoutPageDescriptionLookup[candidateSlug];
+        }
+      }
+
+      __layoutPageDescriptionSource = 'fallback';
+
+      if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+        try {
+          console.warn(
+            'Lumina banner description fallback in use for page candidates:',
+            __layoutResolvedSlugCandidates
+          );
+        } catch (loggingError) {
+          // Swallow logging issues to avoid breaking rendering.
+        }
+      }
+
+      return __layoutFallbackDescription;
+    }
+
+    __layoutPageDescriptionText = __layoutResolvePageDescription();
+    if (!pageDescription && __layoutPageDescriptionText) {
+      pageDescription = __layoutPageDescriptionText;
+    }
+
     var __layoutRawReturnUrl = (typeof returnUrl !== 'undefined' && returnUrl) ? returnUrl : '';
 
     var __layoutInvalidPanelPattern = /usercodeapppanel/i;
@@ -143,6 +269,18 @@
   <?!= includeOnce('ResponsiveStyles') ?>
 
   <script>
+    if (typeof window !== 'undefined') {
+      window.__LUMINA_PAGE_SLUG = <?!= JSON.stringify(__layoutSlugCandidate || '') ?>;
+      window.__LUMINA_PAGE_DESCRIPTION = <?!= JSON.stringify(__layoutPageDescriptionText || '') ?>;
+      window.__LUMINA_PAGE_DESCRIPTION_SOURCE = <?!= JSON.stringify(__layoutPageDescriptionSource || '') ?>;
+      window.__LUMINA_PAGE_DESCRIPTION_LOOKUP = <?!= JSON.stringify(__layoutPageDescriptionLookup) ?>;
+      window.__LUMINA_PAGE_DESCRIPTION_DEBUG = <?!= JSON.stringify({
+        candidates: __layoutResolvedSlugCandidates,
+        resolvedSlug: __layoutResolvedDescriptionSlug,
+        fallbackDescription: __layoutFallbackDescription
+      }) ?>;
+    }
+
     (function initializeLuminaTheme() {
       const STORAGE_KEY = 'lumina-theme';
       const docEl = document.documentElement;
@@ -2008,15 +2146,15 @@
     .lumina-banner {
       position: relative;
       background:
-        radial-gradient(140% 115% at -10% 15%, rgba(34, 197, 247, 0.35) 0%, rgba(2, 132, 199, 0) 55%),
-        radial-gradient(160% 140% at 110% 15%, rgba(6, 182, 212, 0.28) 0%, rgba(13, 71, 161, 0) 60%),
-        conic-gradient(from 210deg at 70% 75%, rgba(56, 189, 248, 0.2) 0deg, rgba(30, 64, 175, 0) 160deg),
-        linear-gradient(150deg, rgba(2, 6, 23, 0.96) 0%, rgba(12, 19, 41, 0.96) 42%, rgba(4, 47, 46, 0.92) 100%);
-      border: 1px solid rgba(125, 211, 252, 0.18);
+        radial-gradient(135% 120% at -15% 15%, rgba(56, 189, 248, 0.32) 0%, rgba(56, 189, 248, 0) 60%),
+        radial-gradient(150% 150% at 110% 5%, rgba(4, 120, 211, 0.35) 0%, rgba(4, 120, 211, 0) 65%),
+        conic-gradient(from 210deg at 70% 78%, rgba(3, 87, 153, 0.28) 0deg, rgba(11, 27, 63, 0) 165deg),
+        linear-gradient(160deg, rgba(11, 27, 63, 0.96) 0%, rgba(16, 48, 96, 0.95) 45%, rgba(3, 87, 153, 0.92) 100%);
+      border: 1px solid rgba(56, 189, 248, 0.22);
       border-radius: 34px;
       padding: clamp(1.9rem, 3.5vw, 3.1rem);
       margin-bottom: 2.5rem;
-      box-shadow: 0 40px 80px -45px rgba(2, 6, 23, 0.85), 0 20px 40px -35px rgba(12, 74, 110, 0.5);
+      box-shadow: 0 42px 90px -48px rgba(8, 23, 53, 0.9), 0 24px 55px -40px rgba(4, 120, 211, 0.4);
       color: #e2e8f0;
       overflow: hidden;
       backdrop-filter: blur(9px);
@@ -2028,13 +2166,13 @@
       position: absolute;
       inset: -12% -8% -20% -8%;
       background:
-        radial-gradient(50% 50% at 15% 25%, rgba(125, 211, 252, 0.45) 0%, rgba(125, 211, 252, 0) 62%),
-        radial-gradient(60% 60% at 85% 18%, rgba(191, 219, 254, 0.3) 0%, rgba(191, 219, 254, 0) 70%),
-        conic-gradient(from 140deg at 80% 65%, rgba(14, 165, 233, 0.5) 0deg, rgba(8, 145, 178, 0.05) 140deg, rgba(14, 165, 233, 0.4) 320deg, rgba(14, 165, 233, 0) 360deg),
-        linear-gradient(115deg, rgba(59, 130, 246, 0.25) 0%, rgba(13, 148, 136, 0) 40%);
+        radial-gradient(48% 55% at 16% 26%, rgba(148, 197, 255, 0.5) 0%, rgba(148, 197, 255, 0) 65%),
+        radial-gradient(58% 62% at 82% 15%, rgba(56, 189, 248, 0.4) 0%, rgba(56, 189, 248, 0) 72%),
+        conic-gradient(from 135deg at 78% 64%, rgba(4, 120, 211, 0.55) 0deg, rgba(3, 105, 161, 0.08) 150deg, rgba(4, 120, 211, 0.45) 320deg, rgba(4, 120, 211, 0) 360deg),
+        linear-gradient(112deg, rgba(3, 87, 153, 0.25) 0%, rgba(56, 189, 248, 0.08) 40%);
       mix-blend-mode: screen;
       pointer-events: none;
-      opacity: 0.9;
+      opacity: 0.92;
       filter: blur(0.5px);
     }
 
@@ -2043,10 +2181,10 @@
       position: absolute;
       inset: 1px;
       border-radius: 32px;
-      border: 1px solid rgba(148, 197, 255, 0.2);
+      border: 1px solid rgba(148, 197, 255, 0.22);
       background:
-        radial-gradient(120% 180% at 105% 105%, rgba(56, 189, 248, 0.16) 0%, rgba(56, 189, 248, 0) 60%),
-        linear-gradient(160deg, rgba(148, 163, 184, 0.08) 0%, rgba(14, 116, 144, 0.12) 45%, rgba(2, 6, 23, 0) 100%);
+        radial-gradient(120% 180% at 105% 105%, rgba(4, 120, 211, 0.18) 0%, rgba(4, 120, 211, 0) 60%),
+        linear-gradient(158deg, rgba(148, 197, 255, 0.12) 0%, rgba(11, 27, 63, 0.1) 55%, rgba(3, 87, 153, 0) 100%);
       pointer-events: none;
     }
 
@@ -2076,15 +2214,15 @@
       letter-spacing: 0.2em;
       text-transform: uppercase;
       font-weight: 700;
-      color: rgba(226, 240, 254, 0.88);
-      background: linear-gradient(120deg, rgba(15, 118, 110, 0.55) 0%, rgba(14, 165, 233, 0.5) 100%);
+      color: rgba(226, 240, 254, 0.9);
+      background: linear-gradient(125deg, rgba(4, 120, 211, 0.7) 0%, rgba(56, 189, 248, 0.6) 100%);
       padding: 0.45rem 0.95rem;
       border-radius: 999px;
-      box-shadow: inset 0 0 0 1px rgba(165, 243, 252, 0.55), 0 10px 18px -15px rgba(59, 130, 246, 0.65);
+      box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.55), 0 10px 18px -15px rgba(4, 120, 211, 0.65);
     }
 
     .lumina-banner__eyebrow i {
-      color: #bef264;
+      color: #38bdf8;
     }
 
     .lumina-banner__title-row {

--- a/tools/verify_page_descriptions.py
+++ b/tools/verify_page_descriptions.py
@@ -1,0 +1,108 @@
+"""Utility to validate Lumina layout banner descriptions.
+
+Run with `python tools/verify_page_descriptions.py` from the repository root
+to ensure every HTML file that includes the shared `layout` template
+resolves to a non-empty description via either inline metadata or the
+central lookup table.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Dict, Iterable, List, Tuple
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LAYOUT_PATH = os.path.join(ROOT, "layout.html")
+
+
+def slugify(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower())
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value
+
+
+def read_layout_lookup() -> Dict[str, str]:
+    with open(LAYOUT_PATH, "r", encoding="utf-8", errors="ignore") as handle:
+        layout_text = handle.read()
+
+    entries_match = re.search(
+        r"var __layoutPageDescriptionEntries = \{([\s\S]*?)\};",
+        layout_text,
+    )
+    if not entries_match:
+        raise RuntimeError("Could not locate __layoutPageDescriptionEntries in layout.html")
+
+    entries = dict(re.findall(r"'([^']+)':\s*'([^']+)'", entries_match.group(1)))
+    lookup: Dict[str, str] = {}
+    for key, description in entries.items():
+        if not description:
+            continue
+        lookup[key] = description
+        collapsed = key.replace("-", "")
+        if collapsed and collapsed != key and collapsed not in entries and collapsed not in lookup:
+            lookup[collapsed] = description
+    return lookup
+
+
+def iter_layout_pages(root: str) -> Iterable[Tuple[str, str, bool]]:
+    include_pattern = re.compile(r"include\((?:'|\")layout(?:'|\")\s*,\s*\{([\s\S]*?)\}\)")
+    for current_root, _, files in os.walk(root):
+        for filename in files:
+            if not filename.endswith(".html"):
+                continue
+            path = os.path.join(current_root, filename)
+            with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+                text = handle.read()
+            match = include_pattern.search(text)
+            if not match:
+                continue
+            block = match.group(1)
+            has_inline_description = "pageDescription" in block
+            props = dict(re.findall(r"(\w+)\s*:\s*([^,\n]+)", block))
+            slug_candidate = ""
+            for key in ("pageSlug", "currentPage"):
+                if key in props:
+                    value = props[key]
+                    if "||" in value:
+                        value = value.split("||")[1]
+                    value = re.sub(r"['\"()]", "", value).strip()
+                    if value:
+                        slug_candidate = value
+                        break
+            if not slug_candidate:
+                slug_candidate = os.path.splitext(filename)[0]
+            yield path, slugify(slug_candidate), has_inline_description
+
+
+def main() -> int:
+    lookup = read_layout_lookup()
+    missing: List[Tuple[str, str]] = []
+    coverage: List[Tuple[str, str]] = []
+
+    for path, slug, has_inline in iter_layout_pages(ROOT):
+        if has_inline:
+            coverage.append((path, slug))
+            continue
+        if slug not in lookup:
+            missing.append((path, slug))
+        else:
+            coverage.append((path, slug))
+
+    report = {
+        "total_pages": len(coverage),
+        "missing_descriptions": missing,
+    }
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if missing:
+        for path, slug in missing:
+            print(f"Missing description for slug '{slug}' from {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- expand the shared banner description lookup to cover every slug, add alias handling, and log fallbacks when a page relies on the generic copy
- expose resolved banner metadata globally so downstream scripts can inspect the selected description, slug candidates, and lookup catalog
- add a verification utility that scans every layout-backed HTML file to confirm a description is supplied inline or via the central lookup

## Testing
- python tools/verify_page_descriptions.py

------
https://chatgpt.com/codex/tasks/task_e_68e44584fde88326a6fa1e70ef8eca68