### PR TITLE
Improve shift slot creation fallback handling

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2350,63 +2350,119 @@
                 try {
                     this.showLoading(true);
 
+                    const getElementValue = (id) => document.getElementById(id)?.value ?? '';
+                    const getNumericValue = (id, fallback, { allowFloat = false, min = null, max = null } = {}) => {
+                        const element = document.getElementById(id);
+                        const rawValue = element ? element.value : '';
+                        const resolvedFallback = (() => {
+                            if (fallback !== undefined) {
+                                return fallback;
+                            }
+                            if (element && element.defaultValue !== undefined && element.defaultValue !== '') {
+                                const parsedDefault = allowFloat
+                                    ? parseFloat(element.defaultValue)
+                                    : parseInt(element.defaultValue, 10);
+                                if (Number.isFinite(parsedDefault)) {
+                                    return parsedDefault;
+                                }
+                            }
+                            return null;
+                        })();
+
+                        if (rawValue === '' || rawValue === null || rawValue === undefined) {
+                            return resolvedFallback;
+                        }
+
+                        const parsed = allowFloat ? parseFloat(rawValue) : parseInt(rawValue, 10);
+                        if (!Number.isFinite(parsed)) {
+                            return resolvedFallback;
+                        }
+
+                        let value = parsed;
+                        if (typeof min === 'number' && value < min) {
+                            value = min;
+                        }
+                        if (typeof max === 'number' && value > max) {
+                            value = max;
+                        }
+
+                        return value;
+                    };
+
                     // Get selected days
                     const selectedDays = [];
                     const dayCheckboxes = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
                     dayCheckboxes.forEach(day => {
                         const checkbox = document.getElementById(day);
                         if (checkbox && checkbox.checked) {
-                            selectedDays.push(parseInt(checkbox.value));
+                            const parsedDay = parseInt(checkbox.value, 10);
+                            if (!Number.isNaN(parsedDay)) {
+                                selectedDays.push(parsedDay);
+                            }
                         }
                     });
 
                     // Enhanced slot data with all new fields (skills removed)
                     const slotData = {
                         // Basic Information
-                        name: document.getElementById('slotName').value,
-                        startTime: document.getElementById('slotStartTime').value,
-                        endTime: document.getElementById('slotEndTime').value,
+                        name: getElementValue('slotName'),
+                        startTime: getElementValue('slotStartTime'),
+                        endTime: getElementValue('slotEndTime'),
                         daysOfWeek: selectedDays,
-                        department: document.getElementById('slotDepartment').value,
-                        location: document.getElementById('slotLocation').value,
-                        description: document.getElementById('slotDescription').value,
+                        department: getElementValue('slotDepartment'),
+                        location: getElementValue('slotLocation'),
+                        description: getElementValue('slotDescription'),
 
                         // Capacity & Staffing
-                        maxCapacity: parseInt(document.getElementById('slotCapacity').value),
-                        minCoverage: parseInt(document.getElementById('slotMinCoverage').value),
-                        priority: parseInt(document.getElementById('slotPriority').value),
+                        maxCapacity: getNumericValue('slotCapacity', 10, { min: 1, max: 100 }),
+                        minCoverage: getNumericValue('slotMinCoverage', 1, { min: 1 }),
+                        priority: getNumericValue('slotPriority', 2, { min: 1, max: 4 }),
 
                         // Break & Lunch Configuration
-                        break1Duration: parseInt(document.getElementById('slotBreak1Duration').value),
-                        lunchDuration: parseInt(document.getElementById('slotLunchDuration').value),
-                        break2Duration: parseInt(document.getElementById('slotBreak2Duration').value),
+                        break1Duration: getNumericValue('slotBreak1Duration', 15, { min: 5, max: 30 }),
+                        lunchDuration: getNumericValue('slotLunchDuration', 30, { min: 15, max: 60 }),
+                        break2Duration: getNumericValue('slotBreak2Duration', 0, { min: 0, max: 30 }),
 
                         // Staggered Breaks
                         enableStaggeredBreaks: document.getElementById('enableStaggeredBreaks').checked,
-                        breakGroups: parseInt(document.getElementById('slotBreakGroups').value),
-                        staggerInterval: parseInt(document.getElementById('slotStaggerInterval').value),
-                        minCoveragePct: parseInt(document.getElementById('slotMinCoveragePct').value),
+                        breakGroups: getNumericValue('slotBreakGroups', 3, { min: 2, max: 5 }),
+                        staggerInterval: getNumericValue('slotStaggerInterval', 15, { min: 10, max: 30 }),
+                        minCoveragePct: getNumericValue('slotMinCoveragePct', 70, { min: 50, max: 95 }),
 
                         // Overtime Configuration
                         enableOvertime: document.getElementById('enableOvertime').checked,
-                        maxDailyOT: parseFloat(document.getElementById('slotMaxDailyOT').value),
-                        maxWeeklyOT: parseFloat(document.getElementById('slotMaxWeeklyOT').value),
-                        otApproval: document.getElementById('slotOTApproval').value,
-                        otRate: parseFloat(document.getElementById('slotOTRate').value),
-                        otPolicy: document.getElementById('slotOTPolicy').value,
+                        maxDailyOT: getNumericValue('slotMaxDailyOT', 0, { allowFloat: true, min: 0 }),
+                        maxWeeklyOT: getNumericValue('slotMaxWeeklyOT', 0, { allowFloat: true, min: 0 }),
+                        otApproval: getElementValue('slotOTApproval'),
+                        otRate: getNumericValue('slotOTRate', 1.5, { allowFloat: true, min: 1 }),
+                        otPolicy: getElementValue('slotOTPolicy'),
 
                         // Advanced Settings (skills removed)
                         allowSwaps: document.getElementById('allowSwaps').checked,
                         weekendPremium: document.getElementById('weekendPremium').checked,
                         holidayPremium: document.getElementById('holidayPremium').checked,
                         autoAssignment: document.getElementById('autoAssignment').checked,
-                        restPeriod: parseInt(document.getElementById('slotRestPeriod').value),
-                        notificationLead: parseInt(document.getElementById('slotNotificationLead').value),
-                        handoverTime: parseInt(document.getElementById('slotHandoverTime').value),
+                        restPeriod: getNumericValue('slotRestPeriod', 8, { min: 0 }),
+                        notificationLead: getNumericValue('slotNotificationLead', 24, { min: 0 }),
+                        handoverTime: getNumericValue('slotHandoverTime', 15, { min: 0 }),
 
                         // System fields
                         createdBy: this.getCurrentUserId() || 'System'
                     };
+
+                    if (Number.isFinite(slotData.maxCapacity) && Number.isFinite(slotData.minCoverage)) {
+                        if (slotData.minCoverage > slotData.maxCapacity) {
+                            slotData.minCoverage = slotData.maxCapacity;
+                        }
+                        if (slotData.minCoverage < 1) {
+                            slotData.minCoverage = 1;
+                        }
+                    }
+
+                    if (!slotData.enableOvertime) {
+                        slotData.maxDailyOT = 0;
+                        slotData.maxWeeklyOT = 0;
+                    }
 
                     // Enhanced validation
                     const validation = this.validateEnhancedShiftSlot(slotData);
@@ -2416,14 +2472,36 @@
 
                     console.log('Creating enhanced shift slot with data:', slotData);
 
-                    const result = await this.callServerFunction('clientCreateEnhancedShiftSlot', slotData);
+                    let result;
+                    let usedLegacyEndpoint = false;
 
-                    if (result && result.success) {
-                        this.showToast('Enhanced shift slot created successfully!', 'success');
+                    try {
+                        result = await this.callServerFunction('clientCreateEnhancedShiftSlot', slotData);
+                    } catch (primaryError) {
+                        if (this.shouldFallbackToLegacySlotCreation(primaryError)) {
+                            console.warn('Enhanced endpoint unavailable, retrying legacy shift slot creation.', primaryError);
+                            usedLegacyEndpoint = true;
+                            result = await this.callServerFunction('clientCreateShiftSlot', slotData);
+                        } else {
+                            throw primaryError;
+                        }
+                    }
+
+                    let normalized = this.normalizeShiftSlotCreationResponse(result);
+                    if (!normalized.success && !usedLegacyEndpoint && normalized.needsLegacyFallback) {
+                        console.warn('Enhanced endpoint returned an unexpected response. Falling back to legacy shift slot creation.');
+                        usedLegacyEndpoint = true;
+                        result = await this.callServerFunction('clientCreateShiftSlot', slotData);
+                        normalized = this.normalizeShiftSlotCreationResponse(result);
+                    }
+
+                    if (normalized.success) {
+                        const successMessage = normalized.message || 'Shift slot created successfully!';
+                        this.showToast(successMessage, 'success');
                         this.resetShiftSlotForm();
                         await this.loadShiftSlots();
                     } else {
-                        throw new Error(result?.error || 'Failed to create shift slot');
+                        throw new Error(normalized.error || 'Failed to create shift slot');
                     }
 
                 } catch (error) {
@@ -2432,6 +2510,141 @@
                 } finally {
                     this.showLoading(false);
                 }
+            }
+
+            shouldFallbackToLegacySlotCreation(error) {
+                if (!error) {
+                    return false;
+                }
+
+                const message = typeof error === 'string' ? error : (error.message || '');
+                if (!message) {
+                    return false;
+                }
+
+                const normalized = message.toLowerCase();
+                return normalized.includes('not a function') ||
+                    normalized.includes('is not defined') ||
+                    normalized.includes('unknown function') ||
+                    normalized.includes('cannot call');
+            }
+
+            normalizeShiftSlotCreationResponse(rawResult) {
+                const coerceString = (value) => {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+                    return String(value).trim();
+                };
+
+                if (rawResult && typeof rawResult === 'object') {
+                    if (rawResult.success === true) {
+                        return {
+                            success: true,
+                            message: coerceString(rawResult.message) || coerceString(rawResult.status),
+                            data: rawResult,
+                            needsLegacyFallback: false
+                        };
+                    }
+
+                    if (rawResult.success === false) {
+                        const errorMessage = coerceString(rawResult.error) || coerceString(rawResult.message) || 'Server reported failure without details';
+                        return {
+                            success: false,
+                            error: errorMessage,
+                            data: rawResult,
+                            needsLegacyFallback: false
+                        };
+                    }
+
+                    const potentialMessage = coerceString(rawResult.message || rawResult.status || rawResult.result);
+                    if (potentialMessage && potentialMessage.toLowerCase().includes('success')) {
+                        return {
+                            success: true,
+                            message: potentialMessage,
+                            data: Object.assign({ success: true }, rawResult),
+                            needsLegacyFallback: false
+                        };
+                    }
+
+                    if (Object.keys(rawResult).length === 0) {
+                        return {
+                            success: false,
+                            error: 'Empty response object received from server',
+                            data: rawResult,
+                            needsLegacyFallback: true
+                        };
+                    }
+
+                    return {
+                        success: false,
+                        error: 'Unexpected response structure from server',
+                        data: rawResult,
+                        needsLegacyFallback: true
+                    };
+                }
+
+                if (rawResult === true) {
+                    return {
+                        success: true,
+                        message: 'Shift slot created successfully',
+                        data: { success: true },
+                        needsLegacyFallback: false
+                    };
+                }
+
+                if (rawResult === false) {
+                    return {
+                        success: false,
+                        error: 'Server indicated shift slot creation failure',
+                        data: { success: false },
+                        needsLegacyFallback: false
+                    };
+                }
+
+                if (typeof rawResult === 'string') {
+                    const trimmed = rawResult.trim();
+                    if (!trimmed) {
+                        return {
+                            success: false,
+                            error: 'Empty response received from server',
+                            data: rawResult,
+                            needsLegacyFallback: true
+                        };
+                    }
+
+                    if (['success', 'ok', 'created', 'done', 'completed'].some(token => trimmed.toLowerCase().includes(token))) {
+                        return {
+                            success: true,
+                            message: trimmed,
+                            data: { success: true, message: trimmed },
+                            needsLegacyFallback: false
+                        };
+                    }
+
+                    return {
+                        success: false,
+                        error: trimmed,
+                        data: rawResult,
+                        needsLegacyFallback: false
+                    };
+                }
+
+                if (rawResult === null || rawResult === undefined) {
+                    return {
+                        success: false,
+                        error: 'No response received from server',
+                        data: rawResult,
+                        needsLegacyFallback: true
+                    };
+                }
+
+                return {
+                    success: false,
+                    error: 'Unexpected response type received from server',
+                    data: rawResult,
+                    needsLegacyFallback: true
+                };
             }
 
             validateEnhancedShiftSlot(slotData) {
@@ -2460,45 +2673,61 @@
                     }
 
                     const duration = (end - start) / (1000 * 60 * 60); // hours
