### PR TITLE
Handle asynchronous listener warning on login

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -4020,6 +4020,25 @@
     // ───────────────────────────────────────────────────────────────────────────────
     // ERROR HANDLING
     // ───────────────────────────────────────────────────────────────────────────────
+    window.addEventListener('unhandledrejection', function(event) {
+      const reason = event && event.reason ? event.reason : null;
+      const message = reason && typeof reason.message === 'string' ? reason.message : '';
+
+      if (message.includes('A listener indicated an asynchronous response')) {
+        console.warn('Suppressed async messaging warning from host environment.', reason);
+        if (typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      console.error('Unhandled promise rejection:', reason);
+      if (elements.loginBtn.disabled) {
+        setLoading(false);
+        showAlert('error', 'An unexpected error occurred. Please try again.');
+      }
+    });
+
     window.addEventListener('error', function(e) {
       console.error('Global error:', e.error);
       if (elements.loginBtn.disabled) {


### PR DESCRIPTION
## Summary
- add a global unhandled promise rejection handler on the login page
- suppress the noisy asynchronous listener warning emitted by the container environment
- fall back to the existing error alert flow when other promise errors occur

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7bf6e254c83269860b405949a6506