### PR TITLE
Prevent placeholder deletion dates from blocking logins

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -400,10 +400,29 @@ var AuthenticationService = (function () {
     if (!str) {
       return null;
     }
+
+    const normalized = str.replace(/\s+/g, '').toLowerCase();
+    if (normalized === '0'
+      || normalized === '0000-00-00'
+      || normalized === '0000-00-00t00:00:00z'
+      || normalized === 'null'
+      || normalized === 'false') {
+      return null;
+    }
+
     const parsed = new Date(str);
     if (isNaN(parsed.getTime())) {
       return null;
     }
+
+    if (parsed.getTime() === 0) {
+      return null;
+    }
+
+    if (parsed.getFullYear && parsed.getFullYear() <= 1901 && /1899|1900/.test(normalized)) {
+      return null;
+    }
+
     return parsed;
   }
 
@@ -1211,8 +1230,36 @@ var AuthenticationService = (function () {
       return isNaN(ms) ? null : ms;
     }
     if (!value && value !== 0) return null;
-    const parsed = Date.parse(String(value));
-    return isNaN(parsed) ? null : parsed;
+
+    const str = String(value).trim();
+    if (!str) return null;
+
+    const normalized = str.replace(/\s+/g, '').toLowerCase();
+    if (normalized === '0'
+      || normalized === '0000-00-00'
+      || normalized === '0000-00-00t00:00:00z'
+      || normalized === 'null'
+      || normalized === 'false') {
+      return null;
+    }
+
+    const parsed = Date.parse(str);
+    if (isNaN(parsed)) {
+      return null;
+    }
+
+    if (parsed === 0) {
+      return null;
+    }
+
+    if (normalized.indexOf('1899') !== -1 || normalized.indexOf('1900') !== -1) {
+      const parsedDate = new Date(parsed);
+      if (parsedDate.getFullYear && parsedDate.getFullYear() <= 1901) {
+        return null;
+      }
+    }
+
+    return parsed;
   }
 
   function parseIdleTimeoutMinutes(value) {

--- a/IdentityService.js
+++ b/IdentityService.js
@@ -146,14 +146,34 @@ var IdentityService = (function () {
     if (value instanceof Date) {
       return value;
     }
+
     var str = coerceString(value).trim();
     if (!str) {
       return null;
     }
+
+    var normalized = str.replace(/\s+/g, '').toLowerCase();
+    if (normalized === '0'
+      || normalized === '0000-00-00'
+      || normalized === '0000-00-00t00:00:00z'
+      || normalized === 'null'
+      || normalized === 'false') {
+      return null;
+    }
+
     var parsed = new Date(str);
     if (isNaN(parsed.getTime())) {
       return null;
     }
+
+    if (parsed.getTime() === 0) {
+      return null;
+    }
+
+    if (parsed.getFullYear && parsed.getFullYear() <= 1901 && /1899|1900/.test(normalized)) {
+      return null;
+    }
+
     return parsed;
   }
 


### PR DESCRIPTION
## Summary
- treat placeholder values such as 0 or 0000-00-00 as missing dates when parsing user deletion timestamps
- avoid flagging accounts as deleted when spreadsheets supply zero-date placeholders during authentication and identity evaluation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f2d55d0c8326ad25c2cd2908c9c1