### PR TITLE
Rebuild QA dashboard frontend and add snapshot API

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -15,6412 +15,1035 @@
 
 <style>
   :root {
-    /* Brand Color Palette */
-    --navy-primary: #003177;
-    --cyan-accent: #00BFFF;
-    --gold-highlight: #FFB800;
-    --fire-red: #FF4000;
-
-    /* Modern UI Colors */
-    --primary-gradient: linear-gradient(135deg, var(--navy-primary) 0%, #004ba0 100%);
-    --info-gradient: linear-gradient(135deg, var(--cyan-accent) 0%, #0099cc 100%);
-    --success-gradient: linear-gradient(135deg, #10b981 0%, #059669 100%);
-    --warning-gradient: linear-gradient(135deg, var(--gold-highlight) 0%, #d97706 100%);
-    --danger-gradient: linear-gradient(135deg, var(--fire-red) 0%, #dc2626 100%);
-    --surface-gradient: linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%);
-    --card-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    --card-shadow-hover: 0 20px 60px rgba(0, 0, 0, 0.15);
-    --glass-bg: rgba(255, 255, 255, 0.25);
-    --glass-border: rgba(255, 255, 255, 0.18);
-    --backdrop-blur: blur(10px);
-    --border-radius-lg: 16px;
-    --border-radius-xl: 24px;
-    --transition-smooth: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    --qa-bg: #f7f9fc;
+    --qa-card-bg: #ffffff;
+    --qa-border: #e5e7eb;
+    --qa-primary: #2563eb;
+    --qa-accent: #0ea5e9;
+    --qa-success: #10b981;
+    --qa-warning: #f59e0b;
+    --qa-danger: #ef4444;
+    --qa-muted: #6b7280;
+    --qa-radius-lg: 18px;
+    --qa-radius-md: 14px;
+    --qa-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    --qa-shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.06);
   }
 
-  /* Modern Page Header with Live Status */
-  .modern-page-header {
-    background: var(--primary-gradient);
-    border-radius: var(--border-radius-xl);
-    padding: 2rem;
-    margin-bottom: 2rem;
-    color: white;
-    position: relative;
-    overflow: hidden;
+  body {
+    background: var(--qa-bg);
   }
 
-  .modern-page-header::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 200px;
-    height: 200px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 50%;
-    transform: translate(50%, -50%);
+  .qa-dashboard {
+    font-family: 'Inter', sans-serif;
+    color: #0f172a;
   }
 
-  .modern-page-header h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin: 0;
-    position: relative;
-    z-index: 2;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .modern-page-header p {
-    font-size: 1.1rem;
-    opacity: 0.9;
-    margin: 0.5rem 0 0 0;
-    position: relative;
-    z-index: 2;
-  }
-
-  .live-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: rgba(255, 255, 255, 0.15);
-    padding: 1rem 1.5rem;
-    border-radius: 12px;
-    margin-top: 1.5rem;
-    font-size: 1rem;
-    position: relative;
-    z-index: 2;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(10px);
-  }
-
-  .live-status {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 600;
-  }
-
-  .live-indicator {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: #10b981;
-    animation: pulse-live 2s infinite;
-    box-shadow: 0 0 15px rgba(16, 185, 129, 0.6);
-    position: relative;
-  }
-
-  .live-indicator::before {
-    content: '';
-    position: absolute;
-    top: -2px;
-    left: -2px;
-    right: -2px;
-    bottom: -2px;
-    border-radius: 50%;
-    border: 2px solid rgba(16, 185, 129, 0.3);
-    animation: ripple 2s infinite;
-  }
-
-  .datetime-display {
-    font-family: 'Courier New', monospace;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-    font-size: 1rem;
-    padding: 0.5rem 1rem;
-    background: rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-
-  .status-text {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .status-text i {
-    color: #10b981;
-    font-size: 1.1rem;
-  }
-
-  .data-refresh-status {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 600;
-    padding: 0.5rem 1rem;
-    border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    background: rgba(255, 255, 255, 0.15);
-    color: #e2e8f0;
-    box-shadow: 0 4px 15px rgba(15, 23, 42, 0.08);
-    transition: var(--transition-smooth);
-  }
-
-  .data-refresh-status i {
-    font-size: 0.95rem;
-  }
-
-  .data-refresh-status.success {
-    color: #10b981;
-    border-color: rgba(16, 185, 129, 0.4);
-    background: rgba(16, 185, 129, 0.15);
-  }
-
-  .data-refresh-status.updating {
-    color: #f59e0b;
-    border-color: rgba(245, 158, 11, 0.35);
-    background: rgba(245, 158, 11, 0.12);
-  }
-
-  .data-refresh-status.error {
-    color: #ef4444;
-    border-color: rgba(239, 68, 68, 0.4);
-    background: rgba(239, 68, 68, 0.12);
-  }
-
-  .data-refresh-status .status-label {
-    white-space: nowrap;
-  }
-
-  @keyframes pulse-live {
-    0%, 100% {
-      opacity: 1;
-      transform: scale(1);
-      box-shadow: 0 0 15px rgba(16, 185, 129, 0.6);
-    }
-    50% {
-      opacity: 0.7;
-      transform: scale(1.3);
-      box-shadow: 0 0 25px rgba(16, 185, 129, 0.8);
-    }
-  }
-
-  @keyframes ripple {
-    0% {
-      transform: scale(1);
-      opacity: 1;
-    }
-    100% {
-      transform: scale(2);
-      opacity: 0;
-    }
-  }
-
-  /* Modern Control Panel */
-  .modern-controls {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.5rem;
-    margin-bottom: 2rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-
-  .modern-controls .control-section {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .modern-controls .control-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .modern-controls label {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #64748b;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .modern-controls select,
-  .modern-controls input {
-    border: 2px solid #e2e8f0;
-    border-radius: 12px;
-    padding: 0.75rem 1rem;
-    font-size: 0.9rem;
-    transition: var(--transition-smooth);
-    background: white;
-    min-width: 140px;
-  }
-
-  .modern-controls select:focus,
-  .modern-controls input:focus {
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-    outline: none;
-  }
-
-  /* Modern Action Buttons */
-  .modern-actions {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    flex-wrap: wrap;
-    margin-bottom: 2rem;
-  }
-
-  .modern-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.5rem;
+  .qa-dashboard .card {
     border: none;
-    border-radius: 12px;
+    border-radius: var(--qa-radius-lg);
+    box-shadow: var(--qa-shadow-soft);
+  }
+
+  .qa-dashboard .card-header {
+    background: transparent;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    padding: 1.25rem 1.75rem 0.75rem;
     font-weight: 600;
-    font-size: 0.9rem;
-    text-decoration: none;
-    transition: var(--transition-smooth);
-    position: relative;
-    overflow: hidden;
+    color: #0f172a;
   }
 
-  .modern-btn::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-    transition: left 0.5s;
+  .qa-dashboard .card-body {
+    padding: 1.75rem;
   }
 
-  .modern-btn:hover::before {
-    left: 100%;
-  }
-
-  .modern-btn-primary {
-    background: var(--primary-gradient);
-    color: white;
-    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
-  }
-
-  .modern-btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
-    color: white;
-  }
-
-  .modern-btn-secondary {
-    background: #f8fafc;
-    color: #475569;
-    border: 2px solid #e2e8f0;
-  }
-
-  .modern-btn-secondary:hover {
-    background: #f1f5f9;
-    transform: translateY(-2px);
-    color: #475569;
-  }
-
-  .modern-btn-success {
-    background: var(--success-gradient);
-    color: white;
-    box-shadow: 0 4px 15px rgba(17, 153, 142, 0.3);
-  }
-
-  .modern-btn-success:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(17, 153, 142, 0.4);
-    color: white;
-  }
-
-  /* Modern KPI Cards */
-  .modern-kpi-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  }
-
-  .modern-kpi-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 2rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: var(--transition-smooth);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .modern-kpi-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background: var(--primary-gradient);
-    transform: scaleX(0);
-    transition: transform 0.3s ease;
-  }
-
-  .modern-kpi-card:hover {
-    transform: translateY(-8px);
-    box-shadow: var(--card-shadow-hover);
-  }
-
-  .modern-kpi-card:hover::before {
-    transform: scaleX(1);
-  }
-
-  .modern-kpi-card .kpi-icon {
-    width: 60px;
-    height: 60px;
-    border-radius: 16px;
-    background: var(--primary-gradient);
+  .qa-filters {
     display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .qa-filters .form-select,
+  .qa-filters .form-control {
+    border-radius: var(--qa-radius-md);
+    border-color: var(--qa-border);
+    padding: 0.6rem 2.5rem 0.6rem 1rem;
+    box-shadow: none;
+  }
+
+  .qa-filters .btn-primary {
+    background: linear-gradient(135deg, var(--qa-primary), var(--qa-accent));
+    border: none;
+    border-radius: var(--qa-radius-md);
+    padding: 0.6rem 1.4rem;
+    font-weight: 600;
+    box-shadow: 0 14px 30px rgba(37, 99, 235, 0.25);
+  }
+
+  .qa-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1.25rem;
+    margin-top: 1.75rem;
+  }
+
+  .qa-summary-card {
+    background: var(--qa-card-bg);
+    border-radius: var(--qa-radius-lg);
+    padding: 1.75rem;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: var(--qa-shadow-soft);
+  }
+
+  .qa-summary-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.35s ease;
+  }
+
+  .qa-summary-card:hover::after {
+    opacity: 1;
+  }
+
+  .qa-summary-card__label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--qa-muted);
+    margin-bottom: 0.9rem;
+  }
+
+  .qa-summary-card__value {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+  }
+
+  .qa-summary-card__delta {
+    font-size: 0.95rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .qa-summary-card__delta.positive {
+    color: var(--qa-success);
+  }
+
+  .qa-summary-card__delta.negative {
+    color: var(--qa-danger);
+  }
+
+  .qa-summary-card__delta.neutral {
+    color: var(--qa-muted);
+  }
+
+  .qa-section-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #0f172a;
+    margin-bottom: 0.75rem;
+  }
+
+  .qa-insight-list,
+  .qa-action-list {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .qa-insight-item,
+  .qa-action-item {
+    border-radius: var(--qa-radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background: rgba(255, 255, 255, 0.9);
+    padding: 1rem 1.25rem;
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .qa-insight-icon,
+  .qa-action-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--qa-primary);
+    font-size: 1.2rem;
+  }
+
+  .qa-insight-item[data-tone="positive"] .qa-insight-icon {
+    background: rgba(16, 185, 129, 0.12);
+    color: var(--qa-success);
+  }
+
+  .qa-insight-item[data-tone="negative"] .qa-insight-icon,
+  .qa-action-item[data-tone="urgent"] .qa-action-icon {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--qa-danger);
+  }
+
+  .qa-insight-text strong,
+  .qa-action-text strong {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+  }
+
+  #qa-trend-chart {
+    min-height: 320px;
+  }
+
+  .qa-trend-summary {
+    margin-top: 1.5rem;
+    padding: 1.1rem 1.3rem;
+    border-radius: var(--qa-radius-md);
+    background: rgba(37, 99, 235, 0.08);
+    color: #1e3a8a;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
+  .qa-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .qa-table thead th {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: var(--qa-muted);
+    border: none;
+    padding: 0.75rem 0.6rem;
+    background: transparent;
+  }
+
+  .qa-table tbody tr {
+    border-radius: var(--qa-radius-md);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
+  }
+
+  .qa-table tbody td {
+    padding: 0.9rem 0.6rem;
+    vertical-align: middle;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+  }
+
+  .qa-delta-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.25rem 0.65rem;
+  }
+
+  .qa-delta-badge.positive {
+    background: rgba(16, 185, 129, 0.12);
+    color: var(--qa-success);
+  }
+
+  .qa-delta-badge.negative {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--qa-danger);
+  }
+
+  .qa-delta-badge.neutral {
+    background: rgba(148, 163, 184, 0.2);
+    color: #475569;
+  }
+
+  .qa-empty-state {
+    text-align: center;
+    padding: 4rem 1rem;
+    border-radius: var(--qa-radius-lg);
+    border: 2px dashed rgba(148, 163, 184, 0.3);
+    background: rgba(255, 255, 255, 0.7);
+    color: #475569;
+  }
+
+  .qa-empty-state i {
+    font-size: 2rem;
+    color: var(--qa-primary);
+    margin-bottom: 0.75rem;
+  }
+
+  .qa-loading-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(247, 249, 252, 0.85);
+    display: none;
     align-items: center;
     justify-content: center;
-    margin-bottom: 1.5rem;
-    color: white;
-    font-size: 1.5rem;
+    z-index: 10;
+    border-radius: var(--qa-radius-lg);
   }
 
