### PR TITLE
Fix QA dashboard chart rendering issues

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -1180,7 +1180,6 @@
         destroyChart('gauge');
         return;
       }
-    }
 
       destroyChart('gauge');
       state.charts.gauge = new Chart(ctx, {
@@ -1318,15 +1317,15 @@
               grid: { display: false }
             }
           },
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                callbacks: {
-                  label: tooltipPercentLabel
-                }
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: tooltipPercentLabel
               }
             }
           }
+        }
       });
     }
 
@@ -1447,15 +1446,15 @@
               grid: { display: false }
             }
           },
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                callbacks: {
-                  label: tooltipCountLabel
-                }
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: tooltipCountLabel
               }
             }
           }
+        }
       });
     }
 
@@ -1466,11 +1465,6 @@
       if (dom.insightCount) {
         dom.insightCount.textContent = `${items.length} AI insight${items.length === 1 ? '' : 's'}`;
       }
-      const tone = delta > 0 ? 'positive' : (delta < 0 ? 'negative' : 'neutral');
-      const value = Math.round(delta * 10) / 10;
-      const sign = value > 0 ? '+' : '';
-      return `<span class="qa-delta-badge ${tone}">${sign}${value}</span>`;
-    }
 
       dom.insights.innerHTML = '';
       if (!items.length) {


### PR DESCRIPTION
## Summary
- keep the gauge chart initialization inside the render function to avoid runtime errors
- restore the insights renderer so it updates the DOM instead of returning early
- clean up chart option structures for category and distribution charts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50bad56b08326b049afe14a1ed4f4