### PR TITLE
Ensure session token remains stored after session refresh

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -778,8 +778,8 @@ var AuthenticationService = (function () {
         }
       }
 
-      if (getRecordValue(record, 'Token')) {
-        setRecordValue(record, 'Token', '');
+      if (sessionToken) {
+        setRecordValue(record, 'Token', sessionToken);
       }
 
       try {


### PR DESCRIPTION
## Summary
- keep the plain session token value in session records when the session is refreshed so it is not cleared during navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c865a0248326a85a9e231aea0b22