### PR TITLE
Fix QA dashboard period derivation helpers

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -3119,6 +3119,34 @@
           return date ? date.toISOString() : null;
       }
 
+      function toISOWeek(date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return '';
+        }
+
+        const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        let day = utcDate.getUTCDay();
+        if (day === 0) {
+          day = 7;
+        }
+
+        utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+        const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+        const diff = utcDate - yearStart;
+        const week = Math.ceil(((diff / 86400000) + 1) / 7);
+
+        return `${utcDate.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+      }
+
+      function getQuarter(date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return '';
+        }
+
+        const quarter = Math.floor(date.getMonth() / 3) + 1;
+        return `Q${quarter}`;
+      }
+
       function normalizeKeyName(key) {
         return String(key || '')
           .toLowerCase()


### PR DESCRIPTION
## Summary
- add ISO week and quarter derivation helpers to the QA dashboard client script
- ensure granular period filters can resolve and label week and quarter values without runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45235d4e8832696fbc056d7cfadf3