### PR TITLE
Improve QA dashboard agent naming and spacing

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -200,6 +200,7 @@
     grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
     gap: 1.25rem;
     margin-top: 1.25rem;
+    margin-bottom: 1.5rem;
   }
 
   .qa-summary-card {
@@ -1180,7 +1181,6 @@
         destroyChart('gauge');
         return;
       }
-    }
 
       destroyChart('gauge');
       state.charts.gauge = new Chart(ctx, {
@@ -1318,15 +1318,15 @@
               grid: { display: false }
             }
           },
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                callbacks: {
-                  label: tooltipPercentLabel
-                }
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: tooltipPercentLabel
               }
             }
           }
+        }
       });
     }
 
@@ -1334,7 +1334,7 @@
       if (!dom.agentCanvas) return;
       const ctx = dom.agentCanvas.getContext('2d');
       const topAgents = (agents || []).slice(0, 8);
-      const labels = topAgents.map(agent => agent.name || 'Agent');
+      const labels = topAgents.map(agent => agent.displayName || agent.name || 'Agent');
       const data = topAgents.map(agent => Number(agent.evaluations) || 0);
       const hasData = labels.length > 0;
 
@@ -1447,15 +1447,15 @@
               grid: { display: false }
             }
           },
-            plugins: {
-              legend: { display: false },
-              tooltip: {
-                callbacks: {
-                  label: tooltipCountLabel
-                }
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: tooltipCountLabel
               }
             }
           }
+        }
       });
     }
 
@@ -1466,11 +1466,6 @@
       if (dom.insightCount) {
         dom.insightCount.textContent = `${items.length} AI insight${items.length === 1 ? '' : 's'}`;
       }
