### PR TITLE
Refresh Lumina marketing pages with wide blue sections

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -1,35 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <base target="_top">
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>LuminaHQ – Intelligent Workforce Command Center</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LuminaHQ • Command the Future of Workforce Intelligence</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <style>
     :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-navy-alt: #103060;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #ffffff;
-      --lumina-muted: #f1f5fb;
-      --lumina-muted-dark: #d6e2f5;
-      --lumina-text: #101828;
-      --lumina-text-muted: #475467;
-      --shadow-primary: 0 12px 24px rgba(4, 120, 211, 0.18);
-      --shadow-card: 0 8px 18px rgba(15, 23, 42, 0.08);
-      --radius-lg: 24px;
-      --radius-md: 16px;
-      --radius-sm: 12px;
-      --transition: all 0.28s ease;
+      --navy: #0f172a;
+      --blue: #1d4ed8;
+      --deep-blue: #0b1950;
+      --sky: #38bdf8;
+      --aqua: #06b6d4;
+      --mint: #10b981;
+      --slate: #1e293b;
+      --stone: #475569;
+      --cloud: #f1f5f9;
+      --white: #ffffff;
+      --gradient-blue: linear-gradient(120deg, rgba(11, 25, 80, 0.95), rgba(29, 78, 216, 0.85));
+      --gradient-sky: linear-gradient(135deg, rgba(29, 78, 216, 0.12), rgba(6, 182, 212, 0.08));
+      --gradient-cta: linear-gradient(120deg, #0b1950, #1d4ed8 55%, #38bdf8);
+      --shadow-soft: 0 30px 70px rgba(15, 23, 42, 0.22);
+      --transition: all 0.3s ease;
     }
 
     * {
@@ -37,720 +35,843 @@
     }
 
     body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       margin: 0;
-      color: var(--lumina-text);
-      background: var(--lumina-surface);
+      font-family: "Inter", sans-serif;
+      color: var(--slate);
+      background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 45%, #ffffff 100%);
       min-height: 100vh;
-      display: flex;
-      flex-direction: column;
+      overflow-x: hidden;
     }
 
-    body.landing-page {
-      background: var(--lumina-surface);
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      inset: auto auto 5% -10%;
+      width: 520px;
+      height: 520px;
+      border-radius: 50%;
+      background: radial-gradient(circle at center, rgba(56, 189, 248, 0.18), transparent 70%);
+      filter: blur(60px);
+      opacity: 0.45;
+      z-index: -1;
     }
 