-  .modern-kpi-card .kpi-value {
-    font-size: 2.5rem;
-    font-weight: 800;
-    background: var(--primary-gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-    line-height: 1;
-  }
-
-  .modern-kpi-card .kpi-label {
-    font-size: 0.9rem;
-    color: #64748b;
-    font-weight: 600;
-    margin-top: 0.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .modern-kpi-card .kpi-trend {
+  .qa-dashboard.is-loading .qa-loading-overlay {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-top: 1rem;
-    font-size: 0.85rem;
-    font-weight: 600;
   }
 
-  .modern-kpi-card .kpi-trend.positive {
-    color: #10b981;
-  }
-
-  .modern-kpi-card .kpi-trend.negative {
-    color: #ef4444;
-  }
-
-  /* Modern Category KPIs */
-  .category-kpis-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1rem;
-    margin-bottom: 2rem;
-  }
-
-  .category-kpi-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.5rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: var(--transition-smooth);
-    text-align: center;
-  }
-
-  .category-kpi-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--card-shadow-hover);
-  }
-
-  .category-kpi-card h6 {
-    font-size: 0.9rem;
-    color: #475569;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .category-metrics {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .category-metric {
-    text-align: center;
-  }
-
-  .category-metric .value {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #1e293b;
-  }
-
-  .category-metric .label {
-    font-size: 0.75rem;
-    color: #64748b;
-    text-transform: uppercase;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-  }
-
-  /* Modern Chart Cards */
-  .modern-chart-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 2rem;
-    margin-bottom: 2rem;
-  }
-
-  .modern-chart-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 2rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: var(--transition-smooth);
-  }
-
-  .modern-chart-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--card-shadow-hover);
-  }
-
-  .modern-chart-card h6 {
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: #1e293b;
-    margin-bottom: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .modern-chart-card h6::before {
-    content: '';
-    width: 4px;
-    height: 20px;
-    background: var(--primary-gradient);
-    border-radius: 2px;
-  }
-
-  /* Chart Container Constraints */
-  .chart-container {
-    position: relative;
-    height: 300px;
-    width: 100%;
-    margin-bottom: 1rem;
-  }
-
-  .chart-container.small {
-    height: 200px;
-  }
-
-  .chart-container canvas {
-    max-height: 100% !important;
-    max-width: 100% !important;
-  }
-
-  /* Full width chart container */
-  .full-width-chart {
-    position: relative;
-    height: 250px;
-    width: 100%;
-    margin-bottom: 1rem;
-  }
-
-  /* Modern Tables */
-  .modern-table-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 2rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    margin-bottom: 2rem;
-    overflow: hidden;
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  /* Intelligence Cards */
-  .ai-intel-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin: 2rem 0;
-  }
-
-  .ai-intel-card {
-    background: white;
-    border-radius: var(--border-radius-lg);
-    padding: 1.75rem;
-    box-shadow: var(--card-shadow);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .ai-intel-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.05));
-    opacity: 0.75;
-    pointer-events: none;
-  }
-
-  .ai-card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-card-header i {
-    color: #667eea;
-    font-size: 1.25rem;
-  }
-
-  .ai-header-meta {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .ai-confidence-badge,
-  .ai-source-chip {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-source-chip {
-    background: rgba(79, 70, 229, 0.08);
-    color: #3730a3;
-  }
-
-  .ai-source-chip.server {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  .ai-source-chip.client {
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-automation-state {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(102, 126, 234, 0.12);
-    color: #4338ca;
-  }
-
-  .ai-automation-state.active {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-  }
-
-  .ai-trend-health {
-    margin-left: auto;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-  }
-
-  .ai-trend-health.improving {
-    background: rgba(16, 185, 129, 0.18);
-    color: #047857;
-  }
-
-  .ai-trend-health.risk {
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-  }
-
-  .ai-insights-summary,
-  .ai-automation-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-insights-list,
-  .ai-actions-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .ai-insight-item,
-  .ai-action-item {
-    display: flex;
-    gap: 0.85rem;
-    align-items: flex-start;
-    border-radius: 14px;
-    padding: 0.85rem 1rem;
-    background: rgba(102, 126, 234, 0.08);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    backdrop-filter: blur(6px);
-  }
-
-  .ai-insight-item.negative,
-  .ai-action-item.urgent {
-    background: rgba(248, 113, 113, 0.12);
-    border-color: rgba(248, 113, 113, 0.3);
-  }
-
-  .ai-insight-item.positive {
-    background: rgba(16, 185, 129, 0.12);
-    border-color: rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    background: white;
-    color: #4338ca;
-    box-shadow: 0 6px 15px rgba(102, 126, 234, 0.18);
-  }
-
-  .ai-insight-item.negative .ai-icon,
-  .ai-action-item.urgent .ai-icon {
-    color: #b91c1c;
-    box-shadow: 0 6px 15px rgba(248, 113, 113, 0.25);
-  }
-
-  .ai-insight-item.positive .ai-icon {
-    color: #059669;
-    box-shadow: 0 6px 15px rgba(16, 185, 129, 0.25);
-  }
-
-  .ai-insight-content strong,
-  .ai-action-content strong {
-    display: block;
-    font-size: 0.95rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .ai-insight-content span,
-  .ai-action-content span {
-    font-size: 0.9rem;
-    color: #475569;
-    line-height: 1.5;
-  }
-
-  .ai-next-best-action {
-    margin-top: 1.5rem;
-    padding: 1rem 1.2rem;
-    border-radius: 14px;
-    background: rgba(59, 130, 246, 0.1);
-    border: 1px dashed rgba(59, 130, 246, 0.3);
-    position: relative;
-    z-index: 2;
-    font-size: 0.9rem;
-    color: #1d4ed8;
-    display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-  }
-
-  .ai-next-best-action i {
-    font-size: 1.1rem;
-    margin-top: 0.1rem;
-  }
-
-  .ai-next-best-action strong {
-    display: block;
-    font-size: 0.95rem;
-  }
-
-  .ai-trend-summary {
-    position: relative;
-    z-index: 2;
-    color: #475569;
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual {
-    position: relative;
-    z-index: 2;
-    background: rgba(102, 126, 234, 0.06);
-    border: 1px solid rgba(226, 232, 240, 0.6);
-    border-radius: 14px;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .ai-trend-visual canvas {
-    width: 100% !important;
-    height: 180px !important;
-  }
-
-  .ai-trend-forecast {
-    margin-top: 0.75rem;
-    font-size: 0.85rem;
-    color: #334155;
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .ai-trend-forecast span {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(15, 118, 110, 0.12);
-    color: #0f766e;
-    font-weight: 600;
-  }
-
-  @media (max-width: 992px) {
-    .ai-intel-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .modern-table-card h6 {
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: #1e293b;
-    margin-bottom: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .modern-table-card h6::before {
-    content: '';
-    width: 4px;
-    height: 20px;
-    background: var(--success-gradient);
-    border-radius: 2px;
-  }
-
-  .modern-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.9rem;
-  }
-
-  .modern-table th {
-    background: #f8fafc;
-    color: #475569;
-    font-weight: 600;
-    padding: 1rem;
-    text-align: left;
-    border-bottom: 2px solid #e2e8f0;
-    text-transform: uppercase;
-    font-size: 0.8rem;
-    letter-spacing: 0.5px;
-  }
-
-  .modern-table td {
-    padding: 1rem;
-    border-bottom: 1px solid #f1f5f9;
-    color: #334155;
-  }
-
-  .modern-table tbody tr {
-    transition: background-color 0.2s ease;
-  }
-
-  .modern-table tbody tr:hover {
-    background: #f8fafc;
-  }
-
-  /* Badge styles for agent table */
-  .status-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem 0.75rem;
-    border-radius: 20px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .status-badge.excellent {
-    background: rgba(16, 185, 129, 0.1);
-    color: #10b981;
-    border: 1px solid rgba(16, 185, 129, 0.2);
-  }
-
-  .status-badge.good {
-    background: rgba(59, 130, 246, 0.1);
-    color: #3b82f6;
-    border: 1px solid rgba(59, 130, 246, 0.2);
-  }
-
-  .status-badge.needs-improvement {
-    background: rgba(245, 158, 11, 0.1);
-    color: #f59e0b;
-    border: 1px solid rgba(245, 158, 11, 0.2);
-  }
-
-  .status-badge .badge-dot {
-    width: 6px;
-    height: 6px;
+  .qa-spinner {
+    width: 48px;
+    height: 48px;
     border-radius: 50%;
-    background: currentColor;
+    border: 4px solid rgba(37, 99, 235, 0.15);
+    border-top-color: var(--qa-primary);
+    animation: qa-spin 0.9s linear infinite;
   }
 
-  /* Responsive Design */
-  @media (max-width: 768px) {
-    .modern-page-header {
-      padding: 1.5rem;
-      text-align: center;
+  @keyframes qa-spin {
+    to {
+      transform: rotate(360deg);
     }
+  }
 
-    .modern-page-header h1 {
-      font-size: 2rem;
-      justify-content: center;
-    }
+  .qa-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--qa-primary);
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
 
-    .live-header {
-      flex-direction: column;
-      gap: 1rem;
-      text-align: center;
-    }
+  .qa-next-best {
+    border-radius: var(--qa-radius-lg);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.08));
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    margin-top: 1.25rem;
+  }
 
-    .datetime-display {
-      font-size: 0.9rem;
-    }
+  .qa-next-best i {
+    color: var(--qa-primary);
+    font-size: 1.5rem;
+  }
 
-    .modern-controls .control-section {
+  .qa-next-best strong {
+    display: block;
+    font-weight: 600;
+    color: #0f172a;
+    margin-bottom: 0.2rem;
+  }
+
+  .qa-dashboard-alert {
+    margin-top: 1rem;
+  }
+
+  @media (max-width: 992px) {
+    .qa-filters {
       flex-direction: column;
       align-items: stretch;
     }
 
-    .modern-controls select,
-    .modern-controls input {
-      min-width: auto;
+    .qa-insight-item,
+    .qa-action-item {
+      grid-template-columns: 36px 1fr;
     }
-
-    .modern-chart-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .chart-container {
-      height: 250px;
-    }
-
-    .full-width-chart {
-      height: 200px;
-    }
-
-    .modern-kpi-grid {
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    }
-
-    .modern-actions {
-      justify-content: center;
-    }
-
-    .modern-btn {
-      font-size: 0.8rem;
-      padding: 0.75rem 1.25rem;
-    }
-  }
-
-  /* Animation Enhancements */
-  .fade-in {
-    animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  }
-
-  @keyframes fadeInUp {
-    from {
-      opacity: 0;
-      transform: translateY(30px);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .stagger-animation>* {
-    opacity: 0;
-    animation: fadeInUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  }
-
-  .stagger-animation>*:nth-child(1) {
-    animation-delay: 0.1s;
-  }
-
-  .stagger-animation>*:nth-child(2) {
-    animation-delay: 0.2s;
-  }
-
-  .stagger-animation>*:nth-child(3) {
-    animation-delay: 0.3s;
-  }
-
-  .stagger-animation>*:nth-child(4) {
-    animation-delay: 0.4s;
-  }
-
-  .stagger-animation>*:nth-child(5) {
-    animation-delay: 0.5s;
-  }
-
-  .stagger-animation>*:nth-child(6) {
-    animation-delay: 0.6s;
   }
 </style>
 
-<!-- Modern Page Header with Live Status -->
-<div class="modern-page-header fade-in">
-  <p>
-    Monitor performance metrics and quality assurance
-    <? if (typeof campaignName !== 'undefined' && campaignName) { ?>
-    for <strong><?= campaignName ?></strong> campaign
-    <? } else { ?>
-    across all agents
-    <? } ?>
-  </p>
-  
-  <div class="live-header">
-    <div class="live-status">
-      <div class="live-indicator"></div>
-      <div class="status-text">
-        <i class="fas fa-wifi"></i>
-        <span>Dashboard Live</span>
-      </div>
-    </div>
-    <div class="data-refresh-status updating" id="dataRefreshStatus">
-      <i class="fas fa-sync-alt fa-spin"></i>
-      <span class="status-label">Initializing…</span>
-    </div>
-    <div class="datetime-display" id="liveDatetime">Loading...</div>
+<div class="container py-4 position-relative qa-dashboard" id="qa-dashboard">
+  <div class="qa-loading-overlay">
+    <div class="qa-spinner"></div>
   </div>
-</div>
 
-<!-- Modern Control Panel -->
-<div class="modern-controls fade-in">
-  <div class="row">
-    <div class="col-md-8">
-      <div class="control-section">
-        <div class="control-group">
-          <label>Time Period</label>
-          <select class="form-select" id="granularitySelect">
-                <option value="Week" selected>Week</option>
-                <option value="Bi-Weekly">Bi-Weekly</option>
-                <option value="Month">Month</option>
-                <option value="Quarter">Quarter</option>
-                <option value="Year">Year</option>
-              </select>
-        </div>
-
-        <div class="control-group">
-          <label>Period Selection</label>
-          <select class="form-select" id="periodSelect">
-            <option value="" disabled selected>Loading periods…</option>
-          </select>
-        </div>
-
-        <div class="control-group">
-          <label>Agent Filter</label>
-          <select class="form-select" id="agentSelect">
-                <option value="">
-                    All Agents
-                </option>
-                <? userList.forEach(function(u) { ?>
-                  <option value="<?= u ?>" <?= u === selectedAgent ? "selected" : "" ?>>
-                    <?= u ?>
-                  </option>
-                <? }); ?>
-              </select>
-        </div>
-
-        <!-- Period Pickers -->
-        <div class="control-group" id="weekPicker" style="display: none;">
-          <label>Week</label>
-          <input type="week" class="form-control" id="weekInput" />
-        </div>
-        <div class="control-group" id="monthPicker" style="display: none;">
-          <label>Month</label>
-          <input type="month" class="form-control" id="monthInput" />
-        </div>
-        <div class="control-group" id="quarterPicker" style="display: none;">
-          <label>Quarter</label>
-          <div class="d-flex gap-2">
-            <select class="form-select" id="quarterSelect">
-                  <option value="Q1">Q1</option>
-                  <option value="Q2">Q2</option>
-                  <option value="Q3">Q3</option>
-                  <option value="Q4">Q4</option>
-                </select>
-            <input type="number" class="form-control" id="quarterYearInput" placeholder="YYYY" min="2000" max="2100" style="width: 100px;" />
+  <div class="d-flex flex-column gap-3 mb-4">
+    <div class="card border-0">
+      <div class="card-body">
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-3">
+          <div>
+            <span class="qa-badge"><i class="fa-solid fa-shield-check"></i> Quality Assurance</span>
+            <h1 class="h3 fw-bold mt-3 mb-2">QA Performance Command Center</h1>
+            <p class="text-muted mb-0" id="qa-context-summary">
+              Monitor live quality health, trending scores, and AI-powered recommendations across your teams.
+            </p>
+          </div>
+          <div class="qa-filters">
+            <select id="qa-granularity" class="form-select">
+              <option value="Week">Week</option>
+              <option value="Month">Month</option>
+              <option value="Quarter">Quarter</option>
+              <option value="Year">Year</option>
+            </select>
+            <select id="qa-period" class="form-select">
+              <option value="">Latest Period</option>
+            </select>
+            <select id="qa-agent" class="form-select">
+              <option value="">All Agents</option>
+            </select>
+            <button type="button" class="btn btn-primary" id="qa-refresh">
+              <i class="fa-solid fa-rotate"></i>
+              <span class="ms-1">Refresh</span>
+            </button>
           </div>
         </div>
-        <div class="control-group" id="yearPicker" style="display: none;">
-          <label>Year</label>
-          <input type="number" class="form-control" id="yearInput" placeholder="YYYY" min="2000" max="2100"/>
+      </div>
+    </div>
+
+    <div class="qa-summary-grid" id="qa-summary-cards">
+      <div class="qa-summary-card" data-metric="avg">
+        <div class="qa-summary-card__label">Average QA Score</div>
+        <div class="qa-summary-card__value" data-role="value">--</div>
+        <div class="qa-summary-card__delta neutral" data-role="delta">Awaiting data</div>
+      </div>
+      <div class="qa-summary-card" data-metric="pass">
+        <div class="qa-summary-card__label">Pass Rate</div>
+        <div class="qa-summary-card__value" data-role="value">--</div>
+        <div class="qa-summary-card__delta neutral" data-role="delta">Awaiting data</div>
+      </div>
+      <div class="qa-summary-card" data-metric="coverage">
+        <div class="qa-summary-card__label">Agent Coverage</div>
+        <div class="qa-summary-card__value" data-role="value">--</div>
+        <div class="qa-summary-card__delta neutral" data-role="delta">Awaiting data</div>
+      </div>
+      <div class="qa-summary-card" data-metric="evaluations">
+        <div class="qa-summary-card__label">Evaluations</div>
+        <div class="qa-summary-card__value" data-role="value">--</div>
+        <div class="qa-summary-card__delta neutral" data-role="delta">Awaiting data</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="alert alert-danger d-none qa-dashboard-alert" id="qa-dashboard-error"></div>
+
+  <div class="qa-empty-state d-none" id="qa-empty-state">
+    <i class="fa-solid fa-chart-line"></i>
+    <h4 class="fw-semibold mb-2">No evaluations found for the selected filters</h4>
+    <p class="mb-0">Adjust your filters or capture new QA reviews to populate this dashboard.</p>
+  </div>
+
+  <div class="row g-4" id="qa-dashboard-content">
+    <div class="col-12 col-lg-8">
+      <div class="card h-100">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Performance Trend</span>
+          <span class="badge bg-light text-primary" id="qa-trend-granularity">Weekly</span>
+        </div>
+        <div class="card-body">
+          <canvas id="qa-trend-chart"></canvas>
+          <div class="qa-trend-summary mt-3" id="qa-trend-summary">
+            Trend analysis will appear once data is loaded.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-lg-4">
+      <div class="card mb-4">
+        <div class="card-header">AI Insights</div>
+        <div class="card-body">
+          <div class="qa-insight-list" id="qa-insights"></div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header">Recommended Actions</div>
+        <div class="card-body">
+          <div id="qa-next-best" class="qa-next-best d-none"></div>
+          <div class="qa-action-list mt-3" id="qa-actions"></div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-<!-- Modern Action Buttons -->
-<div class="modern-actions fade-in" data-banner-source>
-  <? 
-        // Build clean URLs without exposing campaign context
-        function buildUrl(page) {
-          return baseUrl + '?page=' + page;
-        }
-      ?>
-  <a href="<?= buildUrl('qualityform') ?>" class="modern-btn modern-btn-primary">
-    <i class="fas fa-clipboard-check"></i> New Quality
-  </a>
-  <a href="<?= buildUrl('qualitylist') ?>" class="modern-btn modern-btn-secondary">
-    <i class="fas fa-list"></i> Quality List
-  </a>
-  <button id="exportCsvBtn" class="modern-btn modern-btn-success">
-        <i class="fas fa-file-csv"></i> Export CSV
-      </button>
-  <a href="<?= buildUrl('coachinglist') ?>" class="modern-btn modern-btn-secondary">
-    <i class="fas fa-chalkboard-teacher"></i> Coaching
-  </a>
-  <a href="<?= buildUrl('qualityform') ?>" class="modern-btn modern-btn-primary">
-    <i class="fas fa-users"></i> New Collab Quality
-  </a>
-  <a href="<?= buildUrl('qacollablist') ?>" class="modern-btn modern-btn-secondary">
-    <i class="fas fa-list-check"></i> Quality Collab List
-  </a>
-</div>
-
-<!-- Modern KPI Cards -->
-<div class="modern-kpi-grid stagger-animation">
-  <div class="modern-kpi-card">
-    <div class="kpi-icon">
-      <i class="fas fa-chart-line"></i>
+  <div class="row g-4 mt-1" id="qa-lower-section">
+    <div class="col-12 col-lg-6">
+      <div class="card h-100">
+        <div class="card-header">Category Performance</div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-borderless align-middle qa-table">
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th class="text-center">Avg Score</th>
+                  <th class="text-center">Trend</th>
+                </tr>
+              </thead>
+              <tbody id="qa-categories-body">
+                <tr>
+                  <td colspan="3" class="text-center text-muted py-4">Awaiting data</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="kpi-value" id="kpiAvgScore">0%</div>
-    <div class="kpi-label">Average Score</div>
-    <div class="kpi-trend" id="kpiAvgScoreTrend">
-      <i class="fas fa-arrow-up"></i>
-      <span>0% vs last period</span>
-    </div>
-  </div>
-
-  <div class="modern-kpi-card">
-    <div class="kpi-icon" style="background: var(--success-gradient);">
-      <i class="fas fa-check-circle"></i>
-    </div>
-    <div class="kpi-value" id="kpiPassRate">0%</div>
-    <div class="kpi-label">Pass Rate</div>
-    <div class="kpi-trend" id="kpiPassRateTrend">
-      <i class="fas fa-arrow-up"></i>
-      <span>0% vs last period</span>
-    </div>
-  </div>
-
-  <div class="modern-kpi-card">
-    <div class="kpi-icon" style="background: var(--info-gradient);">
-      <i class="fas fa-users"></i>
-    </div>
-    <div class="kpi-value" id="kpiAgentsEval">0%</div>
-    <div class="kpi-label">Agents Evaluated</div>
-    <div class="kpi-trend" id="kpiAgentsEvalTrend">
-      <i class="fas fa-arrow-up"></i>
-      <span>0% vs last period</span>
-    </div>
-  </div>
-
-  <div class="modern-kpi-card">
-    <div class="kpi-icon" style="background: var(--warning-gradient);">
-      <i class="fas fa-tasks"></i>
-    </div>
-    <div class="kpi-value" id="kpiEvalsDone">0%</div>
-    <div class="kpi-label">Evaluations Completed</div>
-    <div class="kpi-trend" id="kpiEvalsDoneTrend">
-      <i class="fas fa-arrow-up"></i>
-      <span>0% vs last period</span>
+    <div class="col-12 col-lg-6">
+      <div class="card h-100">
+        <div class="card-header">Agent Leaderboard</div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-borderless align-middle qa-table">
+              <thead>
+                <tr>
+                  <th>Agent</th>
+                  <th class="text-center">Score</th>
+                  <th class="text-center">Pass Rate</th>
+                  <th class="text-center">Evaluations</th>
+                </tr>
+              </thead>
+              <tbody id="qa-agents-body">
+                <tr>
+                  <td colspan="4" class="text-center text-muted py-4">Awaiting data</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 
 <script>
-      const rawQASource = <?!= (typeof qaRecords !== 'undefined' && qaRecords) ? qaRecords : '[]' ?>;
-      let currentGran = '<?= granularity ?>';
-      let currentPeriod = '<?= periodValue ?>';
-      let currentAgent = '<?= selectedAgent ?>';
-      let userList = <?!= JSON.stringify(userList || []) ?>;
-      let qaIntelligenceRequestToken = 0;
-      let latestAIIntelligence = null;
-      const DEFAULT_GRANULARITIES = ['Week', 'Bi-Weekly', 'Month', 'Quarter', 'Year'];
-      const defaultPeriods = {};
-      const availablePeriods = {
-        Week: [],
-        'Bi-Weekly': [],
-        Month: [],
-        Quarter: [],
-        Year: []
+  (function () {
+    const dashboardEl = document.getElementById('qa-dashboard');
+    if (!dashboardEl) {
+      return;
+    }
+
+    const state = {
+      filters: {
+        granularity: 'Week',
+        period: '',
+        agent: '',
+        campaignId: '',
+        program: ''
+      },
+      loading: false,
+      data: null,
+      chart: null
+    };
+
+    const dom = {
+      granularity: document.getElementById('qa-granularity'),
+      period: document.getElementById('qa-period'),
+      agent: document.getElementById('qa-agent'),
+      refresh: document.getElementById('qa-refresh'),
+      summaryCards: dashboardEl.querySelectorAll('[data-metric]'),
+      error: document.getElementById('qa-dashboard-error'),
+      empty: document.getElementById('qa-empty-state'),
+      content: document.getElementById('qa-dashboard-content'),
+      lower: document.getElementById('qa-lower-section'),
+      trendGranularity: document.getElementById('qa-trend-granularity'),
+      trendSummary: document.getElementById('qa-trend-summary'),
+      trendCanvas: document.getElementById('qa-trend-chart'),
+      insights: document.getElementById('qa-insights'),
+      actions: document.getElementById('qa-actions'),
+      nextBest: document.getElementById('qa-next-best'),
+      categoriesBody: document.getElementById('qa-categories-body'),
+      agentsBody: document.getElementById('qa-agents-body'),
+      contextSummary: document.getElementById('qa-context-summary')
+    };
+
+    function setLoading(isLoading) {
+      state.loading = isLoading;
+      dashboardEl.classList.toggle('is-loading', Boolean(isLoading));
+      if (dom.refresh) {
+        dom.refresh.disabled = Boolean(isLoading);
+      }
+    }
+
+    function safePercent(value) {
+      if (value === null || value === undefined || Number.isNaN(value)) {
+        return '--';
+      }
+      return `${Math.round(value)}%`;
+    }
+
+    function formatNumber(value) {
+      if (value === null || value === undefined || Number.isNaN(value)) {
+        return '--';
+      }
+      return new Intl.NumberFormat().format(value);
+    }
+
+    function formatDelta(value, isPercent) {
+      if (value === null || value === undefined || Number.isNaN(value)) {
+        return { text: 'No prior period', tone: 'neutral' };
+      }
+      const rounded = Math.round(value * 10) / 10;
+      if (rounded === 0) {
+        return { text: 'No change', tone: 'neutral' };
+      }
+      const sign = rounded > 0 ? '+' : '';
+      const unit = isPercent ? '%' : '';
+      return {
+        text: `${sign}${rounded}${unit} vs prior`,
+        tone: rounded > 0 ? 'positive' : 'negative'
+      };
+    }
+
+    function populateSelect(selectEl, options, placeholder) {
+      if (!selectEl) return;
+      const currentValue = selectEl.value;
+      selectEl.innerHTML = '';
+      const defaultOption = document.createElement('option');
+      defaultOption.value = '';
+      defaultOption.textContent = placeholder;
+      selectEl.appendChild(defaultOption);
+      (options || []).forEach(option => {
+        const opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label || option.value;
+        selectEl.appendChild(opt);
+      });
+      if (options && options.some(option => option.value === currentValue)) {
+        selectEl.value = currentValue;
+      }
+    }
+
+    function renderSummary(summary) {
+      const config = {
+        avg: { formatter: safePercent, isPercent: true },
+        pass: { formatter: safePercent, isPercent: true },
+        coverage: { formatter: safePercent, isPercent: true },
+        evaluations: { formatter: formatNumber, isPercent: false }
       };
 
-      const PASS_MARK = 0.95;
-      const PASS_SCORE_THRESHOLD = Math.round(PASS_MARK * 100);
+      dom.summaryCards.forEach(card => {
+        const metric = card.getAttribute('data-metric');
+        const valueEl = card.querySelector('[data-role="value"]');
+        const deltaEl = card.querySelector('[data-role="delta"]');
+        const formatter = config[metric] ? config[metric].formatter : formatNumber;
+        const isPercent = config[metric] ? config[metric].isPercent : false;
+        if (valueEl) {
+          const baseValue = summary && metric in summary ? summary[metric] : null;
+          valueEl.textContent = formatter(baseValue);
+        }
+        if (deltaEl) {
+          const deltaValue = summary && summary.delta ? summary.delta[metric] : null;
+          const delta = formatDelta(deltaValue, isPercent);
+          deltaEl.textContent = delta.text;
+          deltaEl.className = `qa-summary-card__delta ${delta.tone}`;
+        }
+      });
 
-      const QA_MONITOR = (() => {
-        const startTimes = new Map();
-        const makeTimestamp = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
-        const sanitize = value => {
-          if (value === undefined) return undefined;
-          if (value === null) return null;
-          if (typeof value === 'string' && value.length > 500) {
-            return `${value.slice(0, 497)}…`;
-          }
-          if (Array.isArray(value) && value.length > 50) {
-            return value.slice(0, 50).concat('…');
-          }
-          return value;
-        };
-        function emit(level, label, payload) {
-          let cleaned = payload;
-          if (payload && typeof payload === 'object') {
-            try {
-              cleaned = JSON.parse(JSON.stringify(payload, (key, value) => sanitize(value)));
-            } catch (jsonError) {
-              cleaned = '[unserializable payload]';
+      if (summary && dom.contextSummary) {
+        const evaluations = formatNumber(summary.evaluations);
+        const agents = formatNumber(summary.agents);
+        dom.contextSummary.textContent = `Tracking ${evaluations} evaluation${summary.evaluations === 1 ? '' : 's'} across ${agents} agent${summary.agents === 1 ? '' : 's'} this period.`;
+      }
+    }
+
+    function renderTrend(trend, granularity) {
+      if (!dom.trendCanvas) return;
+      const ctx = dom.trendCanvas.getContext('2d');
+      if (!ctx) {
+        console.warn('Unable to acquire canvas context for QA trend chart.');
+        return;
+      }
+      const labels = (trend && trend.series ? trend.series : []).map(entry => entry.label);
+      const avgDataset = (trend && trend.series ? trend.series : []).map(entry => entry.avgScore || 0);
+      const passDataset = (trend && trend.series ? trend.series : []).map(entry => entry.passRate || 0);
+
+      if (state.chart) {
+        state.chart.destroy();
+        state.chart = null;
+      }
+
+      if (typeof Chart === 'undefined') {
+        console.warn('Chart.js is not available; skipping trend rendering.');
+        dom.trendSummary.textContent = 'Chart library unavailable. Unable to render trend visualization.';
+        return;
+      }
+
+      if (!labels.length) {
+        ctx.clearRect(0, 0, dom.trendCanvas.width, dom.trendCanvas.height);
+        dom.trendSummary.textContent = 'No trend data available for the selected filters yet.';
+        return;
+      }
+
+      state.chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Average Score',
+              data: avgDataset,
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.12)',
+              tension: 0.35,
+              fill: true,
+              pointRadius: 4,
+              pointHoverRadius: 5
+            },
+            {
+              label: 'Pass Rate',
+              data: passDataset,
+              borderColor: '#10b981',
+              backgroundColor: 'rgba(16, 185, 129, 0.12)',
+              tension: 0.35,
+              fill: true,
+              pointRadius: 4,
+              pointHoverRadius: 5
             }
-          }
-          const prefix = '[QA Dashboard]';
-          switch (level) {
-            case 'warn':
-              console.warn(prefix, label, cleaned);
-              break;
-            case 'error':
-              console.error(prefix, label, cleaned);
-              break;
-            default:
-              console.log(prefix, label, cleaned);
-          }
-        }
-        function start(label, payload) {
-          startTimes.set(label, makeTimestamp());
-          emit('log', `BEGIN ${label}`, payload);
-        }
-        function end(label, payload) {
-          const started = startTimes.get(label);
-          const duration = started ? Math.round(makeTimestamp() - started) : null;
-          emit('log', `END ${label}${duration !== null ? ` (+${duration}ms)` : ''}`, payload);
-          if (started) {
-            startTimes.delete(label);
-          }
-        }
-        function safe(label, fn, options = {}) {
-          const { rethrow = true, onError = null, defaultValue = undefined, context = null } = options;
-          start(label, { context });
-          try {
-            const result = fn();
-            end(label, { context });
-            return result;
-          } catch (error) {
-            emit('error', `ERROR ${label}`, { context, message: error?.message, stack: error?.stack });
-            if (typeof onError === 'function') {
-              try {
-                onError(error);
-              } catch (callbackError) {
-                emit('error', `ERROR ${label} onError callback`, { message: callbackError?.message, stack: callbackError?.stack });
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: true,
+              position: 'bottom',
+              labels: {
+                usePointStyle: true,
+                padding: 16
+              }
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.dataset.label}: ${Math.round(context.parsed.y)}%`;
+                }
               }
             }
-            if (rethrow) {
-              end(label, { context, failed: true });
-              throw error;
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              max: 100,
+              ticks: {
+                callback(value) {
+                  return `${value}%`;
+                }
+              },
+              grid: {
+                color: 'rgba(148, 163, 184, 0.25)'
+              }
+            },
+            x: {
+              grid: {
+                display: false
+              }
             }
-            end(label, { context, failed: true });
-            return defaultValue;
           }
         }
-        function instrument(name, fn) {
-          if (typeof fn !== 'function') {
-            emit('warn', 'Attempted to instrument non-function', { name, type: typeof fn });
-            return fn;
-          }
-          return function instrumentedFunction(...args) {
-            return safe(name, () => fn.apply(this, args), { rethrow: true, context: { argsCount: args.length } });
-          };
-        }
-        return {
-          log: (label, payload) => emit('log', label, payload),
-          warn: (label, payload) => emit('warn', label, payload),
-          error: (label, payload) => emit('error', label, payload),
-          safe,
-          instrument,
-          start,
-          end
-        };
-      })();
+      });
 
-      function updateLiveDatetime() {
-        const datetimeDisplay = document.getElementById('liveDatetime');
-        if (!datetimeDisplay) {
-          QA_MONITOR.warn('liveDatetime element missing');
-          return;
-        }
-
-        try {
-          const now = new Date();
-          const options = {
-            weekday: 'short',
-            year: 'numeric',
-            month: 'short',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-            hour12: true,
-            timeZoneName: 'short'
-          };
-
-          const formatted = typeof now.toLocaleString === 'function'
-            ? now.toLocaleString('en-US', options)
-            : now.toISOString();
-
-          datetimeDisplay.textContent = formatted;
-        } catch (error) {
-          QA_MONITOR.warn('updateLiveDatetime failed', { message: error?.message });
-          datetimeDisplay.textContent = new Date().toISOString();
-        }
+      if (dom.trendGranularity) {
+        dom.trendGranularity.textContent = granularity ? `${granularity}ly` : '';
       }
 
-      function updateDataRefreshStatus(state, message) {
-        const statusEl = document.getElementById('dataRefreshStatus');
-        if (!statusEl) {
-          QA_MONITOR.warn('dataRefreshStatus element missing');
-          return;
-        }
+      if (dom.trendSummary) {
+        const summary = trend && trend.analysis && trend.analysis.summary
+          ? trend.analysis.summary
+          : 'Trend analysis ready once evaluations post across multiple periods.';
+        dom.trendSummary.textContent = summary;
+      }
+    }
 
-        const normalized = typeof state === 'string' ? state.toLowerCase() : 'success';
-        const configs = {
-          success: {
-            className: 'success',
-            icon: 'fa-check-circle',
-            text: message || 'Data Current'
-          },
-          updating: {
-            className: 'updating',
-            icon: 'fa-sync-alt fa-spin',
-            text: message || 'Refreshing…'
-          },
-          loading: {
-            className: 'updating',
-            icon: 'fa-sync-alt fa-spin',
-            text: message || 'Loading…'
-          },
-          error: {
-            className: 'error',
-            icon: 'fa-exclamation-triangle',
-            text: message || 'Attention Required'
-          }
-        };
-
-        const config = configs[normalized] || configs.success;
-
-        statusEl.classList.remove('success', 'updating', 'error');
-        statusEl.classList.add(config.className);
-
-        const iconEl = statusEl.querySelector('i');
-        if (iconEl) {
-          iconEl.className = `fas ${config.icon}`;
-        }
-
-        const labelEl = statusEl.querySelector('.status-label') || statusEl.querySelector('span');
-        if (labelEl) {
-          labelEl.textContent = config.text;
-        } else {
-          statusEl.textContent = config.text;
-        }
+    function renderInsights(insights) {
+      if (!dom.insights) return;
+      dom.insights.innerHTML = '';
+      if (!insights || !insights.length) {
+        const empty = document.createElement('p');
+        empty.className = 'text-muted mb-0';
+        empty.textContent = 'No insights available for the selected filters yet.';
+        dom.insights.appendChild(empty);
+        return;
       }
 
-      window.addEventListener('error', event => {
-        QA_MONITOR.error('Global error captured', {
-          message: event?.message,
-          filename: event?.filename,
-          lineno: event?.lineno,
-          colno: event?.colno
-        });
-      });
-
-      window.addEventListener('unhandledrejection', event => {
-        QA_MONITOR.error('Unhandled promise rejection', {
-          message: event?.reason?.message || String(event?.reason || 'unknown'),
-          stack: event?.reason?.stack || null
-        });
-      });
-
-      let rawQA = [];
-
-      QA_MONITOR.safe('Parse QA records', () => {
-        if (typeof rawQASource === 'string') {
-          const trimmed = rawQASource.trim();
-          if (trimmed) {
-            const firstPass = JSON.parse(trimmed);
-            rawQA = typeof firstPass === 'string' ? JSON.parse(firstPass) : firstPass;
-          } else {
-            rawQA = [];
-          }
-        } else if (Array.isArray(rawQASource)) {
-          rawQA = rawQASource;
-        } else if (rawQASource && typeof rawQASource === 'object') {
-          rawQA = JSON.parse(JSON.stringify(rawQASource));
-        } else {
-          rawQA = [];
+      insights.forEach(item => {
+        const row = document.createElement('div');
+        row.className = 'qa-insight-item';
+        if (item.tone) {
+          row.dataset.tone = item.tone;
         }
-      }, {
-        rethrow: false,
-        onError: () => {
-          rawQA = [];
-        }
-      });
 
-      if (!Array.isArray(rawQA)) {
-        QA_MONITOR.warn('QA records payload was not an array', { detectedType: typeof rawQA });
-        rawQA = [];
+        const icon = document.createElement('div');
+        icon.className = 'qa-insight-icon';
+        icon.innerHTML = `<i class="fa-solid ${item.icon || 'fa-lightbulb'}"></i>`;
+
+        const text = document.createElement('div');
+        text.className = 'qa-insight-text';
+        const title = item.title ? `<strong>${item.title}</strong>` : '';
+        const body = item.text || '';
+        text.innerHTML = `${title}${body}`;
+
+        row.appendChild(icon);
+        row.appendChild(text);
+        dom.insights.appendChild(row);
+      });
+    }
+
+    function renderActions(actions, nextBest) {
+      if (!dom.actions || !dom.nextBest) return;
+
+      dom.actions.innerHTML = '';
+      dom.nextBest.classList.add('d-none');
+      dom.nextBest.innerHTML = '';
+
+      if (nextBest && (nextBest.title || nextBest.text)) {
+        dom.nextBest.classList.remove('d-none');
+        dom.nextBest.innerHTML = `
+          <i class="fa-solid ${nextBest.icon || 'fa-rocket'} mt-1"></i>
+          <div>
+            <strong>${nextBest.title || 'Next Best Action'}</strong>
+            <span class="d-block text-muted">${nextBest.text || ''}</span>
+          </div>`;
       }
 
-      QA_MONITOR.log('QA Dashboard bootstrapped', {
-        granularity: currentGran,
-        period: currentPeriod,
-        selectedAgent: currentAgent,
-        recordCount: rawQA.length,
-        userCount: Array.isArray(userList) ? userList.length : 'unknown'
-      });
+      if (!actions || !actions.length) {
+        const empty = document.createElement('p');
+        empty.className = 'text-muted mb-0';
+        empty.textContent = 'AI has no urgent playbook steps at the moment.';
+        dom.actions.appendChild(empty);
+        return;
+      }
 
-      const weightsMap = { Q1:5,Q2:5,Q3:8,Q4:10,Q5:5,Q6:5,Q7:5,Q8:10,Q9:10,Q10:5,Q11:5,Q12:5,Q13:8,Q14:5,Q15:2,Q16:1,Q17:1,Q18:5 };
-      const categories = {
-        'Courtesy & Communication':['Q1','Q2','Q3','Q4','Q5'],
-        'Resolution':['Q6','Q7','Q8','Q9'],
-        'Case Documentation':['Q10','Q11','Q12','Q13','Q14'],
-        'Process Compliance':['Q15','Q16','Q17','Q18']
+      actions.forEach(action => {
+        const row = document.createElement('div');
+        row.className = 'qa-action-item';
+        if (action.tone) {
+          row.dataset.tone = action.tone;
+        }
+
+        const icon = document.createElement('div');
+        icon.className = 'qa-action-icon';
+        icon.innerHTML = `<i class="fa-solid ${action.icon || 'fa-sparkles'}"></i>`;
+
+        const text = document.createElement('div');
+        text.className = 'qa-action-text';
+        const title = action.title ? `<strong>${action.title}</strong>` : '';
+        const body = action.text || '';
+        text.innerHTML = `${title}${body}`;
+
+        row.appendChild(icon);
+        row.appendChild(text);
+        dom.actions.appendChild(row);
+      });
+    }
+
+    function createDeltaBadge(delta) {
+      if (delta === null || delta === undefined || Number.isNaN(delta)) {
+        return '<span class="qa-delta-badge neutral">--</span>';
+      }
+      const tone = delta > 0 ? 'positive' : (delta < 0 ? 'negative' : 'neutral');
+      const value = Math.round(delta * 10) / 10;
+      const sign = value > 0 ? '+' : '';
+      return `<span class="qa-delta-badge ${tone}">${sign}${value}</span>`;
+    }
+
+    function renderCategories(categories) {
+      if (!dom.categoriesBody) return;
+      dom.categoriesBody.innerHTML = '';
+      if (!categories || !categories.length) {
+        const row = document.createElement('tr');
+        row.innerHTML = '<td colspan="3" class="text-center text-muted py-4">No category metrics available.</td>';
+        dom.categoriesBody.appendChild(row);
+        return;
+      }
+
+      categories.forEach(category => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>
+            <div class="fw-semibold">${category.category}</div>
+            <div class="text-muted small">${category.passPct || 0}% pass</div>
+          </td>
+          <td class="text-center fw-semibold">${category.avgScore || 0}%</td>
+          <td class="text-center">${createDeltaBadge(category.delta)}</td>`;
+        dom.categoriesBody.appendChild(row);
+      });
+    }
+
+    function renderAgents(agents) {
+      if (!dom.agentsBody) return;
+      dom.agentsBody.innerHTML = '';
+      if (!agents || !agents.length) {
+        const row = document.createElement('tr');
+        row.innerHTML = '<td colspan="4" class="text-center text-muted py-4">No agent performance captured yet.</td>';
+        dom.agentsBody.appendChild(row);
+        return;
+      }
+
+      agents.forEach(agent => {
+        const deltaScore = createDeltaBadge(agent.deltas ? agent.deltas.avgScore : null);
+        const deltaPass = createDeltaBadge(agent.deltas ? agent.deltas.passRate : null);
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>
+            <div class="fw-semibold">${agent.name}</div>
+            <div class="text-muted small">${agent.recentDate || 'No recent date'}</div>
+          </td>
+          <td class="text-center">
+            <div class="fw-semibold">${agent.avgScore || 0}%</div>
+            <div class="small">${deltaScore}</div>
+          </td>
+          <td class="text-center">
+            <div class="fw-semibold">${agent.passRate || 0}%</div>
+            <div class="small">${deltaPass}</div>
+          </td>
+          <td class="text-center fw-semibold">${agent.evaluations || 0}</td>`;
+        dom.agentsBody.appendChild(row);
+      });
+    }
+
+    function updateFiltersFromResponse(response) {
+      const periodOptions = (response && response.periodOptions) || [];
+      populateSelect(dom.period, periodOptions, 'Latest Period');
+      if (dom.period && response && response.context && response.context.period) {
+        dom.period.value = response.context.period;
+      }
+
+      const availableAgents = (response && response.availableAgents) || [];
+      const agentOptions = availableAgents.map(name => ({ value: name, label: name }));
+      populateSelect(dom.agent, agentOptions, 'All Agents');
+      if (dom.agent && state.filters.agent) {
+        dom.agent.value = state.filters.agent;
+      }
+
+      if (dom.granularity && response && response.context && response.context.granularity) {
+        dom.granularity.value = response.context.granularity;
+      }
+    }
+
+    function showError(message) {
+      if (!dom.error) return;
+      dom.error.textContent = message || 'Unable to load QA dashboard data.';
+      dom.error.classList.remove('d-none');
+    }
+
+    function clearError() {
+      if (!dom.error) return;
+      dom.error.classList.add('d-none');
+      dom.error.textContent = '';
+    }
+
+    function toggleEmptyState(visible) {
+      if (!dom.empty || !dom.content || !dom.lower) return;
+      dom.empty.classList.toggle('d-none', !visible);
+      dom.content.classList.toggle('d-none', Boolean(visible));
+      dom.lower.classList.toggle('d-none', Boolean(visible));
+    }
+
+    function handleResponse(response) {
+      setLoading(false);
+      if (!response || response.success === false) {
+        const errorMessage = response && response.error ? response.error : 'QA dashboard data unavailable.';
+        showError(errorMessage);
+        toggleEmptyState(true);
+        return;
+      }
+
+      clearError();
+      state.data = response;
+
+      updateFiltersFromResponse(response);
+
+      const summary = response.summary || null;
+      renderSummary(summary);
+
+      const trend = response.trend || null;
+      renderTrend(trend, response.context ? response.context.granularity : 'Week');
+
+      renderInsights(response.insights || []);
+      renderActions(response.actions || [], response.nextBest || null);
+      renderCategories(response.categories || []);
+      renderAgents((response.agents || []).slice(0, 8));
+
+      const hasEvaluations = summary && summary.evaluations > 0;
+      toggleEmptyState(!hasEvaluations);
+    }
+
+    function handleError(error) {
+      console.error('QA dashboard load failed:', error);
+      setLoading(false);
+      showError('Unable to reach the QA service. Please try again in a moment.');
+      toggleEmptyState(true);
+    }
+
+    function buildRequest() {
+      return {
+        granularity: state.filters.granularity,
+        period: state.filters.period,
+        agent: state.filters.agent,
+        campaignId: state.filters.campaignId,
+        program: state.filters.program
       };
+    }
 
-      rawQA = rawQA
-        .map((record, index) => QA_MONITOR.safe('normalizeClientQaRecord', () => normalizeClientQaRecord(record, index), {
-          rethrow: false,
-          context: { index },
-          defaultValue: null
-        }))
-        .filter(Boolean);
-
-      QA_MONITOR.log('QA records normalized', { recordCount: rawQA.length });
-
-      refreshDefaultPeriods(rawQA);
-
-      if (!DEFAULT_GRANULARITIES.includes(currentGran)) {
-        currentGran = 'Week';
+    function loadData() {
+      if (state.loading) {
+        return;
       }
 
-      if (!currentPeriod) {
-        currentPeriod = ensurePeriodForGranularity(currentGran, rawQA);
+      setLoading(true);
+      const request = buildRequest();
+
+      if (window.google && google.script && google.script.run) {
+        google.script.run
+          .withSuccessHandler(handleResponse)
+          .withFailureHandler(handleError)
+          .clientGetQADashboardSnapshot(request);
+      } else {
+        console.warn('google.script.run not available; QA dashboard operating in static mode.');
+        setLoading(false);
+        showError('Live data unavailable outside Google Workspace context.');
+        toggleEmptyState(true);
       }
+    }
 
-      syncPeriodInputs(currentGran, currentPeriod);
-
-      function safeToDate(value) {
-        return coerceDateValue(value);
-      }
-
-      function safeToISOString(dateValue) {
-          const date = safeToDate(dateValue);
-          return date ? date.toISOString() : null;
-      }
-
-      function toISOWeek(date) {
-        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-          return '';
-        }
-
-        const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-        let day = utcDate.getUTCDay();
-        if (day === 0) {
-          day = 7;
-        }
-
-        utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
-        const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
-        const diff = utcDate - yearStart;
-        const week = Math.ceil(((diff / 86400000) + 1) / 7);
-
-        return `${utcDate.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
-      }
-
-      function getQuarter(date) {
-        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-          return '';
-        }
-
-        const quarter = Math.floor(date.getMonth() / 3) + 1;
-        return `Q${quarter}`;
-      }
-
-      function normalizeKeyName(key) {
-        return String(key || '')
-          .toLowerCase()
-          .replace(/[^a-z0-9]/g, '');
-      }
-
-      function getRecordField(record, candidates) {
-        if (!record || typeof record !== 'object') {
-          return null;
-        }
-
-        const lookup = {};
-        Object.keys(record).forEach(existingKey => {
-          const normalized = normalizeKeyName(existingKey);
-          if (!(normalized in lookup)) {
-            lookup[normalized] = existingKey;
-          }
-        });
-
-        for (let i = 0; i < candidates.length; i += 1) {
-          const normalizedKey = normalizeKeyName(candidates[i]);
-          const actualKey = lookup[normalizedKey];
-          if (actualKey && record[actualKey] !== undefined && record[actualKey] !== null && record[actualKey] !== '') {
-            return record[actualKey];
-          }
-        }
-
-        return null;
-      }
-
-      function clamp01(value) {
-        if (!isFinite(value)) {
-          return 0;
-        }
-        if (value < 0) return 0;
-        if (value > 1) return 1;
-        return value;
-      }
-
-      function parsePercentageValue(value) {
-        if (value === null || value === undefined || value === '') {
-          return 0;
-        }
-
-        if (typeof value === 'number' && isFinite(value)) {
-          const normalized = value > 1.0001 ? value / 100 : value;
-          return clamp01(normalized);
-        }
-
-        const numeric = parseFloat(String(value).replace(/[^0-9.\-]/g, ''));
-        if (!isFinite(numeric)) {
-          return 0;
-        }
-
-        const normalized = numeric > 1.0001 ? numeric / 100 : numeric;
-        return clamp01(normalized);
-      }
-
-      function excelSerialToDate(serial) {
-        if (typeof serial !== 'number' || !isFinite(serial)) {
-          return null;
-        }
-
-        if (serial <= 60) {
-          return null;
-        }
-
-        const utcDays = Math.floor(serial - 25569);
-        const utcMilliseconds = utcDays * 86400000;
-        const remainder = serial - Math.floor(serial);
-        const remainderMs = Math.round(remainder * 86400000);
-        const date = new Date(utcMilliseconds + remainderMs);
-        return isNaN(date.getTime()) ? null : date;
-      }
-
-      function parseFlexibleDateString(raw) {
-        if (!raw) {
-          return null;
-        }
-
-        const value = String(raw).trim();
-        if (!value) {
-          return null;
-        }
-
-        if (/^\d+(\.\d+)?$/.test(value)) {
-          const asNumber = parseFloat(value);
-          const excelDate = excelSerialToDate(asNumber);
-          if (excelDate) {
-            return excelDate;
-          }
-        }
-
-        if (/^\d{8}$/.test(value)) {
-          const year = Number(value.slice(0, 4));
-          const month = Number(value.slice(4, 6)) - 1;
-          const day = Number(value.slice(6, 8));
-          const ymdDate = new Date(year, month, day);
-          if (!isNaN(ymdDate.getTime())) {
-            return ymdDate;
-          }
-        }
-
-        let parsed = new Date(value);
-        if (!isNaN(parsed.getTime())) {
-          return parsed;
-        }
-
-        if (value.includes(' ') && !value.includes('T')) {
-          parsed = new Date(value.replace(' ', 'T'));
-          if (!isNaN(parsed.getTime())) {
-            return parsed;
-          }
-        }
-
-        const parts = value.split(/[\/\-]/).map(part => part.trim());
-        if (parts.length === 3 && parts.every(part => /^\d+$/.test(part))) {
-          let [p1, p2, p3] = parts.map(Number);
-          if (p3 < 100) {
-            p3 = p3 < 50 ? 2000 + p3 : 1900 + p3;
-          }
-
-          let month;
-          let day;
-          let year;
-
-          if (p1 > 12 && p2 <= 12) {
-            day = p1;
-            month = p2;
-            year = p3;
-          } else if (p2 > 12 && p1 <= 12) {
-            month = p1;
-            day = p2;
-            year = p3;
-          } else {
-            month = p1;
-            day = p2;
-            year = p3;
-          }
-
-          const manualDate = new Date(year, month - 1, day);
-          if (!isNaN(manualDate.getTime())) {
-            return manualDate;
-          }
-        }
-
-        return null;
-      }
-
-      function coerceDateValue(value) {
-        if (value === null || value === undefined || value === '') {
-          return null;
-        }
-
-        if (value instanceof Date) {
-          return isNaN(value.getTime()) ? null : value;
-        }
-
-        if (typeof value === 'number' && isFinite(value)) {
-          const excelDate = excelSerialToDate(value);
-          if (excelDate) {
-            return excelDate;
-          }
-
-          const numericDate = new Date(value);
-          return isNaN(numericDate.getTime()) ? null : numericDate;
-        }
-
-        return parseFlexibleDateString(value);
-      }
-
-      function startOfIsoWeek(year, week) {
-        if (!year || !week) return null;
-        const reference = new Date(Date.UTC(year, 0, 4));
-        let day = reference.getUTCDay();
-        if (day === 0) day = 7;
-        reference.setUTCDate(reference.getUTCDate() - day + 1);
-        reference.setUTCDate(reference.getUTCDate() + (week - 1) * 7);
-        return reference;
-      }
-
-      function isoWeeksInYear(year) {
-        if (!year) return 52;
-        const dec28 = new Date(Date.UTC(year, 11, 28));
-        let decDay = dec28.getUTCDay();
-        if (decDay === 0) decDay = 7;
-        dec28.setUTCDate(dec28.getUTCDate() + (4 - decDay));
-
-        const jan4 = new Date(Date.UTC(year, 0, 4));
-        let janDay = jan4.getUTCDay();
-        if (janDay === 0) janDay = 7;
-        jan4.setUTCDate(jan4.getUTCDate() + (4 - janDay));
-
-        const diff = dec28.getTime() - jan4.getTime();
-        return Math.round(diff / 604800000) + 1;
-      }
-
-      function parseIsoWeek(period) {
-        const match = /^(\d{4})-W(\d{2})$/.exec(period || '');
-        if (!match) return null;
-        const year = Number(match[1]);
-        const week = Number(match[2]);
-        if (!year || !week) return null;
-        return { year, week };
-      }
-
-      function toBiWeeklyPeriod(date) {
-        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-          return '';
-        }
-        if (typeof toISOWeek !== 'function') {
-          return '';
-        }
-        const iso = toISOWeek(date);
-        const parsed = parseIsoWeek(iso);
-        if (!parsed) return '';
-        const biIndex = Math.ceil(parsed.week / 2);
-        return `${parsed.year}-BW${String(biIndex).padStart(2, '0')}`;
-      }
-
-      function parseBiWeeklyPeriod(period) {
-        const match = /^(\d{4})-BW(\d{2})$/.exec(period || '');
-        if (!match) return null;
-        const year = Number(match[1]);
-        const biIndex = Number(match[2]);
-        if (!year || !biIndex) return null;
-        const firstWeek = (biIndex - 1) * 2 + 1;
-        return { year, biIndex, firstWeek };
-      }
-
-      function biWeeklySortValue(period) {
-        const parsed = parseBiWeeklyPeriod(period);
-        if (!parsed) return 0;
-        const start = startOfIsoWeek(parsed.year, parsed.firstWeek);
-        return start ? start.getTime() : 0;
-      }
-
-      function previousBiWeeklyPeriod(period) {
-        const parsed = parseBiWeeklyPeriod(period);
-        if (!parsed) return '';
-        let { year, firstWeek } = parsed;
-        firstWeek -= 2;
-        if (firstWeek < 1) {
-          year -= 1;
-          const lastWeek = isoWeeksInYear(year);
-          const lastBiIndex = Math.ceil(lastWeek / 2);
-          return `${year}-BW${String(lastBiIndex).padStart(2, '0')}`;
-        }
-        const biIndex = Math.ceil(firstWeek / 2);
-        return `${year}-BW${String(biIndex).padStart(2, '0')}`;
-      }
-
-      function getPreviousPeriod(granularity, period) {
-        if (!period) return '';
-        try {
-          switch (granularity) {
-            case 'Week': {
-              const parsed = parseIsoWeek(period);
-              if (!parsed) return '';
-              let { year, week } = parsed;
-              week -= 1;
-              if (week < 1) {
-                year -= 1;
-                week = isoWeeksInYear(year);
-              }
-              return `${year}-W${String(week).padStart(2, '0')}`;
-            }
-            case 'Bi-Weekly':
-              return previousBiWeeklyPeriod(period);
-            case 'Month': {
-              const match = /^(\d{4})-(\d{2})$/.exec(period || '');
-              if (!match) return '';
-              let year = Number(match[1]);
-              let month = Number(match[2]) - 1;
-              if (month < 1) {
-                year -= 1;
-                month = 12;
-              }
-              return `${year}-${String(month).padStart(2, '0')}`;
-            }
-            case 'Quarter': {
-              const match = /^Q([1-4])-(\d{4})$/.exec(period || '');
-              if (!match) return '';
-              let quarter = Number(match[1]) - 1;
-              let year = Number(match[2]);
-              if (quarter < 1) {
-                quarter = 4;
-                year -= 1;
-              }
-              return `Q${quarter}-${year}`;
-            }
-            case 'Year':
-              return String(Number(period) - 1);
-            default:
-              return '';
-          }
-        } catch (error) {
-          QA_MONITOR.warn('getPreviousPeriod failed', {
-            granularity,
-            period,
-            message: error?.message,
-            stack: error?.stack || null
-          });
-          return '';
-        }
-      }
-
-      function normalizeClientQaRecord(record, index) {
-        const normalized = { ...record };
-
-        const agentValue = getRecordField(record, ['AgentName', 'Agent Name', 'Agent', 'AgentEmail', 'Agent Email', 'Associate']);
-        const campaignValue = getRecordField(record, ['Campaign', 'Campaign Name', 'Program', 'Program Name', 'Line Of Business', 'LineOfBusiness', 'LOB']);
-        const percentageValue = getRecordField(record, ['Percentage', 'QA Score', 'QA%', 'QA %', 'Final Score', 'FinalScore', 'Score', 'Overall Score']);
-        const callDateValue = getRecordField(record, ['CallDate', 'Call Date', 'CallTime', 'Call Time', 'EvaluationDate', 'Evaluation Date', 'QA Date', 'Date', 'Timestamp']);
-
-        const agentName = agentValue ? String(agentValue).trim() : '';
-        const campaign = campaignValue ? String(campaignValue).trim() : '';
-        const callDate = coerceDateValue(callDateValue);
-        const percentage = parsePercentageValue(percentageValue);
-
-        if (agentName) {
-          normalized.AgentName = agentName;
-        } else if (!normalized.AgentName) {
-          normalized.AgentName = 'Unassigned';
-        }
-
-        if (campaign) {
-          normalized.Campaign = campaign;
-        }
-
-        normalized.Percentage = percentage;
-        normalized.callDateObj = callDate;
-        normalized.CallDate = callDate instanceof Date ? callDate.toISOString() : null;
-        normalized.__recordIndex = index;
-
-        return normalized;
-      }
-
-      function isValidDate(dateValue) {
-          return safeToDate(dateValue) !== null;
-      }
-      
-      let dailyChart, agentChart, categoryChart, trendSparklineChart;
-
-      function showLoader(detail = 'Loading QA metrics…') {
-        const loaderApi = window.LuminaLoader;
-        loaderApi?.show({
-          title: 'Refreshing QA Dashboard',
-          detail,
-          tip: 'Crunching performance metrics…',
-          progress: 25
+    function attachEvents() {
+      if (dom.refresh) {
+        dom.refresh.addEventListener('click', () => {
+          loadData();
         });
       }
 
-      function updateAITrendPanel({ series, granularity }, analysisOverride = null) {
-        const summaryEl = document.getElementById('aiTrendSummary');
-        const listEl = document.getElementById('aiTrendList');
-        const forecastEl = document.getElementById('aiTrendForecast');
-        const healthEl = document.getElementById('aiTrendHealth');
-
-        if (!summaryEl || !listEl) {
-          return;
-        }
-
-        const analysis = analysisOverride || analyzeTrendSeries(series, { granularity });
-
-        summaryEl.textContent = analysis.summary;
-        listEl.innerHTML = '';
-
-        if (analysis.points.length) {
-          listEl.innerHTML = analysis.points.map(point => {
-            const tone = point.tone ? ` ${point.tone}` : '';
-            return `<li class="ai-insight-item${tone}"><div class="ai-icon"><i class="fas ${point.icon}"></i></div><div class="ai-insight-content"><strong>${point.title}</strong><span>${point.text}</span></div></li>`;
-          }).join('');
-        } else {
-          listEl.innerHTML = '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>No trend data yet</strong><span>Capture a few periods of QA to unlock longitudinal intelligence.</span></div></li>';
-        }
-      }
-
-      function computeCategoryMetrics(data){
-        const out={};
-        Object.entries(categories).forEach(([cat,keys])=>{
-          const scores=[], passes=[];
-          data.forEach(r=>{
-            const ans=keys.map(k=>(r[k]||'').toString().toLowerCase()==='yes');
-            const earned=keys.reduce((s,k,i)=> s + (ans[i]?weightsMap[k]:0),0);
-            const totalW=keys.reduce((s,k)=> s + weightsMap[k],0);
-            scores.push(totalW? Math.round(earned/totalW*100):0);
-            passes.push(ans.every(Boolean)?1:0);
-          });
-          const avgScore=scores.length? Math.round(scores.reduce((a,b)=>a+b,0)/scores.length):0;
-          const passPct=passes.length? Math.round(passes.reduce((a,b)=>a+b,0)/passes.length*100):0;
-          out[cat]={ avgScore, passPct };
-        });
-        return out;
-      }
-
-      function formatPeriodLabel(granularity, period) {
-        if (!period) return 'Period';
-        switch (granularity) {
-          case 'Week':
-            if (/^(\d{4})-W(\d{2})$/.test(period)) {
-              const [, year, week] = period.match(/^(\d{4})-W(\d{2})$/);
-              return `W${week} ${year}`;
-            }
-            return period;
-          case 'Bi-Weekly': {
-            const parsed = parseBiWeeklyPeriod(period);
-            if (!parsed) return period;
-            return `Bi-Wk ${String(parsed.biIndex).padStart(2, '0')} ${parsed.year}`;
-          }
-          case 'Month': {
-            const [y, m] = period.split('-');
-            const date = new Date(Number(y), Number(m) - 1, 1);
-            return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
-          }
-          case 'Quarter':
-            return period.replace('-', ' ');
-          case 'Year':
-            return period;
-          default:
-            return period;
-        }
-      }
-
-      function filterRecordsByPeriod(data, granularity, periodValue) {
-        if (!periodValue) return [];
-        return data.filter(record => {
-          const dt = record.callDateObj;
-          if (!dt) return false;
-          try {
-            switch (granularity) {
-              case 'Week':
-                return toISOWeek(dt) === periodValue;
-              case 'Bi-Weekly':
-                return toBiWeeklyPeriod(dt) === periodValue;
-              case 'Month':
-                return dt.toISOString().slice(0, 7) === periodValue;
-              case 'Quarter':
-                return `${getQuarter(dt)}-${dt.getFullYear()}` === periodValue;
-              case 'Year':
-                return String(dt.getFullYear()) === periodValue;
-              default:
-                return true;
-            }
-          } catch (err) {
-            QA_MONITOR.warn('filterRecordsByPeriod error', {
-              granularity,
-              periodValue,
-              recordIndex: data.indexOf(record),
-              message: err?.message,
-              stack: err?.stack || null
-            });
-            return false;
-          }
+      if (dom.granularity) {
+        dom.granularity.addEventListener('change', event => {
+          state.filters.granularity = event.target.value;
+          state.filters.period = '';
+          loadData();
         });
       }
 
-      function deriveLatestPeriod(granularity, data) {
-        if (!Array.isArray(data) || !data.length) return '';
-        const valid = data
-          .filter(item => item && item.callDateObj instanceof Date && !Number.isNaN(item.callDateObj.getTime()))
-          .sort((a, b) => b.callDateObj - a.callDateObj);
-
-        if (!valid.length) {
-          return '';
-        }
-
-        const latest = valid[0].callDateObj;
-        switch (granularity) {
-          case 'Week':
-            return toISOWeek(latest);
-          case 'Bi-Weekly':
-            return toBiWeeklyPeriod(latest);
-          case 'Month':
-            return latest.toISOString().slice(0, 7);
-          case 'Quarter':
-            return `${getQuarter(latest)}-${latest.getFullYear()}`;
-          case 'Year':
-            return String(latest.getFullYear());
-          default:
-            return '';
-        }
-      }
-
-      function periodSortValue(granularity, period) {
-        if (!period) return 0;
-        try {
-          switch (granularity) {
-            case 'Week': {
-              const match = period.match(/^(\d{4})-W(\d{2})$/);
-              if (!match) return 0;
-              const year = Number(match[1]);
-              const week = Number(match[2]);
-              const simple = new Date(Date.UTC(year, 0, 1));
-              const day = simple.getUTCDay() || 7;
-              simple.setUTCDate(simple.getUTCDate() + (week - 1) * 7 + (1 - day));
-              return simple.getTime();
-            }
-            case 'Bi-Weekly':
-              return biWeeklySortValue(period);
-            case 'Month': {
-              const [y, m] = period.split('-').map(Number);
-              if (!y || !m) return 0;
-              return new Date(Date.UTC(y, m - 1, 1)).getTime();
-            }
-            case 'Quarter': {
-              const match = period.match(/^Q([1-4])-(\d{4})$/);
-              if (!match) return 0;
-              const quarterIndex = Number(match[1]) - 1;
-              const year = Number(match[2]);
-              return new Date(Date.UTC(year, quarterIndex * 3, 1)).getTime();
-            }
-            case 'Year':
-              return new Date(Date.UTC(Number(period), 0, 1)).getTime();
-            default:
-              return 0;
-          }
-        } catch (err) {
-          QA_MONITOR.warn('periodSortValue failed', {
-            granularity,
-            period,
-            message: err?.message,
-            stack: err?.stack || null
-          });
-          return 0;
-        }
-      }
-
-      function derivePeriodsForGranularity(granularity, data) {
-        if (!Array.isArray(data) || !data.length) {
-          return [];
-        }
-
-        const set = new Set();
-        data.forEach(item => {
-          const dt = item?.callDateObj;
-          if (!(dt instanceof Date) || Number.isNaN(dt.getTime())) {
-            return;
-          }
-          try {
-            switch (granularity) {
-              case 'Week':
-                set.add(toISOWeek(dt));
-                break;
-              case 'Bi-Weekly':
-                set.add(toBiWeeklyPeriod(dt));
-                break;
-              case 'Month':
-                set.add(dt.toISOString().slice(0, 7));
-                break;
-              case 'Quarter':
-                set.add(`${getQuarter(dt)}-${dt.getFullYear()}`);
-                break;
-              case 'Year':
-                set.add(String(dt.getFullYear()));
-                break;
-              default:
-                break;
-            }
-          } catch (err) {
-            QA_MONITOR.warn('derivePeriodsForGranularity error', {
-              granularity,
-              itemIndex: data.indexOf(item),
-              message: err?.message,
-              stack: err?.stack || null
-            });
-          }
-        });
-
-        const sorted = Array.from(set)
-          .filter(Boolean)
-          .sort((a, b) => periodSortValue(granularity, b) - periodSortValue(granularity, a));
-
-        const limitMap = {
-          Week: 104,
-          'Bi-Weekly': 52,
-          Month: 36,
-          Quarter: 16,
-          Year: 12
-        };
-
-        const limit = limitMap[granularity] || sorted.length;
-        return sorted.slice(0, limit);
-      }
-
-      function refreshDefaultPeriods(data) {
-        DEFAULT_GRANULARITIES.forEach(granularity => {
-          const periods = derivePeriodsForGranularity(granularity, data);
-          availablePeriods[granularity] = periods;
-
-          if (periods.length === 0) {
-            delete defaultPeriods[granularity];
-            return;
-          }
-
-          if (!defaultPeriods[granularity] || !periods.includes(defaultPeriods[granularity])) {
-            defaultPeriods[granularity] = periods[0];
-          }
+      if (dom.period) {
+        dom.period.addEventListener('change', event => {
+          state.filters.period = event.target.value;
+          loadData();
         });
       }
 
-      function isPeriodInData(granularity, period, data) {
-        if (!period) return false;
-        const matches = filterRecordsByPeriod(data, granularity, period);
-        return matches.length > 0;
-      }
-
-      function ensurePeriodForGranularity(granularity, data) {
-        const normalizedGranularity = DEFAULT_GRANULARITIES.includes(granularity) ? granularity : 'Week';
-
-        const periods = availablePeriods[normalizedGranularity]?.length
-          ? availablePeriods[normalizedGranularity]
-          : derivePeriodsForGranularity(normalizedGranularity, data);
-
-        if (!availablePeriods[normalizedGranularity] || !availablePeriods[normalizedGranularity].length) {
-          availablePeriods[normalizedGranularity] = periods;
-        }
-
-        if (currentPeriod && periods.includes(currentPeriod)) {
-          defaultPeriods[normalizedGranularity] = currentPeriod;
-          return currentPeriod;
-        }
-
-        if (defaultPeriods[normalizedGranularity] && periods.includes(defaultPeriods[normalizedGranularity])) {
-          currentPeriod = defaultPeriods[normalizedGranularity];
-          return currentPeriod;
-        }
-
-        if (periods.length) {
-          currentPeriod = periods[0];
-          defaultPeriods[normalizedGranularity] = currentPeriod;
-          return currentPeriod;
-        }
-
-        currentPeriod = '';
-        delete defaultPeriods[normalizedGranularity];
-        return currentPeriod;
-      }
-
-      function syncPeriodInputs(granularity, period) {
-        const weekInput = document.getElementById('weekInput');
-        if (weekInput) {
-          weekInput.value = granularity === 'Week' ? (period || '') : '';
-        }
-
-        const monthInput = document.getElementById('monthInput');
-        if (monthInput) {
-          monthInput.value = granularity === 'Month' ? (period || '') : '';
-        }
-
-        const yearInput = document.getElementById('yearInput');
-        if (yearInput) {
-          yearInput.value = granularity === 'Year' ? (period || '') : '';
-        }
-
-        const quarterSelect = document.getElementById('quarterSelect');
-        const quarterYearInput = document.getElementById('quarterYearInput');
-        if (quarterSelect && quarterYearInput) {
-          if (granularity === 'Quarter' && period) {
-            const match = /^Q([1-4])-(\d{4})$/.exec(period);
-            if (match) {
-              quarterSelect.value = `Q${match[1]}`;
-              quarterYearInput.value = match[2];
-            }
-          } else if (granularity === 'Quarter' && !period) {
-            quarterYearInput.value = '';
-          }
-        }
-
-        const periodSelect = document.getElementById('periodSelect');
-        if (periodSelect) {
-          const periods = availablePeriods[granularity] || [];
-
-          if (period && !periods.includes(period)) {
-            const optionExists = Array.from(periodSelect.options).some(opt => opt.value === period);
-            if (!optionExists) {
-              const opt = document.createElement('option');
-              opt.value = period;
-              opt.textContent = formatPeriodLabel(granularity, period);
-              opt.dataset.synthetic = 'true';
-              periodSelect.appendChild(opt);
-            }
-          }
-
-          if (period) {
-            periodSelect.value = period;
-          } else {
-            periodSelect.value = '';
-          }
-        }
-      }
-
-      function refreshPeriodSelectOptions() {
-        const periodSelect = document.getElementById('periodSelect');
-        if (!periodSelect) {
-          return;
-        }
-
-        const periods = availablePeriods[currentGran] || [];
-        const previousValue = periodSelect.value;
-
-        periodSelect.innerHTML = '';
-
-        if (!periods.length) {
-          const placeholder = document.createElement('option');
-          placeholder.value = '';
-          placeholder.textContent = 'No periods available';
-          placeholder.disabled = true;
-          placeholder.selected = true;
-          periodSelect.appendChild(placeholder);
-          periodSelect.disabled = true;
-          currentPeriod = '';
-          delete defaultPeriods[currentGran];
-          return;
-        }
-
-        periodSelect.disabled = false;
-
-        periods.forEach(period => {
-          const option = document.createElement('option');
-          option.value = period;
-          option.textContent = formatPeriodLabel(currentGran, period);
-          periodSelect.appendChild(option);
-        });
-
-        const hasCurrent = currentPeriod && periods.includes(currentPeriod);
-        const fallback = hasCurrent
-          ? currentPeriod
-          : (defaultPeriods[currentGran] && periods.includes(defaultPeriods[currentGran])
-            ? defaultPeriods[currentGran]
-            : periods[0]);
-
-        if (fallback) {
-          currentPeriod = fallback;
-          defaultPeriods[currentGran] = fallback;
-          periodSelect.value = fallback;
-        } else {
-          periodSelect.value = '';
-        }
-
-        if (previousValue && previousValue !== periodSelect.value) {
-          QA_MONITOR.log('Period selection realigned', {
-            from: previousValue,
-            to: periodSelect.value,
-            granularity: currentGran
-          });
-        }
-
-        syncPeriodInputs(currentGran, currentPeriod);
-      }
-
-      function buildTrendSeries(granularity, currentPeriod, data, depth = 4) {
-        const series = [];
-        let cursor = currentPeriod;
-        let steps = 0;
-        const visited = new Set();
-
-        while (cursor && steps < depth && !visited.has(cursor)) {
-          visited.add(cursor);
-          const bucket = filterRecordsByPeriod(data, granularity, cursor);
-          const evalCount = bucket.length;
-          const agentCount = new Set(bucket.map(r => r.AgentName)).size;
-          const avgScore = evalCount ? Math.round(bucket.reduce((sum, r) => sum + (r.Percentage || 0), 0) / evalCount * 100) : 0;
-          const passRate = safePercentage(bucket.filter(r => r.Percentage >= PASS_MARK).length, evalCount);
-          const coverage = userList.length ? safePercentage(agentCount, userList.length) : (agentCount > 0 ? 100 : 0);
-
-          series.push({
-            period: cursor,
-            label: formatPeriodLabel(granularity, cursor),
-            avgScore,
-            passRate,
-            evalCount,
-            agentCount,
-            coverage
-          });
-
-          cursor = getPreviousPeriod(granularity, cursor);
-          steps += 1;
-        }
-
-        return series.reverse();
-      }
-
-      function linearRegression(points) {
-        if (!points || !points.length) {
-          return { slope: 0, intercept: 0 };
-        }
-
-        if (points.length === 1) {
-          return { slope: 0, intercept: points[0].y };
-        }
-
-        const n = points.length;
-        let sumX = 0;
-        let sumY = 0;
-        let sumXY = 0;
-        let sumXX = 0;
-
-        points.forEach(point => {
-          sumX += point.x;
-          sumY += point.y;
-          sumXY += point.x * point.y;
-          sumXX += point.x * point.x;
-        });
-
-        const denominator = (n * sumXX) - (sumX * sumX);
-        if (denominator === 0) {
-          return { slope: 0, intercept: sumY / n };
-        }
-
-        const slope = ((n * sumXY) - (sumX * sumY)) / denominator;
-        const intercept = (sumY - slope * sumX) / n;
-        return { slope, intercept };
-      }
-
-      function clampPercent(value) {
-        if (Number.isNaN(value)) return 0;
-        return Math.max(0, Math.min(100, Math.round(value)));
-      }
-
-      function analyzeTrendSeries(series, context = {}) {
-        const { granularity = 'Period' } = context;
-        const lowerGran = granularity.toLowerCase();
-
-        if (!series || !series.length) {
-          return {
-            summary: `Trend radar is waiting for enough history to analyze ${lowerGran} trends.`,
-            points: [],
-            health: 'monitoring',
-            forecast: { avg: 0, pass: 0 },
-            nextLabel: `next ${lowerGran}`
-          };
-        }
-
-        const first = series[0];
-        const last = series[series.length - 1];
-
-        const avgPoints = series.map((point, index) => ({ x: index, y: point.avgScore }));
-        const passPoints = series.map((point, index) => ({ x: index, y: point.passRate }));
-        const avgReg = linearRegression(avgPoints);
-        const passReg = linearRegression(passPoints);
-
-        const avgDelta = last.avgScore - first.avgScore;
-        const passDelta = last.passRate - first.passRate;
-        const volumeDelta = last.evalCount - first.evalCount;
-
-        const slopeAvg = avgReg.slope;
-        const slopePass = passReg.slope;
-
-        const improving = slopeAvg > 0.5 || slopePass > 0.5;
-        const declining = slopeAvg < -0.5 || slopePass < -0.5;
-
-        let health = 'stable';
-        if (improving) health = 'improving';
-        if (declining) health = 'risk';
-
-        const summaryParts = [];
-        summaryParts.push(`Average quality is ${avgDelta >= 0 ? 'up' : 'down'} ${Math.abs(avgDelta).toFixed(1)} pts`);
-        summaryParts.push(`pass rate ${passDelta >= 0 ? 'gained' : 'slid'} ${Math.abs(passDelta).toFixed(1)} pts`);
-        summaryParts.push(`${last.evalCount} evaluations this ${lowerGran}`);
-
-        const points = [];
-
-        points.push({
-          icon: improving ? 'fa-arrow-up' : declining ? 'fa-arrow-down' : 'fa-arrows-alt-h',
-          tone: improving ? 'positive' : declining ? 'negative' : '',
-          title: `Average score ${improving ? 'rising' : declining ? 'dropping' : 'steady'}`,
-          text: `${first.avgScore}% → ${last.avgScore}% across the last ${series.length} ${series.length === 1 ? lowerGran : lowerGran + 's'}.`
-        });
-
-        points.push({
-          icon: passDelta >= 0 ? 'fa-shield-alt' : 'fa-exclamation-triangle',
-          tone: passDelta >= 0 ? 'positive' : 'negative',
-          title: `Pass rate ${passDelta >= 0 ? 'improving' : 'at risk'}`,
-          text: `${first.passRate}% → ${last.passRate}% (${passDelta >= 0 ? '+' : ''}${passDelta.toFixed(1)} pts).`
-        });
-
-        if (Math.abs(volumeDelta) > 0) {
-          points.push({
-            icon: volumeDelta >= 0 ? 'fa-users' : 'fa-user-slash',
-            tone: volumeDelta >= 0 ? 'positive' : 'negative',
-            title: `Evaluation volume ${volumeDelta >= 0 ? 'growing' : 'contracting'}`,
-            text: `${first.evalCount} → ${last.evalCount} evaluations (${volumeDelta >= 0 ? '+' : ''}${volumeDelta}).`
-          });
-        } else {
-          points.push({
-            icon: 'fa-stopwatch',
-            tone: '',
-            title: 'Volume steady',
-            text: `Evaluation count steady at ${last.evalCount} per ${lowerGran}.`
-          });
-        }
-
-        if (last.coverage < 80) {
-          points.push({
-            icon: 'fa-user-shield',
-            tone: 'negative',
-            title: 'Coverage gap detected',
-            text: `Only ${last.coverage}% of agents covered in the latest ${lowerGran}.`
-          });
-        }
-
-        const avgForecast = clampPercent(avgReg.intercept + avgReg.slope * avgPoints.length);
-        const passForecast = clampPercent(passReg.intercept + passReg.slope * passPoints.length);
-
-        const summary = `${summaryParts.join(', ')}.`;
-
-        return {
-          summary,
-          points,
-          health,
-          forecast: { avg: avgForecast, pass: passForecast },
-          nextLabel: `next ${lowerGran}`
-        };
-      }
-
-      function renderTrendSparkline(series, granularity) {
-        const visual = document.getElementById('aiTrendVisual');
-        const canvas = document.getElementById('aiTrendSparkline');
-
-        if (!visual || !canvas) {
-          return;
-        }
-
-        if (!series || !series.length) {
-          visual.style.display = 'none';
-          if (trendSparklineChart) {
-            trendSparklineChart.destroy();
-            trendSparklineChart = null;
-          }
-          return;
-        }
-
-        visual.style.display = '';
-
-        if (trendSparklineChart) {
-          trendSparklineChart.destroy();
-          trendSparklineChart = null;
-        }
-
-        const labels = series.map(point => point.label || formatPeriodLabel(granularity, point.period));
-        const avgData = series.map(point => point.avgScore);
-        const passData = series.map(point => point.passRate);
-
-        trendSparklineChart = new Chart(canvas, {
-          type: 'line',
-          data: {
-            labels,
-            datasets: [
-              {
-                label: 'Avg Score',
-                data: avgData,
-                borderColor: '#6366f1',
-                backgroundColor: 'rgba(99,102,241,0.15)',
-                tension: 0.4,
-                pointRadius: 4,
-                pointBackgroundColor: '#6366f1',
-                fill: true
-              },
-              {
-                label: 'Pass Rate',
-                data: passData,
-                borderColor: '#10b981',
-                backgroundColor: 'rgba(16,185,129,0.12)',
-                tension: 0.4,
-                pointRadius: 4,
-                pointBackgroundColor: '#10b981',
-                fill: true
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: {
-                display: true,
-                labels: {
-                  usePointStyle: true,
-                  font: {
-                    family: "'Google Sans', sans-serif",
-                    size: 11
-                  }
-                }
-              },
-              tooltip: {
-                backgroundColor: 'rgba(15,23,42,0.9)',
-                titleColor: '#fff',
-                bodyColor: '#e2e8f0',
-                cornerRadius: 10,
-                padding: 10
-              }
-            },
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 100,
-                grid: { color: 'rgba(15,23,42,0.05)' },
-                ticks: { font: { family: "'Google Sans', sans-serif" } }
-              },
-              x: {
-                grid: { display: false },
-                ticks: { font: { family: "'Google Sans', sans-serif" } }
-              }
-            }
-          }
+      if (dom.agent) {
+        dom.agent.addEventListener('change', event => {
+          state.filters.agent = event.target.value;
+          loadData();
         });
       }
-
-      function updateAITrendPanel({ series, granularity }, analysisOverride = null) {
-        const summaryEl = document.getElementById('aiTrendSummary');
-        const listEl = document.getElementById('aiTrendList');
-        const forecastEl = document.getElementById('aiTrendForecast');
-        const healthEl = document.getElementById('aiTrendHealth');
-
-        if (!summaryEl || !listEl) {
-          return;
-        }
-
-        const analysis = analysisOverride || analyzeTrendSeries(series, { granularity });
-
-        summaryEl.textContent = analysis.summary;
-        listEl.innerHTML = '';
-
-        if (analysis.points.length) {
-          listEl.innerHTML = analysis.points.map(point => {
-            const tone = point.tone ? ` ${point.tone}` : '';
-            return `<li class="ai-insight-item${tone}"><div class="ai-icon"><i class="fas ${point.icon}"></i></div><div class="ai-insight-content"><strong>${point.title}</strong><span>${point.text}</span></div></li>`;
-          }).join('');
-        } else {
-          listEl.innerHTML = '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>No trend data yet</strong><span>Capture a few periods of QA to unlock longitudinal intelligence.</span></div></li>';
-        }
-
-      function computeCategoryMetrics(data){
-        const out={};
-        Object.entries(categories).forEach(([cat,keys])=>{
-          const scores=[], passes=[];
-          data.forEach(r=>{
-            const ans=keys.map(k=>(r[k]||'').toString().toLowerCase()==='yes');
-            const earned=keys.reduce((s,k,i)=> s + (ans[i]?weightsMap[k]:0),0);
-            const totalW=keys.reduce((s,k)=> s + weightsMap[k],0);
-            scores.push(totalW? Math.round(earned/totalW*100):0);
-            passes.push(ans.every(Boolean)?1:0);
-          });
-          const avgScore=scores.length? Math.round(scores.reduce((a,b)=>a+b,0)/scores.length):0;
-          const passPct=passes.length? Math.round(passes.reduce((a,b)=>a+b,0)/passes.length*100):0;
-          out[cat]={ avgScore, passPct };
-        });
-        return out;
-      }
-
-      function formatPeriodLabel(granularity, period) {
-        if (!period) return 'Period';
-        switch (granularity) {
-          case 'Week':
-            if (/^(\d{4})-W(\d{2})$/.test(period)) {
-              const [, year, week] = period.match(/^(\d{4})-W(\d{2})$/);
-              return `W${week} ${year}`;
-            }
-            return period;
-          case 'Bi-Weekly': {
-            const parsed = parseBiWeeklyPeriod(period);
-            if (!parsed) return period;
-            return `Bi-Wk ${String(parsed.biIndex).padStart(2, '0')} ${parsed.year}`;
-          }
-          case 'Month': {
-            const [y, m] = period.split('-');
-            const date = new Date(Number(y), Number(m) - 1, 1);
-            return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
-          }
-          case 'Quarter':
-            return period.replace('-', ' ');
-          case 'Year':
-            return period;
-          default:
-            return period;
-        }
-      }
-
-      function filterRecordsByPeriod(data, granularity, periodValue) {
-        if (!periodValue) return [];
-        return data.filter(record => {
-          const dt = record.callDateObj;
-          if (!dt) return false;
-          try {
-            switch (granularity) {
-              case 'Week':
-                return toISOWeek(dt) === periodValue;
-              case 'Bi-Weekly':
-                return toBiWeeklyPeriod(dt) === periodValue;
-              case 'Month':
-                return dt.toISOString().slice(0, 7) === periodValue;
-              case 'Quarter':
-                return `${getQuarter(dt)}-${dt.getFullYear()}` === periodValue;
-              case 'Year':
-                return String(dt.getFullYear()) === periodValue;
-              default:
-                return true;
-            }
-          } catch (err) {
-            QA_MONITOR.warn('filterRecordsByPeriod error', {
-              granularity,
-              periodValue,
-              recordIndex: data.indexOf(record),
-              message: err?.message,
-              stack: err?.stack || null
-            });
-            return false;
-          }
-        });
-      }
-
-      function deriveLatestPeriod(granularity, data) {
-        if (!Array.isArray(data) || !data.length) return '';
-        const valid = data
-          .filter(item => item && item.callDateObj instanceof Date && !Number.isNaN(item.callDateObj.getTime()))
-          .sort((a, b) => b.callDateObj - a.callDateObj);
-
-        if (!valid.length) {
-          return '';
-        }
-
-        const latest = valid[0].callDateObj;
-        switch (granularity) {
-          case 'Week':
-            return toISOWeek(latest);
-          case 'Bi-Weekly':
-            return toBiWeeklyPeriod(latest);
-          case 'Month':
-            return latest.toISOString().slice(0, 7);
-          case 'Quarter':
-            return `${getQuarter(latest)}-${latest.getFullYear()}`;
-          case 'Year':
-            return String(latest.getFullYear());
-          default:
-            return '';
-        }
-      }
-
-      function periodSortValue(granularity, period) {
-        if (!period) return 0;
-        try {
-          switch (granularity) {
-            case 'Week': {
-              const match = period.match(/^(\d{4})-W(\d{2})$/);
-              if (!match) return 0;
-              const year = Number(match[1]);
-              const week = Number(match[2]);
-              const simple = new Date(Date.UTC(year, 0, 1));
-              const day = simple.getUTCDay() || 7;
-              simple.setUTCDate(simple.getUTCDate() + (week - 1) * 7 + (1 - day));
-              return simple.getTime();
-            }
-            case 'Bi-Weekly':
-              return biWeeklySortValue(period);
-            case 'Month': {
-              const [y, m] = period.split('-').map(Number);
-              if (!y || !m) return 0;
-              return new Date(Date.UTC(y, m - 1, 1)).getTime();
-            }
-            case 'Quarter': {
-              const match = period.match(/^Q([1-4])-(\d{4})$/);
-              if (!match) return 0;
-              const quarterIndex = Number(match[1]) - 1;
-              const year = Number(match[2]);
-              return new Date(Date.UTC(year, quarterIndex * 3, 1)).getTime();
-            }
-            case 'Year':
-              return new Date(Date.UTC(Number(period), 0, 1)).getTime();
-            default:
-              return 0;
-          }
-        } catch (err) {
-          QA_MONITOR.warn('periodSortValue failed', {
-            granularity,
-            period,
-            message: err?.message,
-            stack: err?.stack || null
-          });
-          return 0;
-        }
-      }
-
-      function derivePeriodsForGranularity(granularity, data) {
-        if (!Array.isArray(data) || !data.length) {
-          return [];
-        }
-
-        const set = new Set();
-        data.forEach(item => {
-          const dt = item?.callDateObj;
-          if (!(dt instanceof Date) || Number.isNaN(dt.getTime())) {
-            return;
-          }
-          try {
-            switch (granularity) {
-              case 'Week':
-                set.add(toISOWeek(dt));
-                break;
-              case 'Bi-Weekly':
-                set.add(toBiWeeklyPeriod(dt));
-                break;
-              case 'Month':
-                set.add(dt.toISOString().slice(0, 7));
-                break;
-              case 'Quarter':
-                set.add(`${getQuarter(dt)}-${dt.getFullYear()}`);
-                break;
-              case 'Year':
-                set.add(String(dt.getFullYear()));
-                break;
-              default:
-                break;
-            }
-          } catch (err) {
-            QA_MONITOR.warn('derivePeriodsForGranularity error', {
-              granularity,
-              itemIndex: data.indexOf(item),
-              message: err?.message,
-              stack: err?.stack || null
-            });
-          }
-        });
-
-        const sorted = Array.from(set)
-          .filter(Boolean)
-          .sort((a, b) => periodSortValue(granularity, b) - periodSortValue(granularity, a));
-
-        const limitMap = {
-          Week: 104,
-          'Bi-Weekly': 52,
-          Month: 36,
-          Quarter: 16,
-          Year: 12
-        };
-
-        const limit = limitMap[granularity] || sorted.length;
-        return sorted.slice(0, limit);
-      }
-
-      function refreshDefaultPeriods(data) {
-        DEFAULT_GRANULARITIES.forEach(granularity => {
-          const periods = derivePeriodsForGranularity(granularity, data);
-          availablePeriods[granularity] = periods;
-
-          if (periods.length === 0) {
-            delete defaultPeriods[granularity];
-            return;
-          }
-
-          if (!defaultPeriods[granularity] || !periods.includes(defaultPeriods[granularity])) {
-            defaultPeriods[granularity] = periods[0];
-          }
-        });
-      }
-
-      function isPeriodInData(granularity, period, data) {
-        if (!period) return false;
-        const matches = filterRecordsByPeriod(data, granularity, period);
-        return matches.length > 0;
-      }
-
-      function ensurePeriodForGranularity(granularity, data) {
-        const normalizedGranularity = DEFAULT_GRANULARITIES.includes(granularity) ? granularity : 'Week';
-
-        const periods = availablePeriods[normalizedGranularity]?.length
-          ? availablePeriods[normalizedGranularity]
-          : derivePeriodsForGranularity(normalizedGranularity, data);
-
-        if (!availablePeriods[normalizedGranularity] || !availablePeriods[normalizedGranularity].length) {
-          availablePeriods[normalizedGranularity] = periods;
-        }
-
-        if (currentPeriod && periods.includes(currentPeriod)) {
-          defaultPeriods[normalizedGranularity] = currentPeriod;
-          return currentPeriod;
-        }
-
-        if (defaultPeriods[normalizedGranularity] && periods.includes(defaultPeriods[normalizedGranularity])) {
-          currentPeriod = defaultPeriods[normalizedGranularity];
-          return currentPeriod;
-        }
-
-        if (periods.length) {
-          currentPeriod = periods[0];
-          defaultPeriods[normalizedGranularity] = currentPeriod;
-          return currentPeriod;
-        }
-
-        currentPeriod = '';
-        delete defaultPeriods[normalizedGranularity];
-        return currentPeriod;
-      }
-
-      function syncPeriodInputs(granularity, period) {
-        const weekInput = document.getElementById('weekInput');
-        if (weekInput) {
-          weekInput.value = granularity === 'Week' ? (period || '') : '';
-        }
-
-        const monthInput = document.getElementById('monthInput');
-        if (monthInput) {
-          monthInput.value = granularity === 'Month' ? (period || '') : '';
-        }
-
-        const yearInput = document.getElementById('yearInput');
-        if (yearInput) {
-          yearInput.value = granularity === 'Year' ? (period || '') : '';
-        }
-
-        const quarterSelect = document.getElementById('quarterSelect');
-        const quarterYearInput = document.getElementById('quarterYearInput');
-        if (quarterSelect && quarterYearInput) {
-          if (granularity === 'Quarter' && period) {
-            const match = /^Q([1-4])-(\d{4})$/.exec(period);
-            if (match) {
-              quarterSelect.value = `Q${match[1]}`;
-              quarterYearInput.value = match[2];
-            }
-          } else if (granularity === 'Quarter' && !period) {
-            quarterYearInput.value = '';
-          }
-        }
-
-        const periodSelect = document.getElementById('periodSelect');
-        if (periodSelect) {
-          const periods = availablePeriods[granularity] || [];
-
-          if (period && !periods.includes(period)) {
-            const optionExists = Array.from(periodSelect.options).some(opt => opt.value === period);
-            if (!optionExists) {
-              const opt = document.createElement('option');
-              opt.value = period;
-              opt.textContent = formatPeriodLabel(granularity, period);
-              opt.dataset.synthetic = 'true';
-              periodSelect.appendChild(opt);
-            }
-          }
-
-          if (period) {
-            periodSelect.value = period;
-          } else {
-            periodSelect.value = '';
-          }
-        }
-      }
-
-      function refreshPeriodSelectOptions() {
-        const periodSelect = document.getElementById('periodSelect');
-        if (!periodSelect) {
-          return;
-        }
-
-        const periods = availablePeriods[currentGran] || [];
-        const previousValue = periodSelect.value;
-
-        periodSelect.innerHTML = '';
-
-        if (!periods.length) {
-          const placeholder = document.createElement('option');
-          placeholder.value = '';
-          placeholder.textContent = 'No periods available';
-          placeholder.disabled = true;
-          placeholder.selected = true;
-          periodSelect.appendChild(placeholder);
-          periodSelect.disabled = true;
-          currentPeriod = '';
-          delete defaultPeriods[currentGran];
-          return;
-        }
-
-        periodSelect.disabled = false;
-
-        periods.forEach(period => {
-          const option = document.createElement('option');
-          option.value = period;
-          option.textContent = formatPeriodLabel(currentGran, period);
-          periodSelect.appendChild(option);
-        });
-
-        const hasCurrent = currentPeriod && periods.includes(currentPeriod);
-        const fallback = hasCurrent
-          ? currentPeriod
-          : (defaultPeriods[currentGran] && periods.includes(defaultPeriods[currentGran])
-            ? defaultPeriods[currentGran]
-            : periods[0]);
-
-        if (fallback) {
-          currentPeriod = fallback;
-          defaultPeriods[currentGran] = fallback;
-          periodSelect.value = fallback;
-        } else {
-          periodSelect.value = '';
-        }
-
-        if (previousValue && previousValue !== periodSelect.value) {
-          QA_MONITOR.log('Period selection realigned', {
-            from: previousValue,
-            to: periodSelect.value,
-            granularity: currentGran
-          });
-        }
-
-        syncPeriodInputs(currentGran, currentPeriod);
-      }
-
-      function buildTrendSeries(granularity, currentPeriod, data, depth = 4) {
-        const series = [];
-        let cursor = currentPeriod;
-        let steps = 0;
-        const visited = new Set();
-
-        while (cursor && steps < depth && !visited.has(cursor)) {
-          visited.add(cursor);
-          const bucket = filterRecordsByPeriod(data, granularity, cursor);
-          const evalCount = bucket.length;
-          const agentCount = new Set(bucket.map(r => r.AgentName)).size;
-          const avgScore = evalCount ? Math.round(bucket.reduce((sum, r) => sum + (r.Percentage || 0), 0) / evalCount * 100) : 0;
-          const passRate = safePercentage(bucket.filter(r => r.Percentage >= PASS_MARK).length, evalCount);
-          const coverage = userList.length ? safePercentage(agentCount, userList.length) : (agentCount > 0 ? 100 : 0);
-
-          series.push({
-            period: cursor,
-            label: formatPeriodLabel(granularity, cursor),
-            avgScore,
-            passRate,
-            evalCount,
-            agentCount,
-            coverage
-          });
-
-          cursor = getPreviousPeriod(granularity, cursor);
-          steps += 1;
-        }
-
-        return series.reverse();
-      }
-
-      function linearRegression(points) {
-        if (!points || !points.length) {
-          return { slope: 0, intercept: 0 };
-        }
-
-        if (points.length === 1) {
-          return { slope: 0, intercept: points[0].y };
-        }
-
-        const n = points.length;
-        let sumX = 0;
-        let sumY = 0;
-        let sumXY = 0;
-        let sumXX = 0;
-
-        points.forEach(point => {
-          sumX += point.x;
-          sumY += point.y;
-          sumXY += point.x * point.y;
-          sumXX += point.x * point.x;
-        });
-
-        const denominator = (n * sumXX) - (sumX * sumX);
-        if (denominator === 0) {
-          return { slope: 0, intercept: sumY / n };
-        }
-
-        const slope = ((n * sumXY) - (sumX * sumY)) / denominator;
-        const intercept = (sumY - slope * sumX) / n;
-        return { slope, intercept };
-      }
-
-      function clampPercent(value) {
-        if (Number.isNaN(value)) return 0;
-        return Math.max(0, Math.min(100, Math.round(value)));
-      }
-
-      function analyzeTrendSeries(series, context = {}) {
-        const { granularity = 'Period' } = context;
-        const lowerGran = granularity.toLowerCase();
-
-        if (!series || !series.length) {
-          return {
-            summary: `Trend radar is waiting for enough history to analyze ${lowerGran} trends.`,
-            points: [],
-            health: 'monitoring',
-            forecast: { avg: 0, pass: 0 },
-            nextLabel: `next ${lowerGran}`
-          };
-        }
-
-        const first = series[0];
-        const last = series[series.length - 1];
-
-        const avgPoints = series.map((point, index) => ({ x: index, y: point.avgScore }));
-        const passPoints = series.map((point, index) => ({ x: index, y: point.passRate }));
-        const avgReg = linearRegression(avgPoints);
-        const passReg = linearRegression(passPoints);
-
-        const avgDelta = last.avgScore - first.avgScore;
-        const passDelta = last.passRate - first.passRate;
-        const volumeDelta = last.evalCount - first.evalCount;
-
-        const slopeAvg = avgReg.slope;
-        const slopePass = passReg.slope;
-
-        const improving = slopeAvg > 0.5 || slopePass > 0.5;
-        const declining = slopeAvg < -0.5 || slopePass < -0.5;
-
-        let health = 'stable';
-        if (improving) health = 'improving';
-        if (declining) health = 'risk';
-
-        const summaryParts = [];
-        summaryParts.push(`Average quality is ${avgDelta >= 0 ? 'up' : 'down'} ${Math.abs(avgDelta).toFixed(1)} pts`);
-        summaryParts.push(`pass rate ${passDelta >= 0 ? 'gained' : 'slid'} ${Math.abs(passDelta).toFixed(1)} pts`);
-        summaryParts.push(`${last.evalCount} evaluations this ${lowerGran}`);
-
-        const points = [];
-
-        points.push({
-          icon: improving ? 'fa-arrow-up' : declining ? 'fa-arrow-down' : 'fa-arrows-alt-h',
-          tone: improving ? 'positive' : declining ? 'negative' : '',
-          title: `Average score ${improving ? 'rising' : declining ? 'dropping' : 'steady'}`,
-          text: `${first.avgScore}% → ${last.avgScore}% across the last ${series.length} ${series.length === 1 ? lowerGran : lowerGran + 's'}.`
-        });
-
-        points.push({
-          icon: passDelta >= 0 ? 'fa-shield-alt' : 'fa-exclamation-triangle',
-          tone: passDelta >= 0 ? 'positive' : 'negative',
-          title: `Pass rate ${passDelta >= 0 ? 'improving' : 'at risk'}`,
-          text: `${first.passRate}% → ${last.passRate}% (${passDelta >= 0 ? '+' : ''}${passDelta.toFixed(1)} pts).`
-        });
-
-        if (Math.abs(volumeDelta) > 0) {
-          points.push({
-            icon: volumeDelta >= 0 ? 'fa-users' : 'fa-user-slash',
-            tone: volumeDelta >= 0 ? 'positive' : 'negative',
-            title: `Evaluation volume ${volumeDelta >= 0 ? 'growing' : 'contracting'}`,
-            text: `${first.evalCount} → ${last.evalCount} evaluations (${volumeDelta >= 0 ? '+' : ''}${volumeDelta}).`
-          });
-        } else {
-          points.push({
-            icon: 'fa-stopwatch',
-            tone: '',
-            title: 'Volume steady',
-            text: `Evaluation count steady at ${last.evalCount} per ${lowerGran}.`
-          });
-        }
-
-        if (last.coverage < 80) {
-          points.push({
-            icon: 'fa-user-shield',
-            tone: 'negative',
-            title: 'Coverage gap detected',
-            text: `Only ${last.coverage}% of agents covered in the latest ${lowerGran}.`
-          });
-        }
-
-        const avgForecast = clampPercent(avgReg.intercept + avgReg.slope * avgPoints.length);
-        const passForecast = clampPercent(passReg.intercept + passReg.slope * passPoints.length);
-
-        const summary = `${summaryParts.join(', ')}.`;
-
-        return {
-          summary,
-          points,
-          health,
-          forecast: { avg: avgForecast, pass: passForecast },
-          nextLabel: `next ${lowerGran}`
-        };
-      }
-
-      function renderTrendSparkline(series, granularity) {
-        const visual = document.getElementById('aiTrendVisual');
-        const canvas = document.getElementById('aiTrendSparkline');
-
-        if (!visual || !canvas) {
-          return;
-        }
-
-        if (!series || !series.length) {
-          visual.style.display = 'none';
-          if (trendSparklineChart) {
-            trendSparklineChart.destroy();
-            trendSparklineChart = null;
-          }
-          return;
-        }
-
-        visual.style.display = '';
-
-        if (trendSparklineChart) {
-          trendSparklineChart.destroy();
-          trendSparklineChart = null;
-        }
-
-        const labels = series.map(point => point.label || formatPeriodLabel(granularity, point.period));
-        const avgData = series.map(point => point.avgScore);
-        const passData = series.map(point => point.passRate);
-
-        trendSparklineChart = new Chart(canvas, {
-          type: 'line',
-          data: {
-            labels,
-            datasets: [
-              {
-                label: 'Avg Score',
-                data: avgData,
-                borderColor: '#6366f1',
-                backgroundColor: 'rgba(99,102,241,0.15)',
-                tension: 0.4,
-                pointRadius: 4,
-                pointBackgroundColor: '#6366f1',
-                fill: true
-              },
-              {
-                label: 'Pass Rate',
-                data: passData,
-                borderColor: '#10b981',
-                backgroundColor: 'rgba(16,185,129,0.12)',
-                tension: 0.4,
-                pointRadius: 4,
-                pointBackgroundColor: '#10b981',
-                fill: true
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: {
-                display: true,
-                labels: {
-                  usePointStyle: true,
-                  font: {
-                    family: "'Google Sans', sans-serif",
-                    size: 11
-                  }
-                }
-              },
-              tooltip: {
-                backgroundColor: 'rgba(15,23,42,0.9)',
-                titleColor: '#fff',
-                bodyColor: '#e2e8f0',
-                cornerRadius: 10,
-                padding: 10
-              }
-            },
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 100,
-                grid: { color: 'rgba(15,23,42,0.05)' },
-                ticks: { font: { family: "'Google Sans', sans-serif" } }
-              },
-              x: {
-                grid: { display: false },
-                ticks: { font: { family: "'Google Sans', sans-serif" } }
-              }
-            }
-          }
-        });
-      }
-
-      function updateAITrendPanel({ series, granularity }, analysisOverride = null) {
-        const summaryEl = document.getElementById('aiTrendSummary');
-        const listEl = document.getElementById('aiTrendList');
-        const forecastEl = document.getElementById('aiTrendForecast');
-        const healthEl = document.getElementById('aiTrendHealth');
-
-        if (!summaryEl || !listEl) {
-          return;
-        }
-
-        const analysis = analysisOverride || analyzeTrendSeries(series, { granularity });
-
-        summaryEl.textContent = analysis.summary;
-        listEl.innerHTML = '';
-
-        if (analysis.points.length) {
-          listEl.innerHTML = analysis.points.map(point => {
-            const tone = point.tone ? ` ${point.tone}` : '';
-            return `<li class="ai-insight-item${tone}"><div class="ai-icon"><i class="fas ${point.icon}"></i></div><div class="ai-insight-content"><strong>${point.title}</strong><span>${point.text}</span></div></li>`;
-          }).join('');
-        } else {
-          listEl.innerHTML = '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>No trend data yet</strong><span>Capture a few periods of QA to unlock longitudinal intelligence.</span></div></li>';
-        }
-
-        if (forecastEl) {
-          if (analysis.forecast && (analysis.forecast.avg || analysis.forecast.pass)) {
-            forecastEl.innerHTML = `
-              <span><i class="fas fa-forward"></i>${analysis.nextLabel}: ${analysis.forecast.avg}% avg</span>
-              <span><i class="fas fa-shield-alt"></i>${analysis.forecast.pass}% pass</span>
-            `;
-          } else {
-            forecastEl.innerHTML = '';
-          }
-        }
-
-        if (healthEl) {
-          healthEl.textContent = analysis.health === 'improving' ? 'Improving' : analysis.health === 'risk' ? 'At Risk' : analysis.health === 'monitoring' ? 'Monitoring' : 'Stable';
-          healthEl.classList.remove('improving', 'risk');
-          if (analysis.health === 'improving') {
-            healthEl.classList.add('improving');
-          } else if (analysis.health === 'risk') {
-            healthEl.classList.add('risk');
-          }
-        }
-
-        renderTrendSparkline(series, granularity);
-      }
-
-      // CHANGED: uses PASS_SCORE_THRESHOLD / no undefined class access
-      function renderCategoryTable(metrics){
-        const tbody=document.querySelector('#categoryTable tbody'); tbody.innerHTML='';
-        Object.entries(metrics).forEach(([cat,m])=>{
-          const passScore=PASS_SCORE_THRESHOLD;
-          const goodScore=Math.round(passScore*0.8);
-          const avgClass = m.avgScore>=passScore ? 'excellent' : m.avgScore>=goodScore ? 'good':'needs-improvement';
-          const passClass= m.passPct >=passScore ? 'excellent' : m.passPct >=goodScore ? 'good':'needs-improvement';
-          const row=document.createElement('tr');
-          row.innerHTML=`
-            <td><strong>${cat}</strong></td>
-            <td><span class="status-badge ${avgClass}"><span class="badge-dot"></span>${m.avgScore}%</span></td>
-            <td><span class="status-badge ${passClass}"><span class="badge-dot"></span>${m.passPct}%</span></td>`;
-          tbody.appendChild(row);
-        });
-      }
-
-      function renderCategoryChart(metrics){
-        const labels=Object.keys(metrics);
-        const data=labels.map(l=>metrics[l].avgScore);
-        if(categoryChart){ categoryChart.destroy(); categoryChart=null; }
-        const ctx=document.getElementById('categoryChart'); if(!ctx) return;
-        categoryChart=new Chart(ctx,{type:'bar',data:{labels,datasets:[{label:'Average Score %',data,backgroundColor:'rgba(102,126,234,.1)',borderColor:'#667eea',borderWidth:2,borderRadius:8,borderSkipped:false}]},options:{...chartConfig,plugins:{...chartConfig.plugins,legend:{display:false}}}});
-      }
-
-      // CHANGED: weekday-only + correct thresholds
-      function renderDailyChart(data) {
-          const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-          const cnt = {}, sums = {}, ps = {};
-          days.forEach(d => { cnt[d] = 0; sums[d] = 0; ps[d] = 0; });
-          
-          data.forEach(r => {
-              // Use the cleaned date object
-              const dt = r.callDateObj || safeToDate(r.CallDate);
-              if (!dt) {
-                  QA_MONITOR.warn('renderDailyChart invalid date', {
-                      record: r,
-                      reason: 'missing callDateObj',
-                      index: data.indexOf(r)
-                  });
-                  return;
-              }
-              
-              const idx = (dt.getDay() + 6) % 7; 
-              if (idx > 4) return; // skip Sat/Sun
-              
-              const day = days[idx];
-              cnt[day]++; 
-              sums[day] += r.recordScore;
-              if (r.recordScore >= PASS_SCORE_THRESHOLD) ps[day]++;
-          });
-          
-          const tot = data.length;
-          const evalPct = days.map(d => tot ? Math.round(cnt[d] / tot * 100) : 0);
-          const avgData = days.map(d => cnt[d] ? Math.round(sums[d] / cnt[d]) : 0);
-          const passPct = days.map(d => cnt[d] ? Math.round(ps[d] / cnt[d] * 100) : 0);
-
-          if (dailyChart) { dailyChart.destroy(); dailyChart = null; }
-          const ctx = document.getElementById('dailyChart'); 
-          if (!ctx) return;
-          
-          dailyChart = new Chart(ctx, {
-              data: {
-                  labels: days, 
-                  datasets: [
-                      { type: 'bar', label: 'Evaluations %', data: evalPct, backgroundColor: 'rgba(102,126,234,.1)', borderColor: '#667eea', borderWidth: 2, borderRadius: 6 },
-                      { type: 'line', label: 'Average Score', data: avgData, yAxisID: 'y1', tension: .4, borderColor: '#10b981', backgroundColor: 'rgba(16,185,129,.1)', pointBackgroundColor: '#10b981', pointBorderColor: '#fff', pointBorderWidth: 2, pointRadius: 5 },
-                      { type: 'line', label: 'Pass Rate', data: passPct, yAxisID: 'y1', tension: .4, borderColor: '#f59e0b', backgroundColor: 'rgba(245,158,11,.1)', pointBackgroundColor: '#f59e0b', pointBorderColor: '#fff', pointBorderWidth: 2, pointRadius: 5 }
-                  ]
-              },
-              options: { ...chartConfig, scales: { y: chartConfig.scales.y, y1: { ...chartConfig.scales.y, position: 'right', grid: { drawOnChartArea: false } }, x: chartConfig.scales.x } }
-          });
-      }
-
-      function renderAgentTable(data) {
-          const tbody = document.querySelector('#agentTable tbody');
-          if (!tbody) return;
-          tbody.innerHTML = '';
-
-          const { profiles } = calculateAgentProfiles(data);
-
-          profiles.forEach(profile => {
-              const recentDateFormatted = profile.recentDate ? profile.recentDate.toLocaleDateString() : 'N/A';
-              const row = document.createElement('tr');
-              row.innerHTML = `
-                  <td><strong>${profile.name}</strong></td>
-                  <td>${profile.evaluationShare}%</td>
-                  <td><span class="status-badge ${profile.avgScore >= 95 ? 'excellent' : profile.avgScore >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${profile.avgScore}%</span></td>
-                  <td><span class="status-badge ${profile.passRate >= 95 ? 'excellent' : profile.passRate >= 80 ? 'good' : 'needs-improvement'}"><span class="badge-dot"></span>${profile.passRate}%</span></td>
-                  <td>${recentDateFormatted}</td>`;
-              tbody.appendChild(row);
-          });
-      }
-
-      function debugInvalidDates() {
-          QA_MONITOR.log('QA Data Date Debug begin', { total: rawQA.length });
-          let invalidCount = 0;
-
-          rawQA.forEach((record, index) => {
-              if (!(record.callDateObj instanceof Date) || isNaN(record.callDateObj.getTime())) {
-                  QA_MONITOR.warn('QA record invalid date', {
-                      index,
-                      callDate: record.CallDate,
-                      sourceCallDate: getRecordField(record, ['CallDate', 'Call Date', 'CallTime', 'Call Time', 'EvaluationDate', 'Evaluation Date', 'QA Date', 'Date', 'Timestamp']),
-                      agentName: record.AgentName,
-                      recordIndex: record.__recordIndex || null
-                  });
-                  invalidCount++;
-              }
-          });
-
-          QA_MONITOR.log('QA Data Date Debug summary', {
-              invalidCount,
-              total: rawQA.length
-          });
-          return invalidCount;
-      }
-
-      function renderAgentChart(data){
-        const { profiles } = calculateAgentProfiles(data);
-        const agents = profiles.map(p => p.name);
-        const evalPct = profiles.map(p => p.evaluationShare);
-        const avgScore = profiles.map(p => p.avgScore);
-        const passPct = profiles.map(p => p.passRate);
-
-        if(agentChart){ agentChart.destroy(); agentChart=null; }
-        const ctx=document.getElementById('agentChart'); if(!ctx) return;
-        agentChart=new Chart(ctx,{type:'bar',data:{labels:agents,datasets:[
-          {label:'Evaluations %',data:evalPct,backgroundColor:'rgba(102,126,234,.1)',borderColor:'#667eea',borderWidth:2,borderRadius:6},
-          {label:'Average Score',data:avgScore,backgroundColor:'rgba(16,185,129,.1)',borderColor:'#10b981',borderWidth:2,borderRadius:6},
-          {label:'Pass Rate',data:passPct,backgroundColor:'rgba(245,158,11,.1)',borderColor:'#f59e0b',borderWidth:2,borderRadius:6}]},
-          options:chartConfig});
-      }
-
-      function renderCategoryKpis(metrics){
-        const container=document.getElementById('categoryKpis'); container.innerHTML='';
-        Object.entries(metrics).forEach(([cat,m])=>{
-          const card=document.createElement('div'); card.className='category-kpi-card';
-          card.innerHTML=`<h6>${cat}</h6>
-            <div class="category-metrics">
-              <div class="category-metric"><div class="value">${m.avgScore}%</div><div class="label">Avg Score</div></div>
-              <div class="category-metric"><div class="value">${m.passPct}%</div><div class="label">Pass Rate</div></div>
-            </div>`;
-          container.appendChild(card);
-        });
-      }
-
-      const chartConfig={responsive:true,maintainAspectRatio:false,interaction:{intersect:false,mode:'index'},plugins:{legend:{labels:{usePointStyle:true,padding:20,font:{family:"'Google Sans', sans-serif",size:12,weight:'500'}}},tooltip:{backgroundColor:'rgba(0,0,0,.8)',titleColor:'#fff',bodyColor:'#fff',borderColor:'#667eea',borderWidth:1,cornerRadius:8,padding:12}},scales:{y:{beginAtZero:true,max:100,grid:{color:'rgba(0,0,0,.05)'},ticks:{font:{family:"'Google Sans', sans-serif"}}},x:{grid:{display:false},ticks:{font:{family:"'Google Sans', sans-serif"}}}},layout:{padding:{top:10,bottom:10}}};
-
-      function safePercentage(numerator, denominator, maxCap = 100, debugLabel = '') {
-        if (debugLabel) {
-          QA_MONITOR.log('safePercentage debug', {
-            label: debugLabel,
-            numerator,
-            denominator,
-            maxCap
-          });
-        }
-        if (!denominator || denominator <= 0) return 0;
-        const result = Math.round((numerator / denominator) * 100);
-        return Math.min(result, maxCap);
-      }
-
-      function calculateAgentProfiles(data) {
-          const totalEvaluations = data.length;
-          const aggregates = {};
-
-          data.forEach(record => {
-              const agentName = record.AgentName || 'Unassigned';
-              if (!aggregates[agentName]) {
-                  aggregates[agentName] = {
-                      count: 0,
-                      scoreSum: 0,
-                      passCount: 0,
-                      recent: null
-                  };
-              }
-
-              const bucket = aggregates[agentName];
-              bucket.count += 1;
-              bucket.scoreSum += record.recordScore || 0;
-              if (record.Percentage >= PASS_MARK) {
-                  bucket.passCount += 1;
-              }
-
-              const callDate = safeToDate(record.CallDate);
-              if (callDate) {
-                  if (!bucket.recent || callDate > bucket.recent) {
-                      bucket.recent = callDate;
-                  }
-              }
-          });
-
-          const profiles = Object.entries(aggregates).map(([name, stats]) => {
-              const avgScore = stats.count ? Math.round(stats.scoreSum / stats.count) : 0;
-              const passRate = stats.count ? Math.round(stats.passCount / stats.count * 100) : 0;
-              const evaluationShare = totalEvaluations ? Math.round(stats.count / totalEvaluations * 100) : 0;
-
-              return {
-                  name,
-                  evaluations: stats.count,
-                  avgScore,
-                  passRate,
-                  evaluationShare,
-                  recentDate: stats.recent || null
-              };
-          }).sort((a, b) => b.avgScore - a.avgScore);
-
-          return { totalEvaluations, profiles };
-      }
-
-      function summarizeCategoryChange(currentMetrics, previousMetrics = {}) {
-          const details = Object.entries(currentMetrics).map(([category, metrics]) => {
-              const prev = previousMetrics[category];
-              const delta = prev ? Math.round((metrics.avgScore - prev.avgScore) * 10) / 10 : null;
-              return {
-                  category,
-                  avgScore: metrics.avgScore,
-                  passPct: metrics.passPct,
-                  delta
-              };
-          });
-
-          details.sort((a, b) => b.avgScore - a.avgScore);
-          return details;
-      }
-
-      function buildAIIntelligenceAnalysis({ filtered, prevFiltered, catMetrics, prevCatMetrics, kpis }) {
-          const { totalEvaluations, profiles } = calculateAgentProfiles(filtered || []);
-          const { profiles: prevProfiles } = calculateAgentProfiles(prevFiltered || []);
-          const categorySummary = summarizeCategoryChange(catMetrics || {}, prevCatMetrics || {});
-
-          const metrics = kpis || {};
-          const avgScore = Math.round(Math.min(metrics.avg ?? 0, 100));
-          const passRate = Math.round(Math.min(metrics.pass ?? 0, 100));
-          const coverage = Math.round(Math.min(metrics.coverage ?? 0, 100));
-          const completion = Math.round(Math.min(metrics.completion ?? 0, 100));
-          const confidenceScore = Math.max(5, Math.min(100, Math.round((coverage * 0.4) + (passRate * 0.3) + (avgScore * 0.3))));
-
-          const base = {
-              summary: '',
-              automationSummary: '',
-              confidence: confidenceScore,
-              automationState: 'Monitoring',
-              insights: [],
-              actions: [],
-              nextBest: null,
-              meta: {
-                  totalEvaluations,
-                  totalAgents: profiles.length,
-                  periodLabel: currentGran ? currentGran.toLowerCase() : 'period',
-                  source: 'local',
-                  generatedAt: new Date().toISOString(),
-                  cache: 'miss'
-              }
-          };
-
-          if (!totalEvaluations) {
-          base.summary = 'Trend radar is monitoring for new evaluations. Adjust your filters or capture fresh QA reviews to generate insights.';
-              base.automationSummary = 'No automation required yet. Log additional evaluations to unlock targeted recommendations.';
-              return base;
-          }
-
-          const totalAgents = profiles.length;
-          const evaluationsWord = totalEvaluations === 1 ? 'evaluation' : 'evaluations';
-          const agentWord = totalAgents === 1 ? 'agent' : 'agents';
-          const periodLabel = base.meta.periodLabel;
-
-          base.summary = `The insights engine reviewed ${totalEvaluations} ${evaluationsWord} across ${totalAgents} ${agentWord} for this ${periodLabel}, spotlighting performance opportunities instantly.`;
-          base.automationSummary = `Coverage at ${coverage}% and completion at ${completion}% give the automation engine enough signal to trigger proactive workflows.`;
-
-          if (profiles.length) {
-              const topAgent = profiles[0];
-              base.insights.push({
-                  icon: 'fa-star',
-                  tone: 'positive',
-                  title: `${topAgent.name} is leading`,
-                  text: `${topAgent.name} is averaging ${topAgent.avgScore}% quality with a ${topAgent.passRate}% pass rate.`
-              });
-
-              const bottomAgent = profiles[profiles.length - 1];
-              if (bottomAgent && bottomAgent.avgScore < PASS_SCORE_THRESHOLD) {
-                  base.insights.push({
-                      icon: 'fa-life-ring',
-                      tone: 'negative',
-                      title: `${bottomAgent.name} needs attention`,
-                      text: `${bottomAgent.name} is trending at ${bottomAgent.avgScore}% with ${bottomAgent.passRate}% pass rate.`
-                  });
-                  base.actions.push({
-                      icon: 'fa-user-graduate',
-                      tone: 'urgent',
-                      title: `Launch coaching for ${bottomAgent.name}`,
-                      text: `Auto-create a coaching session to lift ${bottomAgent.name}'s quality score back above ${PASS_SCORE_THRESHOLD}%.`
-                  });
-              }
-
-              const prevProfileMap = Object.fromEntries(prevProfiles.map(p => [p.name, p]));
-              let strongestImprovement = null;
-              let largestRegression = null;
-
-              profiles.forEach(profile => {
-                  const prev = prevProfileMap[profile.name];
-                  if (!prev) return;
-                  const delta = profile.avgScore - prev.avgScore;
-                  if (strongestImprovement === null || delta > strongestImprovement.delta) {
-                      strongestImprovement = { ...profile, delta };
-                  }
-                  if (largestRegression === null || delta < largestRegression.delta) {
-                      largestRegression = { ...profile, delta };
-                  }
-              });
-
-              if (strongestImprovement && strongestImprovement.delta > 2) {
-                  base.insights.push({
-                      icon: 'fa-rocket',
-                      tone: 'positive',
-                      title: `${strongestImprovement.name} is improving`,
-                      text: `Up ${strongestImprovement.delta.toFixed(1)} pts vs last period.`
-                  });
-              }
-
-              if (largestRegression && largestRegression.delta < -2) {
-                  base.actions.push({
-                      icon: 'fa-reply',
-                      tone: 'urgent',
-                      title: `Check-in with ${largestRegression.name}`,
-                      text: `${largestRegression.name} dropped ${Math.abs(largestRegression.delta).toFixed(1)} pts period-over-period.`
-                  });
-              }
-          }
-
-          if (categorySummary.length) {
-              const bestCategory = categorySummary[0];
-              base.insights.push({
-                  icon: 'fa-thumbs-up',
-                  tone: 'positive',
-                  title: `${bestCategory.category} excels`,
-                  text: `${bestCategory.category} is averaging ${bestCategory.avgScore}% quality.`
-              });
-
-              const weakestCategory = categorySummary[categorySummary.length - 1];
-              if (weakestCategory && weakestCategory.avgScore < PASS_SCORE_THRESHOLD) {
-                  base.actions.push({
-                      icon: 'fa-sitemap',
-                      tone: 'urgent',
-                      title: `Reinforce ${weakestCategory.category}`,
-                      text: `Automate a calibration focused on ${weakestCategory.category} where scores average ${weakestCategory.avgScore}%.`
-                  });
-              }
-
-              const largestDelta = categorySummary.reduce((acc, entry) => {
-                  if (entry.delta === null) return acc;
-                  if (!acc || entry.delta < acc.delta) return entry;
-                  return acc;
-              }, null);
-
-              if (largestDelta && largestDelta.delta < -3) {
-                  base.actions.push({
-                      icon: 'fa-exclamation-circle',
-                      tone: 'urgent',
-                      title: `Reverse slide in ${largestDelta.category}`,
-                      text: `${largestDelta.category} fell ${Math.abs(largestDelta.delta).toFixed(1)} pts from the previous period.`
-                  });
-              }
-          }
-
-          if (passRate < 90) {
-              base.actions.push({
-                  icon: 'fa-headset',
-                  tone: 'urgent',
-                  title: 'Boost pass rate',
-                  text: `Configure an automated refresher for agents with pass rates below 90%. Current pass rate is ${passRate}%.`
-              });
-          }
-
-          if (coverage < 85) {
-              base.actions.push({
-                  icon: 'fa-user-check',
-                  tone: 'urgent',
-                  title: 'Increase agent coverage',
-                  text: `Auto-assign additional evaluations to reach at least 90% agent coverage. Currently at ${coverage}%.`
-              });
-          }
-
-          if (!base.insights.length) {
-              base.insights.push({
-                  icon: 'fa-lightbulb',
-                  tone: 'positive',
-                  title: 'All clear',
-                  text: 'No critical anomalies detected. We will notify if trends change.'
-              });
-          }
-
-          base.automationState = base.actions.length ? 'Action Required' : 'Monitoring';
-          base.nextBest = base.actions.length ? base.actions[0] : null;
-          return base;
-      }
-
-      function normalizeAIIntelligenceAnalysis(analysis) {
-          const previous = latestAIIntelligence;
-          const meta = analysis && analysis.meta ? { ...analysis.meta } : {};
-          const normalized = {
-              summary: analysis && typeof analysis.summary === 'string' ? analysis.summary : '',
-              automationSummary: analysis && typeof analysis.automationSummary === 'string' ? analysis.automationSummary : '',
-              confidence: analysis && typeof analysis.confidence === 'number' ? analysis.confidence : null,
-              automationState: analysis && typeof analysis.automationState === 'string' ? analysis.automationState : 'Monitoring',
-              insights: Array.isArray(analysis && analysis.insights) ? analysis.insights.filter(Boolean).map(item => ({ ...item })) : [],
-              actions: Array.isArray(analysis && analysis.actions) ? analysis.actions.filter(Boolean).map(item => ({ ...item })) : [],
-              nextBest: analysis && analysis.nextBest ? { ...analysis.nextBest } : null,
-              meta
-          };
-
-          const hasServerSource = (meta.source || '').toLowerCase() === 'server';
-          if (hasServerSource && previous) {
-              if (!normalized.insights.length && Array.isArray(previous.insights) && previous.insights.length) {
-                  normalized.insights = previous.insights.map(item => ({ ...item }));
-              }
-              if (!normalized.actions.length && Array.isArray(previous.actions) && previous.actions.length) {
-                  normalized.actions = previous.actions.map(item => ({ ...item }));
-                  normalized.automationState = previous.automationState || normalized.automationState;
-                  normalized.nextBest = previous.nextBest ? { ...previous.nextBest } : normalized.nextBest;
-              }
-              if (!normalized.summary && previous.summary) {
-                  normalized.summary = previous.summary;
-              }
-              if (!normalized.automationSummary && previous.automationSummary) {
-                  normalized.automationSummary = previous.automationSummary;
-              }
-              if (normalized.confidence === null && typeof previous.confidence === 'number') {
-                  normalized.confidence = previous.confidence;
-              }
-          }
-
-          return normalized;
-      }
-
-      function renderAIIntelligence(analysis) {
-          const summaryEl = document.getElementById('aiInsightsSummary');
-          const automationSummaryEl = document.getElementById('aiAutomationSummary');
-          const confidenceEl = document.getElementById('aiConfidenceBadge');
-          const sourceEl = document.getElementById('aiInsightSource');
-          const automationStateEl = document.getElementById('aiAutomationState');
-          const nextBestWrapper = document.getElementById('aiNextBestAction');
-          const nextBestText = document.getElementById('aiNextBestActionText');
-          const insightsList = document.getElementById('aiInsightsList');
-          const recommendationsList = document.getElementById('aiRecommendationsList');
-
-          if (!insightsList || !recommendationsList) {
-              return;
-          }
-
-          const normalized = normalizeAIIntelligenceAnalysis(analysis || {});
-          const {
-              summary,
-              automationSummary,
-              confidence,
-              automationState,
-              insights,
-              actions,
-              nextBest,
-              meta
-          } = normalized;
-
-          if (confidenceEl && confidence !== null) {
-              confidenceEl.textContent = `Confidence ${Math.round(confidence)}%`;
-          }
-
-          if (sourceEl) {
-              const source = (meta && meta.source ? meta.source : 'local').toLowerCase();
-              sourceEl.classList.remove('server', 'client');
-
-              let label = 'Local Analysis';
-              const tooltipParts = [];
-              if (source === 'server') {
-                  label = 'QA Service';
-                  sourceEl.classList.add('server');
-                  tooltipParts.push('Insights generated by the QA service');
-              } else {
-                  sourceEl.classList.add('client');
-                  tooltipParts.push('Insights generated in-browser');
-              }
-
-              sourceEl.textContent = label;
-
-              if (meta && meta.generatedAt) {
-                  try {
-                      const generated = new Date(meta.generatedAt);
-                      if (!Number.isNaN(generated.getTime())) {
-                          tooltipParts.push(generated.toLocaleString());
-                      }
-                  } catch (dateError) {
-                      QA_MONITOR.warn('Unable to format intelligence timestamp', {
-                          message: dateError?.message,
-                          stack: dateError?.stack || null
-                      });
-                  }
-              }
-
-              if (meta && meta.cache === 'hit') {
-                  tooltipParts.push('Served from cache');
-              } else if (meta && meta.cache === 'miss') {
-                  tooltipParts.push('Fresh analysis');
-              }
-
-              sourceEl.title = tooltipParts.join(' • ');
-          }
-
-          if (summaryEl) {
-              summaryEl.textContent = summary || 'Trend radar is processing your QA signals.';
-          }
-
-          if (automationSummaryEl) {
-              automationSummaryEl.textContent = automationSummary || 'Recommendations will populate after analysis.';
-          }
-
-          insightsList.innerHTML = insights.length
-              ? insights.map(item => {
-                  const toneClass = item.tone ? ` ${item.tone}` : '';
-                  return `<li class="ai-insight-item${toneClass}"><div class="ai-icon"><i class="fas ${item.icon}"></i></div><div class="ai-insight-content"><strong>${item.title}</strong><span>${item.text}</span></div></li>`;
-              }).join('')
-              : '<li class="ai-insight-item"><div class="ai-icon"><i class="fas fa-info-circle"></i></div><div class="ai-insight-content"><strong>Insights pending</strong><span>Collect more QA evaluations to surface intelligence.</span></div></li>';
-
-          if (actions.length) {
-              recommendationsList.innerHTML = actions.map(action => {
-                  const toneClass = action.tone === 'urgent' ? ' urgent' : '';
-                  return `<li class="ai-action-item${toneClass}"><div class="ai-icon"><i class="fas ${action.icon}"></i></div><div class="ai-action-content"><strong>${action.title}</strong><span>${action.text}</span></div></li>`;
-              }).join('');
-          } else {
-              recommendationsList.innerHTML = `<li class="ai-action-item"><div class="ai-icon"><i class="fas fa-shield-alt"></i></div><div class="ai-action-content"><strong>Automations standing by</strong><span>All monitored metrics are stable. Automations will trigger playbooks if trends shift.</span></div></li>`;
-          }
-
-          if (automationStateEl) {
-              automationStateEl.textContent = automationState;
-              if (automationState === 'Action Required') {
-                  automationStateEl.classList.add('active');
-              } else {
-                  automationStateEl.classList.remove('active');
-              }
-          }
-
-          if (nextBestWrapper) {
-              if (nextBest && nextBestText) {
-                  nextBestWrapper.style.display = '';
-                  nextBestText.textContent = nextBest.text || '';
-              } else {
-                  nextBestWrapper.style.display = 'none';
-                  if (nextBestText) {
-                      nextBestText.textContent = '';
-                  }
-              }
-          }
-
-          latestAIIntelligence = normalized;
-      }
-
-      function updateAIIntelligencePanel(context, analysisOverride = null) {
-          if (analysisOverride) {
-              renderAIIntelligence(analysisOverride);
-              return;
-          }
-
-          if (!context) {
-              return;
-          }
-
-          const analysis = buildAIIntelligenceAnalysis(context);
-          renderAIIntelligence(analysis);
-      }
-
-      function fetchServerQAIntelligence(context = {}, requestToken = null) {
-          if (!context) {
-              return Promise.resolve({ token: requestToken, result: null });
-          }
-
-          if (!(window.google && google.script && google.script.run)) {
-              return Promise.resolve({ token: requestToken, result: null });
-          }
-
-          return new Promise(resolve => {
-              try {
-                  google.script.run
-                      .withSuccessHandler(result => resolve({ token: requestToken, result: result || null }))
-                      .withFailureHandler(error => {
-                          QA_MONITOR.warn('clientGetQAIntelligence failed', {
-                              message: error?.message,
-                              stack: error?.stack || null
-                          });
-                          resolve({ token: requestToken, result: null });
-                      })
-                      .clientGetQAIntelligence(context);
-              } catch (error) {
-                  QA_MONITOR.warn('Unable to request QA intelligence from service', {
-                      message: error?.message,
-                      stack: error?.stack || null
-                  });
-                  resolve({ token: requestToken, result: null });
-              }
-          });
-      }
-
-      function applyFilters(){
-          QA_MONITOR.log('applyFilters invoked', {
-              currentGran,
-              currentPeriod,
-              currentAgent,
-              rawCount: Array.isArray(rawQA) ? rawQA.length : 'unknown'
-          });
-          showLoader('Preparing filtered results…');
-          setTimeout(()=>{
-              QA_MONITOR.safe('applyFilters cycle', () => {
-              // STEP 1: Clean and validate the raw QA data first
-              const cleanedQA = rawQA.filter(r => {
-                  const valid = r.callDateObj instanceof Date && !isNaN(r.callDateObj.getTime());
-                  if (!valid) {
-                      QA_MONITOR.warn('Invalid CallDate found in record', {
-                          record: r,
-                          agentName: r?.AgentName || null
-                      });
-                  }
-                  return valid;
-              });
-
-              // STEP 2: Calculate scores safely
-              const scored = cleanedQA.map(r => {
-                  let s = 0;
-                  Object.entries(weightsMap).forEach(([q, w]) => {
-                      if ((r[q] || '').toString().toLowerCase() === 'yes') s += w;
-                  });
-                  return { ...r, recordScore: s };
-              });
-
-              const activePeriod = ensurePeriodForGranularity(currentGran, scored);
-              currentPeriod = activePeriod;
-              if (activePeriod) {
-                  defaultPeriods[currentGran] = activePeriod;
-              } else {
-                  delete defaultPeriods[currentGran];
-              }
-              syncPeriodInputs(currentGran, activePeriod);
-
-              // STEP 3: Apply period and agent filters safely
-              const filtered = scored.filter(r => {
-                  // Agent filter
-                  if (currentAgent && r.AgentName !== currentAgent) return false;
-
-                  // Use the cleaned Date object for period filtering
-                  const dt = r.callDateObj;
-
-                  try {
-                      if (!activePeriod) {
-                          return true;
-                      }
-                      switch (currentGran) {
-                          case 'Week':
-                              return toISOWeek(dt) === activePeriod;
-                          case 'Bi-Weekly':
-                              return toBiWeeklyPeriod(dt) === activePeriod;
-                          case 'Month':
-                              return dt.toISOString().slice(0, 7) === activePeriod;
-                          case 'Quarter':
-                              return `${getQuarter(dt)}-${dt.getFullYear()}` === activePeriod;
-                          case 'Year':
-                              return String(dt.getFullYear()) === activePeriod;
-                          default:
-                              return true;
-                      }
-                  } catch (error) {
-                      QA_MONITOR.warn('Error filtering record by period', {
-                          record: r,
-                          message: error?.message,
-                          stack: error?.stack || null
-                      });
-                      return false; // Exclude problematic records
-                  }
-              });
-
-              lastFilteredData = filtered;
-
-              const tot = filtered.length;
-              const agentsInPeriod = new Set(filtered.map(r => r.AgentName)).size;
-              const uniqueAgentsInData = Array.from(new Set(filtered.map(r => r.AgentName)));
-
-              QA_MONITOR.log('Agents Evaluated Debug', {
-                  totalEvaluations: tot,
-                  agentsInPeriod,
-                  agentNames: uniqueAgentsInData,
-                  userListLength: userList.length,
-                  userList
-              });
-
-              // Calculate KPIs with enhanced Agents Evaluated logic
-              const avgPct = tot ? Math.round(filtered.reduce((s, r) => s + (r.Percentage || 0), 0) / tot * 100) : 0;
-              const passPct = safePercentage(filtered.filter(r => r.Percentage >= PASS_MARK).length, tot);
-              
-              // Agents Evaluated: percentage of total agents that have evaluations
-              let agentsEvalPct = 0;
-              if (userList.length > 0) {
-                  // Primary method: percentage of known agents that have evaluations
-                  agentsEvalPct = safePercentage(agentsInPeriod, userList.length, 100, 'Agents Evaluated (primary)');
-              } else {
-                  // Fallback method: if userList is empty, use a different approach
-                  // Get all unique agents from the entire QA dataset as the universe
-                  const allAgentsInQA = new Set(rawQA.map(r => r.AgentName).filter(Boolean)).size;
-                  if (allAgentsInQA > 0) {
-                      agentsEvalPct = safePercentage(agentsInPeriod, allAgentsInQA, 100, 'Agents Evaluated (fallback)');
-                      QA_MONITOR.log('Agents evaluated fallback using QA data');
-                  } else {
-                      // Last resort: show 100% if there are any evaluations
-                      agentsEvalPct = agentsInPeriod > 0 ? 100 : 0;
-                      QA_MONITOR.log('Agents evaluated last resort triggered');
-                  }
-              }
-              
-              // Evaluations Completed: average evaluations per agent (capped at 100%)
-              const evalsCompletedPct = agentsInPeriod > 0 ? 
-                  Math.min(Math.round(tot / agentsInPeriod * 10), 100) : 0;
-
-              QA_MONITOR.log('Agent KPIs computed', {
-                  agentsEvalPct,
-                  evalsCompletedPct
-              });
-
-              // Previous period calculations...
-              const prevPeriod = activePeriod ? getPreviousPeriod(currentGran, activePeriod) : '';
-              const prevFiltered = scored.filter(r => {
-                  if (currentAgent && r.AgentName !== currentAgent) return false;
-
-                  const dt = r.callDateObj;
-
-                  try {
-                      if (!prevPeriod) {
-                          return false;
-                      }
-                      switch (currentGran) {
-                          case 'Week':
-                              return toISOWeek(dt) === prevPeriod;
-                          case 'Bi-Weekly':
-                              return toBiWeeklyPeriod(dt) === prevPeriod;
-                          case 'Month':
-                              return dt.toISOString().slice(0, 7) === prevPeriod;
-                          case 'Quarter': 
-                              return `${getQuarter(dt)}-${dt.getFullYear()}` === prevPeriod;
-                          case 'Year': 
-                              return String(dt.getFullYear()) === prevPeriod;
-                          default: 
-                              return false;
-                      }
-                  } catch (error) {
-                      QA_MONITOR.warn('Error filtering previous period record', {
-                          record: r,
-                          message: error?.message,
-                          stack: error?.stack || null
-                      });
-                      return false;
-                  }
-              });
-
-              const prevTot = prevFiltered.length;
-              const prevAgentsInPeriod = new Set(prevFiltered.map(r => r.AgentName)).size;
-              
-              // Previous period KPIs with same logic
-              const prevAvgPct = prevTot ? Math.round(prevFiltered.reduce((s, r) => s + (r.Percentage || 0), 0) / prevTot * 100) : 0;
-              const prevPassPct = safePercentage(prevFiltered.filter(r => r.Percentage >= PASS_MARK).length, prevTot);
-              
-              let prevAgentsEvalPct = 0;
-              if (userList.length > 0) {
-                  prevAgentsEvalPct = safePercentage(prevAgentsInPeriod, userList.length);
-              } else {
-                  const allAgentsInQA = new Set(rawQA.map(r => r.AgentName).filter(Boolean)).size;
-                  if (allAgentsInQA > 0) {
-                      prevAgentsEvalPct = safePercentage(prevAgentsInPeriod, allAgentsInQA);
-                  } else {
-                      prevAgentsEvalPct = prevAgentsInPeriod > 0 ? 100 : 0;
-                  }
-              }
-              
-              const prevEvalsCompletedPct = prevAgentsInPeriod > 0 ? 
-                  Math.min(Math.round(prevTot / prevAgentsInPeriod * 10), 100) : 0;
-
-              // Safe change calculation
-              const change = (cur, prev) => {
-                  if (prev === 0) {
-                      return cur === 0 ? 0 : (cur > 0 ? 100 : -100);
-                  }
-                  const result = Math.round((cur - prev) * 100) / 100;
-                  return Math.max(-100, Math.min(100, result));
-              };
-
-              // Update KPIs
-              [
-                  { id: 'kpiAvgScore', trendId: 'kpiAvgScoreTrend', value: Math.min(avgPct, 100), change: change(avgPct, prevAvgPct) },
-                  { id: 'kpiPassRate', trendId: 'kpiPassRateTrend', value: passPct, change: change(passPct, prevPassPct) },
-                  { id: 'kpiAgentsEval', trendId: 'kpiAgentsEvalTrend', value: agentsEvalPct, change: change(agentsEvalPct, prevAgentsEvalPct) },
-                  { id: 'kpiEvalsDone', trendId: 'kpiEvalsDoneTrend', value: evalsCompletedPct, change: change(evalsCompletedPct, prevEvalsCompletedPct) },
-              ].forEach(({ id, trendId, value, change }) => {
-                  const el = document.getElementById(id), tr = document.getElementById(trendId);
-                  if (el && tr) {
-                      el.style.transform = 'scale(1.1)'; 
-                      el.textContent = Math.min(value, 100) + '%';
-                      setTimeout(() => el.style.transform = 'scale(1)', 200);
-                      
-                      const pos = change >= 0; 
-                      const txt = change === 0 ? 'No change' : `${Math.abs(change).toFixed(1)}% vs last period`;
-                      tr.className = `kpi-trend ${pos ? 'positive' : 'negative'}`;
-                      tr.innerHTML = `<i class="fas ${pos ? 'fa-arrow-up' : 'fa-arrow-down'}"></i><span>${txt}</span>`;
-                  }
-              });
-
-              // Update charts and tables
-              const catMetrics = computeCategoryMetrics(filtered);
-              const prevCatMetrics = computeCategoryMetrics(prevFiltered);
-              const trendSeries = buildTrendSeries(currentGran, activePeriod, scored, 5);
-              renderCategoryKpis(catMetrics);
-              renderCategoryChart(catMetrics);
-              renderCategoryTable(catMetrics);
-              renderDailyChart(filtered);
-              renderAgentChart(filtered);
-              renderAgentTable(filtered);
-
-              const currentKpis = {
-                  avg: Math.min(avgPct, 100),
-                  pass: passPct,
-                  coverage: agentsEvalPct,
-                  completion: evalsCompletedPct
-              };
-
-              updateAIIntelligencePanel({
-                  filtered,
-                  prevFiltered,
-                  catMetrics,
-                  prevCatMetrics,
-                  kpis: currentKpis
-              });
-
-              updateAITrendPanel({
-                  series: trendSeries,
-                  granularity: currentGran || 'Period'
-              });
-
-              const serverContext = {
-                  granularity: currentGran || 'Week',
-                  period: activePeriod,
-                  agent: currentAgent || '',
-                  campaignId: typeof campaignId !== 'undefined' ? campaignId : '',
-                  agentUniverse: Array.isArray(userList) ? userList.length : 0,
-                  depth: 6,
-                  timezone: (function() {
-                      try {
-                          if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
-                              const opts = Intl.DateTimeFormat().resolvedOptions();
-                              return opts?.timeZone;
-                          }
-                      } catch (tzError) {
-                          QA_MONITOR.warn('Timezone detection failed', {
-                              message: tzError?.message,
-                              stack: tzError?.stack || null
-                          });
-                      }
-                      return undefined;
-                  })(),
-                  passMark: PASS_MARK
-              };
-
-              if (!serverContext.timezone) {
-                  delete serverContext.timezone;
-              }
-
-              qaIntelligenceRequestToken += 1;
-              const requestToken = qaIntelligenceRequestToken;
-
-              fetchServerQAIntelligence(serverContext, requestToken)
-                  .then(payload => {
-                      if (!payload || payload.token !== qaIntelligenceRequestToken) {
-                          return;
-                      }
-
-                      const serverResult = payload.result;
-                      if (!serverResult) {
-                          return;
-                      }
-
-                      if (serverResult.intelligence) {
-                          updateAIIntelligencePanel(null, serverResult.intelligence);
-                      }
-
-                      if (serverResult.trend) {
-                          const serverSeries = Array.isArray(serverResult.trend.series) && serverResult.trend.series.length
-                              ? serverResult.trend.series
-                              : trendSeries;
-                          updateAITrendPanel({
-                              series: serverSeries,
-                              granularity: serverResult.trend.granularity || currentGran || 'Period'
-                          }, serverResult.trend.analysis || null);
-                      }
-                  })
-                  .catch(error => {
-                      QA_MONITOR.warn('Server QA intelligence unavailable', {
-                          message: error?.message,
-                          stack: error?.stack || null
-                      });
-                  });
-
-              window.LuminaLoader?.update({ detail: 'Dashboard refreshed!', progress: 100, tip: 'Latest QA metrics are ready.' });
-              hideLoader();
-              QA_MONITOR.log('applyFilters completed', {
-                  filteredCount: filtered.length,
-                  activePeriod,
-                  prevPeriod,
-                  agent: currentAgent || 'All'
-              });
-          }, {
-              rethrow: false,
-              context: { step: 'filter-cycle' },
-              onError: error => {
-                  QA_MONITOR.error('applyFilters cycle failed', { message: error?.message });
-              }
-          });
-          }, 100);
-      }
-
-      function convertToCSV(arr){
-        if(!arr.length) return '';
-        const keys=Object.keys(arr[0]);
-        const header=keys.join(',');
-        const rows=arr.map(o=> keys.map(k=>{ let c=o[k]!=null?o[k].toString():''; c=c.replace(/"/g,'""'); return `"${c}"`; }).join(',') );
-        return [header].concat(rows).join('\r\n');
-      }
-
-      function prepareWeeklyMatrix(data){
-        const dates=Array.from(new Set(data.map(r=>r.CallDate.slice(0,10)))).sort();
-        const agents=Array.from(new Set(data.map(r=>r.AgentName))).sort();
-        const rows=agents.map(agent=>{
-          const row={AgentName:agent};
-          const dayValues=dates.map(d=>{
-            const recs=data.filter(r=> r.AgentName===agent && r.CallDate.slice(0,10)===d);
-            if(!recs.length) return '';
-            const sum=recs.reduce((s,r)=>{ let p=Number(r.Percentage); if(p<=1) p*=100; return s+p; },0);
-            return (sum/recs.length).toFixed(2);
-          });
-          dates.forEach((d,i)=>row[d]=dayValues[i]);
-          const nums=dayValues.filter(v=>v!=='').map(Number);
-          const weekly=nums.length? (nums.reduce((a,b)=>a+b,0)/nums.length):0;
-          row['Weekly Percentage']=weekly.toFixed(2);
-          return row;
-        });
-        return { header:['AgentName',...dates,'Weekly Percentage'], rows };
-      }
-
-      function downloadCSV(csv,filename){
-        const blob=new Blob([csv],{type:'text/csv;charset=utf-8;'});
-        const link=document.createElement('a'); link.href=URL.createObjectURL(blob); link.setAttribute('download',filename);
-        document.body.appendChild(link); link.click(); document.body.removeChild(link);
-      }
-
-      function exportWeeklyCsv(){
-        if(!lastFilteredData.length) return alert('No data to export for the selected filters.');
-        const {header,rows}=prepareWeeklyMatrix(lastFilteredData);
-        let csv=header.join(',')+'\r\n'; rows.forEach(r=>{ csv+=header.map(c=>r[c]||'').join(',')+'\r\n'; });
-        const filename=`quality_weekly_${currentPeriod||'all'}.csv`; downloadCSV(csv,filename);
-      }
-
-      const esc = s => String(s||'').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
-
-      // Rebuilds the <select id="agentSelect">
-      function populateAgentSelect(list){
-        const sel = document.getElementById('agentSelect');
-        if (!sel) return;
-        sel.innerHTML = ['<option value="">All Agents</option>']
-          .concat((list||[]).map(n => `<option value="${esc(n)}"${n===currentAgent?' selected':''}>${esc(n)}</option>`))
-          .join('');
-      }
-
-        // Pull names via Code.gs (no edits needed there)
-        function hydrateAgentList(){
-          QA_MONITOR.log('hydrateAgentList invoked', {
-            hasGoogleScript: !!(window.google && google.script && google.script.run)
-          });
-          if (!(window.google && google.script && google.script.run)) {
-              QA_MONITOR.warn('google.script.run not available, using fallback agent list');
-              // Fallback: extract unique agents from QA data
-              const fallbackAgents = Array.from(new Set(rawQA.map(r => r.AgentName).filter(Boolean))).sort();
-              userList = fallbackAgents;
-              populateAgentSelect(fallbackAgents);
-              QA_MONITOR.log('Fallback userList populated', {
-                count: userList.length,
-                sample: userList.slice(0, 10)
-              });
-              applyFilters();
-              return;
-          }
-
-        const cid = (typeof campaignId !== 'undefined' && campaignId) ? campaignId : '';
-
-          google.script.run
-              .withSuccessHandler(names => {
-                  QA_MONITOR.log('hydrateAgentList success', { namesCount: Array.isArray(names) ? names.length : 'invalid' });
-                  QA_MONITOR.log('Agent names received', {
-                    count: Array.isArray(names) ? names.length : 'invalid',
-                    sample: Array.isArray(names) ? names.slice(0, 10) : null
-                  });
-                  if (!Array.isArray(names) || names.length === 0) {
-                      QA_MONITOR.warn('Empty or invalid names payload, falling back');
-                      fallbackToGetUsers();
-                      return;
-                  }
-                  userList = names;
-                  populateAgentSelect(names);
-                  QA_MONITOR.log('User list updated from agent names', {
-                    count: userList.length,
-                    sample: userList.slice(0, 10)
-                  });
-                  applyFilters();
-              })
-              .withFailureHandler(err => {
-                  QA_MONITOR.error('hydrateAgentList failed', { message: err?.message });
-                  QA_MONITOR.warn('clientGetAssignedAgentNames failed', {
-                      message: err?.message,
-                      stack: err?.stack || null
-                  });
-                  fallbackToGetUsers();
-              })
-              .clientGetAssignedAgentNames(cid);
-
-          function fallbackToGetUsers(){
-              QA_MONITOR.log('fallbackToGetUsers invoked');
-              google.script.run
-                  .withSuccessHandler(users => {
-                      QA_MONITOR.log('fallbackToGetUsers success', { usersCount: Array.isArray(users) ? users.length : 'invalid' });
-                      QA_MONITOR.log('User directory payload received', {
-                          count: Array.isArray(users) ? users.length : 'invalid',
-                          sample: Array.isArray(users) ? users.slice(0, 5) : null
-                      });
-                      const names = (users||[])
-                          .map(u => u.FullName || u.UserName || u.Email)
-                          .filter(Boolean)
-                          .sort((a,b)=>a.localeCompare(b));
-
-                      if (names.length === 0) {
-                          QA_MONITOR.warn('No users found, using QA data as fallback');
-                          const qaAgents = Array.from(new Set(rawQA.map(r => r.AgentName).filter(Boolean))).sort();
-                          userList = qaAgents;
-                          populateAgentSelect(qaAgents);
-                      } else {
-                          userList = names;
-                          populateAgentSelect(names);
-                      }
-
-                      QA_MONITOR.log('Final userList prepared', {
-                          count: userList.length,
-                          sample: userList.slice(0, 10)
-                      });
-                      applyFilters();
-                  })
-                  .withFailureHandler(err => {
-                      QA_MONITOR.error('fallbackToGetUsers failed', { message: err?.message });
-                      QA_MONITOR.error('getUsers failed', { message: err?.message, stack: err?.stack || null });
-                      // Ultimate fallback: use agents from QA data
-                      const qaAgents = Array.from(new Set(rawQA.map(r => r.AgentName).filter(Boolean))).sort();
-                      userList = qaAgents;
-                      populateAgentSelect(qaAgents);
-                      QA_MONITOR.log('Ultimate fallback userList', {
-                          count: userList.length,
-                          sample: userList.slice(0, 10)
-                      });
-                      applyFilters();
-                  })
-                  .getUsers();
-          }
-      }
-
-      const QA_GLOBAL = typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : {});
-      const QA_FUNCTIONS_TO_INSTRUMENT = Array.from(new Set([
-        'safeToDate',
-        'safeToISOString',
-        'normalizeKeyName',
-        'getRecordField',
-        'clamp01',
-        'parsePercentageValue',
-        'excelSerialToDate',
-        'parseFlexibleDateString',
-        'coerceDateValue',
-        'startOfIsoWeek',
-        'isoWeeksInYear',
-        'parseIsoWeek',
-        'toBiWeeklyPeriod',
-        'parseBiWeeklyPeriod',
-        'biWeeklySortValue',
-        'previousBiWeeklyPeriod',
-        'getPreviousPeriod',
-        'normalizeClientQaRecord',
-        'isValidDate',
-        'showLoader',
-        'updateLiveDatetime',
-        'updateDataRefreshStatus',
-        'updateAITrendPanel',
-        'computeCategoryMetrics',
-        'formatPeriodLabel',
-        'filterRecordsByPeriod',
-        'deriveLatestPeriod',
-        'periodSortValue',
-        'derivePeriodsForGranularity',
-        'refreshDefaultPeriods',
-        'isPeriodInData',
-        'ensurePeriodForGranularity',
-        'syncPeriodInputs',
-        'refreshPeriodSelectOptions',
-        'buildTrendSeries',
-        'linearRegression',
-        'clampPercent',
-        'analyzeTrendSeries',
-        'renderTrendSparkline',
-        'renderCategoryTable',
-        'renderCategoryChart',
-        'renderDailyChart',
-        'renderAgentTable',
-        'debugInvalidDates',
-        'renderAgentChart',
-        'renderCategoryKpis',
-        'safePercentage',
-        'calculateAgentProfiles',
-        'summarizeCategoryChange',
-        'buildAIIntelligenceAnalysis',
-        'normalizeAIIntelligenceAnalysis',
-        'renderAIIntelligence',
-        'updateAIIntelligencePanel',
-        'fetchServerQAIntelligence',
-        'applyFilters',
-        'convertToCSV',
-        'prepareWeeklyMatrix',
-        'downloadCSV',
-        'exportWeeklyCsv',
-        'populateAgentSelect',
-        'sanitizeNavigationUrl',
-        'resolveDashboardBaseUrl',
-        'showPicker',
-        'setPeriod',
-        'setQuarter',
-        'hydrateAgentList'
-      ]));
-
-      QA_FUNCTIONS_TO_INSTRUMENT.forEach(name => {
-        try {
-          const fn = QA_GLOBAL[name];
-          if (typeof fn === 'function') {
-            QA_GLOBAL[name] = QA_MONITOR.instrument(name, fn);
-          } else {
-            QA_MONITOR.warn('Function unavailable for instrumentation', { name, detectedType: typeof fn });
-          }
-        } catch (instrumentError) {
-          QA_MONITOR.error('Failed to instrument function', { name, message: instrumentError?.message });
-        }
-      });
-
-      function attachMonitoredListener(target, eventName, handler, options = {}) {
-        const { label = null, listenerOptions = undefined, rethrow = false } = options;
-        if (!target || typeof target.addEventListener !== 'function') {
-          QA_MONITOR.warn('attachMonitoredListener target invalid', { eventName, label });
-          return () => {};
-        }
-
-        const descriptor = label || `${eventName}:${target.id || target.className || 'anonymous'}`;
-        const wrapped = event => QA_MONITOR.safe(`event:${descriptor}`, () => handler.call(target, event), {
-          rethrow,
-          context: {
-            eventType: eventName,
-            targetId: target.id || null,
-            targetClass: target.className || null
-          },
-          defaultValue: undefined
-        });
-
-        target.addEventListener(eventName, wrapped, listenerOptions);
-        return () => {
-          try {
-            target.removeEventListener(eventName, wrapped, listenerOptions);
-          } catch (removeError) {
-            QA_MONITOR.error('Failed to remove monitored listener', {
-              descriptor,
-              message: removeError?.message
-            });
-          }
-        };
-      }
-
-      function monitoredTimeout(label, callback, delay) {
-        return setTimeout(() => {
-          QA_MONITOR.safe(`timeout:${label}`, () => callback(), { rethrow: false, context: { delay } });
-        }, delay);
-      }
-
-      function monitoredInterval(label, callback, delay) {
-        return setInterval(() => {
-          QA_MONITOR.safe(`interval:${label}`, () => callback(), { rethrow: false, context: { delay } });
-        }, delay);
-      }
-
-      document.addEventListener('DOMContentLoaded', function() {
-        QA_MONITOR.log('DOMContentLoaded event fired');
-        QA_MONITOR.safe('DOMContentLoaded init', () => {
-          QA_MONITOR.log('Dashboard initialization starting...');
-
-          QA_MONITOR.safe('Initialize animations', () => {
-            const observer = new IntersectionObserver(entries => {
-              entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                  entry.target.style.opacity = '1';
-                  entry.target.style.transform = 'translateY(0)';
-                }
-              });
-            });
-            document.querySelectorAll('.fade-in, .stagger-animation > *').forEach(el => observer.observe(el));
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Initialize live datetime updates', () => {
-            if (typeof updateLiveDatetime === 'function') {
-              updateLiveDatetime();
-              monitoredInterval('liveDatetime', updateLiveDatetime, 1000);
-            } else {
-              QA_MONITOR.warn('updateLiveDatetime unavailable');
-            }
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Initialize data status', () => {
-            if (typeof updateDataRefreshStatus === 'function') {
-              updateDataRefreshStatus('success', 'System Ready');
-            } else {
-              QA_MONITOR.warn('updateDataRefreshStatus unavailable');
-            }
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Live status click handler setup', () => {
-            const liveStatus = document.querySelector('.live-status');
-            if (!liveStatus) {
-              QA_MONITOR.warn('live-status element missing');
-              return;
-            }
-
-            attachMonitoredListener(liveStatus, 'click', () => {
-              const indicator = document.querySelector('.live-indicator');
-              if (indicator) {
-                indicator.style.animation = 'none';
-                monitoredTimeout('liveIndicatorPulseReset', () => {
-                  indicator.style.animation = 'pulse-live 2s infinite';
-                }, 100);
-              }
-            }, { label: 'liveStatus:click' });
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Data status click handler setup', () => {
-            const dataStatus = document.getElementById('dataRefreshStatus');
-            if (!dataStatus) {
-              QA_MONITOR.warn('dataRefreshStatus element missing');
-              return;
-            }
-
-            attachMonitoredListener(dataStatus, 'click', () => {
-              if (typeof updateDataRefreshStatus === 'function') {
-                updateDataRefreshStatus('updating', 'Refreshing...');
-              }
-              monitoredTimeout('dataStatusRefresh', () => {
-                if (typeof updateDataRefreshStatus === 'function') {
-                  updateDataRefreshStatus('success', `Data Current • ${new Date().toLocaleTimeString()}`);
-                }
-              }, 1500);
-            }, { label: 'dataRefreshStatus:click' });
-
-            dataStatus.style.cursor = 'pointer';
-            dataStatus.title = 'Click to simulate refresh';
-          }, { rethrow: false });
-
-          function sanitizeNavigationUrl(candidate) {
-            if (!candidate) {
-              return '';
-            }
-
-            const trimmed = String(candidate).trim();
-            if (!trimmed || /<|>/.test(trimmed)) {
-              return '';
-            }
-
-            return QA_MONITOR.safe('sanitizeNavigationUrl:parse', () => {
-              const parsed = new URL(trimmed, window.location.href);
-              if (!/^https?:$/i.test(parsed.protocol)) {
-                return '';
-              }
-              return parsed.origin + parsed.pathname;
-            }, { rethrow: false, defaultValue: '', context: { candidate: trimmed } });
-          }
-
-          function resolveDashboardBaseUrl() {
-            return QA_MONITOR.safe('resolveDashboardBaseUrl', () => {
-              const sanitizedBase = typeof baseUrl !== 'undefined' ? sanitizeNavigationUrl(baseUrl) : '';
-              if (sanitizedBase) {
-                return sanitizedBase;
-              }
-              const sanitizedScript = typeof scriptUrl !== 'undefined' ? sanitizeNavigationUrl(scriptUrl) : '';
-              if (sanitizedScript) {
-                return sanitizedScript;
-              }
-              if (window.location) {
-                return sanitizeNavigationUrl(window.location.href);
-              }
-              return '';
-            }, { rethrow: false, defaultValue: '' });
-          }
-
-          QA_MONITOR.safe('Granularity select setup', () => {
-            const granularitySelect = document.getElementById('granularitySelect');
-            if (!granularitySelect) {
-              QA_MONITOR.warn('granularitySelect not found');
-              return;
-            }
-
-            granularitySelect.value = currentGran;
-            const handleGranularityChange = () => {
-              currentGran = granularitySelect.value || 'Week';
-              ensurePeriodForGranularity(currentGran, rawQA);
-              refreshPeriodSelectOptions();
-              if (currentPeriod) {
-                defaultPeriods[currentGran] = currentPeriod;
-              } else {
-                delete defaultPeriods[currentGran];
-              }
-              showPicker();
-              applyFilters();
-            };
-
-            attachMonitoredListener(granularitySelect, 'change', handleGranularityChange, { label: 'granularitySelect:change' });
-            QA_MONITOR.safe('granularitySelect:initialSync', handleGranularityChange, { rethrow: false });
-          }, { rethrow: false });
-
-          const monitorPeriodSelect = () => {
-            const periodSelect = document.getElementById('periodSelect');
-            if (!periodSelect) {
-              QA_MONITOR.warn('periodSelect not found');
-              return;
-            }
-
-            attachMonitoredListener(periodSelect, 'change', event => {
-              currentPeriod = event?.target?.value || '';
-              if (currentPeriod) {
-                defaultPeriods[currentGran] = currentPeriod;
-              } else {
-                delete defaultPeriods[currentGran];
-              }
-              syncPeriodInputs(currentGran, currentPeriod);
-              applyFilters();
-            }, { label: 'periodSelect:change' });
-          };
-
-          QA_MONITOR.safe('Period select setup', monitorPeriodSelect, { rethrow: false });
-
-
-          QA_MONITOR.safe('Agent select setup', () => {
-            const agentSelect = document.getElementById('agentSelect');
-            if (!agentSelect) {
-              QA_MONITOR.warn('agentSelect not found');
-              return;
-            }
-
-            attachMonitoredListener(agentSelect, 'change', event => {
-              currentAgent = event?.target?.value || '';
-              applyFilters();
-            }, { label: 'agentSelect:change' });
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Period inputs setup', () => {
-            ['weekInput', 'monthInput', 'yearInput'].forEach(id => {
-              const el = document.getElementById(id);
-              if (!el) {
-                QA_MONITOR.warn('period input missing', { id });
-                return;
-              }
-
-              attachMonitoredListener(el, 'change', () => {
-                setPeriod();
-                if (currentPeriod) {
-                  defaultPeriods[currentGran] = currentPeriod;
-                } else {
-                  delete defaultPeriods[currentGran];
-                }
-                refreshPeriodSelectOptions();
-                syncPeriodInputs(currentGran, currentPeriod);
-                applyFilters();
-              }, { label: `periodInput:${id}` });
-            });
-
-            ['quarterSelect', 'quarterYearInput'].forEach(id => {
-              const el = document.getElementById(id);
-              if (!el) {
-                QA_MONITOR.warn('quarter input missing', { id });
-                return;
-              }
-
-              attachMonitoredListener(el, 'change', () => {
-                setQuarter();
-                if (currentPeriod) {
-                  defaultPeriods[currentGran] = currentPeriod;
-                } else {
-                  delete defaultPeriods[currentGran];
-                }
-                refreshPeriodSelectOptions();
-                syncPeriodInputs(currentGran, currentPeriod);
-                applyFilters();
-              }, { label: `quarterInput:${id}` });
-            });
-          }, { rethrow: false });
-
-          QA_MONITOR.safe('Export button setup', () => {
-            const exportBtn = document.getElementById('exportCsvBtn');
-            if (!exportBtn) {
-              QA_MONITOR.warn('exportCsvBtn not found');
-              return;
-            }
-
-            attachMonitoredListener(exportBtn, 'click', () => {
-              exportWeeklyCsv();
-            }, { label: 'exportCsvBtn:click' });
-          }, { rethrow: false });
-
-        // Helper functions
-        function showPicker() {
-          QA_MONITOR.safe('showPicker:render', () => {
-            ['weekPicker', 'monthPicker', 'quarterPicker', 'yearPicker'].forEach(id => {
-              const el = document.getElementById(id);
-              if (el) el.style.display = 'none';
-            });
-
-            const map = {
-              'Week': 'weekPicker',
-              'Bi-Weekly': null,
-              'Month': 'monthPicker',
-              'Quarter': 'quarterPicker',
-              'Year': 'yearPicker'
-            };
-
-            const targetId = map[currentGran];
-            if (targetId) {
-              const target = document.getElementById(targetId);
-              if (target) {
-                target.style.display = (currentGran === 'Quarter') ? 'flex' : 'block';
-              }
-            }
-          }, { rethrow: false });
-        }
-
-        function setPeriod() {
-          QA_MONITOR.safe('setPeriod:update', () => {
-            const map = {
-              'Week': 'weekInput',
-              'Month': 'monthInput',
-              'Year': 'yearInput'
-            };
-            const input = document.getElementById(map[currentGran]);
-            if (currentGran === 'Quarter') {
-              setQuarter();
-              return;
-            }
-            if (input && input.value) {
-              currentPeriod = input.value;
-            } else {
-              currentPeriod = ensurePeriodForGranularity(currentGran, rawQA);
-            }
-            syncPeriodInputs(currentGran, currentPeriod);
-          }, { rethrow: false });
-        }
-
-        function setQuarter() {
-          QA_MONITOR.safe('setQuarter:update', () => {
-            const q = document.getElementById('quarterSelect')?.value;
-            const y = document.getElementById('quarterYearInput')?.value;
-            if (q && y) {
-              currentPeriod = `${q}-${y}`;
-            } else {
-              currentPeriod = ensurePeriodForGranularity('Quarter', rawQA);
-            }
-          }, { rethrow: false });
-        }
-
-        QA_MONITOR.safe('UI initialization', () => {
-          refreshPeriodSelectOptions();
-          showPicker();
-          syncPeriodInputs(currentGran, currentPeriod);
-        }, { rethrow: false });
-
-        QA_MONITOR.safe('Initial data load queue', () => {
-          monitoredTimeout('initialApplyFilters', () => {
-            QA_MONITOR.log('Starting data load...');
-            applyFilters();
-          }, 300);
-
-          debugInvalidDates();
-          hydrateAgentList();
-        }, { rethrow: false });
-
-        QA_MONITOR.log('Quality Dashboard initialization completed');
-        });
-      });
+    }
+
+    function bootstrap() {
+      attachEvents();
+      loadData();
+    }
+
+    bootstrap();
+  })();
 </script>
-<!-- Category KPIs -->
-<div class="category-kpis-grid stagger-animation" id="categoryKpis">
-  <!-- Dynamically populated by JavaScript -->
-</div>
-
-<!-- Intelligence Layer -->
-<div class="ai-intel-grid fade-in">
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-robot"></i>
-      <span>Insights</span>
-      <div class="ai-header-meta">
-        <span class="ai-source-chip client" id="aiInsightSource" title="Analysis generated in-browser">Local Analysis</span>
-        <span class="ai-confidence-badge" id="aiConfidenceBadge">Confidence 0%</span>
-      </div>
-    </div>
-    <p class="ai-insights-summary" id="aiInsightsSummary">Insights will appear once data loads.</p>
-    <ul class="ai-insights-list" id="aiInsightsList"></ul>
-  </div>
-
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-bolt"></i>
-      <span>Automation Playbook</span>
-      <span class="ai-automation-state" id="aiAutomationState">Monitoring</span>
-    </div>
-    <p class="ai-automation-summary" id="aiAutomationSummary">Recommendations will populate after analysis.</p>
-    <ul class="ai-actions-list" id="aiRecommendationsList"></ul>
-    <div class="ai-next-best-action" id="aiNextBestAction" style="display: none;">
-      <i class="fas fa-magic"></i>
-      <div>
-        <strong>Next best automation</strong>
-        <span id="aiNextBestActionText"></span>
-      </div>
-    </div>
-  </div>
-  <div class="ai-intel-card">
-    <div class="ai-card-header">
-      <i class="fas fa-chart-line"></i>
-      <span>Trend Radar</span>
-      <span class="ai-trend-health" id="aiTrendHealth">Monitoring</span>
-    </div>
-    <p class="ai-trend-summary" id="aiTrendSummary">Trend intelligence will populate after analysis.</p>
-    <div class="ai-trend-visual" id="aiTrendVisual" style="display: none;">
-      <canvas id="aiTrendSparkline"></canvas>
-      <div class="ai-trend-forecast" id="aiTrendForecast"></div>
-    </div>
-    <ul class="ai-insights-list" id="aiTrendList"></ul>
-  </div>
-</div>
-
-<!-- Modern Charts -->
-<div class="modern-chart-grid stagger-animation">
-  <div class="modern-chart-card">
-    <h6><i class="fas fa-calendar-day me-2"></i>Daily Performance</h6>
-    <div class="chart-container">
-      <canvas id="dailyChart"></canvas>
-    </div>
-</div>
-
-
-</body>
-
-
-</html>


### PR DESCRIPTION
## Summary
- replace the QA dashboard page with a modernized layout featuring filters, KPI cards, trend visualizations, and AI insight panels
- introduce a Google Apps Script snapshot endpoint that assembles QA KPIs, agent leaderboards, categories, and period options for the new UI
- add reusable helpers for metric deltas to power the refreshed dashboard visuals

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4891031a88326b50d25e87eee0b82