-      const tone = delta > 0 ? 'positive' : (delta < 0 ? 'negative' : 'neutral');
-      const value = Math.round(delta * 10) / 10;
-      const sign = value > 0 ? '+' : '';
-      return `<span class="qa-delta-badge ${tone}">${sign}${value}</span>`;
-    }
 
       dom.insights.innerHTML = '';
       if (!items.length) {
@@ -1603,7 +1598,7 @@
         const row = document.createElement('tr');
         row.innerHTML = `
           <td>
-            <div class="fw-semibold">${agent.name}</div>
+            <div class="fw-semibold">${agent.displayName || agent.name}</div>
             <div class="text-muted small">${agent.recentDate || 'No recent date'}</div>
           </td>
           <td class="text-center">
@@ -1627,7 +1622,16 @@
       }
 
       const availableAgents = (response && response.availableAgents) || [];
-      const agentOptions = availableAgents.map(name => ({ value: name, label: name }));
+      const lookup = response && response.agentNameLookup ? response.agentNameLookup : {};
+      const preferredOptions = Array.isArray(response && response.agentOptions)
+        ? response.agentOptions
+        : null;
+      const agentOptions = preferredOptions && preferredOptions.length
+        ? preferredOptions
+        : availableAgents.map(name => ({
+          value: name,
+          label: lookup && lookup[name] ? lookup[name] : name
+        }));
       populateSelect(dom.agent, agentOptions, 'All Agents');
       if (dom.agent && state.filters.agent) {
         dom.agent.value = state.filters.agent;

--- a/QAService.js
+++ b/QAService.js
@@ -942,18 +942,23 @@ function clientGetQADashboardSnapshot(request = {}) {
     const prevCategoryMetrics = computeCategoryMetrics_(prevFiltered);
     const categorySummary = summarizeCategoryChange_(categoryMetrics, prevCategoryMetrics);
 
-    const { profiles } = calculateAgentProfiles_(filtered);
-    const { profiles: prevProfiles } = calculateAgentProfiles_(prevFiltered);
+    const agentDisplayLookup = buildAgentDisplayLookup_(records);
+
+    const { profiles } = calculateAgentProfiles_(filtered, { displayLookup: agentDisplayLookup });
+    const { profiles: prevProfiles } = calculateAgentProfiles_(prevFiltered, { displayLookup: agentDisplayLookup });
     const prevProfileLookup = {};
     prevProfiles.forEach(profile => {
-      prevProfileLookup[profile.name] = profile;
+      prevProfileLookup[profile.id || profile.name] = profile;
     });
 
     const timezone = context.timezone || Session.getScriptTimeZone();
     const agents = profiles.map(profile => {
-      const previous = prevProfileLookup[profile.name] || null;
+      const key = profile.id || profile.name;
+      const previous = prevProfileLookup[key] || null;
       return {
+        id: profile.id || profile.name,
         name: profile.name,
+        displayName: profile.displayName || profile.name,
         avgScore: profile.avgScore,
         passRate: profile.passRate,
         evaluations: profile.evaluations,
@@ -975,7 +980,8 @@ function clientGetQADashboardSnapshot(request = {}) {
       categoryMetrics,
       prevCategoryMetrics,
       kpis,
-      granularity: context.granularity
+      granularity: context.granularity,
+      agentLookup: agentDisplayLookup
     });
 
     const summary = Object.assign({}, kpis, {
@@ -996,6 +1002,15 @@ function clientGetQADashboardSnapshot(request = {}) {
       .map(entry => ({ value: entry.period, label: entry.label }));
 
     const availableAgents = Array.from(new Set(records.map(record => record.agent).filter(Boolean))).sort();
+    const agentNameLookup = {};
+    const agentOptions = availableAgents.map(identifier => {
+      const label = resolveAgentDisplayNameFromLookup_(identifier, agentDisplayLookup);
+      agentNameLookup[identifier] = label;
+      return {
+        value: identifier,
+        label
+      };
+    });
 
     return {
       success: true,
@@ -1016,7 +1031,9 @@ function clientGetQADashboardSnapshot(request = {}) {
         totalRecords: records.length
       },
       periodOptions,
-      availableAgents
+      availableAgents,
+      agentOptions,
+      agentNameLookup
     };
   } catch (error) {
     console.error('clientGetQADashboardSnapshot failed:', error);
@@ -1421,7 +1438,15 @@ function clampPercent_(value) {
 }
 
 function buildAIIntelligenceAnalysis_(payload) {
-  const { filtered = [], prevFiltered = [], categoryMetrics = {}, prevCategoryMetrics = {}, kpis = {}, granularity } = payload;
+  const {
+    filtered = [],
+    prevFiltered = [],
+    categoryMetrics = {},
+    prevCategoryMetrics = {},
+    kpis = {},
+    granularity,
+    agentLookup = {}
+  } = payload || {};
 
   const totalEvaluations = filtered.length;
   const periodLabel = granularity ? granularity.toLowerCase() : 'period';
@@ -1460,8 +1485,8 @@ function buildAIIntelligenceAnalysis_(payload) {
     };
   }
 
-  const { profiles } = calculateAgentProfiles_(filtered);
-  const { profiles: prevProfiles } = calculateAgentProfiles_(prevFiltered);
+  const { profiles } = calculateAgentProfiles_(filtered, { displayLookup: agentLookup });
+  const { profiles: prevProfiles } = calculateAgentProfiles_(prevFiltered, { displayLookup: agentLookup });
   const categorySummary = summarizeCategoryChange_(categoryMetrics, prevCategoryMetrics);
 
   const totalAgents = profiles.length;
@@ -1497,14 +1522,16 @@ function buildAIIntelligenceAnalysis_(payload) {
 
     const prevProfileMap = {};
     prevProfiles.forEach(profile => {
-      prevProfileMap[profile.name] = profile;
+      const key = profile.id || profile.name;
+      prevProfileMap[key] = profile;
     });
 
     let strongestImprovement = null;
     let largestRegression = null;
 
     profiles.forEach(profile => {
-      const prev = prevProfileMap[profile.name];
+      const key = profile.id || profile.name;
+      const prev = prevProfileMap[key];
       if (!prev) return;
       const delta = profile.avgScore - prev.avgScore;
       if (strongestImprovement === null || delta > strongestImprovement.delta) {
@@ -1602,9 +1629,10 @@ function buildAIIntelligenceAnalysis_(payload) {
   return base;
 }
 
-function calculateAgentProfiles_(records) {
+function calculateAgentProfiles_(records, options = {}) {
   const totalEvaluations = records.length;
   const aggregates = {};
+  const displayLookup = options.displayLookup || {};
 
   records.forEach(record => {
     const name = record.agent || 'Unassigned';
@@ -1613,7 +1641,8 @@ function calculateAgentProfiles_(records) {
         count: 0,
         scoreSum: 0,
         passCount: 0,
-        recent: null
+        recent: null,
+        displayName: ''
       };
     }
 
@@ -1629,6 +1658,13 @@ function calculateAgentProfiles_(records) {
         bucket.recent = record.callDate;
       }
     }
+
+    const candidateName = inferAgentDisplayNameFromRecord_(record, displayLookup);
+    if (candidateName) {
+      if (!bucket.displayName || bucket.displayName === name || bucket.displayName === prettifyAgentIdentifier_(name)) {
+        bucket.displayName = candidateName;
+      }
+    }
   });
 
   const profiles = Object.keys(aggregates).map(name => {
@@ -1636,9 +1672,13 @@ function calculateAgentProfiles_(records) {
     const avgScore = stats.count ? Math.round(stats.scoreSum / stats.count) : 0;
     const passRate = stats.count ? Math.round((stats.passCount / stats.count) * 100) : 0;
     const evaluationShare = totalEvaluations ? Math.round((stats.count / totalEvaluations) * 100) : 0;
+    const displayName = resolveAgentDisplayNameForIdentifier_(name, stats, displayLookup);
 
     return {
-      name,
+      id: name,
+      name: displayName,
+      displayName,
+      rawName: name,
       evaluations: stats.count,
       avgScore,
       passRate,
@@ -1648,6 +1688,151 @@ function calculateAgentProfiles_(records) {
   }).sort((a, b) => b.avgScore - a.avgScore);
 
   return { totalEvaluations, profiles };
+}
+
+function buildAgentDisplayLookup_(records) {
+  const lookup = {};
+
+  const assign = (key, display) => {
+    const normalizedKey = normalizeAgentKey_(key);
+    const cleanedDisplay = display ? String(display).trim() : '';
+    if (!normalizedKey || !cleanedDisplay) {
+      return;
+    }
+    const existing = lookup[normalizedKey];
+    if (!existing || existing === prettifyAgentIdentifier_(key) || existing === String(key || '').trim()) {
+      lookup[normalizedKey] = cleanedDisplay;
+    }
+  };
+
+  try {
+    const users = (typeof getUsers === 'function') ? getUsers() : [];
+    if (Array.isArray(users)) {
+      users.forEach(user => {
+        const display = String(user.FullName || user.UserName || user.Email || '').trim();
+        if (!display) {
+          return;
+        }
+        [user.ID, user.UserName, user.Email].forEach(candidate => assign(candidate, display));
+      });
+    }
+  } catch (directoryError) {
+    console.warn('Unable to load user directory for QA dashboard:', directoryError);
+  }
+
+  (records || []).forEach(record => {
+    if (!record || !record.raw) {
+      return;
+    }
+    const raw = record.raw;
+    const displayCandidate = getRecordFieldValue_(raw, [
+      'AgentName',
+      'Agent Name',
+      'AgentFullName',
+      'Agent Full Name',
+      'Associate Name',
+      'Associate'
+    ]);
+    const displayName = displayCandidate ? String(displayCandidate).trim() : '';
+    if (!displayName) {
+      return;
+    }
+
+    assign(record.agent, displayName);
+    const emailCandidate = getRecordFieldValue_(raw, ['AgentEmail', 'Agent Email', 'Email']);
+    assign(emailCandidate, displayName);
+    const idCandidate = getRecordFieldValue_(raw, ['AgentID', 'Agent Id', 'UserID', 'User Id', 'AgentIdentifier', 'Agent Identifier']);
+    assign(idCandidate, displayName);
+  });
+
+  return lookup;
+}
+
+function inferAgentDisplayNameFromRecord_(record, lookup) {
+  if (!record) {
+    return '';
+  }
+  const raw = record.raw || {};
+  const direct = getRecordFieldValue_(raw, [
+    'AgentName',
+    'Agent Name',
+    'AgentFullName',
+    'Agent Full Name',
+    'Associate Name',
+    'Associate'
+  ]);
+  if (direct) {
+    const name = String(direct).trim();
+    if (name) {
+      return name;
+    }
+  }
+
+  const normalized = normalizeAgentKey_(record.agent);
+  if (normalized && lookup && lookup[normalized]) {
+    return lookup[normalized];
+  }
+
+  return '';
+}
+
+function resolveAgentDisplayNameForIdentifier_(identifier, stats, lookup) {
+  const resolved = resolveAgentDisplayNameFromLookup_(identifier, lookup);
+  if (resolved && resolved !== 'Unassigned') {
+    return resolved;
+  }
+  if (stats && stats.displayName) {
+    return stats.displayName;
+  }
+  if (resolved) {
+    return resolved;
+  }
+  return 'Unassigned';
+}
+
+function resolveAgentDisplayNameFromLookup_(identifier, lookup) {
+  const normalized = normalizeAgentKey_(identifier);
+  if (normalized && lookup && lookup[normalized]) {
+    return lookup[normalized];
+  }
+  const fallback = prettifyAgentIdentifier_(identifier);
+  return fallback || 'Unassigned';
+}
+
+function normalizeAgentKey_(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim().toLowerCase();
+}
+
+function prettifyAgentIdentifier_(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const raw = String(value).trim();
+  if (!raw) {
+    return '';
+  }
+  if (raw.toLowerCase() === 'unassigned') {
+    return 'Unassigned';
+  }
+  if (raw.includes('@')) {
+    const local = raw.split('@')[0];
+    return capitalizeAgentWords_(local.replace(/[._-]+/g, ' '));
+  }
+  if (raw.indexOf(' ') === -1 && /[._-]/.test(raw)) {
+    return capitalizeAgentWords_(raw.replace(/[._-]+/g, ' '));
+  }
+  return capitalizeAgentWords_(raw);
+}
+
+function capitalizeAgentWords_(value) {
+  return String(value || '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
 }
 
 function summarizeCategoryChange_(currentMetrics, previousMetrics) {


### PR DESCRIPTION
## Summary
- add friendly agent name resolution on the QA dashboard service so UI cards, insights, and filters show display names instead of identifiers
- expose agent display labels to the client and update dashboard rendering to use them in charts, tables, and filters
- add breathing room beneath the summary metric grid so subsequent cards no longer crowd it

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50bad56b08326b049afe14a1ed4f4