-    body.landing-page::before {
-      display: none;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-    }
-
-    .landing-main {
-      width: 100%;
-      max-width: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    .hero {
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.25rem clamp(3rem, 5vw, 5rem);
-      width: 100%;
-      margin: 0;
-      position: relative;
-      background: var(--lumina-navy-alt);
-      color: rgba(226, 232, 240, 0.92);
-    }
-
-    .hero-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .hero-surface {
-      background: transparent;
-      border-radius: var(--radius-lg);
-      border: none;
-      box-shadow: none;
-      padding: clamp(2.5rem, 5vw, 3.2rem);
+    body::after {
+      inset: -12% -8% auto auto;
+      background: radial-gradient(circle at center, rgba(29, 78, 216, 0.22), transparent 70%);
     }
 
     header {
       position: sticky;
       top: 0;
-      z-index: 10;
-      backdrop-filter: blur(14px);
-      background: rgba(255, 255, 255, 0.85);
-      border-bottom: 1px solid rgba(226, 232, 240, 0.7);
-      margin: 0;
-      padding: 0;
+      z-index: 60;
+      background: rgba(255, 255, 255, 0.94);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.06);
     }
 
-    .nav-container {
+    .nav-wrap {
       max-width: 1200px;
       margin: 0 auto;
-      padding: 1rem 1.25rem;
+      padding: 1.1rem 2.75rem;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-    }
-
-    .brand-logo {
-      height: 46px;
-      width: auto;
-      display: block;
-    }
-
-    .brand h1 {
-      font-size: 1.35rem;
-      font-weight: 700;
-      color: var(--lumina-navy);
-      margin: 0;
-      letter-spacing: 0.01em;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 500;
-      text-transform: uppercase;
-      color: var(--lumina-text-muted);
-      letter-spacing: 0.14em;
-    }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .nav-actions a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.3rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .nav-actions .btn-outline {
-      color: var(--lumina-blue-dark);
-      background: transparent;
-      border: 1px solid rgba(4, 120, 211, 0.36);
-    }
-
-    .nav-actions .btn-outline:hover {
-      background: rgba(4, 120, 211, 0.1);
-      transform: translateY(-1px);
-    }
-
-    .nav-actions .btn-primary {
-      color: white;
-      background: var(--lumina-blue);
-      box-shadow: none;
-    }
-
-    .nav-actions .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 10px 20px rgba(4, 120, 211, 0.24);
-    }
-
-    .hero-content {
-      position: relative;
-      display: grid;
-      gap: clamp(2.5rem, 5vw, 3.5rem);
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      z-index: 1;
-    }
-
-    .hero-copy {
-      display: flex;
-      flex-direction: column;
-      gap: 1.75rem;
-    }
-
-    .hero-tag {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.55rem 1rem;
-      background: rgba(56, 189, 248, 0.16);
-      color: var(--lumina-surface);
-      border-radius: 999px;
-      font-weight: 600;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .hero-title {
-      font-size: clamp(2.4rem, 3.4vw + 1rem, 3.7rem);
-      line-height: 1.1;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .hero-subtitle {
-      margin: 0;
-      max-width: 520px;
-      font-size: 1.05rem;
-      color: rgba(226, 232, 240, 0.72);
-    }
-
-    .hero-ctas {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-
-    .hero-ctas a {
-      text-decoration: none;
-      font-weight: 600;
-      padding: 0.8rem 1.6rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      transition: var(--transition);
-    }
-
-    .hero-ctas .primary {
-      background: var(--lumina-blue);
-      color: white;
-      box-shadow: none;
-    }
-
-    .hero-ctas .primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 12px 24px rgba(4, 120, 211, 0.22);
-    }
-
-    .hero-ctas .ghost {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .hero-ctas .ghost:hover {
-      background: rgba(255, 255, 255, 0.18);
-      color: var(--lumina-surface);
-      border-color: rgba(226, 232, 240, 0.32);
-    }
-
-    .hero-showcase {
-      background: rgba(11, 27, 63, 0.55);
-      border-radius: var(--radius-md);
-      padding: clamp(1.5rem, 3vw, 2rem);
-      box-shadow: none;
-      border: 1px solid rgba(226, 232, 240, 0.15);
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .showcase-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .showcase-header h2 {
-      font-size: 1.1rem;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .status-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.45rem 0.85rem;
-      border-radius: 999px;
-      background: rgba(56, 189, 248, 0.24);
-      color: var(--lumina-surface);
-      font-size: 0.8rem;
-      font-weight: 600;
-    }
-
-    .metrics-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 1.25rem;
-    }
-
-    .metric-card {
-      background: rgba(15, 23, 42, 0.45);
-      color: var(--lumina-surface);
-      padding: 1.4rem;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(226, 232, 240, 0.12);
-      position: relative;
-    }
-
-    .metric-card strong {
-      display: block;
-      font-size: 2rem;
-      font-weight: 700;
-    }
-
-    .metric-card span {
-      font-size: 0.85rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgba(226, 232, 240, 0.7);
-    }
-
-    .metric-card i {
-      font-size: 1.4rem;
-      opacity: 0.85;
-    }
-
-    .metric-card .icon-circle {
-      width: 48px;
-      height: 48px;
-      border-radius: 50%;
-      background: rgba(255, 255, 255, 0.14);
-      display: grid;
-      place-items: center;
-      margin-bottom: 1rem;
-    }
-
-    .section {
-      width: 100%;
-      margin: 0;
-      padding: clamp(3rem, 5vw + 1rem, 4.5rem) 1.25rem;
-    }
-
-    .section-light {
-      background: var(--lumina-surface);
-    }
-
-    .section-dark {
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-    }
-
-    .section-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    .section-dark .section-shell {
-      max-width: 1100px;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 0.75rem;
-      max-width: 720px;
-    }
-
-    .section-header h2 {
-      margin: 0;
-      font-size: clamp(2rem, 2vw + 1rem, 2.6rem);
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      font-size: 1.02rem;
-    }
-
-    .section-dark .section-header h2 {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .section-header p {
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    .feature-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.6rem;
-    }
-
-    .feature-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      padding: 1.8rem;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      display: grid;
-      gap: 1rem;
-      transition: var(--transition);
-    }
-
-    .feature-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.1);
-    }
-
-    .feature-icon {
-      width: 54px;
-      height: 54px;
-      border-radius: 16px;
-      background: #e6f2ff;
-      display: grid;
-      place-items: center;
-      color: var(--lumina-blue-dark);
-      font-size: 1.35rem;
-    }
-
-    .feature-card h3 {
-      margin: 0;
-      font-size: 1.2rem;
-      color: var(--lumina-navy);
-    }
-
-    .feature-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .section-cta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .section-cta a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.35rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .section-cta a.primary {
-      background: var(--lumina-blue);
-      color: #fff;
-      box-shadow: 0 12px 20px rgba(4, 120, 211, 0.18);
-      border: 1px solid transparent;
-    }
-
-    .section-cta a.ghost {
-      background: transparent;
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.28);
-    }
-
-    .section-cta a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .section-dark .section-cta a {
-      box-shadow: none;
-    }
-
-    .section-dark .section-cta a.primary {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(255, 255, 255, 0.28);
-    }
-
-    .section-dark .section-cta a.ghost {
-      color: rgba(226, 232, 240, 0.9);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .section-dark .section-cta a:hover {
-      background: rgba(255, 255, 255, 0.14);
-      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
-    }
-
-    .about-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
       gap: 2rem;
     }
 
-    .about-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 2rem;
-      display: grid;
+    .brand {
+      display: inline-flex;
+      align-items: center;
       gap: 0.75rem;
-      box-shadow: none;
-    }
-
-    .section-dark .feature-card {
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(226, 232, 240, 0.18);
-    }
-
-    .section-dark .feature-card h3,
-    .section-dark .feature-card p {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card p {
-      color: rgba(226, 232, 240, 0.78);
-    }
-
-    .section-dark .feature-icon {
-      background: rgba(56, 189, 248, 0.18);
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card:hover {
-      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
-    }
-
-    .about-card small {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--lumina-blue-dark);
+      font-family: "Space Grotesk", sans-serif;
       font-weight: 600;
-    }
-
-    .about-card h3 {
-      margin: 0;
-      color: var(--lumina-navy);
-    }
-
-    .about-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    footer {
-      padding: 2.5rem 1.25rem 2rem;
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-      margin-top: auto;
-      width: 100%;
-      margin-left: 0;
-      margin-right: 0;
-    }
-
-    .footer-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .footer-shell a {
-      color: rgba(226, 232, 240, 0.85);
+      color: var(--navy);
+      letter-spacing: 0.02em;
       text-decoration: none;
+    }
+
+    .brand img {
+      width: 48px;
+      height: 48px;
+      object-fit: contain;
+    }
+
+    nav ul {
+      display: flex;
+      list-style: none;
+      gap: 1.6rem;
+      margin: 0;
+      padding: 0;
       font-weight: 500;
     }
 
-    .footer-shell a:hover {
-      color: white;
+    nav a {
+      color: var(--stone);
+      text-decoration: none;
+      position: relative;
+      padding-bottom: 0.2rem;
+      transition: var(--transition);
     }
 
-    @media (max-width: 720px) {
+    nav a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -0.35rem;
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg, var(--blue), var(--sky));
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: var(--transition);
+    }
+
+    nav a:hover,
+    nav a:focus {
+      color: var(--blue);
+    }
+
+    nav a:hover::after,
+    nav a:focus::after {
+      transform: scaleX(1);
+    }
+
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.75rem 1.65rem;
+      border-radius: 999px;
+      font-weight: 600;
+      color: var(--white);
+      background: var(--gradient-cta);
+      text-decoration: none;
+      box-shadow: 0 18px 36px rgba(29, 78, 216, 0.24);
+      transition: var(--transition);
+    }
+
+    .nav-cta:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 26px 46px rgba(15, 23, 42, 0.28);
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+    }
+
+    section {
+      width: 100%;
+      padding: 6.25rem 0;
+      position: relative;
+    }
+
+    .container {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 0 2.75rem;
+    }
+
+    .hero {
+      background: var(--gradient-blue);
+      color: var(--white);
+      padding-top: 7rem;
+      padding-bottom: 7.5rem;
+      overflow: hidden;
+    }
+
+    .hero::after {
+      content: "";
+      position: absolute;
+      top: 15%;
+      right: -8%;
+      width: 520px;
+      height: 520px;
+      background: radial-gradient(circle at center, rgba(56, 189, 248, 0.25), transparent 68%);
+      filter: blur(10px);
+      opacity: 0.7;
+      transform: rotate(-12deg);
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 3rem;
+      align-items: center;
+      position: relative;
+      z-index: 1;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.78);
+      margin-bottom: 1.4rem;
+    }
+
+    .eyebrow span {
+      width: 34px;
+      height: 2px;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.9);
+    }
+
+    .hero h1 {
+      font-family: "Space Grotesk", sans-serif;
+      font-weight: 700;
+      font-size: clamp(2.8rem, 5vw, 3.8rem);
+      line-height: 1.05;
+      margin: 0;
+    }
+
+    .hero p {
+      margin: 1.6rem 0 2.6rem;
+      font-size: 1.12rem;
+      line-height: 1.7;
+      color: rgba(241, 245, 249, 0.88);
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-bottom: 2.8rem;
+    }
+
+    .primary-btn,
+    .ghost-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.95rem 1.95rem;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: var(--transition);
+      font-size: 1rem;
+    }
+
+    .primary-btn {
+      color: var(--white);
+      background: linear-gradient(120deg, #2563eb, #38bdf8);
+      box-shadow: 0 20px 40px rgba(14, 116, 233, 0.35);
+    }
+
+    .primary-btn:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 28px 52px rgba(15, 23, 42, 0.35);
+    }
+
+    .ghost-btn {
+      color: var(--white);
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      background: rgba(15, 23, 42, 0.25);
+    }
+
+    .ghost-btn:hover {
+      background: rgba(15, 23, 42, 0.45);
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .hero-metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1.6rem;
+    }
+
+    .hero-metrics div {
+      padding-left: 1.4rem;
+      border-left: 3px solid rgba(56, 189, 248, 0.9);
+    }
+
+    .hero-metrics strong {
+      display: block;
+      font-size: 1.7rem;
+      font-family: "Space Grotesk", sans-serif;
+    }
+
+    .hero-visual {
+      position: relative;
+    }
+
+    .hero-visual::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 28px;
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(16, 185, 129, 0.16));
+      filter: blur(0px);
+      transform: rotate(2deg);
+      opacity: 0.9;
+    }
+
+    .hero-visual svg,
+    .hero-visual img {
+      position: relative;
+      width: 100%;
+      border-radius: 26px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      backdrop-filter: blur(4px);
+    }
+
+    .section-heading {
+      display: grid;
+      gap: 0.65rem;
+      margin-bottom: 3.5rem;
+    }
+
+    .section-heading span {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      color: var(--blue);
+      font-weight: 600;
+    }
+
+    .section-heading h2 {
+      font-family: "Space Grotesk", sans-serif;
+      font-size: clamp(2rem, 3.2vw, 2.8rem);
+      color: var(--navy);
+      margin: 0;
+    }
+
+    .section-heading p {
+      margin: 0;
+      max-width: 620px;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .momentum {
+      background: linear-gradient(180deg, rgba(240, 249, 255, 0.65) 0%, rgba(255, 255, 255, 0.9) 100%);
+    }
+
+    .momentum-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 2.2rem;
+    }
+
+    .momentum-item {
+      padding-left: 1.4rem;
+      border-left: 3px solid rgba(29, 78, 216, 0.28);
+    }
+
+    .momentum-item h3 {
+      margin: 0;
+      font-size: 1.4rem;
+      color: var(--navy);
+      font-family: "Space Grotesk", sans-serif;
+    }
+
+    .momentum-item p {
+      margin: 0.6rem 0 0;
+      color: var(--stone);
+      line-height: 1.6;
+    }
+
+    .solutions {
+      background: var(--white);
+    }
+
+    .solutions-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 2.4rem;
+    }
+
+    .solution {
+      padding: 0 0 0 1.4rem;
+      border-left: 3px solid rgba(29, 78, 216, 0.2);
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .solution i {
+      color: var(--blue);
+      font-size: 1.45rem;
+    }
+
+    .solution h3 {
+      margin: 0;
+      font-size: 1.35rem;
+      color: var(--navy);
+      font-family: "Space Grotesk", sans-serif;
+    }
+
+    .solution p {
+      margin: 0;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .platform {
+      background: var(--gradient-sky);
+    }
+
+    .platform-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2.8rem;
+      align-items: center;
+    }
+
+    .platform-highlights {
+      display: grid;
+      gap: 1.6rem;
+    }
+
+    .highlight {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 20px;
+      padding: 1.5rem 1.7rem;
+      box-shadow: 0 16px 44px rgba(15, 23, 42, 0.08);
+      backdrop-filter: blur(6px);
+    }
+
+    .highlight strong {
+      display: block;
+      font-size: 1.05rem;
+      color: var(--navy);
+      margin-bottom: 0.5rem;
+    }
+
+    .highlight span {
+      color: var(--stone);
+      line-height: 1.6;
+    }
+
+    .platform-visual {
+      position: relative;
+      padding: 2.4rem;
+      border-radius: 28px;
+      background: linear-gradient(145deg, rgba(29, 78, 216, 0.18), rgba(6, 182, 212, 0.14));
+      box-shadow: 0 26px 60px rgba(15, 23, 42, 0.14);
+    }
+
+    .platform-visual::after {
+      content: "";
+      position: absolute;
+      inset: 18% -10% -18% 28%;
+      background: radial-gradient(circle at center, rgba(15, 118, 110, 0.18), transparent 65%);
+      z-index: 0;
+    }
+
+    .platform-visual svg {
+      position: relative;
+      width: 100%;
+      filter: drop-shadow(0 18px 36px rgba(15, 23, 42, 0.2));
+    }
+
+    .cta {
+      background: var(--gradient-blue);
+      color: var(--white);
+      text-align: center;
+    }
+
+    .cta .container {
+      display: grid;
+      gap: 1.5rem;
+      justify-items: center;
+    }
+
+    .cta p {
+      max-width: 720px;
+      margin: 0 auto 1.2rem;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.95);
+    }
+
+    .cta .cta-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+    }
+
+    footer {
+      background: linear-gradient(180deg, #0b1950 0%, #0f172a 100%);
+      color: rgba(241, 245, 249, 0.9);
+      padding: 4.5rem 0 3rem;
+    }
+
+    .footer-grid {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 0 2.75rem;
+      display: grid;
+      gap: 3.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .footer-brand {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .footer-brand img {
+      width: 52px;
+      height: 52px;
+      object-fit: contain;
+    }
+
+    .footer-nav,
+    .footer-contact {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .footer-nav a {
+      color: rgba(148, 163, 184, 0.95);
+      text-decoration: none;
+      transition: var(--transition);
+    }
+
+    .footer-nav a:hover {
+      color: var(--sky);
+    }
+
+    .footer-bottom {
+      max-width: 1180px;
+      margin: 3rem auto 0;
+      padding: 0 2.75rem;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 1rem;
+      justify-content: space-between;
+      font-size: 0.9rem;
+      color: rgba(148, 163, 184, 0.82);
+    }
+
+    @media (max-width: 960px) {
+      .nav-wrap {
+        padding: 1rem 1.6rem;
+        flex-wrap: wrap;
+        gap: 1.2rem;
+      }
+
+      nav ul {
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .nav-cta {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .container {
+        padding: 0 1.6rem;
+      }
+
+      footer {
+        padding: 3.5rem 0 2.5rem;
+      }
+    }
+
+    @media (max-width: 640px) {
       header {
         position: static;
       }
 
-      .nav-container {
+      .hero {
+        padding: 5.5rem 0 6rem;
+      }
+
+      .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .primary-btn,
+      .ghost-btn,
+      .nav-cta {
+        justify-content: center;
+      }
+
+      .footer-bottom {
         flex-direction: column;
         align-items: flex-start;
       }
-
-      .hero {
-        padding-top: 3rem;
-      }
-
-      .hero-ctas {
-        width: 100%;
-      }
-
-      .hero-ctas a {
-        flex: 1;
-        justify-content: center;
-      }
     }
   </style>
-  <?
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-    var landingWorkspaceUrl = __landingBase ? __landingBase + '?page=dashboard' : 'Dashboard.html';
-  ?>
 </head>
-
-<body class="landing-page">
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="#top" aria-label="LuminaHQ home">
-          <img class="brand-logo" src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
+<body>
+  <header>
+    <div class="nav-wrap">
+      <a class="brand" href="Landing.html">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <span>LuminaHQ</span>
+      </a>
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="#banner">Home</a></li>
+          <li><a href="#solutions">Solutions</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+        </ul>
+      </nav>
+      <a class="nav-cta" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+        <i class="fa-solid fa-right-to-bracket"></i>
+        Enter platform
+      </a>
+    </div>
+  </header>
+  <main>
+    <section class="hero" id="banner">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <div class="eyebrow"><span></span> Workforce intelligence</div>
+          <h1>Command every dimension of workforce performance from a single cockpit.</h1>
+          <p>
+            LuminaHQ centralizes scheduling, coaching, quality, and performance telemetry into one live control center. Activate
+            accurate decisions, orchestrate automations, and energize your teams with real-time clarity.
+          </p>
+          <div class="hero-actions">
+            <a class="primary-btn" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+              <i class="fa-solid fa-rocket"></i>
+              Enter platform
+            </a>
+            <a class="ghost-btn" href="LandingCapabilities.html">
+              <i class="fa-solid fa-diagram-project"></i>
+              Explore capabilities
+            </a>
           </div>
-        </a>
-        <div class="nav-actions">
-          <a class="btn-outline" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="btn-primary" href="<?!= landingWorkspaceUrl ?>"><i class="fa-solid fa-chart-simple"></i> Enter workspace</a>
-        </div>
-      </div>
-    </header>
-
-    <main class="landing-main">
-      <section class="hero" id="top">
-        <div class="hero-inner">
-          <div class="hero-surface">
-            <div class="hero-content">
-              <div class="hero-copy">
-                <span class="hero-tag"><i class="fa-solid fa-sparkles"></i> Modern Operations Platform</span>
-                <h2 class="hero-title">Unify your workforce intelligence from one elevated workspace.</h2>
-                <p class="hero-subtitle">LuminaHQ brings call center scheduling, performance, coaching, and collaboration into a single, secure control tower built for high-performing teams.</p>
-                <div class="hero-ctas">
-                  <a class="primary" href="<?!= landingWorkspaceUrl ?>"><i class="fa-solid fa-chart-simple"></i> Open the workspace</a>
-                  <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-                </div>
-              </div>
-              <aside class="hero-showcase" aria-label="Platform highlights">
-                <div class="showcase-header">
-                  <h2>Live intelligence snapshot</h2>
-                  <span class="status-pill"><i class="fa-solid fa-signal"></i> Real-time sync</span>
-                </div>
-                <div class="metrics-grid">
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
-                    <strong>2.8K</strong>
-                    <span>Active agents</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
-                    <strong>98%</strong>
-                    <span>Service level</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
-                    <strong>15m</strong>
-                    <span>Avg. onboarding</span>
-                  </div>
-                </div>
-                <p class="hero-subtitle" style="margin:0;">Designed for managers, analysts, and specialists who need actionable clarity every hour.</p>
-              </aside>
+          <div class="hero-metrics">
+            <div>
+              <strong>+32%</strong>
+              <span>Productivity lift across global programs</span>
+            </div>
+            <div>
+              <strong>Real-time</strong>
+              <span>Signal routing keeps leaders informed instantly</span>
+            </div>
+            <div>
+              <strong>Unified</strong>
+              <span>Scheduling, QA, analytics, and coaching in one workspace</span>
             </div>
           </div>
         </div>
-      </section>
-
-      <section class="section section-dark" id="features">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Why teams trust LuminaHQ</h2>
-            <p>Built with a modern flat UI system, LuminaHQ keeps your workforce aligned while surfacing the KPIs that matter. Every module is orchestrated to boost operational clarity and coach teams at scale.</p>
-          </div>
-          <div class="feature-grid">
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-headset"></i></div>
-              <h3>Unified agent visibility</h3>
-              <p>Track live schedules, skill coverage, and coaching plans without hopping between spreadsheets or dashboards.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-gauge-high"></i></div>
-              <h3>Performance intelligence</h3>
-              <p>Layer KPIs, QA feedback, and campaign health into interactive scorecards that spotlight opportunities faster.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-shield-halved"></i></div>
-              <h3>Secure, tenant-ready</h3>
-              <p>Multi-tenant architecture keeps each campaign isolated with granular access controls for admins and managers.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-rocket"></i></div>
-              <h3>Ready in minutes</h3>
-              <p>Deploy LuminaHQ directly on Google Workspace infrastructure so your team stays productive without new logins.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore full capabilities</a>
-            <a class="ghost" href="<?!= landingWorkspaceUrl ?>"><i class="fa-solid fa-chart-simple"></i> Open the workspace</a>
-          </div>
-        </div>
-      </section>
-
-      <section class="section section-light" id="about">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Where LuminaHQ was crafted</h2>
-            <p>Conceived inside Lumina's Innovation Lab in Kingston, Jamaica, the platform blends contact center expertise with modern data engineering to streamline every customer interaction.</p>
-          </div>
-          <div class="about-grid">
-            <article class="about-card">
-              <small>Purpose</small>
-              <h3>Elevate every customer moment</h3>
-              <p>Give managers, analysts, and enablement leaders a cohesive view of scheduling, coaching, QA, and collaboration so they can focus on people instead of manual busywork.</p>
-            </article>
-            <article class="about-card">
-              <small>Built For</small>
-              <h3>Global call center teams</h3>
-              <p>From BPO networks to in-house support centers, LuminaHQ adapts to campaigns of every scale with tenant-aware governance baked in.</p>
-            </article>
-            <article class="about-card">
-              <small>Crafted In</small>
-              <h3>Kingston, Jamaica</h3>
-              <p>Engineered by Lumina's product studio with a focus on modern, flat UI systems and a seamless Google Apps Script backbone.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> Discover our story</a>
-            <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <p>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</p>
-        <div>
-          <a href="PrivacyPolicy.html">Privacy</a> &middot;
-          <a href="TermsOfService.html">Terms</a> &middot;
-          <a href="<?!= landingWorkspaceUrl ?>">Workspace</a>
+        <div class="hero-visual" aria-hidden="true">
+          <svg viewBox="0 0 520 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="heroGradient" x1="62" y1="38" x2="462" y2="454" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#38bdf8" stop-opacity="0.85" />
+                <stop offset="0.45" stop-color="#2563eb" stop-opacity="0.75" />
+                <stop offset="1" stop-color="#0f172a" stop-opacity="0.95" />
+              </linearGradient>
+            </defs>
+            <rect x="54" y="68" width="412" height="320" rx="32" stroke="url(#heroGradient)" stroke-width="3" fill="rgba(15, 23, 42, 0.45)" />
+            <path d="M92 132h336" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" opacity="0.7" />
+            <circle cx="124" cy="102" r="8" fill="#38bdf8" />
+            <circle cx="152" cy="102" r="8" fill="#10b981" />
+            <circle cx="180" cy="102" r="8" fill="#38bdf8" opacity="0.75" />
+            <g opacity="0.8">
+              <path d="M132 180h190" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+              <path d="M132 212h260" stroke="#0ea5e9" stroke-width="2" stroke-linecap="round" opacity="0.85" />
+              <path d="M132 244h220" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.75" />
+            </g>
+            <g opacity="0.7">
+              <circle cx="364" cy="220" r="54" stroke="#38bdf8" stroke-width="2" />
+              <path d="M364 166v108" stroke="#38bdf8" stroke-width="2" stroke-dasharray="6 10" />
+              <path d="M310 220h108" stroke="#0ea5e9" stroke-width="2" stroke-dasharray="6 10" />
+            </g>
+            <rect x="122" y="288" width="260" height="68" rx="18" fill="rgba(56, 189, 248, 0.12)" stroke="#38bdf8" stroke-opacity="0.35" />
+            <path d="M142 326h86" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+            <path d="M252 326h84" stroke="#10b981" stroke-width="2" stroke-linecap="round" />
+            <circle cx="404" cy="308" r="12" fill="#38bdf8" />
+          </svg>
         </div>
       </div>
-    </footer>
-  </div>
-</body>
+    </section>
 
+    <section class="momentum" id="momentum">
+      <div class="container">
+        <div class="section-heading">
+          <span>Momentum</span>
+          <h2>Precision operations at enterprise scale.</h2>
+          <p>
+            Align every stakeholder with unified telemetry, insight routing, and automation. LuminaHQ transforms operations into a
+            living network that reacts instantly to change.
+          </p>
+        </div>
+        <div class="momentum-grid">
+          <div class="momentum-item">
+            <h3>Unified command fabric</h3>
+            <p>
+              Centralize planning, QA, analytics, and reporting with a trusted source of truth that scales across every program and
+              geography.
+            </p>
+          </div>
+          <div class="momentum-item">
+            <h3>Automation without friction</h3>
+            <p>
+              Launch workflows that nudge agents, notify leaders, and rebalance teams as soon as performance signals shift.
+            </p>
+          </div>
+          <div class="momentum-item">
+            <h3>Insights people can act on</h3>
+            <p>
+              Push curated dashboards and alerts to leaders so they can intervene with clarity, speed, and measurable impact.
+            </p>
+          </div>
+          <div class="momentum-item">
+            <h3>Security-ready foundation</h3>
+            <p>
+              Govern access with granular controls, audit transparency, and enterprise SSO to keep your data protected end-to-end.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="solutions" id="solutions">
+      <div class="container">
+        <div class="section-heading">
+          <span>Solutions</span>
+          <h2>The LuminaHQ suite keeps every crew in lockstep.</h2>
+          <p>
+            Equip your teams with intuitive surfaces and deep automation that turn strategy into daily practice.
+          </p>
+        </div>
+        <div class="solutions-grid">
+          <div class="solution">
+            <i class="fa-solid fa-sitemap"></i>
+            <h3>Scheduling intelligence</h3>
+            <p>
+              Optimize rosters and shift coverage with AI-guided forecasts, instant overrides, and real-time adherence telemetry.
+            </p>
+          </div>
+          <div class="solution">
+            <i class="fa-solid fa-headset"></i>
+            <h3>Coaching workflows</h3>
+            <p>
+              Automate coaching cadences, surface key interactions, and deliver personalized development journeys per agent.
+            </p>
+          </div>
+          <div class="solution">
+            <i class="fa-solid fa-chart-line"></i>
+            <h3>Quality and compliance</h3>
+            <p>
+              Standardize evaluations, enforce policy, and escalate faster with configurable quality pipelines and smart routing.
+            </p>
+          </div>
+          <div class="solution">
+            <i class="fa-solid fa-wave-square"></i>
+            <h3>Insights & analytics</h3>
+            <p>
+              Streamline decision making with tailored dashboards, trend detection, and executive-ready reporting streams.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="platform" id="platform">
+      <div class="container">
+        <div class="section-heading">
+          <span>Platform</span>
+          <h2>Designed to flex with your mission.</h2>
+          <p>
+            Plug LuminaHQ into your ecosystem and activate seamless governance for distributed teams.
+          </p>
+        </div>
+        <div class="platform-grid">
+          <div class="platform-highlights">
+            <div class="highlight">
+              <strong>Composable integrations</strong>
+              <span>Deploy connectors to CRM, WFM, QA, and analytics platforms without reinventing your stack.</span>
+            </div>
+            <div class="highlight">
+              <strong>Adaptive roles</strong>
+              <span>Control access with fine-grained permissions that match the way your organization operates.</span>
+            </div>
+            <div class="highlight">
+              <strong>Global readiness</strong>
+              <span>Deliver local experiences with multi-language interfaces and localized compliance controls.</span>
+            </div>
+          </div>
+          <div class="platform-visual" aria-hidden="true">
+            <svg viewBox="0 0 420 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="30" y="26" width="360" height="268" rx="28" fill="rgba(15, 23, 42, 0.55)" stroke="rgba(56, 189, 248, 0.45)" stroke-width="2" />
+              <rect x="74" y="74" width="132" height="180" rx="18" fill="rgba(29, 78, 216, 0.22)" stroke="rgba(56, 189, 248, 0.6)" />
+              <rect x="222" y="74" width="132" height="84" rx="18" fill="rgba(15, 118, 110, 0.22)" stroke="rgba(56, 189, 248, 0.45)" />
+              <rect x="222" y="174" width="132" height="80" rx="18" fill="rgba(14, 165, 233, 0.26)" stroke="rgba(15, 23, 42, 0.35)" />
+              <path d="M140 118h-38" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+              <path d="M140 150h-38" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.85" />
+              <path d="M272 118h40" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+              <path d="M272 206h40" stroke="#10b981" stroke-width="2" stroke-linecap="round" />
+              <circle cx="110" cy="210" r="26" fill="rgba(56, 189, 248, 0.45)" />
+              <path d="M108 204l6 6 12-12" stroke="#f8fafc" stroke-width="3" stroke-linecap="round" />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta" id="cta">
+      <div class="container">
+        <span class="eyebrow" style="justify-content: center"><span></span>Ready to engage</span>
+        <h2 style="font-family: 'Space Grotesk', sans-serif; font-size: clamp(2.2rem, 4vw, 3.2rem); margin: 0;">
+          Bring your workforce intelligence online.
+        </h2>
+        <p>
+          Launch LuminaHQ with your teams and unlock an integrated workspace for operations, coaching, quality, and analytics. We
+          partner with you from onboarding to scale.
+        </p>
+        <div class="cta-actions">
+          <a class="primary-btn" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+            <i class="fa-solid fa-right-to-bracket"></i>
+            Enter platform
+          </a>
+          <a class="ghost-btn" href="LandingAbout.html">
+            <i class="fa-solid fa-circle-info"></i>
+            Learn about LuminaHQ
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <p>
+          LuminaHQ connects people, process, and data into one responsive command center so your organization can deliver with
+          confidence.
+        </p>
+      </div>
+      <div class="footer-nav">
+        <strong>Explore</strong>
+        <a href="LandingAbout.html">About</a>
+        <a href="LandingCapabilities.html">Capabilities</a>
+        <a href="Login.html">Sign in</a>
+        <a href="LuminaHQUserGuide.html">User guide</a>
+      </div>
+      <div class="footer-contact">
+        <strong>Connect</strong>
+        <span><i class="fa-solid fa-envelope"></i> support@lumina-hq.com</span>
+        <span><i class="fa-solid fa-phone"></i> +1 (800) 555-0148</span>
+        <span><i class="fa-solid fa-location-dot"></i> Global operations • Remote-first</span>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© <script>document.write(new Date().getFullYear());</script> LuminaHQ. All rights reserved.</span>
+      <span>
+        <a href="TermsOfService.html" style="color: inherit; text-decoration: none; margin-right: 1.2rem;">Terms</a>
+        <a href="PrivacyPolicy.html" style="color: inherit; text-decoration: none;">Privacy</a>
+      </span>
+    </div>
+  </footer>
+</body>
 </html>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -1,36 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About LuminaHQ</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About LuminaHQ • Mission, Story, and Crew</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <style>
     :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f5f8ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --lumina-gradient: linear-gradient(135deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.9));
-      --shadow-card: 0 30px 60px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --transition: all 0.28s ease;
+      --navy: #0f172a;
+      --blue: #1d4ed8;
+      --deep-blue: #0b1950;
+      --sky: #38bdf8;
+      --aqua: #06b6d4;
+      --mint: #10b981;
+      --slate: #1f2937;
+      --stone: #475569;
+      --cloud: #f1f5f9;
+      --white: #ffffff;
+      --gradient-hero: linear-gradient(135deg, rgba(11, 25, 80, 0.92), rgba(29, 78, 216, 0.85));
+      --gradient-band: linear-gradient(120deg, rgba(29, 78, 216, 0.12), rgba(56, 189, 248, 0.1));
+      --gradient-footer: linear-gradient(180deg, #0b1950 0%, #0f172a 100%);
+      --transition: all 0.3s ease;
     }
 
     * {
@@ -39,480 +35,736 @@
 
     body {
       margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: radial-gradient(circle at 20% 20%, rgba(4, 120, 211, 0.08), transparent 55%),
-        radial-gradient(circle at 80% 0, rgba(56, 189, 248, 0.1), transparent 45%),
-        var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
+      font-family: "Inter", sans-serif;
+      color: var(--slate);
+      background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 50%, #ffffff 100%);
+      overflow-x: hidden;
     }
 
     header {
       position: sticky;
       top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.82);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
+      z-index: 60;
+      background: rgba(255, 255, 255, 0.94);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.06);
     }
 
-    .nav-container {
+    .nav-wrap {
       max-width: 1200px;
       margin: 0 auto;
-      padding: 1rem 1.5rem;
+      padding: 1.1rem 2.75rem;
       display: flex;
-      justify-content: space-between;
       align-items: center;
-      gap: 1rem;
+      justify-content: space-between;
+      gap: 2rem;
     }
 
     .brand {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      gap: 0.85rem;
+      gap: 0.75rem;
+      font-family: "Space Grotesk", sans-serif;
+      font-weight: 600;
+      color: var(--navy);
       text-decoration: none;
-      color: inherit;
+      letter-spacing: 0.02em;
     }
 
     .brand img {
-      width: 46px;
-      height: 46px;
+      width: 48px;
+      height: 48px;
+      object-fit: contain;
     }
 
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
+    nav ul {
+      list-style: none;
       display: flex;
-      align-items: center;
-      gap: 0.75rem;
+      gap: 1.6rem;
+      margin: 0;
+      padding: 0;
+      font-weight: 500;
     }
 
-    .nav-actions a {
+    nav a {
+      color: var(--stone);
+      text-decoration: none;
+      position: relative;
+      padding-bottom: 0.2rem;
+      transition: var(--transition);
+    }
+
+    nav a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -0.35rem;
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg, var(--blue), var(--sky));
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: var(--transition);
+    }
+
+    nav a:hover,
+    nav a:focus {
+      color: var(--blue);
+    }
+
+    nav a:hover::after,
+    nav a:focus::after {
+      transform: scaleX(1);
+    }
+
+    .nav-cta {
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
+      gap: 0.6rem;
+      padding: 0.75rem 1.65rem;
       border-radius: 999px;
+      font-weight: 600;
+      color: var(--white);
+      background: linear-gradient(120deg, #0b1950, #1d4ed8 55%, #38bdf8);
+      text-decoration: none;
+      box-shadow: 0 18px 36px rgba(29, 78, 216, 0.24);
       transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.9);
     }
 
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 14px 22px rgba(4, 120, 211, 0.15);
+    .nav-cta:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 26px 46px rgba(15, 23, 42, 0.28);
     }
 
     main {
-      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    section {
+      width: 100%;
+      padding: 6rem 0;
+      position: relative;
+    }
+
+    .container {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 0 2.75rem;
     }
 
     .hero {
+      background: var(--gradient-hero);
+      color: var(--white);
+      padding-top: 7rem;
+      padding-bottom: 7rem;
+      overflow: hidden;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 3.2rem;
+      align-items: center;
       position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
     }
 
-    .hero::before {
-      content: '';
+    .hero-grid::after {
+      content: "";
       position: absolute;
-      inset: 0;
-      border-radius: 0 0 48px 48px;
-      background: var(--lumina-gradient);
-      z-index: 0;
+      inset: -60% 45% 10% -25%;
+      background: radial-gradient(circle at center, rgba(56, 189, 248, 0.25), transparent 68%);
+      filter: blur(12px);
+      opacity: 0.75;
     }
 
-    .hero-inner {
+    .hero-copy {
       position: relative;
       z-index: 1;
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
 
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.5rem;
-    }
-
-    .hero-meta {
-      display: grid;
-      gap: 1rem;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-
-    .meta-card {
-      background: rgba(255, 255, 255, 0.14);
-      padding: 1.25rem 1.4rem;
-      border-radius: var(--radius-md);
-      display: flex;
-      flex-direction: column;
-      gap: 0.4rem;
-      border: 1px solid rgba(255, 255, 255, 0.22);
-    }
-
-    .meta-card span {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      font-weight: 600;
-      font-size: 0.72rem;
-      color: rgba(248, 250, 252, 0.72);
-    }
-
-    .meta-card strong {
-      font-size: 1.4rem;
-      font-weight: 700;
-    }
-
-    .content-section {
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: clamp(3rem, 5vw, 4.5rem) 1.5rem;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin-bottom: 1rem;
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      font-size: 1.05rem;
-      line-height: 1.8;
-      color: var(--lumina-muted);
-    }
-
-    .value-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .value-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .value-card i {
-      font-size: 1.5rem;
-      color: var(--lumina-blue);
-    }
-
-    .value-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .value-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .story-timeline {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.5rem;
+    .hero-visual {
       position: relative;
+      z-index: 1;
     }
 
-    .story-card {
-      background: rgba(255, 255, 255, 0.92);
-      border-radius: var(--radius-md);
-      padding: 1.75rem 1.9rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    .hero-visual::before {
+      content: "";
+      position: absolute;
+      inset: -6% -6% -6% -6%;
+      border-radius: 30px;
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(16, 185, 129, 0.16));
+      opacity: 0.7;
+      z-index: -1;
     }
 
-    .story-card strong {
+    .hero-visual svg {
+      width: 100%;
+      border-radius: 26px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      backdrop-filter: blur(4px);
+    }
+
+    .eyebrow {
       display: inline-flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .story-card h4 {
-      font-size: 1.35rem;
-      margin: 0.75rem 0;
-    }
-
-    .story-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .culture-banner {
-      background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(4, 120, 211, 0.18));
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 2rem;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      border: 1px solid rgba(4, 120, 211, 0.25);
-    }
-
-    .culture-banner h4 {
-      margin: 0;
-      font-size: 1.6rem;
-    }
-
-    .culture-banner ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.9rem;
-    }
-
-    .culture-banner li {
-      display: flex;
-      align-items: flex-start;
       gap: 0.75rem;
-      color: var(--lumina-muted);
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.78);
+      margin-bottom: 1.3rem;
+    }
+
+    .eyebrow span {
+      width: 34px;
+      height: 2px;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.9);
+    }
+
+    .hero h1 {
+      font-family: "Space Grotesk", sans-serif;
+      font-weight: 700;
+      font-size: clamp(2.6rem, 5vw, 3.6rem);
+      line-height: 1.05;
+      margin: 0;
+    }
+
+    .hero p {
+      margin: 1.6rem 0 2.6rem;
+      font-size: 1.12rem;
+      line-height: 1.7;
+      color: rgba(241, 245, 249, 0.88);
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .primary-btn,
+    .ghost-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.95rem 1.95rem;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: var(--transition);
+      font-size: 1rem;
+    }
+
+    .primary-btn {
+      color: var(--white);
+      background: linear-gradient(120deg, #2563eb, #38bdf8);
+      box-shadow: 0 20px 40px rgba(14, 116, 233, 0.35);
+    }
+
+    .primary-btn:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 28px 52px rgba(15, 23, 42, 0.35);
+    }
+
+    .ghost-btn {
+      color: var(--white);
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      background: rgba(15, 23, 42, 0.25);
+    }
+
+    .ghost-btn:hover {
+      background: rgba(15, 23, 42, 0.45);
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .timeline-section {
+      background: var(--white);
+    }
+
+    .timeline-grid {
+      display: grid;
+      gap: 2.6rem;
+    }
+
+    .timeline-heading {
+      display: grid;
+      gap: 0.75rem;
+      margin-bottom: 2rem;
+    }
+
+    .timeline-heading span {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      color: var(--blue);
+      font-weight: 600;
+    }
+
+    .timeline-heading h2 {
+      margin: 0;
+      font-family: "Space Grotesk", sans-serif;
+      font-size: clamp(2rem, 3vw, 2.8rem);
+      color: var(--navy);
+    }
+
+    .timeline {
+      display: grid;
+      gap: 1.6rem;
+      position: relative;
+      padding-left: 2.4rem;
+    }
+
+    .timeline::before {
+      content: "";
+      position: absolute;
+      left: 0.6rem;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(29, 78, 216, 0.4) 0%, rgba(56, 189, 248, 0.2) 100%);
+    }
+
+    .timeline-item {
+      display: grid;
+      gap: 0.4rem;
+      padding-left: 1.2rem;
+      border-left: 3px solid rgba(29, 78, 216, 0.18);
+    }
+
+    .timeline-item strong {
+      font-size: 1.1rem;
+      color: var(--navy);
+    }
+
+    .timeline-item span {
+      color: var(--stone);
       line-height: 1.6;
     }
 
-    .culture-banner li i {
-      color: var(--lumina-blue);
-      margin-top: 0.2rem;
+    .timeline-item time {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--blue);
+      font-weight: 600;
+    }
+
+    .culture-band {
+      background: var(--gradient-band);
+    }
+
+    .culture-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2.4rem;
+      align-items: start;
+    }
+
+    .culture-card {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 22px;
+      padding: 1.6rem 1.9rem;
+      box-shadow: 0 20px 48px rgba(15, 23, 42, 0.12);
+      display: grid;
+      gap: 0.9rem;
+      backdrop-filter: blur(6px);
+    }
+
+    .culture-card h3 {
+      margin: 0;
+      font-size: 1.28rem;
+      font-family: "Space Grotesk", sans-serif;
+      color: var(--navy);
+    }
+
+    .culture-card p {
+      margin: 0;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .leaders-section {
+      background: #ffffff;
+    }
+
+    .leaders-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 2.2rem;
+    }
+
+    .leader {
+      padding: 1rem 0 0 0;
+      border-top: 3px solid rgba(29, 78, 216, 0.18);
+      display: grid;
+      gap: 0.6rem;
+    }
+
+    .leader strong {
+      font-family: "Space Grotesk", sans-serif;
+      font-size: 1.18rem;
+      color: var(--navy);
+    }
+
+    .leader span {
+      color: var(--blue);
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+
+    .leader p {
+      margin: 0;
+      color: var(--stone);
+      line-height: 1.6;
+    }
+
+    .cta {
+      background: var(--gradient-hero);
+      color: var(--white);
+      text-align: center;
+      padding: 5.5rem 0;
+    }
+
+    .cta .container {
+      display: grid;
+      gap: 1.4rem;
+      justify-items: center;
+    }
+
+    .cta p {
+      max-width: 680px;
+      margin: 0;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.95);
     }
 
     footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
+      background: var(--gradient-footer);
+      color: rgba(241, 245, 249, 0.9);
+      padding: 4.5rem 0 3rem;
     }
 
-    .footer-shell {
-      max-width: 1100px;
+    .footer-grid {
+      max-width: 1180px;
       margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
+      padding: 0 2.75rem;
+      display: grid;
+      gap: 3.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
+    .footer-brand {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .footer-brand img {
+      width: 52px;
+      height: 52px;
+      object-fit: contain;
+    }
+
+    .footer-nav,
+    .footer-contact {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .footer-nav a {
+      color: rgba(148, 163, 184, 0.95);
       text-decoration: none;
+      transition: var(--transition);
     }
 
-    .footer-shell a:hover {
-      color: #fff;
+    .footer-nav a:hover {
+      color: var(--sky);
     }
 
-    @media (max-width: 720px) {
+    .footer-bottom {
+      max-width: 1180px;
+      margin: 3rem auto 0;
+      padding: 0 2.75rem;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 1rem;
+      justify-content: space-between;
+      font-size: 0.9rem;
+      color: rgba(148, 163, 184, 0.82);
+    }
+
+    @media (max-width: 960px) {
+      .nav-wrap {
+        padding: 1rem 1.6rem;
+        flex-wrap: wrap;
+        gap: 1.2rem;
+      }
+
+      nav ul {
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .nav-cta {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .container {
+        padding: 0 1.6rem;
+      }
+
+      footer {
+        padding: 3.5rem 0 2.5rem;
+      }
+    }
+
+    @media (max-width: 640px) {
       header {
         position: static;
       }
 
-      .nav-container {
+      .hero {
+        padding: 5.5rem 0 6rem;
+      }
+
+      .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .primary-btn,
+      .ghost-btn,
+      .nav-cta {
+        justify-content: center;
+      }
+
+      .footer-bottom {
         flex-direction: column;
         align-items: flex-start;
       }
     }
   </style>
 </head>
-
 <body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
+  <header>
+    <div class="nav-wrap">
+      <a class="brand" href="Landing.html">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <span>LuminaHQ</span>
+      </a>
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="Landing.html">Home</a></li>
+          <li><a href="#mission">Mission</a></li>
+          <li><a href="#journey">Journey</a></li>
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+        </ul>
+      </nav>
+      <a class="nav-cta" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+        <i class="fa-solid fa-right-to-bracket"></i>
+        Enter platform
+      </a>
+    </div>
+  </header>
+  <main>
+    <section class="hero" id="mission">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <div class="eyebrow"><span></span> Our mission</div>
+          <h1>Amplify the people who power every customer moment.</h1>
+          <p>
+            LuminaHQ unifies the workflows that fuel enterprise operations so teams can focus on coaching, insight, and growth. We
+            exist to make leaders confident in every decision, every shift, and every interaction.
+          </p>
+          <div class="hero-actions">
+            <a class="primary-btn" href="LandingCapabilities.html">
+              <i class="fa-solid fa-diagram-project"></i>
+              Explore capabilities
+            </a>
+            <a class="ghost-btn" href="Landing.html#cta">
+              <i class="fa-solid fa-bullseye"></i>
+              See Lumina in action
+            </a>
           </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <svg viewBox="0 0 520 420" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%;">
+            <defs>
+              <linearGradient id="aboutGradient" x1="40" y1="40" x2="480" y2="360" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#38bdf8" stop-opacity="0.85" />
+                <stop offset="0.52" stop-color="#2563eb" stop-opacity="0.75" />
+                <stop offset="1" stop-color="#0f172a" stop-opacity="0.95" />
+              </linearGradient>
+            </defs>
+            <rect x="48" y="64" width="420" height="280" rx="32" stroke="url(#aboutGradient)" stroke-width="3" fill="rgba(15, 23, 42, 0.45)" />
+            <path d="M96 128h336" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" opacity="0.7" />
+            <g opacity="0.8">
+              <path d="M132 196h260" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+              <path d="M132 228h220" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.85" />
+              <path d="M132 260h180" stroke="#0ea5e9" stroke-width="2" stroke-linecap="round" opacity="0.8" />
+            </g>
+            <circle cx="184" cy="160" r="16" fill="#38bdf8" />
+            <circle cx="232" cy="160" r="16" fill="#10b981" />
+            <circle cx="280" cy="160" r="16" fill="#0ea5e9" />
+            <circle cx="356" cy="236" r="52" stroke="#38bdf8" stroke-width="2" />
+            <path d="M356 184v104" stroke="#38bdf8" stroke-width="2" stroke-dasharray="6 10" />
+            <path d="M304 236h104" stroke="#0ea5e9" stroke-width="2" stroke-dasharray="6 10" />
+          </svg>
         </div>
       </div>
-    </header>
+    </section>
 
-    <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>Built for teams who turn every customer moment into momentum.</h2>
-            <p>LuminaHQ started as a skunkworks experiment inside Lumina's Innovation Lab in Kingston, Jamaica. What began as a scheduling toolkit for a single campaign now orchestrates workforce intelligence across global BPO operations.</p>
-            <div class="hero-meta">
-              <div class="meta-card">
-                <span>Origins</span>
-                <strong>Kingston, Jamaica</strong>
-                <p>Where our product studio designs, prototypes, and ships every module.</p>
-              </div>
-              <div class="meta-card">
-                <span>Focus</span>
-                <strong>Workforce clarity</strong>
-                <p>Unifying scheduling, QA, coaching, and collaboration into one control tower.</p>
-              </div>
-            </div>
+    <section class="timeline-section" id="journey">
+      <div class="container timeline-grid">
+        <div class="timeline-heading">
+          <span>Journey</span>
+          <h2>How LuminaHQ evolved into a unified command center.</h2>
+          <p>
+            We started as operators who needed a way to stitch together data, coaching, and insights across global teams. Each
+            milestone pushed us closer to a single pane of glass.
+          </p>
+        </div>
+        <div class="timeline">
+          <div class="timeline-item">
+            <time>2018</time>
+            <strong>Blueprinting the Lumina framework</strong>
+            <span>We codified operations playbooks across dozens of client teams and mapped the workflows worth unifying.</span>
           </div>
-          <div class="hero-visual" aria-hidden="true">
-            <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1710450011/vlbpo/lumina/about-grid_qws7ir.png" alt="LuminaHQ culture collage" style="width:100%;border-radius:24px;box-shadow:0 32px 60px rgba(8, 47, 73, 0.2);object-fit:cover;">
+          <div class="timeline-item">
+            <time>2020</time>
+            <strong>Pilot with enterprise contact centers</strong>
+            <span>Our early adopters validated the need for integrated scheduling, QA, and coaching with real-time governance.</span>
           </div>
-        </div>
-      </section>
-
-      <section class="content-section">
-        <div class="section-header">
-          <h3>Why we exist</h3>
-          <p>Call center leaders are asked to coach, staff, report, and innovate without friction. LuminaHQ removes the swivel-chair work by giving teams an integrated workspace that adapts to each campaign, geography, and client requirement.</p>
-        </div>
-        <div class="value-grid">
-          <article class="value-card">
-            <i class="fa-solid fa-compass"></i>
-            <h4>Customer-first design</h4>
-            <p>Every workflow is tested with active operations teams to ensure the UI stays intuitive even for fast-scaling programs.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-people-group"></i>
-            <h4>Human-centered automation</h4>
-            <p>Automation is only useful when it empowers analysts and supervisors. Our scripts reduce manual steps while keeping people in control.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-shield-heart"></i>
-            <h4>Secure collaboration</h4>
-            <p>Multi-tenant controls, audit trails, and granular permissions protect customer data while keeping teams aligned.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-globe"></i>
-            <h4>Global reach, local roots</h4>
-            <p>We support distributed teams across the Americas, yet maintain our product craft and culture in the Caribbean.</p>
-          </article>
-        </div>
-      </section>
-
-      <section class="content-section">
-        <div class="section-header">
-          <h3>How LuminaHQ evolved</h3>
-          <p>A cross-functional team of engineers, data analysts, and operations specialists continues to expand LuminaHQ based on real-world call center use cases.</p>
-        </div>
-        <div class="story-timeline">
-          <article class="story-card">
-            <strong><i class="fa-solid fa-flag"></i> 2019</strong>
-            <h4>Scheduling foundations</h4>
-            <p>Introduced the first Google Workspace scripts to automate agent shift updates and broadcast daily coaching plans.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-rocket"></i> 2021</strong>
-            <h4>Unified coaching</h4>
-            <p>Expanded into coaching dashboards, QA data pipelines, and collaboration workflows for hybrid teams.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-shield"></i> 2023</strong>
-            <h4>Enterprise-ready security</h4>
-            <p>Shipped tenant-aware access controls, SSO alignment, and audit logging for compliance-driven partners.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-chart-line"></i> Today</strong>
-            <h4>Predictive intelligence</h4>
-            <p>Integrating forecasting, AI summarization, and proactive alerts so teams anticipate changes instead of reacting to them.</p>
-          </article>
-        </div>
-      </section>
-
-      <section class="content-section" style="padding-bottom:4.5rem;">
-        <div class="culture-banner">
-          <div>
-            <h4>Inside the LuminaHQ culture</h4>
-            <p style="color:var(--lumina-muted);line-height:1.7;margin-top:0.75rem;">We operate with curiosity, empathy, and a bias toward shipping. Our product rituals keep customer teams connected to the builders shaping their tools.</p>
+          <div class="timeline-item">
+            <time>2022</time>
+            <strong>Global rollout and automation fabric</strong>
+            <span>Automations orchestrate interventions across thousands of agents with transparent audit trails.</span>
           </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-lightbulb"></i> Weekly design reviews align engineering, QA, and enablement on new feature experiments.</li>
-              <li><i class="fa-solid fa-person-chalkboard"></i> Immersive onboarding embeds our product team directly inside partner operations for live feedback.</li>
-              <li><i class="fa-solid fa-hands"></i> Community initiatives reinvest in Jamaican tech talent through mentorship, internships, and open-source learning.</li>
-            </ul>
-          </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-headset"></i> Dedicated customer pods pair product managers with operations leads for faster roadmap alignment.</li>
-              <li><i class="fa-solid fa-leaf"></i> We balance rapid delivery with sustainable workloads to maintain a resilient team.</li>
-            </ul>
+          <div class="timeline-item">
+            <time>Now</time>
+            <strong>Co-creating the future of workforce intelligence</strong>
+            <span>We partner with clients to design new telemetry, analytics, and AI workflows that keep humans in command.</span>
           </div>
         </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <strong>Ready to explore the workspace?</strong>
-        <div>
-          <a href="<?!= landingCapabilitiesUrl ?>">Discover LuminaHQ capabilities</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#about">Back to landing overview</a>
-        </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
       </div>
-    </footer>
-  </div>
+    </section>
+
+    <section class="culture-band" id="culture">
+      <div class="container">
+        <div class="timeline-heading">
+          <span>Culture</span>
+          <h2>The principles that guide our crew.</h2>
+          <p>We build trust-first software that keeps humans at the center of every decision.</p>
+        </div>
+        <div class="culture-grid">
+          <div class="culture-card">
+            <h3>Design for clarity</h3>
+            <p>Every surface is crafted so leaders can respond in seconds, not hours.</p>
+          </div>
+          <div class="culture-card">
+            <h3>Co-create with clients</h3>
+            <p>We embed with your teams to understand the nuances that make your operation stand out.</p>
+          </div>
+          <div class="culture-card">
+            <h3>Protect every signal</h3>
+            <p>Security and compliance are engineered into every release and every integration.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="leaders-section" id="team">
+      <div class="container">
+        <div class="timeline-heading">
+          <span>Leadership</span>
+          <h2>The crew keeping LuminaHQ ahead.</h2>
+          <p>Operators, technologists, and strategists with decades of experience guiding complex customer organizations.</p>
+        </div>
+        <div class="leaders-grid">
+          <div class="leader">
+            <span>Chief Executive</span>
+            <strong>Jordan Blake</strong>
+            <p>Obsessed with building systems that elevate human potential across every customer touchpoint.</p>
+          </div>
+          <div class="leader">
+            <span>Head of Operations</span>
+            <strong>Riya Kapoor</strong>
+            <p>Transforms data into coaching playbooks that keep teams resilient and ready for what’s next.</p>
+          </div>
+          <div class="leader">
+            <span>Platform Architect</span>
+            <strong>Mateo Alvarez</strong>
+            <p>Designs the automation mesh and integration fabric that powers LuminaHQ.</p>
+          </div>
+          <div class="leader">
+            <span>Director, Client Success</span>
+            <strong>Camille Rivers</strong>
+            <p>Partners with every client to ensure adoption, governance, and measurable outcomes.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <span class="eyebrow" style="justify-content: center"><span></span> Partner with us</span>
+        <h2 style="font-family: 'Space Grotesk', sans-serif; font-size: clamp(2.2rem, 4vw, 3.2rem); margin: 0;">
+          Let’s design the next generation of workforce intelligence.
+        </h2>
+        <p>
+          LuminaHQ is more than software—we are your partner in orchestrating talent, processes, and insights with precision.
+        </p>
+        <div class="hero-actions" style="justify-content: center;">
+          <a class="primary-btn" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+            <i class="fa-solid fa-right-to-bracket"></i>
+            Enter platform
+          </a>
+          <a class="ghost-btn" href="Landing.html#momentum">
+            <i class="fa-solid fa-chart-line"></i>
+            View operational outcomes
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <p>
+          LuminaHQ connects people, process, and data into one responsive command center so your organization can deliver with
+          confidence.
+        </p>
+      </div>
+      <div class="footer-nav">
+        <strong>Explore</strong>
+        <a href="Landing.html">Home</a>
+        <a href="LandingCapabilities.html">Capabilities</a>
+        <a href="Login.html">Sign in</a>
+        <a href="LuminaHQUserGuide.html">User guide</a>
+      </div>
+      <div class="footer-contact">
+        <strong>Connect</strong>
+        <span><i class="fa-solid fa-envelope"></i> support@lumina-hq.com</span>
+        <span><i class="fa-solid fa-phone"></i> +1 (800) 555-0148</span>
+        <span><i class="fa-solid fa-location-dot"></i> Global operations • Remote-first</span>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© <script>document.write(new Date().getFullYear());</script> LuminaHQ. All rights reserved.</span>
+      <span>
+        <a href="TermsOfService.html" style="color: inherit; text-decoration: none; margin-right: 1.2rem;">Terms</a>
+        <a href="PrivacyPolicy.html" style="color: inherit; text-decoration: none;">Privacy</a>
+      </span>
+    </div>
+  </footer>
 </body>
-
 </html>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -1,37 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Explore LuminaHQ Capabilities</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var workspaceUrl = (scriptUrl || baseUrl || '') ? (scriptUrl || baseUrl) + '?page=dashboard' : 'Dashboard.html';
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Capabilities • LuminaHQ Platform</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <style>
     :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f6f9ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --shadow-card: 0 28px 50px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --radius-sm: 14px;
-      --transition: all 0.28s ease;
+      --navy: #0f172a;
+      --blue: #1d4ed8;
+      --deep-blue: #0b1950;
+      --sky: #38bdf8;
+      --aqua: #06b6d4;
+      --mint: #10b981;
+      --slate: #1f2937;
+      --stone: #475569;
+      --white: #ffffff;
+      --gradient-hero: linear-gradient(135deg, rgba(11, 25, 80, 0.95), rgba(29, 78, 216, 0.85));
+      --gradient-band: linear-gradient(135deg, rgba(29, 78, 216, 0.12), rgba(6, 182, 212, 0.08));
+      --gradient-footer: linear-gradient(180deg, #0b1950 0%, #0f172a 100%);
+      --transition: all 0.3s ease;
     }
 
     * {
@@ -40,631 +34,699 @@
 
     body {
       margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
+      font-family: "Inter", sans-serif;
+      color: var(--slate);
+      background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 45%, #ffffff 100%);
+      overflow-x: hidden;
     }
 
     header {
       position: sticky;
       top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.9);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
+      z-index: 60;
+      background: rgba(255, 255, 255, 0.94);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.06);
     }
 
-    .nav-container {
+    .nav-wrap {
       max-width: 1200px;
       margin: 0 auto;
-      padding: 1rem 1.5rem;
+      padding: 1.1rem 2.75rem;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 1rem;
+      gap: 2rem;
     }
 
     .brand {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      gap: 0.85rem;
+      gap: 0.75rem;
+      font-family: "Space Grotesk", sans-serif;
+      font-weight: 600;
+      color: var(--navy);
       text-decoration: none;
-      color: inherit;
+      letter-spacing: 0.02em;
     }
 
     .brand img {
-      width: 46px;
-      height: 46px;
+      width: 48px;
+      height: 48px;
+      object-fit: contain;
     }
 
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
+    nav ul {
+      list-style: none;
       display: flex;
-      gap: 0.75rem;
-      align-items: center;
+      gap: 1.6rem;
+      margin: 0;
+      padding: 0;
+      font-weight: 500;
     }
 
-    .nav-actions a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
+    nav a {
+      color: var(--stone);
       text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
-      border-radius: 999px;
+      position: relative;
+      padding-bottom: 0.2rem;
       transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.92);
     }
 
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .hero {
-      position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
-      overflow: hidden;
-    }
-
-    .hero::before {
-      content: '';
+    nav a::after {
+      content: "";
       position: absolute;
-      inset: 0;
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      z-index: 0;
-      border-radius: 0 0 48px 48px;
+      left: 0;
+      bottom: -0.35rem;
+      width: 100%;
+      height: 2px;
+      background: linear-gradient(90deg, var(--blue), var(--sky));
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: var(--transition);
     }
 
-    .hero::after {
-      content: '';
-      position: absolute;
-      top: -20%;
-      right: -20%;
-      width: 420px;
-      height: 420px;
-      background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 60%);
-      z-index: 0;
+    nav a:hover,
+    nav a:focus {
+      color: var(--blue);
     }
 
-    .hero-inner {
-      position: relative;
-      z-index: 1;
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    nav a:hover::after,
+    nav a:focus::after {
+      transform: scaleX(1);
     }
 
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.6rem;
-    }
-
-    .hero-cta {
+    .nav-cta {
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
-      background: rgba(255, 255, 255, 0.18);
+      padding: 0.75rem 1.65rem;
       border-radius: 999px;
-      padding: 0.65rem 1.3rem;
       font-weight: 600;
-      color: #fff;
+      color: var(--white);
+      background: linear-gradient(120deg, #0b1950, #1d4ed8 55%, #38bdf8);
       text-decoration: none;
+      box-shadow: 0 18px 36px rgba(29, 78, 216, 0.24);
       transition: var(--transition);
-      border: 1px solid rgba(255, 255, 255, 0.32);
-      max-width: fit-content;
     }
 
-    .hero-cta:hover {
+    .nav-cta:hover {
       transform: translateY(-2px);
-      background: rgba(255, 255, 255, 0.24);
+      box-shadow: 0 26px 46px rgba(15, 23, 42, 0.28);
     }
 
     main {
-      flex: 1;
-    }
-
-    .section {
-      padding: clamp(3.2rem, 5vw, 4.5rem) 1.5rem;
-    }
-
-    .section-shell {
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 1rem;
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin: 0;
-    }
-
-    .section-header p {
-      margin: 0;
-      font-size: 1.05rem;
-      color: var(--lumina-muted);
-      line-height: 1.8;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .module-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
       display: flex;
       flex-direction: column;
-      gap: 0.7rem;
-      transition: var(--transition);
     }
 
-    .module-card:hover {
-      transform: translateY(-6px);
-      box-shadow: 0 32px 70px rgba(11, 27, 63, 0.16);
+    section {
+      width: 100%;
+      padding: 6rem 0;
+      position: relative;
     }
 
-    .module-card span {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
+    .container {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 0 2.75rem;
     }
 
-    .module-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
+    .hero {
+      background: var(--gradient-hero);
+      color: var(--white);
+      padding-top: 7rem;
+      padding-bottom: 7.2rem;
+      overflow: hidden;
     }
 
-    .module-card p {
-      margin: 0;
-      line-height: 1.65;
-      color: var(--lumina-muted);
-    }
-
-    .module-card ul {
-      margin: 0.75rem 0 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .capability-matrix {
+    .hero-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1.5rem;
+      gap: 3rem;
+      align-items: center;
+      position: relative;
     }
 
-    .matrix-card {
-      background: linear-gradient(145deg, rgba(4, 120, 211, 0.1), rgba(56, 189, 248, 0.08));
-      border-radius: var(--radius-md);
-      padding: 2.1rem 2.3rem;
-      border: 1px solid rgba(4, 120, 211, 0.18);
+    .hero-grid::after {
+      content: "";
+      position: absolute;
+      inset: -60% 50% 0% -20%;
+      background: radial-gradient(circle at center, rgba(56, 189, 248, 0.25), transparent 68%);
+      filter: blur(12px);
+      opacity: 0.75;
+    }
+
+    .hero-copy {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-visual {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-visual::before {
+      content: "";
+      position: absolute;
+      inset: -6% -6% -6% -6%;
+      border-radius: 30px;
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(16, 185, 129, 0.16));
+      opacity: 0.7;
+      z-index: -1;
+    }
+
+    .hero-visual svg {
+      width: 100%;
+      border-radius: 26px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      backdrop-filter: blur(4px);
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.78);
+      margin-bottom: 1.3rem;
+    }
+
+    .eyebrow span {
+      width: 34px;
+      height: 2px;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.9);
+    }
+
+    .hero h1 {
+      font-family: "Space Grotesk", sans-serif;
+      font-weight: 700;
+      font-size: clamp(2.6rem, 5vw, 3.6rem);
+      line-height: 1.05;
+      margin: 0;
+    }
+
+    .hero p {
+      margin: 1.6rem 0 2.6rem;
+      font-size: 1.12rem;
+      line-height: 1.7;
+      color: rgba(241, 245, 249, 0.88);
+    }
+
+    .hero-actions {
       display: flex;
-      flex-direction: column;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .primary-btn,
+    .ghost-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.95rem 1.95rem;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: var(--transition);
+      font-size: 1rem;
+    }
+
+    .primary-btn {
+      color: var(--white);
+      background: linear-gradient(120deg, #2563eb, #38bdf8);
+      box-shadow: 0 20px 40px rgba(14, 116, 233, 0.35);
+    }
+
+    .primary-btn:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 28px 52px rgba(15, 23, 42, 0.35);
+    }
+
+    .ghost-btn {
+      color: var(--white);
+      border: 1px solid rgba(255, 255, 255, 0.32);
+      background: rgba(15, 23, 42, 0.25);
+    }
+
+    .ghost-btn:hover {
+      background: rgba(15, 23, 42, 0.45);
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .suite-section {
+      background: var(--white);
+    }
+
+    .section-heading {
+      display: grid;
+      gap: 0.7rem;
+      margin-bottom: 3.4rem;
+    }
+
+    .section-heading span {
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      color: var(--blue);
+      font-weight: 600;
+    }
+
+    .section-heading h2 {
+      margin: 0;
+      font-family: "Space Grotesk", sans-serif;
+      font-size: clamp(2rem, 3.2vw, 2.8rem);
+      color: var(--navy);
+    }
+
+    .section-heading p {
+      margin: 0;
+      max-width: 620px;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .suite-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 2.4rem;
+    }
+
+    .suite-item {
+      padding-left: 1.3rem;
+      border-left: 3px solid rgba(29, 78, 216, 0.2);
+      display: grid;
+      gap: 0.8rem;
+    }
+
+    .suite-item h3 {
+      margin: 0;
+      font-size: 1.32rem;
+      font-family: "Space Grotesk", sans-serif;
+      color: var(--navy);
+    }
+
+    .suite-item p {
+      margin: 0;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .automation-section {
+      background: var(--gradient-band);
+    }
+
+    .automation-grid {
+      display: grid;
+      gap: 2.4rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: start;
+    }
+
+    .automation-card {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 22px;
+      padding: 1.6rem 1.9rem;
+      box-shadow: 0 20px 48px rgba(15, 23, 42, 0.12);
+      display: grid;
+      gap: 0.85rem;
+      backdrop-filter: blur(6px);
+    }
+
+    .automation-card h3 {
+      margin: 0;
+      font-size: 1.28rem;
+      font-family: "Space Grotesk", sans-serif;
+      color: var(--navy);
+    }
+
+    .automation-card p {
+      margin: 0;
+      color: var(--stone);
+      line-height: 1.65;
+    }
+
+    .analytics-section {
+      background: #ffffff;
+    }
+
+    .analytics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2.4rem;
+      align-items: start;
+    }
+
+    .analytics-item {
+      padding-top: 1rem;
+      border-top: 3px solid rgba(29, 78, 216, 0.18);
+      display: grid;
       gap: 0.75rem;
     }
 
-    .matrix-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
+    .analytics-item strong {
+      font-family: "Space Grotesk", sans-serif;
+      font-size: 1.18rem;
+      color: var(--navy);
     }
 
-    .matrix-card p {
-      margin: 0;
-      color: var(--lumina-muted);
-      line-height: 1.6;
+    .analytics-item span {
+      color: var(--stone);
+      line-height: 1.65;
     }
 
-    .matrix-points {
-      list-style: none;
-      margin: 0;
-      padding: 0;
+    .cta {
+      background: var(--gradient-hero);
+      color: var(--white);
+      text-align: center;
+      padding: 5.5rem 0;
+    }
+
+    .cta .container {
       display: grid;
-      gap: 0.65rem;
-    }
-
-    .matrix-points li {
-      display: flex;
-      gap: 0.55rem;
-      align-items: flex-start;
-      color: var(--lumina-muted);
-    }
-
-    .matrix-points li i {
-      color: var(--lumina-blue);
-      margin-top: 0.15rem;
-    }
-
-    .integration-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
       gap: 1.4rem;
+      justify-items: center;
     }
 
-    .integration-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-sm);
-      padding: 1.6rem 1.8rem;
-      border: 1px solid var(--lumina-border);
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
-    }
-
-    .integration-card strong {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .integration-card ul {
+    .cta p {
+      max-width: 680px;
       margin: 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .cta-panel {
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      color: #fff;
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 1.5rem;
-      justify-items: start;
-      box-shadow: 0 38px 70px rgba(8, 30, 70, 0.22);
-      text-align: left;
-    }
-
-    .cta-panel h3 {
-      margin: 0;
-      font-size: clamp(2rem, 3.5vw, 2.5rem);
-    }
-
-    .cta-panel p {
-      margin: 0;
-      font-size: 1.05rem;
-      max-width: 520px;
       line-height: 1.7;
-      color: rgba(226, 232, 240, 0.85);
-    }
-
-    .cta-panel a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      background: #fff;
-      color: var(--lumina-blue-dark);
-      text-decoration: none;
-      padding: 0.75rem 1.5rem;
-      border-radius: 999px;
-      font-weight: 600;
-      transition: var(--transition);
-    }
-
-    .cta-panel a:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 30px rgba(255, 255, 255, 0.25);
+      color: rgba(226, 232, 240, 0.95);
     }
 
     footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
+      background: var(--gradient-footer);
+      color: rgba(241, 245, 249, 0.9);
+      padding: 4.5rem 0 3rem;
     }
 
-    .footer-shell {
-      max-width: 1120px;
+    .footer-grid {
+      max-width: 1180px;
       margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
+      padding: 0 2.75rem;
+      display: grid;
+      gap: 3.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
+    .footer-brand {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .footer-brand img {
+      width: 52px;
+      height: 52px;
+      object-fit: contain;
+    }
+
+    .footer-nav,
+    .footer-contact {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .footer-nav a {
+      color: rgba(148, 163, 184, 0.95);
       text-decoration: none;
+      transition: var(--transition);
     }
 
-    .footer-shell a:hover {
-      color: #fff;
+    .footer-nav a:hover {
+      color: var(--sky);
     }
 
-    @media (max-width: 720px) {
+    .footer-bottom {
+      max-width: 1180px;
+      margin: 3rem auto 0;
+      padding: 0 2.75rem;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 1rem;
+      justify-content: space-between;
+      font-size: 0.9rem;
+      color: rgba(148, 163, 184, 0.82);
+    }
+
+    @media (max-width: 960px) {
+      .nav-wrap {
+        padding: 1rem 1.6rem;
+        flex-wrap: wrap;
+        gap: 1.2rem;
+      }
+
+      nav ul {
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .nav-cta {
+        width: 100%;
+        justify-content: center;
+      }
+
+      .container {
+        padding: 0 1.6rem;
+      }
+
+      footer {
+        padding: 3.5rem 0 2.5rem;
+      }
+    }
+
+    @media (max-width: 640px) {
       header {
         position: static;
       }
 
-      .nav-container {
+      .hero {
+        padding: 5.5rem 0 6rem;
+      }
+
+      .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .primary-btn,
+      .ghost-btn,
+      .nav-cta {
+        justify-content: center;
+      }
+
+      .footer-bottom {
         flex-direction: column;
         align-items: flex-start;
       }
     }
   </style>
 </head>
-
 <body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
+  <header>
+    <div class="nav-wrap">
+      <a class="brand" href="Landing.html">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <span>LuminaHQ</span>
+      </a>
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="Landing.html">Home</a></li>
+          <li><a href="#suites">Suites</a></li>
+          <li><a href="#automation">Automation</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+        </ul>
+      </nav>
+      <a class="nav-cta" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+        <i class="fa-solid fa-right-to-bracket"></i>
+        Enter platform
+      </a>
+    </div>
+  </header>
+  <main>
+    <section class="hero" id="banner">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <div class="eyebrow"><span></span> Platform capabilities</div>
+          <h1>Everything you need to orchestrate people, process, and performance.</h1>
+          <p>
+            LuminaHQ fuses scheduling, coaching, quality, automation, and analytics into one responsive system of action. Explore
+            the suite powering modern workforce intelligence.
+          </p>
+          <div class="hero-actions">
+            <a class="primary-btn" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+              <i class="fa-solid fa-rocket"></i>
+              Enter platform
+            </a>
+            <a class="ghost-btn" href="Landing.html#cta">
+              <i class="fa-solid fa-lightbulb"></i>
+              See how teams launch
+            </a>
           </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <svg viewBox="0 0 520 420" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 100%;">
+            <defs>
+              <linearGradient id="capGradient" x1="40" y1="40" x2="480" y2="360" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#38bdf8" stop-opacity="0.85" />
+                <stop offset="0.52" stop-color="#2563eb" stop-opacity="0.75" />
+                <stop offset="1" stop-color="#0f172a" stop-opacity="0.95" />
+              </linearGradient>
+            </defs>
+            <rect x="48" y="64" width="420" height="280" rx="32" stroke="url(#capGradient)" stroke-width="3" fill="rgba(15, 23, 42, 0.45)" />
+            <path d="M96 128h336" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" opacity="0.7" />
+            <g opacity="0.85">
+              <path d="M132 196h220" stroke="#38bdf8" stroke-width="2" stroke-linecap="round" />
+              <path d="M132 228h260" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.85" />
+              <path d="M132 260h180" stroke="#0ea5e9" stroke-width="2" stroke-linecap="round" opacity="0.8" />
+            </g>
+            <circle cx="184" cy="160" r="16" fill="#38bdf8" />
+            <circle cx="232" cy="160" r="16" fill="#10b981" />
+            <circle cx="280" cy="160" r="16" fill="#0ea5e9" />
+            <circle cx="356" cy="236" r="52" stroke="#38bdf8" stroke-width="2" />
+            <path d="M356 184v104" stroke="#38bdf8" stroke-width="2" stroke-dasharray="6 10" />
+            <path d="M304 236h104" stroke="#0ea5e9" stroke-width="2" stroke-dasharray="6 10" />
+          </svg>
         </div>
       </div>
-    </header>
+    </section>
 
-    <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>Every capability connects frontline execution to leadership insight.</h2>
-            <p>Explore the end-to-end modules that power LuminaHQ. From real-time scheduling to QA intelligence, each capability is engineered to help teams anticipate demand and act with confidence.</p>
-            <a class="hero-cta" href="<?!= workspaceUrl ?>"><i class="fa-solid fa-chart-simple"></i> Explore the workspace</a>
+    <section class="suite-section" id="suites">
+      <div class="container">
+        <div class="section-heading">
+          <span>Command suites</span>
+          <h2>A modular set of workspaces for every operations leader.</h2>
+          <p>Activate the suites you need today and expand as your programs evolve.</p>
+        </div>
+        <div class="suite-grid">
+          <div class="suite-item">
+            <h3>Scheduling intelligence</h3>
+            <p>Forecast demand, balance skills, and keep coverage optimized with live adherence and scenario planning.</p>
           </div>
-          <div class="hero-visual" aria-hidden="true" style="display:grid;gap:1rem;">
-            <div style="background:rgba(255,255,255,0.12);border-radius:22px;padding:1.4rem 1.6rem;border:1px solid rgba(255,255,255,0.28);display:grid;gap:0.75rem;">
-              <div style="display:flex;align-items:center;justify-content:space-between;">
-                <strong style="font-size:0.95rem;letter-spacing:0.12em;text-transform:uppercase;">Live insights</strong>
-                <span style="display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;"><i class="fa-solid fa-signal"></i> Synced</span>
-              </div>
-              <div style="display:grid;gap:0.6rem;">
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Schedule adherence</span>
-                  <strong>97.4%</strong>
-                </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>QA coaching cycles</span>
-                  <strong>128</strong>
-                </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Campaign health</span>
-                  <strong>Green</strong>
-                </div>
-              </div>
-            </div>
-            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.75rem;">
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-calendar-check" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Scheduling</p>
-              </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chalkboard-user" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Coaching</p>
-              </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chart-line" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Analytics</p>
-              </div>
-            </div>
+          <div class="suite-item">
+            <h3>Coaching studio</h3>
+            <p>Curate coaching cadences, capture performance signals, and personalize growth paths for every agent.</p>
+          </div>
+          <div class="suite-item">
+            <h3>Quality assurance</h3>
+            <p>Deliver consistent evaluations, escalate instantly, and align compliance frameworks across teams.</p>
+          </div>
+          <div class="suite-item">
+            <h3>Engagement hub</h3>
+            <p>Bring announcements, recognition, and resource libraries together to keep every crew connected.</p>
           </div>
         </div>
-      </section>
-
-      <section class="section" id="modules">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Core modules that power your operations</h3>
-            <p>Each LuminaHQ module is purpose-built for high-volume contact centers. They connect seamlessly, yet can be rolled out independently to match the maturity of each campaign.</p>
-          </div>
-          <div class="module-grid">
-            <article class="module-card">
-              <span><i class="fa-solid fa-calendar-check"></i> Scheduling</span>
-              <h4>Shift orchestration</h4>
-              <p>Broadcast real-time staffing updates, manage shift swaps, and automate exception handling directly in Google Workspace.</p>
-              <ul>
-                <li>Agent swap approvals with audit trails</li>
-                <li>Overtime forecasting and alerts</li>
-                <li>Work-from-home readiness checks</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-user-graduate"></i> Coaching</span>
-              <h4>Enablement playbooks</h4>
-              <p>Give supervisors guided workflows to assign action plans, track completion, and celebrate wins in one place.</p>
-              <ul>
-                <li>Custom coaching templates &amp; sign-offs</li>
-                <li>Performance snapshots and heatmaps</li>
-                <li>Automated reminders for follow-ups</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-shield-heart"></i> Quality</span>
-              <h4>QA intelligence hub</h4>
-              <p>Analyze evaluator feedback, calibrate teams, and surface QA performance trends with a modern reporting layer.</p>
-              <ul>
-                <li>Weighted scoring and variance tracking</li>
-                <li>Calibration dashboards with history</li>
-                <li>AI-ready form exports for deeper insights</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-handshake"></i> Collaboration</span>
-              <h4>Campaign collaboration</h4>
-              <p>Coordinate cross-functional projects, document requirements, and drive accountability across partner teams.</p>
-              <ul>
-                <li>Project boards with owner visibility</li>
-                <li>Documented SLAs and knowledge sharing</li>
-                <li>Escalation routing with follow-through</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="intelligence">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Intelligence woven into every workflow</h3>
-            <p>LuminaHQ turns raw metrics into proactive insights. Supervisors and executives gain the same live picture, tailored to their priorities.</p>
-          </div>
-          <div class="capability-matrix">
-            <article class="matrix-card">
-              <h4>Operational awareness</h4>
-              <p>See how staffing, quality, and coaching interact in real-time.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-signal"></i> Color-coded adherence by site, line of business, or skill group.</li>
-                <li><i class="fa-solid fa-chart-area"></i> Trend analysis that blends historical performance with live data.</li>
-                <li><i class="fa-solid fa-bell"></i> Notifications when service levels or QA thresholds drift.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Guided decisioning</h4>
-              <p>Surface the next best action for every role on the floor.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-route"></i> Prescriptive playbooks for coaching, staffing, and client communication.</li>
-                <li><i class="fa-solid fa-person-chalkboard"></i> Supervisor dashboards tuned for quick huddles.</li>
-                <li><i class="fa-solid fa-gears"></i> Automations triggered by thresholds, statuses, or campaign events.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Executive visibility</h4>
-              <p>Translate frontline operations into boardroom clarity.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-chart-line"></i> Roll-up scorecards across programs with drill-downs to agent level.</li>
-                <li><i class="fa-solid fa-file-lines"></i> Auto-generated executive briefs summarizing wins and risks.</li>
-                <li><i class="fa-solid fa-globe"></i> Global dashboards that segment by client, region, or outsourcing partner.</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="integrations">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Works seamlessly with your existing stack</h3>
-            <p>Built on Google Workspace and Apps Script, LuminaHQ plays nicely with your contact center ecosystem, ensuring data stays secure and in sync.</p>
-          </div>
-          <div class="integration-grid">
-            <article class="integration-card">
-              <strong><i class="fa-brands fa-google"></i> Google Workspace native</strong>
-              <ul>
-                <li>Single sign-on with your Google accounts</li>
-                <li>Drive, Sheets, and Docs automations included</li>
-                <li>Calendar sync for schedule updates</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-cloud-arrow-up"></i> Data pipeline ready</strong>
-              <ul>
-                <li>Export-ready datasets for BI platforms</li>
-                <li>Webhook endpoints for real-time mirroring</li>
-                <li>Tenant-aware API keys and logging</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-lock"></i> Security controls</strong>
-              <ul>
-                <li>Role-based permissions with audit history</li>
-                <li>Granular data residency and retention rules</li>
-                <li>Compliance alignment for SOC 2 readiness</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" style="padding-bottom:4.5rem;">
-        <div class="section-shell">
-          <div class="cta-panel">
-            <h3>See LuminaHQ in action</h3>
-            <p>Log in to your workspace or request a guided walkthrough to explore how LuminaHQ adapts to the rhythm of your operations.</p>
-            <a href="<?!= workspaceUrl ?>"><i class="fa-solid fa-chart-simple"></i> Explore the workspace</a>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <strong>Looking for our story?</strong>
-        <div>
-          <a href="<?!= landingAboutUrl ?>">Visit the LuminaHQ about page</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#features">Return to landing highlights</a>
-        </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</small>
       </div>
-    </footer>
-  </div>
+    </section>
+
+    <section class="automation-section" id="automation">
+      <div class="container">
+        <div class="section-heading">
+          <span>Automation fabric</span>
+          <h2>Keep your operation moving with responsive automations.</h2>
+          <p>Configure interventions that activate precisely when signals shift.</p>
+        </div>
+        <div class="automation-grid">
+          <div class="automation-card">
+            <h3>Intelligent routing</h3>
+            <p>Send alerts, escalations, and acknowledgements to the right leaders in seconds.</p>
+          </div>
+          <div class="automation-card">
+            <h3>Workflow orchestration</h3>
+            <p>Trigger scheduling changes, QA audits, and performance nudges instantly based on live metrics.</p>
+          </div>
+          <div class="automation-card">
+            <h3>Compliance guardrails</h3>
+            <p>Automate policy checks, documentation, and audit trails for a security-first operation.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="analytics-section" id="analytics">
+      <div class="container">
+        <div class="section-heading">
+          <span>Analytics</span>
+          <h2>Illuminate the signals that matter most.</h2>
+          <p>Bring clarity to leaders with dashboards designed for decisive action.</p>
+        </div>
+        <div class="analytics-grid">
+          <div class="analytics-item">
+            <strong>Executive cockpit</strong>
+            <span>Monitor programs with consolidated KPIs, context, and trend detection in one view.</span>
+          </div>
+          <div class="analytics-item">
+            <strong>Operational intelligence</strong>
+            <span>Drill into queues, adherence, QA, and coaching insights to intervene with precision.</span>
+          </div>
+          <div class="analytics-item">
+            <strong>Agent clarity</strong>
+            <span>Deliver personal scorecards and action plans that inspire ownership and improvement.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <span class="eyebrow" style="justify-content: center"><span></span> Deploy Lumina</span>
+        <h2 style="font-family: 'Space Grotesk', sans-serif; font-size: clamp(2.2rem, 4vw, 3.2rem); margin: 0;">
+          Ready to orchestrate your workforce intelligence?
+        </h2>
+        <p>
+          Activate LuminaHQ and give every leader the tools to plan, coach, analyze, and automate with confidence.
+        </p>
+        <div class="hero-actions" style="justify-content: center;">
+          <a class="primary-btn" href="https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec">
+            <i class="fa-solid fa-right-to-bracket"></i>
+            Enter platform
+          </a>
+          <a class="ghost-btn" href="LandingAbout.html#culture">
+            <i class="fa-solid fa-people-group"></i>
+            Meet the Lumina crew
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" />
+        <p>
+          LuminaHQ connects people, process, and data into one responsive command center so your organization can deliver with
+          confidence.
+        </p>
+      </div>
+      <div class="footer-nav">
+        <strong>Explore</strong>
+        <a href="Landing.html">Home</a>
+        <a href="LandingAbout.html">About</a>
+        <a href="Login.html">Sign in</a>
+        <a href="LuminaHQUserGuide.html">User guide</a>
+      </div>
+      <div class="footer-contact">
+        <strong>Connect</strong>
+        <span><i class="fa-solid fa-envelope"></i> support@lumina-hq.com</span>
+        <span><i class="fa-solid fa-phone"></i> +1 (800) 555-0148</span>
+        <span><i class="fa-solid fa-location-dot"></i> Global operations • Remote-first</span>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© <script>document.write(new Date().getFullYear());</script> LuminaHQ. All rights reserved.</span>
+      <span>
+        <a href="TermsOfService.html" style="color: inherit; text-decoration: none; margin-right: 1.2rem;">Terms</a>
+        <a href="PrivacyPolicy.html" style="color: inherit; text-decoration: none;">Privacy</a>
+      </span>
+    </div>
+  </footer>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- redesign the landing, about, and capabilities pages with full-width blue-forward sections, large hero treatments, and a branded footer anchored by the Lumina logo
- replace the previous purple accents with complementary blue, sky, and mint tones while wiring navigation and CTA buttons to the live platform URL from Code.js
- align cross-page links so visitors can move between landing experiences without dummy anchors and always reach the platform entry point

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e9ac6c15208326ba12e900434c0816