### PR TITLE
Fix password verification for legacy hash formats

### DIFF
--- a/PasswordUtilities.js
+++ b/PasswordUtilities.js
@@ -12,10 +12,36 @@ function __createPasswordUtilitiesModule() {
     return raw == null ? '' : String(raw);
   }
 
+  var HEX_HASH_REGEX = /^[0-9a-fA-F]+$/;
+  var BASE64_HASH_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+  var BASE64_WEBSAFE_REGEX = /^[A-Za-z0-9_-]+={0,2}$/;
+
+  function isHexHash(value) {
+    return !!value && HEX_HASH_REGEX.test(value);
+  }
+
+  function isBase64Hash(value) {
+    return !!value && BASE64_HASH_REGEX.test(value);
+  }
+
+  function isBase64WebSafeHash(value) {
+    return !!value && BASE64_WEBSAFE_REGEX.test(value);
+  }
+
+  function stripBase64Padding(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value).replace(/=+$/, '');
+  }
+
   function normalizeHash(hash) {
     if (hash === null || typeof hash === 'undefined') return '';
     if (hash instanceof Date) return hash.toISOString();
-    return String(hash).trim().toLowerCase();
+    var str = String(hash).trim();
+    if (!str) return '';
+    if (isHexHash(str)) {
+      return str.toLowerCase();
+    }
+    return str;
   }
 
   function digestToHex(digest) {
@@ -25,14 +51,31 @@ function __createPasswordUtilitiesModule() {
       .join('');
   }
 
-  function hashPassword(raw) {
+  function computeHashVariants(raw) {
     var normalized = normalizePasswordInput(raw);
     var digest = Utilities.computeDigest(
       Utilities.DigestAlgorithm.SHA_256,
       normalized,
       Utilities.Charset.UTF_8
     );
-    return digestToHex(digest);
+
+    return {
+      hex: digestToHex(digest),
+      base64: Utilities.base64Encode(digest),
+      base64WebSafe: Utilities.base64EncodeWebSafe(digest)
+    };
+  }
+
+  function hashPassword(raw) {
+    return computeHashVariants(raw).hex;
+  }
+
+  function hashPasswordBase64(raw) {
+    return computeHashVariants(raw).base64;
+  }
+
+  function hashPasswordWebSafe(raw) {
+    return computeHashVariants(raw).base64WebSafe;
   }
 
   function constantTimeEquals(a, b) {
@@ -50,8 +93,55 @@ function __createPasswordUtilitiesModule() {
   function verifyPassword(raw, expectedHash) {
     var normalizedExpected = normalizeHash(expectedHash);
     if (!normalizedExpected) return false;
-    var hashed = hashPassword(raw);
-    return constantTimeEquals(hashed, normalizedExpected);
+
+    var variants = computeHashVariants(raw);
+
+    if (constantTimeEquals(variants.hex, normalizedExpected)) {
+      return true;
+    }
+
+    var looksBase64 = isBase64Hash(normalizedExpected);
+    var looksWebSafe = isBase64WebSafeHash(normalizedExpected);
+
+    if (looksBase64 || looksWebSafe) {
+      if (variants.base64 && constantTimeEquals(variants.base64, normalizedExpected)) {
+        return true;
+      }
+
+      if (variants.base64WebSafe && constantTimeEquals(variants.base64WebSafe, normalizedExpected)) {
+        return true;
+      }
+
+      var storedNoPad = stripBase64Padding(normalizedExpected);
+      if (storedNoPad && storedNoPad !== normalizedExpected) {
+        var base64NoPad = stripBase64Padding(variants.base64);
+        var webSafeNoPad = stripBase64Padding(variants.base64WebSafe);
+
+        if (base64NoPad && constantTimeEquals(base64NoPad, storedNoPad)) {
+          return true;
+        }
+
+        if (webSafeNoPad && constantTimeEquals(webSafeNoPad, storedNoPad)) {
+          return true;
+        }
+      }
+
+      try {
+        var decodedHex = digestToHex(Utilities.base64Decode(normalizedExpected));
+        if (decodedHex && constantTimeEquals(decodedHex, variants.hex)) {
+          return true;
+        }
+      } catch (err1) {}
+
+      try {
+        var decodedWebSafeHex = digestToHex(Utilities.base64DecodeWebSafe(normalizedExpected));
+        if (decodedWebSafeHex && constantTimeEquals(decodedWebSafeHex, variants.hex)) {
+          return true;
+        }
+      } catch (err2) {}
+    }
+
+    return false;
   }
 
   function createPasswordHash(raw) {
@@ -62,16 +152,48 @@ function __createPasswordUtilitiesModule() {
     return normalizeHash(hash);
   }
 
+  function detectHashFormat(hash) {
+    if (hash === null || typeof hash === 'undefined') {
+      return 'empty';
+    }
+
+    var trimmed = String(hash).trim();
+    if (!trimmed) {
+      return 'empty';
+    }
+
+    if (isHexHash(trimmed)) {
+      return 'hex';
+    }
+
+    if (isBase64WebSafeHash(trimmed)) {
+      return 'base64-websafe';
+    }
+
+    if (isBase64Hash(trimmed)) {
+      return 'base64';
+    }
+
+    return 'unknown';
+  }
+
   return {
     normalizePasswordInput: normalizePasswordInput,
     normalizeHash: normalizeHash,
     decodePasswordHash: decodePasswordHash,
     digestToHex: digestToHex,
     hashPassword: hashPassword,
+    hashPasswordBase64: hashPasswordBase64,
+    hashPasswordWebSafe: hashPasswordWebSafe,
     createPasswordHash: createPasswordHash,
     verifyPassword: verifyPassword,
     comparePassword: verifyPassword,
-    constantTimeEquals: constantTimeEquals
+    constantTimeEquals: constantTimeEquals,
+    detectHashFormat: detectHashFormat,
+    getPasswordHashVariants: computeHashVariants,
+    isHexHash: isHexHash,
+    isBase64Hash: isBase64Hash,
+    isBase64WebSafeHash: isBase64WebSafeHash
   };
 }
 


### PR DESCRIPTION
## Summary
- extend PasswordUtilities with hash format detection and legacy base64 verification helpers
- update AuthenticationService password checks to detect hash format, reuse new helpers, and log compatibility results

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e785ae32c4832689d2c075068546d2