### PR TITLE
Teach server to read session cookies for auth

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2810,7 +2810,7 @@
       return url;
     }
 
-    function appendSessionTokenToUrl(url) {
+    function appendSessionTokenToUrl(url, options = {}) {
       if (!url) {
         return url;
       }
@@ -2820,15 +2820,12 @@
         return url;
       }
 
-      const sessionToken = resolveSessionTokenForRedirect();
+      const includeTokenInUrl = options && options.includeTokenInUrl === true;
+      const sessionToken = includeTokenInUrl ? resolveSessionTokenForRedirect() : '';
 
       try {
         const base = window.location && window.location.href ? window.location.href : undefined;
         const parsed = new URL(raw, base);
-
-        if (!isAllowedRedirectOrigin(parsed.origin)) {
-          return stripTokenFromUrl(url);
-        }
 
         const tokenParam = SESSION_TOKEN_QUERY_PARAM || 'token';
         const variants = [tokenParam, tokenParam.toLowerCase(), tokenParam.toUpperCase()];
@@ -2838,19 +2835,39 @@
           }
         });
 
-        if (sessionToken) {
+        const sanitizedResult = (function serialize(parsedUrl) {
+          if (raw.startsWith('?')) {
+            return (parsedUrl.search || '') + (parsedUrl.hash || '');
+          }
+
+          if (!/^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.startsWith('//')) {
+            return parsedUrl.pathname + (parsedUrl.search || '') + (parsedUrl.hash || '');
+          }
+
+          return parsedUrl.toString();
+        })(parsed);
+
+        if (!isAllowedRedirectOrigin(parsed.origin)) {
+          return sanitizedResult;
+        }
+
+        if (includeTokenInUrl && sessionToken) {
           parsed.searchParams.set(tokenParam, sessionToken);
         }
 
-        if (raw.startsWith('?')) {
-          return (parsed.search || '') + (parsed.hash || '');
+        if (includeTokenInUrl && sessionToken) {
+          if (raw.startsWith('?')) {
+            return (parsed.search || '') + (parsed.hash || '');
+          }
+
+          if (!/^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.startsWith('//')) {
+            return parsed.pathname + (parsed.search || '') + (parsed.hash || '');
+          }
+
+          return parsed.toString();
         }
 
-        if (!/^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.startsWith('//')) {
-          return parsed.pathname + (parsed.search || '') + (parsed.hash || '');
-        }
-
-        return parsed.toString();
+        return sanitizedResult;
       } catch (error) {
         console.warn('appendSessionTokenToUrl: Unable to append session token to redirect URL', error);
         return url;

--- a/SearchSecurityService.js
+++ b/SearchSecurityService.js
@@ -606,7 +606,20 @@ function createSecurityBlockedPage(url, reason) {
  */
 function getUserIdFromRequest(e) {
     try {
-        const token = e.parameter.token || '';
+        var token = '';
+        try {
+            if (typeof extractSessionTokenFromRequest === 'function') {
+                token = extractSessionTokenFromRequest(e);
+            }
+        } catch (helperError) {
+            // Ignore helper failures and fall back to direct parameter lookup
+            token = '';
+        }
+
+        if (!token) {
+            token = (e && e.parameter && e.parameter.token) ? e.parameter.token : '';
+        }
+
         if (token && typeof AuthenticationService !== 'undefined') {
             const user = AuthenticationService.validateToken(token);
             return user ? (user.ID || user.id || 'anonymous') : 'anonymous';

--- a/layout.html
+++ b/layout.html
@@ -1312,27 +1312,10 @@
       const tokenParam = (typeof options.paramName === 'string' && options.paramName.trim())
         ? options.paramName.trim()
         : (SESSION_TOKEN_QUERY_PARAM || 'token');
-      const sessionToken = resolveClientSessionToken(options.token);
+      const includeTokenInUrl = options && options.includeTokenInUrl === true;
+      const sessionToken = includeTokenInUrl ? resolveClientSessionToken(options.token) : '';
 
-      try {
-        const base = (typeof window !== 'undefined' && window.location) ? window.location.href : undefined;
-        const parsed = new URL(raw, base);
-
-        if (options.sameOriginOnly !== false && parsed.origin && !isAllowedTokenOrigin(parsed.origin)) {
-          return url;
-        }
-
-        const variants = [tokenParam, tokenParam.toLowerCase(), tokenParam.toUpperCase()];
-        variants.forEach(key => {
-          if (key && parsed.searchParams.has(key)) {
-            parsed.searchParams.delete(key);
-          }
-        });
-
-        if (sessionToken) {
-          parsed.searchParams.set(tokenParam, sessionToken);
-        }
-
+      const serializeUrl = parsed => {
         if (raw.startsWith('?')) {
           return (parsed.search || '') + (parsed.hash || '');
         }
@@ -1342,6 +1325,30 @@
         }
 
         return parsed.toString();
+      };
+
+      try {
+        const base = (typeof window !== 'undefined' && window.location) ? window.location.href : undefined;
+        const parsed = new URL(raw, base);
+
+        const variants = [tokenParam, tokenParam.toLowerCase(), tokenParam.toUpperCase()];
+        variants.forEach(key => {
+          if (key && parsed.searchParams.has(key)) {
+            parsed.searchParams.delete(key);
+          }
+        });
+
+        const sanitizedResult = serializeUrl(parsed);
+
+        if (options.sameOriginOnly !== false && parsed.origin && !isAllowedTokenOrigin(parsed.origin)) {
+          return sanitizedResult;
+        }
+
+        if (includeTokenInUrl && sessionToken) {
+          parsed.searchParams.set(tokenParam, sessionToken);
+        }
+
+        return includeTokenInUrl && sessionToken ? serializeUrl(parsed) : sanitizedResult;
       } catch (error) {
         console.warn('appendSessionTokenToUrl: unable to update redirect URL', { url, error });
         return url;


### PR DESCRIPTION
## Summary
- add shared utilities to extract the session token from query parameters or auth cookies when serving pages
- update authentication, logout, and analytics helpers to rely on the extracted cookie token instead of URL parameters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e84b0de41c8326b5e03718301cc6a7