### PR TITLE
Centralize password hashing workflows

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -94,17 +94,25 @@ var AuthenticationService = (function () {
   // ─── Password utilities with error handling ─────────────────────────────────
   
   function getPasswordUtils() {
-    try {
-      if (typeof ensurePasswordUtilities === 'function') {
+    if (typeof ensurePasswordUtilities === 'function') {
+      try {
         return ensurePasswordUtilities();
+      } catch (error) {
+        console.error('getPasswordUtils: ensurePasswordUtilities failed', error);
       }
-      if (typeof PasswordUtilities !== 'undefined' && PasswordUtilities) {
-        return PasswordUtilities;
-      }
-      throw new Error('PasswordUtilities not available');
+    }
+    if (typeof PasswordUtilities !== 'undefined' && PasswordUtilities) {
+      return PasswordUtilities;
+    }
+    throw new Error('Password utilities not available');
+  }
+
+  function safeGetPasswordUtils() {
+    try {
+      return getPasswordUtils();
     } catch (error) {
-      console.error('Error getting password utilities:', error);
-      throw new Error('Password utilities not available');
+      console.warn('safeGetPasswordUtils: password utilities unavailable', error);
+      return null;
     }
   }
 
@@ -4412,14 +4420,12 @@ var AuthenticationService = (function () {
   function verifyUserPassword(inputPassword, storedHash, userInfo = {}) {
     try {
       console.log('verifyUserPassword: Starting verification for user:', userInfo.email || 'unknown');
-      
-      // Check if password was provided
+
       if (!inputPassword && inputPassword !== 0) {
         console.log('verifyUserPassword: No password provided');
         return { success: false, reason: 'NO_PASSWORD_PROVIDED' };
       }
 
-      // Check if user has a stored hash
       const normalizedHash = normalizeString(storedHash);
       if (!normalizedHash) {
         console.log('verifyUserPassword: No stored password hash');
@@ -4428,7 +4434,6 @@ var AuthenticationService = (function () {
 
       console.log('verifyUserPassword: Hash length:', normalizedHash.length);
 
-      // Get password utilities
       let passwordUtils;
       try {
         passwordUtils = getPasswordUtils();
@@ -4437,50 +4442,182 @@ var AuthenticationService = (function () {
         return { success: false, reason: 'UTILS_ERROR', error: utilsError.message };
       }
 
-      // Attempt verification with multiple methods for robustness
       const inputStr = String(inputPassword);
-      
-      // Method 1: Direct verification
+
+      let hashFormat = 'unknown';
+      try {
+        if (passwordUtils && typeof passwordUtils.detectHashFormat === 'function') {
+          hashFormat = passwordUtils.detectHashFormat(normalizedHash);
+        }
+      } catch (formatError) {
+        console.warn('verifyUserPassword: detectHashFormat failed:', formatError);
+      }
+      console.log('verifyUserPassword: Detected hash format:', hashFormat);
+
+      const equalsFn = (passwordUtils && typeof passwordUtils.constantTimeEquals === 'function')
+        ? function (a, b) {
+            try {
+              return passwordUtils.constantTimeEquals(String(a), String(b));
+            } catch (eqError) {
+              console.warn('verifyUserPassword: constantTimeEquals error:', eqError);
+              return String(a) === String(b);
+            }
+          }
+        : function (a, b) {
+            return String(a) === String(b);
+          };
+
+      let hashVariants = null;
+      function ensureHashVariants() {
+        if (hashVariants || !passwordUtils || typeof passwordUtils.getPasswordHashVariants !== 'function') {
+          return hashVariants;
+        }
+        try {
+          hashVariants = passwordUtils.getPasswordHashVariants(inputStr);
+          console.log('verifyUserPassword: Generated hash variants for compatibility checks');
+        } catch (variantError) {
+          console.warn('verifyUserPassword: Failed to generate hash variants:', variantError);
+          hashVariants = null;
+        }
+        return hashVariants;
+      }
+
+      function stripBase64Padding(value) {
+        if (!value && value !== 0) return '';
+        return String(value).replace(/=+$/, '');
+      }
+
+      // Method 1: Direct verification (handles legacy hashes via PasswordUtilities)
       try {
         const isValid = passwordUtils.verifyPassword(inputStr, normalizedHash);
         console.log('verifyUserPassword: Direct verification result:', isValid);
-        
+
         if (isValid) {
-          return { success: true, method: 'direct' };
+          return {
+            success: true,
+            method: 'direct',
+            hashFormat: hashFormat
+          };
         }
       } catch (verifyError) {
         console.warn('verifyUserPassword: Direct verification failed:', verifyError);
       }
 
-      // Method 2: Normalize hash first, then verify
+      // Method 2: Normalize hash first, then verify using hex representation
       try {
         const normalizedStoredHash = passwordUtils.normalizeHash(normalizedHash);
-        const newInputHash = passwordUtils.hashPassword(inputStr);
-        const matches = passwordUtils.constantTimeEquals(newInputHash, normalizedStoredHash);
+        const variants = ensureHashVariants();
+        const newInputHash = (variants && variants.hex)
+          ? variants.hex
+          : passwordUtils.createPasswordHash(inputStr);
+        const matches = equalsFn(newInputHash, normalizedStoredHash);
         console.log('verifyUserPassword: Normalized comparison result:', matches);
-        
+
         if (matches) {
-          return { success: true, method: 'normalized' };
+          return {
+            success: true,
+            method: 'normalized',
+            hashFormat: hashFormat
+          };
         }
       } catch (normalizeError) {
         console.warn('verifyUserPassword: Normalized verification failed:', normalizeError);
       }
 
-      // Method 3: Direct hash comparison
+      // Method 3: Direct hash comparison with stored value
       try {
-        const newInputHash = passwordUtils.hashPassword(inputStr);
-        const matches = passwordUtils.constantTimeEquals(newInputHash, normalizedHash);
+        const variants = ensureHashVariants();
+        const newInputHash = (variants && variants.hex)
+          ? variants.hex
+          : passwordUtils.createPasswordHash(inputStr);
+        const matches = equalsFn(newInputHash, normalizedHash);
         console.log('verifyUserPassword: Direct hash comparison result:', matches);
-        
+
         if (matches) {
-          return { success: true, method: 'direct_hash' };
+          return {
+            success: true,
+            method: 'direct_hash',
+            hashFormat: hashFormat
+          };
         }
       } catch (hashError) {
         console.warn('verifyUserPassword: Direct hash comparison failed:', hashError);
       }
 
+      // Method 4: Legacy base64 compatibility checks
+      try {
+        const variants = ensureHashVariants();
+        if (variants) {
+          let legacyMatch = false;
+          let legacyMethod = (hashFormat === 'base64-websafe') ? 'legacy_base64_websafe' : 'legacy_base64';
+
+          if (variants.base64 && normalizedHash) {
+            if (equalsFn(variants.base64, normalizedHash)) {
+              legacyMatch = true;
+              legacyMethod = 'legacy_base64';
+            }
+          }
+
+          if (!legacyMatch && variants.base64WebSafe && normalizedHash) {
+            if (equalsFn(variants.base64WebSafe, normalizedHash)) {
+              legacyMatch = true;
+              legacyMethod = 'legacy_base64_websafe';
+            }
+          }
+
+          if (!legacyMatch && normalizedHash) {
+            const storedNoPad = stripBase64Padding(normalizedHash);
+            if (storedNoPad) {
+              if (variants.base64 && equalsFn(stripBase64Padding(variants.base64), storedNoPad)) {
+                legacyMatch = true;
+                legacyMethod = 'legacy_base64';
+              } else if (variants.base64WebSafe && equalsFn(stripBase64Padding(variants.base64WebSafe), storedNoPad)) {
+                legacyMatch = true;
+                legacyMethod = 'legacy_base64_websafe';
+              }
+            }
+          }
+
+          if (!legacyMatch && variants.hex) {
+            try {
+              const decodedHex = passwordUtils.digestToHex
+                ? passwordUtils.digestToHex(Utilities.base64Decode(normalizedHash))
+                : null;
+              if (decodedHex && equalsFn(decodedHex, variants.hex)) {
+                legacyMatch = true;
+                legacyMethod = 'legacy_base64';
+              }
+            } catch (decodeError) {
+              try {
+                const decodedWebSafeHex = passwordUtils.digestToHex
+                  ? passwordUtils.digestToHex(Utilities.base64DecodeWebSafe(normalizedHash))
+                  : null;
+                if (decodedWebSafeHex && equalsFn(decodedWebSafeHex, variants.hex)) {
+                  legacyMatch = true;
+                  legacyMethod = 'legacy_base64_websafe';
+                }
+              } catch (decodeWebSafeError) {
+                // Ignore decode errors; we'll fall through to mismatch handling
+              }
+            }
+          }
+
+          console.log('verifyUserPassword: Legacy hash comparison result:', legacyMatch);
+
+          if (legacyMatch) {
+            return {
+              success: true,
+              method: legacyMethod,
+              hashFormat: hashFormat
+            };
+          }
+        }
+      } catch (legacyError) {
+        console.warn('verifyUserPassword: Legacy hash verification failed:', legacyError);
+      }
+
       console.log('verifyUserPassword: All verification methods failed');
-      return { success: false, reason: 'PASSWORD_MISMATCH' };
+      return { success: false, reason: 'PASSWORD_MISMATCH', hashFormat: hashFormat };
 
     } catch (error) {
       console.error('verifyUserPassword: Unexpected error:', error);
@@ -5599,6 +5736,7 @@ function debugAuthenticationIssues(email, password) {
     
     const storedHash = user.PasswordHash || '';
     const hasPassword = storedHash && storedHash.trim() !== '';
+    const passwordUtils = safeGetPasswordUtils();
     
     results.passwordCheck = {
       hasStoredHash: hasPassword,
@@ -5606,7 +5744,8 @@ function debugAuthenticationIssues(email, password) {
       storedHashSample: storedHash ? storedHash.substring(0, 10) + '...' : 'empty',
       canLogin: user.CanLogin,
       emailConfirmed: user.EmailConfirmed,
-      resetRequired: user.ResetRequired
+      resetRequired: user.ResetRequired,
+      passwordUtilsAvailable: !!passwordUtils
     };
 
     if (!hasPassword) {
@@ -5615,40 +5754,46 @@ function debugAuthenticationIssues(email, password) {
     } else {
       // Test password verification methods
       let verificationResults = {};
-      
+
       // Method 1: PasswordUtilities.verifyPassword
-      if (typeof PasswordUtilities !== 'undefined') {
+      if (passwordUtils) {
+        let computedRecord = null;
+
         try {
-          const isValid1 = PasswordUtilities.verifyPassword(password, storedHash);
+          const isValid1 = passwordUtils.verifyPassword(password, storedHash);
           verificationResults.passwordUtilsResult = isValid1;
           console.log('PasswordUtilities.verifyPassword result:', isValid1);
         } catch (e) {
           verificationResults.passwordUtilsError = e.message;
         }
-      }
 
-      // Method 2: Test hash generation
-      if (typeof PasswordUtilities !== 'undefined') {
+        // Method 2: Test hash generation
         try {
-          const newHash = PasswordUtilities.hashPassword(password);
+          computedRecord = passwordUtils.createPasswordRecord(password);
+          const newHash = computedRecord.hash || '';
           verificationResults.newHashMatches = (newHash === storedHash);
-          verificationResults.newHashSample = newHash.substring(0, 10) + '...';
+          verificationResults.newHashSample = newHash ? newHash.substring(0, 10) + '...' : 'empty';
+          verificationResults.generatedFormat = computedRecord.hashFormat;
+          verificationResults.generatedAlgorithm = computedRecord.algorithm;
           console.log('Generated hash matches stored:', newHash === storedHash);
         } catch (e) {
           verificationResults.hashGenError = e.message;
         }
-      }
 
-      // Method 3: Test normalized hash
-      if (typeof PasswordUtilities !== 'undefined') {
+        // Method 3: Test normalized hash
         try {
-          const normalizedStored = PasswordUtilities.normalizeHash(storedHash);
-          const newHash = PasswordUtilities.hashPassword(password);
-          verificationResults.normalizedComparison = (newHash === normalizedStored);
-          console.log('Normalized hash comparison:', newHash === normalizedStored);
+          const normalizedStored = passwordUtils.normalizeHash(storedHash);
+          if (!computedRecord) {
+            computedRecord = passwordUtils.createPasswordRecord(password);
+          }
+          const normalizedHash = computedRecord ? computedRecord.hash : '';
+          verificationResults.normalizedComparison = (normalizedHash === normalizedStored);
+          console.log('Normalized hash comparison:', normalizedHash === normalizedStored);
         } catch (e) {
           verificationResults.normalizeError = e.message;
         }
+      } else {
+        verificationResults.passwordUtilsError = 'Password utilities not available';
       }
 
       results.passwordCheck.verificationTests = verificationResults;
@@ -5687,7 +5832,7 @@ function debugAuthenticationIssues(email, password) {
     
     const systemChecks = {
       authServiceAvailable: typeof AuthenticationService !== 'undefined',
-      passwordUtilsAvailable: typeof PasswordUtilities !== 'undefined',
+      passwordUtilsAvailable: !!passwordUtils,
       usersSheetExists: false,
       usersSheetRowCount: 0
     };
@@ -5728,41 +5873,47 @@ function testPasswordHashing(plainPassword) {
       tests: {}
     };
 
-    if (typeof PasswordUtilities !== 'undefined') {
+    const utils = safeGetPasswordUtils();
+
+    if (utils) {
       // Test 1: Basic hashing
-      const hash1 = PasswordUtilities.hashPassword(plainPassword);
-      const hash2 = PasswordUtilities.hashPassword(plainPassword);
-      
+      const record1 = utils.createPasswordRecord(plainPassword);
+      const record2 = utils.createPasswordRecord(plainPassword);
+
       results.tests.basicHashing = {
-        hash1: hash1,
-        hash2: hash2,
-        consistent: hash1 === hash2,
-        length: hash1.length
+        hash1: record1.hash,
+        hash2: record2.hash,
+        consistent: record1.hash === record2.hash,
+        length: (record1.hash || '').length,
+        format: record1.hashFormat,
+        algorithm: record1.algorithm
       };
 
       // Test 2: Verification
-      const verifies = PasswordUtilities.verifyPassword(plainPassword, hash1);
+      const verifies = utils.verifyPassword(plainPassword, record1.hash);
       results.tests.verification = {
         verifies: verifies
       };
 
       // Test 3: Normalization
-      const normalized = PasswordUtilities.normalizeHash(hash1);
+      const normalized = utils.normalizeHash(record1.hash);
       results.tests.normalization = {
-        original: hash1,
+        original: record1.hash,
         normalized: normalized,
-        same: hash1 === normalized
+        same: record1.hash === normalized
       };
 
       // Test 4: Edge cases
       results.tests.edgeCases = {
-        emptyPassword: PasswordUtilities.hashPassword(''),
-        spacePassword: PasswordUtilities.hashPassword(' '),
-        nullPassword: PasswordUtilities.hashPassword(null)
+        emptyPassword: utils.createPasswordHash(''),
+        spacePassword: utils.createPasswordHash(' '),
+        nullPassword: utils.createPasswordHash(null)
       };
 
+      results.tests.variants = record1.variants;
+
     } else {
-      results.error = 'PasswordUtilities not available';
+      results.error = 'Password utilities not available';
     }
 
     return results;
@@ -5845,13 +5996,30 @@ function fixAuthenticationIssues(email, options = {}) {
       }
     }
 
-    if (generateNewHash && newPassword && typeof PasswordUtilities !== 'undefined') {
-      const passwordHashCol = getColumnIndex('PasswordHash');
-      if (passwordHashCol !== -1) {
-        const newHash = PasswordUtilities.hashPassword(newPassword);
-        sheet.getRange(rowNumber, passwordHashCol + 1).setValue(newHash);
-        results.actions.push('Generated new password hash');
-        results.newHashSample = newHash.substring(0, 10) + '...';
+    if (generateNewHash && newPassword) {
+      const utils = safeGetPasswordUtils();
+      if (utils) {
+        const passwordUpdate = utils.createPasswordUpdate(newPassword);
+        const updateColumns = passwordUpdate.columns || { PasswordHash: passwordUpdate.hash };
+
+        Object.keys(updateColumns).forEach((columnName) => {
+          const colIndex = getColumnIndex(columnName);
+          if (colIndex !== -1) {
+            sheet.getRange(rowNumber, colIndex + 1).setValue(updateColumns[columnName]);
+          }
+        });
+
+        if (passwordUpdate.algorithm) {
+          const algorithmCol = getColumnIndex('PasswordHashAlgorithm');
+          if (algorithmCol !== -1) {
+            sheet.getRange(rowNumber, algorithmCol + 1).setValue(passwordUpdate.algorithm);
+          }
+        }
+
+        results.actions.push('Generated new password hash (' + (passwordUpdate.hashFormat || 'hex') + ')');
+        results.newHashSample = passwordUpdate.hash ? passwordUpdate.hash.substring(0, 10) + '...' : 'empty';
+      } else {
+        results.errors.push('Password utilities unavailable - unable to generate password hash');
       }
     }
 

--- a/PasswordUtilities.js
+++ b/PasswordUtilities.js
@@ -12,10 +12,36 @@ function __createPasswordUtilitiesModule() {
     return raw == null ? '' : String(raw);
   }
 
+  var HEX_HASH_REGEX = /^[0-9a-fA-F]+$/;
+  var BASE64_HASH_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+  var BASE64_WEBSAFE_REGEX = /^[A-Za-z0-9_-]+={0,2}$/;
+
+  function isHexHash(value) {
+    return !!value && HEX_HASH_REGEX.test(value);
+  }
+
+  function isBase64Hash(value) {
+    return !!value && BASE64_HASH_REGEX.test(value);
+  }
+
+  function isBase64WebSafeHash(value) {
+    return !!value && BASE64_WEBSAFE_REGEX.test(value);
+  }
+
+  function stripBase64Padding(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value).replace(/=+$/, '');
+  }
+
   function normalizeHash(hash) {
     if (hash === null || typeof hash === 'undefined') return '';
     if (hash instanceof Date) return hash.toISOString();
-    return String(hash).trim().toLowerCase();
+    var str = String(hash).trim();
+    if (!str) return '';
+    if (isHexHash(str)) {
+      return str.toLowerCase();
+    }
+    return str;
   }
 
   function digestToHex(digest) {
@@ -25,14 +51,89 @@ function __createPasswordUtilitiesModule() {
       .join('');
   }
 
-  function hashPassword(raw) {
+  function computeHashVariants(raw) {
     var normalized = normalizePasswordInput(raw);
     var digest = Utilities.computeDigest(
       Utilities.DigestAlgorithm.SHA_256,
       normalized,
       Utilities.Charset.UTF_8
     );
-    return digestToHex(digest);
+
+    return {
+      hex: digestToHex(digest),
+      base64: Utilities.base64Encode(digest),
+      base64WebSafe: Utilities.base64EncodeWebSafe(digest)
+    };
+  }
+
+  function normalizePreferredHashFormat(format) {
+    var normalized = String(format || '').trim().toLowerCase();
+    if (normalized === 'base64' || normalized === 'b64') {
+      return 'base64';
+    }
+    if (normalized === 'base64-websafe' || normalized === 'base64_websafe'
+      || normalized === 'base64websafe' || normalized === 'websafe'
+      || normalized === 'base64url' || normalized === 'base64-url') {
+      return 'base64-websafe';
+    }
+    return 'hex';
+  }
+
+  function selectHashVariantForFormat(variants, format) {
+    if (!variants) {
+      return '';
+    }
+
+    if (format === 'base64' && typeof variants.base64 !== 'undefined') {
+      return variants.base64 || '';
+    }
+
+    if (format === 'base64-websafe' && typeof variants.base64WebSafe !== 'undefined') {
+      return variants.base64WebSafe || '';
+    }
+
+    if (typeof variants.hex !== 'undefined' && variants.hex) {
+      return variants.hex;
+    }
+
+    if (typeof variants.base64 !== 'undefined' && variants.base64) {
+      return variants.base64;
+    }
+
+    if (typeof variants.base64WebSafe !== 'undefined' && variants.base64WebSafe) {
+      return variants.base64WebSafe;
+    }
+
+    return '';
+  }
+
+  function createPasswordRecord(raw, options) {
+    var variants = computeHashVariants(raw);
+    var preferredFormat = normalizePreferredHashFormat(options && options.format);
+    var selectedHash = selectHashVariantForFormat(variants, preferredFormat);
+
+    return {
+      hash: selectedHash,
+      hashFormat: preferredFormat,
+      algorithm: 'SHA-256',
+      variants: variants
+    };
+  }
+
+  function createPasswordHash(raw, options) {
+    return createPasswordRecord(raw, options).hash;
+  }
+
+  function hashPassword(raw) {
+    return createPasswordHash(raw);
+  }
+
+  function hashPasswordBase64(raw) {
+    return createPasswordHash(raw, { format: 'base64' });
+  }
+
+  function hashPasswordWebSafe(raw) {
+    return createPasswordHash(raw, { format: 'base64-websafe' });
   }
 
   function constantTimeEquals(a, b) {
@@ -50,16 +151,115 @@ function __createPasswordUtilitiesModule() {
   function verifyPassword(raw, expectedHash) {
     var normalizedExpected = normalizeHash(expectedHash);
     if (!normalizedExpected) return false;
-    var hashed = hashPassword(raw);
-    return constantTimeEquals(hashed, normalizedExpected);
-  }
 
-  function createPasswordHash(raw) {
-    return hashPassword(raw);
+    var variants = computeHashVariants(raw);
+
+    if (constantTimeEquals(variants.hex, normalizedExpected)) {
+      return true;
+    }
+
+    var looksBase64 = isBase64Hash(normalizedExpected);
+    var looksWebSafe = isBase64WebSafeHash(normalizedExpected);
+
+    if (looksBase64 || looksWebSafe) {
+      if (variants.base64 && constantTimeEquals(variants.base64, normalizedExpected)) {
+        return true;
+      }
+
+      if (variants.base64WebSafe && constantTimeEquals(variants.base64WebSafe, normalizedExpected)) {
+        return true;
+      }
+
+      var storedNoPad = stripBase64Padding(normalizedExpected);
+      if (storedNoPad && storedNoPad !== normalizedExpected) {
+        var base64NoPad = stripBase64Padding(variants.base64);
+        var webSafeNoPad = stripBase64Padding(variants.base64WebSafe);
+
+        if (base64NoPad && constantTimeEquals(base64NoPad, storedNoPad)) {
+          return true;
+        }
+
+        if (webSafeNoPad && constantTimeEquals(webSafeNoPad, storedNoPad)) {
+          return true;
+        }
+      }
+
+      try {
+        var decodedHex = digestToHex(Utilities.base64Decode(normalizedExpected));
+        if (decodedHex && constantTimeEquals(decodedHex, variants.hex)) {
+          return true;
+        }
+      } catch (err1) {}
+
+      try {
+        var decodedWebSafeHex = digestToHex(Utilities.base64DecodeWebSafe(normalizedExpected));
+        if (decodedWebSafeHex && constantTimeEquals(decodedWebSafeHex, variants.hex)) {
+          return true;
+        }
+      } catch (err2) {}
+    }
+
+    return false;
   }
 
   function decodePasswordHash(hash) {
     return normalizeHash(hash);
+  }
+
+  function createPasswordUpdate(raw, options) {
+    var record = createPasswordRecord(raw, options);
+    var columns = {};
+
+    columns.PasswordHash = typeof record.hash === 'undefined' ? '' : record.hash;
+
+    if (!options || options.includeVariants !== false) {
+      if (record.variants && typeof record.variants.hex !== 'undefined') {
+        columns.PasswordHashHex = record.variants.hex || '';
+      }
+      if (record.variants && typeof record.variants.base64 !== 'undefined') {
+        columns.PasswordHashBase64 = record.variants.base64 || '';
+      }
+      if (record.variants && typeof record.variants.base64WebSafe !== 'undefined') {
+        columns.PasswordHashBase64WebSafe = record.variants.base64WebSafe || '';
+      }
+    }
+
+    if (!options || options.includeFormat !== false) {
+      columns.PasswordHashFormat = record.hashFormat || 'hex';
+    }
+
+    return {
+      hash: record.hash,
+      hashFormat: record.hashFormat,
+      algorithm: record.algorithm,
+      variants: record.variants,
+      columns: columns
+    };
+  }
+
+  function detectHashFormat(hash) {
+    if (hash === null || typeof hash === 'undefined') {
+      return 'empty';
+    }
+
+    var trimmed = String(hash).trim();
+    if (!trimmed) {
+      return 'empty';
+    }
+
+    if (isHexHash(trimmed)) {
+      return 'hex';
+    }
+
+    if (isBase64WebSafeHash(trimmed)) {
+      return 'base64-websafe';
+    }
+
+    if (isBase64Hash(trimmed)) {
+      return 'base64';
+    }
+
+    return 'unknown';
   }
 
   return {
@@ -68,10 +268,19 @@ function __createPasswordUtilitiesModule() {
     decodePasswordHash: decodePasswordHash,
     digestToHex: digestToHex,
     hashPassword: hashPassword,
+    hashPasswordBase64: hashPasswordBase64,
+    hashPasswordWebSafe: hashPasswordWebSafe,
     createPasswordHash: createPasswordHash,
+    createPasswordRecord: createPasswordRecord,
+    createPasswordUpdate: createPasswordUpdate,
     verifyPassword: verifyPassword,
     comparePassword: verifyPassword,
-    constantTimeEquals: constantTimeEquals
+    constantTimeEquals: constantTimeEquals,
+    detectHashFormat: detectHashFormat,
+    getPasswordHashVariants: computeHashVariants,
+    isHexHash: isHexHash,
+    isBase64Hash: isBase64Hash,
+    isBase64WebSafeHash: isBase64WebSafeHash
   };
 }
 


### PR DESCRIPTION
## Summary
- extend PasswordUtilities with hash-format selection and reusable password update helpers
- update IdentityService and SeedData to apply centralized password updates when setting user credentials
- refactor AuthenticationService diagnostics and admin repair flows to rely on the new helpers for generating password hashes and metadata

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e785ae32c4832689d2c075068546d2