-                    if (duration < 2) {
-                        errors.push('Shift must be at least 2 hours long');
-                    }
-                    if (duration > 12) {
-                        errors.push('Shift cannot be longer than 12 hours');
+                    if (!Number.isFinite(duration)) {
+                        errors.push('Unable to determine shift duration. Please verify the start and end times.');
+                    } else {
+                        if (duration < 2) {
+                            errors.push('Shift must be at least 2 hours long');
+                        }
+                        if (duration > 12) {
+                            errors.push('Shift cannot be longer than 12 hours');
+                        }
                     }
                 }
 
                 // Capacity validation
-                if (slotData.maxCapacity < 1 || slotData.maxCapacity > 100) {
+                if (!Number.isFinite(slotData.maxCapacity)) {
+                    errors.push('Max capacity is required');
+                } else if (slotData.maxCapacity < 1 || slotData.maxCapacity > 100) {
                     errors.push('Max capacity must be between 1 and 100');
                 }
 
-                if (slotData.minCoverage < 1 || slotData.minCoverage > slotData.maxCapacity) {
+                if (!Number.isFinite(slotData.minCoverage)) {
+                    errors.push('Minimum coverage is required');
+                } else if (slotData.minCoverage < 1) {
+                    errors.push('Min coverage must be at least 1');
+                } else if (Number.isFinite(slotData.maxCapacity) && slotData.minCoverage > slotData.maxCapacity) {
                     errors.push('Min coverage must be between 1 and max capacity');
                 }
 
                 // Break validation
-                if (slotData.break1Duration < 5 || slotData.break1Duration > 30) {
+                if (Number.isFinite(slotData.break1Duration) && (slotData.break1Duration < 5 || slotData.break1Duration > 30)) {
                     errors.push('First break duration must be between 5 and 30 minutes');
                 }
 
-                if (slotData.lunchDuration < 15 || slotData.lunchDuration > 60) {
+                if (Number.isFinite(slotData.lunchDuration) && (slotData.lunchDuration < 15 || slotData.lunchDuration > 60)) {
                     errors.push('Lunch duration must be between 15 and 60 minutes');
+                }
+
+                if (!Number.isFinite(slotData.minCoveragePct)) {
+                    errors.push('Minimum coverage percentage is required');
+                } else if (slotData.minCoveragePct < 50 || slotData.minCoveragePct > 95) {
+                    errors.push('Minimum coverage percentage must be between 50% and 95%');
                 }
 
                 // Overtime validation
                 if (slotData.enableOvertime) {
-                    if (slotData.maxDailyOT < 0.5 || slotData.maxDailyOT > 4) {
+                    if (!Number.isFinite(slotData.maxDailyOT)) {
+                        errors.push('Max daily overtime is required when overtime is enabled');
+                    } else if (slotData.maxDailyOT < 0.5 || slotData.maxDailyOT > 4) {
                         errors.push('Max daily overtime must be between 0.5 and 4 hours');
                     }
-                    if (slotData.maxWeeklyOT < 2 || slotData.maxWeeklyOT > 20) {
+
+                    if (!Number.isFinite(slotData.maxWeeklyOT)) {
+                        errors.push('Max weekly overtime is required when overtime is enabled');
+                    } else if (slotData.maxWeeklyOT < 2 || slotData.maxWeeklyOT > 20) {
                         errors.push('Max weekly overtime must be between 2 and 20 hours');
                     }
-                }
-
-                // Coverage validation
-                if (slotData.minCoveragePct < 50 || slotData.minCoveragePct > 95) {
-                    errors.push('Minimum coverage percentage must be between 50% and 95%');
                 }
 
                 return {

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -186,6 +186,10 @@ function clientCreateShiftSlot(slotData) {
     const slotId = Utilities.getUuid();
 
     const toNumber = (value, fallback = '') => {
+      if (value === null || value === undefined || value === '') {
+        return fallback;
+      }
+
       const num = Number(value);
       return Number.isFinite(num) ? num : fallback;
     };
@@ -280,10 +284,14 @@ function clientCreateShiftSlot(slotData) {
 
   } catch (error) {
     console.error('❌ Error creating shift slot:', error);
-    safeWriteError('clientCreateShiftSlot', error);
+    try {
+      safeWriteError('clientCreateShiftSlot', error);
+    } catch (loggingError) {
+      console.error('Error logging shift slot failure:', loggingError);
+    }
     return {
       success: false,
-      error: error.message
+      error: error && error.message ? error.message : String(error || 'Unknown error')
     };
   }
 }


### PR DESCRIPTION
## Summary
- sanitize shift slot form inputs with numeric helpers so defaults are applied instead of sending NaN values
- strengthen client-side validation messaging for capacity, break, coverage, and overtime requirements
- harden server-side numeric conversion fallbacks and error reporting for shift slot creation failures
- add legacy endpoint fallback and response normalization so shift slots still save when the enhanced Apps Script function is missing or returns unexpected payloads

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5ae690a8c8326a7d3170164fc5dca