### PR TITLE
Seed campaigns and enrich admin bootstrap

### DIFF
--- a/SeedData.js
+++ b/SeedData.js
@@ -22,6 +22,19 @@ const SEED_ROLE_NAMES = [
 
 const SEED_CAMPAIGNS = [
   { name: 'Lumina HQ', description: 'Lumina internal operations workspace' },
+  { name: 'Credit Suite', description: 'Credit Suite operations campaign' },
+  { name: 'HiyaCar', description: 'HiyaCar mobility support campaign' },
+  { name: 'Benefits Resource Center (iBTR)', description: 'Benefits Resource Center member services' },
+  { name: 'Independence Insurance Agency', description: 'Independence Insurance Agency customer care' },
+  { name: 'JSC', description: 'JSC customer success campaign' },
+  { name: 'Kids in the Game', description: 'Kids in the Game coaching support' },
+  { name: 'Kofi Group', description: 'Kofi Group recruiting operations' },
+  { name: 'PAW Law Firm', description: 'PAW Law Firm client services' },
+  { name: 'Pro House Photos', description: 'Pro House Photos client success' },
+  { name: 'Independence Agency & Credit Suite', description: 'Independence Agency & Credit Suite blended operations' },
+  { name: 'Proozy', description: 'Proozy ecommerce support' },
+  { name: 'The Grounding', description: 'The Grounding campaign (TGC)' },
+  { name: 'CO', description: 'CO services campaign' }
 ];
 
 const SEED_LUMINA_ADMIN_PROFILE = {
@@ -30,7 +43,8 @@ const SEED_LUMINA_ADMIN_PROFILE = {
   email: 'lumina@vlbpo.com',
   password: 'ChangeMe123!',
   defaultCampaign: 'Lumina HQ',
-  roleNames: ['Administrator'],
+  roleNames: ['Super Admin', 'Administrator'],
+  claimTypes: ['system.admin', 'lumina.admin', 'manage.users', 'manage.pages'],
   seedLabel: 'Lumina Administrator'
 };
 
@@ -90,9 +104,10 @@ function seedDefaultData() {
     const campaignIdsByName = ensureCoreCampaigns(summary);
 
     summary.systemPages = ensureSystemPageCatalog();
-    summary.navigation = ensureCampaignNavigationSeeds(campaignIdsByName);
+    const pageCatalog = resolveSeedPageCatalog();
+    summary.navigation = ensureCampaignNavigationSeeds(campaignIdsByName, pageCatalog);
 
-    const luminaAdminInfo = ensureLuminaAdminUser(roleIdsByName, campaignIdsByName);
+    const luminaAdminInfo = ensureLuminaAdminUser(roleIdsByName, campaignIdsByName, pageCatalog);
     summary.luminaAdmin = luminaAdminInfo;
 
     return {
@@ -218,8 +233,8 @@ function getCampaignsIndex(forceRefresh) {
 /**
  * Ensure there is a Lumina admin user with a known password and permissions.
  */
-function ensureLuminaAdminUser(roleIdsByName, campaignIdsByName) {
-  return ensureSeedAdministrator(SEED_LUMINA_ADMIN_PROFILE, roleIdsByName, campaignIdsByName);
+function ensureLuminaAdminUser(roleIdsByName, campaignIdsByName, pageCatalog) {
+  return ensureSeedAdministrator(SEED_LUMINA_ADMIN_PROFILE, roleIdsByName, campaignIdsByName, pageCatalog);
 }
 
 /**
@@ -279,7 +294,7 @@ function ensureSystemPageCatalog() {
 /**
  * Ensure every seeded campaign receives default categories and page assignments.
  */
-function ensureCampaignNavigationSeeds(campaignIdsByName) {
+function ensureCampaignNavigationSeeds(campaignIdsByName, providedPageCatalog) {
   const result = {};
 
   try {
@@ -287,7 +302,9 @@ function ensureCampaignNavigationSeeds(campaignIdsByName) {
       return result;
     }
 
-    const pageCatalog = resolveSeedPageCatalog();
+    const pageCatalog = Array.isArray(providedPageCatalog) && providedPageCatalog.length
+      ? providedPageCatalog
+      : resolveSeedPageCatalog();
     const categoryDefinitions = resolveSeedCategoryDefinitions(pageCatalog);
     const seededCampaignNames = Array.isArray(SEED_CAMPAIGNS)
       ? SEED_CAMPAIGNS.map(c => c && c.name).filter(Boolean)
@@ -1180,7 +1197,7 @@ function applySeedPasswordForUser(userRecord, profile, label) {
 /**
  * Shared implementation for creating or refreshing privileged seed accounts.
  */
-function ensureSeedAdministrator(profile, roleIdsByName, campaignIdsByName) {
+function ensureSeedAdministrator(profile, roleIdsByName, campaignIdsByName, pageCatalog) {
   if (!profile || !profile.email) {
     throw new Error('Seed administrator profile is not configured correctly.');
   }
@@ -1193,6 +1210,10 @@ function ensureSeedAdministrator(profile, roleIdsByName, campaignIdsByName) {
       return roleIdsByName[key] || roleIdsByName[key.toLowerCase()];
     })
     .filter(Boolean);
+  const desiredClaims = Array.isArray(profile.claimTypes)
+    ? profile.claimTypes.filter(Boolean)
+    : [];
+  const resolvedPageCatalog = Array.isArray(pageCatalog) ? pageCatalog : resolveSeedPageCatalog();
 
   const defaultCampaignKey = profile.defaultCampaign
     ? String(profile.defaultCampaign).toLowerCase()
@@ -1239,14 +1260,26 @@ function ensureSeedAdministrator(profile, roleIdsByName, campaignIdsByName) {
 
     existing = applySeedPasswordForUser(existing, profile, label);
     syncUserRoleLinks(existing.ID, desiredRoleIds);
-    assignAdminCampaignAccess(existing.ID, Object.values(campaignIdsByName));
+    const campaignAccess = assignAdminCampaignAccess(existing.ID, Object.values(campaignIdsByName));
     ensureCanLoginFlag(existing.ID, true);
+
+    const claimsResult = ensureUserClaims(existing.ID, desiredClaims);
+    const pageResult = assignUserPageAccess(existing.ID, resolvedPageCatalog);
+    const normalization = ensureUserNormalization(existing.ID, profile);
+    const campaignSummary = summarizeCampaignAssignments(campaignIdsByName, campaignAccess.assigned);
 
     const result = {
       status: 'updated',
       userId: existing.ID,
       email: profile.email,
-      message: (updateResult && updateResult.message) || (label + ' refreshed.')
+      message: (updateResult && updateResult.message) || (label + ' refreshed.'),
+      roles: Array.isArray(profile.roleNames) ? profile.roleNames.slice() : [],
+      roleIds: desiredRoleIds.slice(),
+      claims: claimsResult,
+      campaigns: campaignSummary,
+      campaignAccess,
+      pages: pageResult,
+      normalization
     };
 
     if (profile.password) {
@@ -1272,14 +1305,26 @@ function ensureSeedAdministrator(profile, roleIdsByName, campaignIdsByName) {
   const adminId = persistedRecord.ID || adminRecord.ID;
 
   syncUserRoleLinks(adminId, desiredRoleIds);
-  assignAdminCampaignAccess(adminId, Object.values(campaignIdsByName));
+  const campaignAccess = assignAdminCampaignAccess(adminId, Object.values(campaignIdsByName));
   ensureCanLoginFlag(adminId, true);
+
+  const claimsResult = ensureUserClaims(adminId, desiredClaims);
+  const pageResult = assignUserPageAccess(adminId, resolvedPageCatalog);
+  const normalization = ensureUserNormalization(adminId, profile);
+  const campaignSummary = summarizeCampaignAssignments(campaignIdsByName, campaignAccess.assigned);
 
   const result = {
     status: 'created',
     userId: adminId,
     email: persistedRecord.Email || adminRecord.Email,
-    message: label + ' account created with default credentials. Please change the password after first login.'
+    message: label + ' account created with default credentials. Please change the password after first login.',
+    roles: Array.isArray(profile.roleNames) ? profile.roleNames.slice() : [],
+    roleIds: desiredRoleIds.slice(),
+    claims: claimsResult,
+    campaigns: campaignSummary,
+    campaignAccess,
+    pages: pageResult,
+    normalization
   };
 
   if (profile.password) {
@@ -1500,21 +1545,386 @@ function syncUserRoleLinks(userId, roleIds) {
  * Give the administrator access to every campaign at the ADMIN level.
  */
 function assignAdminCampaignAccess(userId, campaignIds) {
+  const summary = { assigned: [] };
   if (!userId || !Array.isArray(campaignIds)) {
-    return;
+    return summary;
   }
 
   const uniqueIds = Array.from(new Set(campaignIds.map(id => String(id || ''))))
     .filter(id => id);
 
   uniqueIds.forEach(campaignId => {
+    if (!campaignId) return;
     if (typeof setCampaignUserPermissions === 'function') {
       setCampaignUserPermissions(campaignId, userId, 'ADMIN', true, true);
     }
     if (typeof addUserToCampaign === 'function') {
       addUserToCampaign(userId, campaignId);
     }
+    summary.assigned.push(campaignId);
   });
+
+  summary.count = summary.assigned.length;
+  return summary;
+}
+
+function assignUserPageAccess(userId, pageCatalog) {
+  const result = { assigned: [], count: 0, updated: false };
+  if (!userId) {
+    return result;
+  }
+
+  const pageKeys = collectPageKeysFromCatalog(pageCatalog);
+  result.assigned = pageKeys.slice();
+  result.count = pageKeys.length;
+
+  if (!pageKeys.length) {
+    return result;
+  }
+
+  if (typeof SpreadsheetApp === 'undefined' || !SpreadsheetApp || !SpreadsheetApp.getActiveSpreadsheet) {
+    return result;
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sh = ss.getSheetByName(USERS_SHEET);
+  if (!sh) {
+    return result;
+  }
+
+  const data = sh.getDataRange().getValues();
+  if (!data || !data.length) {
+    return result;
+  }
+
+  const headers = data[0];
+  const idIdx = headers.indexOf('ID');
+  const pagesIdx = headers.indexOf('Pages');
+  const updatedIdx = headers.indexOf('UpdatedAt');
+
+  if (idIdx === -1 || pagesIdx === -1) {
+    return result;
+  }
+
+  const desiredCsv = pageKeys.join(',');
+
+  for (let r = 1; r < data.length; r++) {
+    if (String(data[r][idIdx]) !== String(userId)) {
+      continue;
+    }
+
+    const currentRaw = String(data[r][pagesIdx] || '').trim();
+    const currentKeys = currentRaw
+      ? currentRaw.split(',').map(value => value.trim()).filter(Boolean)
+      : [];
+
+    const sameLength = currentKeys.length === pageKeys.length;
+    const sameMembers = sameLength && pageKeys.every(key => currentKeys.indexOf(key) !== -1);
+
+    if (!sameMembers) {
+      sh.getRange(r + 1, pagesIdx + 1).setValue(desiredCsv);
+      if (updatedIdx >= 0) {
+        sh.getRange(r + 1, updatedIdx + 1).setValue(new Date());
+      }
+      if (typeof invalidateCache === 'function') {
+        invalidateCache(USERS_SHEET);
+      }
+      result.updated = true;
+    }
+
+    return result;
+  }
+
+  return result;
+}
+
+function collectPageKeysFromCatalog(pageCatalog) {
+  const source = Array.isArray(pageCatalog) && pageCatalog.length
+    ? pageCatalog
+    : resolveSeedPageCatalog();
+  const seen = new Set();
+  const keys = [];
+
+  (source || []).forEach(entry => {
+    if (!entry) return;
+    const rawKey = entry.key || entry.PageKey || entry.pageKey;
+    if (!rawKey) return;
+    const normalized = String(rawKey).trim();
+    if (!normalized) return;
+    const dedupeKey = normalized.toLowerCase();
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    keys.push(normalized);
+  });
+
+  keys.sort();
+  return keys;
+}
+
+function ensureUserNormalization(userId, profile) {
+  const result = {
+    updated: false,
+    normalizedEmail: '',
+    normalizedUserName: ''
+  };
+
+  if (!userId) {
+    return result;
+  }
+
+  const email = profile && profile.email ? String(profile.email).trim() : '';
+  const userName = profile && profile.userName ? String(profile.userName).trim() : '';
+  const fullName = profile && profile.fullName ? String(profile.fullName).trim() : '';
+  const normalizedEmail = email ? email.toLowerCase() : '';
+  const normalizedUserName = (userName || email).toLowerCase();
+
+  result.normalizedEmail = normalizedEmail;
+  result.normalizedUserName = normalizedUserName;
+
+  if (typeof SpreadsheetApp === 'undefined' || !SpreadsheetApp || !SpreadsheetApp.getActiveSpreadsheet) {
+    return result;
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sh = ss.getSheetByName(USERS_SHEET);
+  if (!sh) {
+    return result;
+  }
+
+  const data = sh.getDataRange().getValues();
+  if (!data || data.length < 2) {
+    return result;
+  }
+
+  const headers = data[0];
+  const lookup = {};
+  headers.forEach((header, idx) => {
+    const key = String(header || '').trim();
+    if (key && !Object.prototype.hasOwnProperty.call(lookup, key)) {
+      lookup[key] = idx;
+    }
+  });
+
+  const idIdx = Object.prototype.hasOwnProperty.call(lookup, 'ID') ? lookup.ID : -1;
+  if (idIdx === -1) {
+    return result;
+  }
+
+  const emailIdx = Object.prototype.hasOwnProperty.call(lookup, 'Email') ? lookup.Email : -1;
+  const normalizedEmailIdx = Object.prototype.hasOwnProperty.call(lookup, 'NormalizedEmail') ? lookup.NormalizedEmail : -1;
+  const userNameIdx = Object.prototype.hasOwnProperty.call(lookup, 'UserName') ? lookup.UserName : -1;
+  const normalizedUserNameIdx = Object.prototype.hasOwnProperty.call(lookup, 'NormalizedUserName') ? lookup.NormalizedUserName : -1;
+  const fullNameIdx = Object.prototype.hasOwnProperty.call(lookup, 'FullName') ? lookup.FullName : -1;
+  const emailConfirmedIdx = Object.prototype.hasOwnProperty.call(lookup, 'EmailConfirmed') ? lookup.EmailConfirmed : -1;
+  const canLoginIdx = Object.prototype.hasOwnProperty.call(lookup, 'CanLogin') ? lookup.CanLogin : -1;
+  const isAdminIdx = Object.prototype.hasOwnProperty.call(lookup, 'IsAdmin') ? lookup.IsAdmin : -1;
+  const resetRequiredIdx = Object.prototype.hasOwnProperty.call(lookup, 'ResetRequired') ? lookup.ResetRequired : -1;
+  const updatedIdx = Object.prototype.hasOwnProperty.call(lookup, 'UpdatedAt') ? lookup.UpdatedAt : -1;
+
+  for (let r = 1; r < data.length; r++) {
+    if (String(data[r][idIdx]) !== String(userId)) {
+      continue;
+    }
+
+    let mutated = false;
+
+    if (emailIdx >= 0 && email && String(data[r][emailIdx] || '').trim() !== email) {
+      sh.getRange(r + 1, emailIdx + 1).setValue(email);
+      mutated = true;
+    }
+
+    if (normalizedEmailIdx >= 0 && normalizedEmail && String(data[r][normalizedEmailIdx] || '').trim().toLowerCase() !== normalizedEmail) {
+      sh.getRange(r + 1, normalizedEmailIdx + 1).setValue(normalizedEmail);
+      mutated = true;
+    }
+
+    if (userNameIdx >= 0) {
+      const desiredUserName = userName || email;
+      if (desiredUserName && String(data[r][userNameIdx] || '').trim() !== desiredUserName) {
+        sh.getRange(r + 1, userNameIdx + 1).setValue(desiredUserName);
+        mutated = true;
+      }
+    }
+
+    if (normalizedUserNameIdx >= 0 && normalizedUserName && String(data[r][normalizedUserNameIdx] || '').trim().toLowerCase() !== normalizedUserName) {
+      sh.getRange(r + 1, normalizedUserNameIdx + 1).setValue(normalizedUserName);
+      mutated = true;
+    }
+
+    if (fullNameIdx >= 0 && fullName && String(data[r][fullNameIdx] || '').trim() !== fullName) {
+      sh.getRange(r + 1, fullNameIdx + 1).setValue(fullName);
+      mutated = true;
+    }
+
+    if (emailConfirmedIdx >= 0 && String(data[r][emailConfirmedIdx] || '').toUpperCase() !== 'TRUE') {
+      sh.getRange(r + 1, emailConfirmedIdx + 1).setValue('TRUE');
+      mutated = true;
+    }
+
+    if (canLoginIdx >= 0 && String(data[r][canLoginIdx] || '').toUpperCase() !== 'TRUE') {
+      sh.getRange(r + 1, canLoginIdx + 1).setValue('TRUE');
+      mutated = true;
+    }
+
+    if (isAdminIdx >= 0 && String(data[r][isAdminIdx] || '').toUpperCase() !== 'TRUE') {
+      sh.getRange(r + 1, isAdminIdx + 1).setValue('TRUE');
+      mutated = true;
+    }
+
+    if (resetRequiredIdx >= 0 && String(data[r][resetRequiredIdx] || '').toUpperCase() !== 'FALSE') {
+      sh.getRange(r + 1, resetRequiredIdx + 1).setValue('FALSE');
+      mutated = true;
+    }
+
+    if (mutated && updatedIdx >= 0) {
+      sh.getRange(r + 1, updatedIdx + 1).setValue(new Date());
+    }
+
+    if (mutated && typeof invalidateCache === 'function') {
+      invalidateCache(USERS_SHEET);
+    }
+
+    result.updated = mutated;
+    return result;
+  }
+
+  return result;
+}
+
+function ensureUserClaims(userId, claimTypes) {
+  const result = { requested: [], created: [], existing: [] };
+  if (!userId) {
+    return result;
+  }
+
+  const requested = Array.from(new Set((Array.isArray(claimTypes) ? claimTypes : [])
+    .map(type => String(type || '').trim())
+    .filter(Boolean)));
+
+  result.requested = requested.slice();
+
+  if (!requested.length) {
+    return result;
+  }
+
+  ensureSheetWithHeaders(USER_CLAIMS_SHEET, CLAIMS_HEADERS);
+
+  const existingRows = (typeof readSheet === 'function') ? (readSheet(USER_CLAIMS_SHEET) || []) : [];
+  const existingSet = new Set();
+
+  existingRows.forEach(row => {
+    if (!row) return;
+    const rowUserId = row.UserId || row.UserID || row.User || row.userId || row.userid;
+    if (String(rowUserId) !== String(userId)) return;
+    const type = row.ClaimType || row.Type || row.Name || row.claimType;
+    if (!type) return;
+    existingSet.add(String(type).trim().toLowerCase());
+  });
+
+  if (typeof SpreadsheetApp === 'undefined' || !SpreadsheetApp || !SpreadsheetApp.getActiveSpreadsheet) {
+    result.existing = requested.filter(type => existingSet.has(type.toLowerCase()));
+    return result;
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sh = ss.getSheetByName(USER_CLAIMS_SHEET);
+  if (!sh) {
+    sh = ss.insertSheet(USER_CLAIMS_SHEET);
+    sh.getRange(1, 1, 1, CLAIMS_HEADERS.length).setValues([CLAIMS_HEADERS]);
+  }
+
+  const lastColumn = sh.getLastColumn() || CLAIMS_HEADERS.length;
+  const headers = sh.getRange(1, 1, 1, lastColumn).getValues()[0];
+  const lookup = {};
+  headers.forEach((header, idx) => {
+    const key = String(header || '').trim();
+    if (key && !Object.prototype.hasOwnProperty.call(lookup, key)) {
+      lookup[key] = idx;
+    }
+  });
+
+  const idxId = Object.prototype.hasOwnProperty.call(lookup, 'ID') ? lookup.ID : -1;
+  const idxUserId = Object.prototype.hasOwnProperty.call(lookup, 'UserId')
+    ? lookup.UserId
+    : (Object.prototype.hasOwnProperty.call(lookup, 'UserID') ? lookup.UserID : -1);
+  const idxClaimType = Object.prototype.hasOwnProperty.call(lookup, 'ClaimType') ? lookup.ClaimType : -1;
+  const idxCreatedAt = Object.prototype.hasOwnProperty.call(lookup, 'CreatedAt') ? lookup.CreatedAt : -1;
+  const idxUpdatedAt = Object.prototype.hasOwnProperty.call(lookup, 'UpdatedAt') ? lookup.UpdatedAt : -1;
+
+  requested.forEach(type => {
+    const normalized = type.toLowerCase();
+    if (existingSet.has(normalized)) {
+      result.existing.push(type);
+      return;
+    }
+
+    const row = new Array(headers.length).fill('');
+    const nowIso = new Date().toISOString();
+    if (idxId >= 0) row[idxId] = Utilities.getUuid();
+    if (idxUserId >= 0) row[idxUserId] = userId;
+    if (idxClaimType >= 0) row[idxClaimType] = type;
+    if (idxCreatedAt >= 0) row[idxCreatedAt] = nowIso;
+    if (idxUpdatedAt >= 0) row[idxUpdatedAt] = nowIso;
+    sh.appendRow(row);
+    existingSet.add(normalized);
+    result.created.push(type);
+  });
+
+  if (result.created.length && typeof invalidateCache === 'function') {
+    invalidateCache(USER_CLAIMS_SHEET);
+  }
+
+  return result;
+}
+
+function summarizeCampaignAssignments(campaignIdsByName, assignedIds) {
+  if (!Array.isArray(assignedIds) || !assignedIds.length) {
+    return [];
+  }
+
+  const nameMap = buildCampaignIdNameMap(campaignIdsByName);
+  const seen = new Set();
+  const summary = [];
+
+  assignedIds.forEach(id => {
+    const key = String(id || '').trim();
+    if (!key || seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    summary.push({ id: key, name: nameMap[key] || key });
+  });
+
+  return summary;
+}
+
+function buildCampaignIdNameMap(campaignIdsByName) {
+  const map = {};
+
+  if (Array.isArray(SEED_CAMPAIGNS)) {
+    SEED_CAMPAIGNS.forEach(campaign => {
+      if (!campaign || !campaign.name) return;
+      const id = resolveCampaignIdByName(campaignIdsByName, campaign.name);
+      if (id) {
+        map[String(id)] = campaign.name;
+      }
+    });
+  }
+
+  if (campaignIdsByName) {
+    Object.keys(campaignIdsByName).forEach(key => {
+      const id = campaignIdsByName[key];
+      if (!id) return;
+      const normalizedKey = String(key || '').trim();
+      if (!normalizedKey) return;
+      const idKey = String(id);
+      if (!map[idKey]) {
+        map[idKey] = normalizedKey;
+      }
+    });
+  }
+
+  return map;
 }
 
 /**


### PR DESCRIPTION
## Summary
- seed every known campaign so the bootstrap data matches the campaign-aware routing configuration
- ensure the Lumina admin seed user receives super-admin roles, normalized identity fields, campaign permissions, and page access
- add helpers that manage admin page assignments, campaign summaries, and claim seeding during bootstrap

## Testing
- not run (Google Apps Script data seeding updates)


------
https://chatgpt.com/codex/tasks/task_e_68ea4b8b46c48326a974fb316e0b6b14