### PR TITLE
Add AI-driven admin control center

### DIFF
--- a/AdminCenter.html
+++ b/AdminCenter.html
@@ -1,0 +1,843 @@
+<?!= include('layout', {
+      baseUrl: baseUrl || '',
+      scriptUrl: scriptUrl,
+      user: user || {},
+      currentPage: currentPage || 'admincenter',
+      pageTitle: 'Lumina Admin Center',
+      pageDescription: 'Unified AI-driven command center for LuminaHQ'
+    }) ?>
+
+<div class="admin-center" id="adminCenter">
+  <section class="admin-hero">
+    <div class="hero-copy">
+      <span class="badge rounded-pill bg-warning-subtle text-warning fw-semibold mb-3">
+        <i class="fas fa-crown me-2"></i>Administrator Access
+      </span>
+      <h1 class="hero-title">Lumina Admin Center</h1>
+      <p class="hero-subtitle">
+        Orchestrate workforce operations, customer experience quality, and governance from a single AI-assisted control plane.
+      </p>
+      <div class="hero-meta">
+        <span><i class="fas fa-robot me-2"></i><span id="aiStatus">Synthesizing signals…</span></span>
+        <span class="separator">•</span>
+        <span><i class="far fa-clock me-2"></i>Last refreshed <span id="snapshotTimestamp">just now</span></span>
+      </div>
+    </div>
+    <div class="hero-metrics" id="heroMetrics">
+      <div class="metric-tile loading"></div>
+      <div class="metric-tile loading"></div>
+      <div class="metric-tile loading"></div>
+    </div>
+  </section>
+
+  <section class="insights" id="insightsSection">
+    <div class="section-header">
+      <div>
+        <h2><i class="fas fa-lightbulb me-2 text-warning"></i>AI Operational Insights</h2>
+        <p class="section-subtitle">Proactive guidance generated from live Lumina telemetry.</p>
+      </div>
+      <button class="btn btn-outline-light btn-sm" id="refreshSnapshotBtn">
+        <i class="fas fa-rotate me-2"></i>Refresh Snapshot
+      </button>
+    </div>
+    <div class="insight-grid" id="insightGrid"></div>
+  </section>
+
+  <section class="module-section">
+    <div class="section-header">
+      <div>
+        <h2><i class="fas fa-sitemap me-2 text-primary"></i>Service Control Modules</h2>
+        <p class="section-subtitle">Deep-link into every Lumina service tier and trigger automation with one click.</p>
+      </div>
+    </div>
+    <div class="module-grid" id="moduleGrid"></div>
+  </section>
+
+  <section class="campaign-pulse" id="campaignPulse">
+    <div class="section-header">
+      <div>
+        <h2><i class="fas fa-bullseye me-2 text-success"></i>Campaign Pulse</h2>
+        <p class="section-subtitle">Multi-campaign staffing footprint, navigation breadth, and adoption telemetry.</p>
+      </div>
+    </div>
+    <div class="table-responsive shadow-sm rounded-4">
+      <table class="table table-hover align-middle mb-0" id="campaignTable">
+        <thead>
+          <tr>
+            <th scope="col">Campaign</th>
+            <th scope="col">Linked Users</th>
+            <th scope="col">Active Pages</th>
+            <th scope="col" class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="campaignTableBody">
+          <tr class="loading-row">
+            <td colspan="4"><span class="skeleton-text w-25"></span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="activity-log" id="controlLog">
+    <div class="section-header">
+      <div>
+        <h2><i class="fas fa-terminal me-2 text-info"></i>Automation Journal</h2>
+        <p class="section-subtitle">Every control executed from the admin center is logged here for transparency.</p>
+      </div>
+    </div>
+    <div class="log-stream" id="logStream">
+      <div class="log-entry muted">Awaiting administrator commands…</div>
+    </div>
+  </section>
+</div>
+
+<style>
+  :root {
+    --admin-gradient: linear-gradient(135deg, #003177 0%, #0059b3 100%);
+    --admin-surface: rgba(255, 255, 255, 0.08);
+  }
+
+  body {
+    background: #0f172a;
+    color: #f8fafc;
+  }
+
+  .admin-center {
+    padding: 2.5rem 3rem 4rem;
+    background: radial-gradient(circle at top right, rgba(0, 93, 255, 0.12), transparent 55%),
+                radial-gradient(circle at 10% 10%, rgba(14, 165, 233, 0.15), transparent 45%);
+    min-height: 100vh;
+  }
+
+  .admin-hero {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2.75rem;
+    border-radius: 2rem;
+    background: var(--admin-gradient);
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .admin-hero::after {
+    content: '';
+    position: absolute;
+    width: 420px;
+    height: 420px;
+    top: -160px;
+    right: -120px;
+    background: radial-gradient(circle, rgba(255,255,255,0.18), transparent 70%);
+    filter: blur(2px);
+    opacity: 0.7;
+  }
+
+  .hero-copy {
+    max-width: 540px;
+    position: relative;
+    z-index: 2;
+  }
+
+  .hero-title {
+    font-size: 3rem;
+    font-weight: 800;
+    margin-bottom: 0.75rem;
+    letter-spacing: -0.5px;
+  }
+
+  .hero-subtitle {
+    font-size: 1.1rem;
+    opacity: 0.92;
+    margin-bottom: 1.5rem;
+  }
+
+  .hero-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.95rem;
+    opacity: 0.85;
+  }
+
+  .hero-meta .separator {
+    opacity: 0.5;
+  }
+
+  .hero-metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(140px, 1fr));
+    gap: 1rem;
+    position: relative;
+    z-index: 2;
+    min-width: 320px;
+  }
+
+  .metric-tile {
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    background: rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(12px);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.3);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .metric-tile:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
+  }
+
+  .metric-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+  }
+
+  .metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    display: block;
+  }
+
+  .metric-trend {
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
+    opacity: 0.8;
+  }
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    margin: 3rem 0 1.5rem;
+  }
+
+  .section-header h2 {
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+
+  .section-subtitle {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.78);
+  }
+
+  .insight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
+
+  .insight-card {
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .insight-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(255,255,255,0.08), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .insight-card:hover::after {
+    opacity: 1;
+  }
+
+  .insight-card h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .insight-card p {
+    margin: 0 0 0.75rem;
+    line-height: 1.5;
+    color: rgba(226, 232, 240, 0.9);
+  }
+
+  .insight-card .recommendation {
+    font-size: 0.9rem;
+    color: rgba(148, 163, 184, 0.95);
+  }
+
+  .severity-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .severity-critical { background: rgba(248, 113, 113, 0.18); color: #fca5a5; border: 1px solid rgba(248,113,113,0.3); }
+  .severity-warning { background: rgba(250, 204, 21, 0.18); color: #facc15; border: 1px solid rgba(250,204,21,0.32); }
+  .severity-info { background: rgba(56, 189, 248, 0.2); color: #38bdf8; border: 1px solid rgba(56,189,248,0.32); }
+  .severity-success { background: rgba(74, 222, 128, 0.18); color: #4ade80; border: 1px solid rgba(74,222,128,0.3); }
+
+  .module-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .module-card {
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 1.75rem;
+    padding: 1.75rem;
+    border: 1px solid rgba(255,255,255,0.08);
+    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+  }
+
+  .module-card:hover {
+    transform: translateY(-8px);
+    border-color: rgba(56, 189, 248, 0.35);
+  }
+
+  .module-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .module-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    background: rgba(56, 189, 248, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    color: #38bdf8;
+  }
+
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .status-good { background: rgba(16, 185, 129, 0.2); color: #34d399; border: 1px solid rgba(16, 185, 129, 0.35); }
+  .status-warning { background: rgba(249, 115, 22, 0.2); color: #fb923c; border: 1px solid rgba(249,115,22,0.32); }
+  .status-critical { background: rgba(248, 113, 113, 0.2); color: #f87171; border: 1px solid rgba(248,113,113,0.3); }
+  .status-unknown { background: rgba(148, 163, 184, 0.22); color: #cbd5f5; border: 1px solid rgba(148,163,184,0.32); }
+
+  .metric-pill {
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 1rem;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+
+  .metric-pill .label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(148, 163, 184, 0.9);
+  }
+
+  .metric-pill .value {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #e2e8f0;
+  }
+
+  .metric-wrap {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .module-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .module-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    font-size: 0.95rem;
+  }
+
+  .module-links a {
+    color: #60a5fa;
+    text-decoration: none;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.18);
+    border: 1px solid rgba(37, 99, 235, 0.32);
+  }
+
+  .module-links a:hover {
+    background: rgba(37, 99, 235, 0.28);
+  }
+
+  .campaign-pulse .table {
+    color: #e2e8f0;
+  }
+
+  .campaign-pulse .table thead th {
+    border-color: rgba(255,255,255,0.08);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: rgba(148, 163, 184, 0.9);
+  }
+
+  .campaign-pulse .table tbody td {
+    border-color: rgba(255,255,255,0.05);
+  }
+
+  .badge-nano {
+    border-radius: 999px;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    background: rgba(56,189,248,0.15);
+    color: #38bdf8;
+  }
+
+  .activity-log {
+    margin-top: 3rem;
+  }
+
+  .log-stream {
+    background: rgba(15, 23, 42, 0.65);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(255,255,255,0.06);
+    padding: 1.5rem;
+    min-height: 160px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.85rem;
+  }
+
+  .log-entry {
+    padding: 0.55rem 0.75rem;
+    border-radius: 0.75rem;
+    background: rgba(30, 41, 59, 0.75);
+    color: rgba(226, 232, 240, 0.92);
+  }
+
+  .log-entry.success { border-left: 3px solid #34d399; }
+  .log-entry.warning { border-left: 3px solid #fbbf24; }
+  .log-entry.error { border-left: 3px solid #f87171; }
+  .log-entry.muted { color: rgba(148, 163, 184, 0.8); background: rgba(30, 41, 59, 0.5); }
+
+  .skeleton-text {
+    display: inline-block;
+    height: 1rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(255,255,255,0.1) 25%, rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.1) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.8s infinite;
+  }
+
+  .loading .skeleton-text {
+    width: 100%;
+    height: 100%;
+  }
+
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  @media (max-width: 992px) {
+    .admin-center { padding: 2rem 1.5rem 3rem; }
+    .hero-metrics { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+  }
+
+  @media (max-width: 768px) {
+    .admin-hero { padding: 2rem; }
+    .hero-title { font-size: 2.25rem; }
+  }
+</style>
+
+<script>
+  (function() {
+    const state = {
+      snapshot: null,
+      actions: {},
+      userId: (user && (user.ID || user.Id || user.id)) || ''
+    };
+
+    const numberFormatter = new Intl.NumberFormat('en-US');
+    const percentFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1, minimumFractionDigits: 0 });
+
+    function init() {
+      document.getElementById('refreshSnapshotBtn').addEventListener('click', fetchSnapshot);
+      fetchSnapshot();
+    }
+
+    function fetchSnapshot() {
+      setLoading(true);
+      google.script.run
+        .withSuccessHandler(handleSnapshot)
+        .withFailureHandler(handleError)
+        .clientGetAdminCenterSnapshot(state.userId, {});
+    }
+
+    function setLoading(isLoading) {
+      const btn = document.getElementById('refreshSnapshotBtn');
+      if (!btn) return;
+      btn.disabled = isLoading;
+      btn.innerHTML = isLoading
+        ? '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Refreshing'
+        : '<i class="fas fa-rotate me-2"></i>Refresh Snapshot';
+    }
+
+    function handleSnapshot(snapshot) {
+      setLoading(false);
+      state.snapshot = snapshot || {};
+      state.actions = Array.isArray(snapshot && snapshot.controlActions)
+        ? snapshot.controlActions.reduce((acc, action) => {
+            acc[action.key] = action;
+            return acc;
+          }, {})
+        : {};
+      renderHero(snapshot.summary || {});
+      renderInsights(snapshot.aiInsights || []);
+      renderModules(snapshot.modules || [], snapshot.summary || {});
+      renderCampaignTable((snapshot.summary && snapshot.summary.campaignStats) || []);
+      document.getElementById('aiStatus').textContent = 'AI orchestration ready';
+      if (snapshot.generatedAt) {
+        document.getElementById('snapshotTimestamp').textContent = formatRelativeTime(snapshot.generatedAt);
+      }
+    }
+
+    function handleError(error) {
+      setLoading(false);
+      const message = error && error.message ? error.message : 'Failed to load admin snapshot.';
+      logEvent('error', 'Snapshot error: ' + message);
+      if (typeof $.notify === 'function') {
+        $.notify(message, 'error');
+      }
+    }
+
+    function renderHero(summary) {
+      const metricsRoot = document.getElementById('heroMetrics');
+      if (!metricsRoot) return;
+      metricsRoot.innerHTML = '';
+      const heroMetrics = [
+        {
+          label: 'Total Workforce',
+          value: summary.totals ? summary.totals.users : null,
+          trend: summary.totals ? summary.totals.activeUsers + ' active' : ''
+        },
+        {
+          label: 'Campaign Coverage',
+          value: summary.totals ? summary.totals.campaigns : null,
+          trend: summary.totals ? summary.totals.admins + ' admins' : ''
+        },
+        {
+          label: 'QA Health',
+          value: summary.health && summary.health.qaAverage != null ? summary.health.qaAverage + '%' : '—',
+          trend: summary.totals ? summary.totals.qaEvaluations + ' evaluations' : ''
+        }
+      ];
+
+      heroMetrics.forEach(metric => {
+        const tile = document.createElement('div');
+        tile.className = 'metric-tile';
+        const label = document.createElement('span');
+        label.className = 'metric-label';
+        label.textContent = metric.label;
+        const value = document.createElement('span');
+        value.className = 'metric-value';
+        value.textContent = formatMetricValue(metric.value);
+        const trend = document.createElement('div');
+        trend.className = 'metric-trend';
+        trend.textContent = metric.trend || '';
+        tile.appendChild(label);
+        tile.appendChild(value);
+        if (metric.trend) tile.appendChild(trend);
+        metricsRoot.appendChild(tile);
+      });
+    }
+
+    function renderInsights(insights) {
+      const container = document.getElementById('insightGrid');
+      if (!container) return;
+      container.innerHTML = '';
+      insights.forEach(function (insight) {
+        const card = document.createElement('div');
+        card.className = 'insight-card';
+        const badge = document.createElement('span');
+        const severity = (insight.severity || 'info').toLowerCase();
+        badge.className = 'severity-badge severity-' + severity;
+        badge.innerHTML = '<i class="fas fa-signal"></i>' + severity;
+        const title = document.createElement('h3');
+        title.textContent = insight.title || 'Insight';
+        const message = document.createElement('p');
+        message.textContent = insight.message || '';
+        const recommendation = document.createElement('div');
+        recommendation.className = 'recommendation';
+        recommendation.innerHTML = '<i class="fas fa-arrow-circle-right me-2"></i>' + (insight.recommendation || 'Maintain monitoring cadence.');
+        card.appendChild(badge);
+        card.appendChild(title);
+        card.appendChild(message);
+        card.appendChild(recommendation);
+        container.appendChild(card);
+      });
+    }
+
+    function renderModules(modules, summary) {
+      const container = document.getElementById('moduleGrid');
+      if (!container) return;
+      container.innerHTML = '';
+      const actionsByModule = buildModuleActionMap();
+
+      modules.forEach(function (module) {
+        const card = document.createElement('div');
+        card.className = 'module-card';
+
+        const header = document.createElement('div');
+        header.className = 'module-header';
+
+        const iconWrap = document.createElement('div');
+        iconWrap.className = 'module-icon';
+        iconWrap.innerHTML = '<i class="' + (module.icon || 'fas fa-circle') + '"></i>';
+
+        const headerText = document.createElement('div');
+        const title = document.createElement('h3');
+        title.className = 'mb-1';
+        title.textContent = module.title || 'Module';
+        const status = document.createElement('span');
+        const level = module.status && module.status.level ? module.status.level : 'unknown';
+        status.className = 'status-badge status-' + level;
+        status.innerHTML = '<i class="fas fa-circle"></i>' + ((module.status && module.status.label) || 'Unknown');
+        headerText.appendChild(title);
+        headerText.appendChild(status);
+
+        header.appendChild(iconWrap);
+        header.appendChild(headerText);
+        card.appendChild(header);
+
+        if (module.description) {
+          const desc = document.createElement('p');
+          desc.className = 'mb-2 text-secondary';
+          desc.textContent = module.description;
+          card.appendChild(desc);
+        }
+
+        const metricWrap = document.createElement('div');
+        metricWrap.className = 'metric-wrap';
+        (module.metrics || []).forEach(function (metric) {
+          const pill = document.createElement('div');
+          pill.className = 'metric-pill';
+          const label = document.createElement('div');
+          label.className = 'label';
+          label.textContent = metric.label || 'Metric';
+          const value = document.createElement('div');
+          value.className = 'value';
+          value.textContent = formatMetricValue(metric.value, metric.unit);
+          pill.appendChild(label);
+          pill.appendChild(value);
+          if (metric.helpText) {
+            pill.setAttribute('title', metric.helpText);
+          }
+          metricWrap.appendChild(pill);
+        });
+        card.appendChild(metricWrap);
+
+        const moduleActions = actionsByModule[module.key] || [];
+        if (moduleActions.length) {
+          const actionWrap = document.createElement('div');
+          actionWrap.className = 'module-actions';
+          moduleActions.forEach(function (action) {
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-' + (action.variant === 'primary' ? 'primary' : 'outline-light');
+            btn.innerHTML = '<i class="' + (action.icon || 'fas fa-bolt') + ' me-2"></i>' + action.label;
+            btn.dataset.actionKey = action.key;
+            btn.addEventListener('click', function () { triggerAction(action.key, btn); });
+            actionWrap.appendChild(btn);
+          });
+          card.appendChild(actionWrap);
+        }
+
+        if (Array.isArray(module.links) && module.links.length) {
+          const linkWrap = document.createElement('div');
+          linkWrap.className = 'module-links';
+          module.links.forEach(function (link) {
+            const anchor = document.createElement('a');
+            anchor.href = buildPageLink(link.page || 'dashboard');
+            anchor.innerHTML = '<i class="' + (link.icon || 'fas fa-arrow-right') + ' me-2"></i>' + link.label;
+            linkWrap.appendChild(anchor);
+          });
+          card.appendChild(linkWrap);
+        }
+
+        container.appendChild(card);
+      });
+    }
+
+    function renderCampaignTable(stats) {
+      const tbody = document.getElementById('campaignTableBody');
+      if (!tbody) return;
+      tbody.innerHTML = '';
+      if (!stats.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.className = 'text-center text-secondary py-4';
+        cell.textContent = 'No campaign telemetry available yet.';
+        row.appendChild(cell);
+        tbody.appendChild(row);
+        return;
+      }
+
+      stats.forEach(function (stat) {
+        const row = document.createElement('tr');
+        const campaignCell = document.createElement('td');
+        campaignCell.innerHTML = '<span class="fw-semibold">' + (stat.id || 'Campaign') + '</span>';
+        const usersCell = document.createElement('td');
+        usersCell.innerHTML = '<span class="badge-nano"><i class="fas fa-users me-1"></i>' + numberFormatter.format(stat.userCount || 0) + '</span>';
+        const pagesCell = document.createElement('td');
+        pagesCell.innerHTML = '<span class="badge-nano"><i class="fas fa-layer-group me-1"></i>' + numberFormatter.format(stat.pageCount || 0) + '</span>';
+        const actionsCell = document.createElement('td');
+        actionsCell.className = 'text-end';
+        const viewLink = document.createElement('a');
+        viewLink.href = buildPageLink('managecampaign') + '&campaign=' + encodeURIComponent(stat.id || '');
+        viewLink.className = 'btn btn-sm btn-outline-light';
+        viewLink.innerHTML = '<i class="fas fa-arrow-up-right-from-square me-2"></i>Open';
+        actionsCell.appendChild(viewLink);
+        row.appendChild(campaignCell);
+        row.appendChild(usersCell);
+        row.appendChild(pagesCell);
+        row.appendChild(actionsCell);
+        tbody.appendChild(row);
+      });
+    }
+
+    function buildModuleActionMap() {
+      const map = {};
+      Object.keys(state.actions).forEach(function (key) {
+        const action = state.actions[key];
+        if (!action || !action.moduleKey) return;
+        if (!map[action.moduleKey]) map[action.moduleKey] = [];
+        map[action.moduleKey].push(action);
+      });
+      return map;
+    }
+
+    function triggerAction(actionKey, button) {
+      if (!actionKey) return;
+      const action = state.actions[actionKey];
+      if (!action) return;
+      const originalHtml = button.innerHTML;
+      button.disabled = true;
+      button.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Running';
+      google.script.run
+        .withSuccessHandler(function (result) {
+          button.disabled = false;
+          button.innerHTML = originalHtml;
+          const status = (result && result.status) || 'ok';
+          const message = (result && result.message) || 'Action completed.';
+          logEvent(status, action.label + ': ' + message);
+          if (status === 'ok' && typeof $.notify === 'function') {
+            $.notify(message, 'success');
+          } else if (status === 'warning' && typeof $.notify === 'function') {
+            $.notify(message, 'warn');
+          } else if (status === 'error' && typeof $.notify === 'function') {
+            $.notify(message, 'error');
+          }
+        })
+        .withFailureHandler(function (error) {
+          button.disabled = false;
+          button.innerHTML = originalHtml;
+          const message = error && error.message ? error.message : 'Action failed.';
+          logEvent('error', action.label + ': ' + message);
+          if (typeof $.notify === 'function') {
+            $.notify(message, 'error');
+          }
+        })
+        .clientRunAdminControlAction(actionKey, { requestingUserId: state.userId }, state.userId);
+    }
+
+    function formatMetricValue(value, unit) {
+      if (value === null || typeof value === 'undefined' || value === '') {
+        return '—';
+      }
+      if (typeof value === 'number') {
+        if (unit && unit.indexOf('%') !== -1) {
+          return percentFormatter.format(value) + '%';
+        }
+        return numberFormatter.format(value);
+      }
+      return value;
+    }
+
+    function buildPageLink(page) {
+      var base = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+      var script = (typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : '';
+      var target = base || script || '';
+      if (!target) {
+        return '?page=' + encodeURIComponent(page);
+      }
+      var hasQuery = target.indexOf('?') !== -1;
+      var separator = hasQuery ? (/[?&]$/.test(target) ? '' : '&') : '?';
+      return target + separator + 'page=' + encodeURIComponent(page);
+    }
+
+    function formatRelativeTime(isoString) {
+      try {
+        const date = new Date(isoString);
+        const diff = Date.now() - date.getTime();
+        if (!isFinite(diff)) return 'moments ago';
+        const minutes = Math.round(diff / 60000);
+        if (minutes <= 1) return 'just now';
+        if (minutes < 60) return minutes + ' minutes ago';
+        const hours = Math.round(minutes / 60);
+        if (hours < 24) return hours + ' hours ago';
+        const days = Math.round(hours / 24);
+        return days + ' days ago';
+      } catch (_) {
+        return 'moments ago';
+      }
+    }
+
+    function logEvent(level, message) {
+      const stream = document.getElementById('logStream');
+      if (!stream) return;
+      if (stream.firstElementChild && stream.firstElementChild.classList.contains('muted')) {
+        stream.removeChild(stream.firstElementChild);
+      }
+      const entry = document.createElement('div');
+      entry.className = 'log-entry ' + (level || 'info');
+      entry.textContent = '[' + new Date().toLocaleTimeString() + '] ' + message;
+      stream.prepend(entry);
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+  })();
+</script>

--- a/AdminCenterService.js
+++ b/AdminCenterService.js
@@ -1,0 +1,615 @@
+(function (global) {
+  'use strict';
+
+  var root = (typeof global !== 'undefined' && global) || (typeof this !== 'undefined' && this) || {};
+  var G = (typeof root.G === 'object' && root.G) || (typeof G === 'object' && G) || {};
+
+  function toNumber(value) {
+    if (value === null || typeof value === 'undefined') return null;
+    var num = Number(value);
+    return isNaN(num) ? null : num;
+  }
+
+  function toIsoString(date) {
+    if (date instanceof Date && !isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+    return new Date().toISOString();
+  }
+
+  function safeArray(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function truthy(value) {
+    if (value === null || typeof value === 'undefined') return false;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    var str = String(value).toLowerCase();
+    if (!str) return false;
+    return str === 'true' || str === '1' || str === 'yes' || str === 'y';
+  }
+
+  function normalizeStatus(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value).trim().toLowerCase();
+  }
+
+  function isActiveStatus(record) {
+    var statusKeys = ['EmploymentStatus', 'Status', 'State', 'Active'];
+    for (var i = 0; i < statusKeys.length; i++) {
+      var key = statusKeys[i];
+      if (!record || !Object.prototype.hasOwnProperty.call(record, key)) continue;
+      var val = record[key];
+      if (typeof val === 'boolean') return val;
+      var normalized = normalizeStatus(val);
+      if (!normalized) continue;
+      if (normalized === 'active' || normalized === 'enabled' || normalized === 'current') return true;
+      if (normalized === 'inactive' || normalized === 'terminated' || normalized === 'disabled') return false;
+    }
+    return false;
+  }
+
+  function isAdminRecord(record) {
+    if (!record) return false;
+    var keys = ['isAdminBool', 'IsAdmin', 'isAdmin'];
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+      if (truthy(record[key])) return true;
+    }
+    if (Array.isArray(record.Roles)) {
+      for (var j = 0; j < record.Roles.length; j++) {
+        if (/admin/i.test(String(record.Roles[j]))) return true;
+      }
+    }
+    return false;
+  }
+
+  function safeWorkspace(userId, options) {
+    try {
+      if (root.CallCenterWorkflowService && typeof root.CallCenterWorkflowService.getWorkspace === 'function') {
+        return root.CallCenterWorkflowService.getWorkspace(userId, options || {});
+      }
+    } catch (err) {
+      try { root.safeWriteError && root.safeWriteError('AdminCenter.getWorkspace', err); } catch (_) {}
+    }
+    return null;
+  }
+
+  function safeCampaignStats() {
+    try {
+      if (typeof root.csGetCampaignStatsV2 === 'function') {
+        return root.csGetCampaignStatsV2();
+      }
+      if (typeof root.csGetCampaignStats === 'function') {
+        return root.csGetCampaignStats();
+      }
+    } catch (err) {
+      try { root.safeWriteError && root.safeWriteError('AdminCenter.campaignStats', err); } catch (_) {}
+    }
+    return [];
+  }
+
+  function deriveCollaborationVelocity(collaboration, campaigns) {
+    var totalMessages = 0;
+    if (collaboration && typeof collaboration.totalMessages === 'number') {
+      totalMessages = collaboration.totalMessages;
+    } else if (collaboration && Array.isArray(collaboration.messages)) {
+      totalMessages = collaboration.messages.length;
+    }
+    var campaignCount = campaigns && campaigns.length ? campaigns.length : 1;
+    return Math.round((totalMessages / campaignCount) * 100) / 100;
+  }
+
+  function buildSummary(workspace, campaignStats) {
+    var users = (workspace && workspace.users && safeArray(workspace.users.records)) || [];
+    var campaigns = safeArray(workspace && workspace.campaigns);
+    var performance = workspace && workspace.performance || {};
+    var coaching = workspace && workspace.coaching || {};
+    var scheduling = workspace && workspace.scheduling || {};
+    var collaboration = workspace && workspace.collaboration || {};
+
+    var qaSummary = performance.qa && performance.qa.summary || {};
+    var attendanceSummary = performance.attendance && performance.attendance.summary || {};
+    var adherenceSummary = performance.adherence && performance.adherence.summary || {};
+    var coachingSummary = coaching.summary || {};
+
+    var totalUsers = users.length;
+    var adminCount = 0;
+    var activeCount = 0;
+    for (var i = 0; i < users.length; i++) {
+      if (isAdminRecord(users[i])) adminCount += 1;
+      if (isActiveStatus(users[i])) activeCount += 1;
+    }
+
+    var attendanceRate = toNumber(attendanceSummary.attendanceRate);
+    var qaAverage = toNumber(qaSummary.averageScore);
+    var adherenceAverage = toNumber(adherenceSummary.averageScore);
+    var pendingCoaching = toNumber(coachingSummary.pendingCount);
+    var overdueCoaching = toNumber(coachingSummary.overdueCount);
+
+    var adminCoverage = totalUsers > 0 ? Math.round((adminCount / totalUsers) * 10000) / 100 : null;
+    var scheduleToday = safeArray(scheduling.today).length;
+    var scheduleUpcoming = safeArray(scheduling.upcoming).length;
+    var collaborationVelocity = deriveCollaborationVelocity(collaboration, campaigns);
+
+    return {
+      totals: {
+        users: totalUsers,
+        activeUsers: activeCount,
+        admins: adminCount,
+        campaigns: campaigns.length,
+        qaEvaluations: toNumber(qaSummary.totalEvaluations) || 0,
+        attendanceEvents: toNumber(attendanceSummary.totalEvents) || 0,
+        coachingSessions: toNumber(coachingSummary.totalSessions) || 0,
+        todayShifts: scheduleToday,
+        upcomingShifts: scheduleUpcoming,
+        collaborationMessages: collaboration && typeof collaboration.totalMessages === 'number'
+          ? collaboration.totalMessages
+          : safeArray(collaboration.messages).length
+      },
+      health: {
+        qaAverage: qaAverage,
+        attendanceRate: attendanceRate,
+        adherenceAverage: adherenceAverage,
+        pendingCoaching: pendingCoaching,
+        overdueCoaching: overdueCoaching,
+        adminCoverage: adminCoverage,
+        collaborationVelocity: collaborationVelocity
+      },
+      campaignStats: Array.isArray(campaignStats) ? campaignStats : [],
+      workspaceAvailable: !!workspace
+    };
+  }
+
+  function evaluateMetric(metricKey, summary) {
+    var health = summary.health || {};
+    switch (metricKey) {
+      case 'qaAverage':
+        return classifyThreshold(health.qaAverage, { good: 90, warning: 80 }, true);
+      case 'attendanceRate':
+        return classifyThreshold(health.attendanceRate, { good: 97, warning: 93 }, true);
+      case 'adherenceAverage':
+        return classifyThreshold(health.adherenceAverage, { good: 95, warning: 90 }, true);
+      case 'pendingCoaching':
+        return classifyThreshold(health.pendingCoaching, { good: 5, warning: 10 }, false);
+      case 'adminCoverage':
+        return classifyThreshold(health.adminCoverage, { good: 12, warning: 8 }, true);
+      case 'collaborationVelocity':
+        return classifyThreshold(health.collaborationVelocity, { good: 20, warning: 10 }, true);
+      default:
+        return { level: 'unknown', label: 'No Signal' };
+    }
+  }
+
+  function classifyThreshold(value, thresholds, higherIsBetter) {
+    if (value === null || typeof value === 'undefined') {
+      return { level: 'unknown', label: 'No Data' };
+    }
+    if (higherIsBetter) {
+      if (value >= thresholds.good) return { level: 'good', label: 'Healthy' };
+      if (value >= thresholds.warning) return { level: 'warning', label: 'Watch' };
+      return { level: 'critical', label: 'Critical' };
+    }
+    if (value <= thresholds.good) return { level: 'good', label: 'Healthy' };
+    if (value <= thresholds.warning) return { level: 'warning', label: 'Watch' };
+    return { level: 'critical', label: 'Critical' };
+  }
+
+  function buildMetric(label, value, options) {
+    var metric = {
+      label: label,
+      value: value
+    };
+    if (options) {
+      if (options.unit) metric.unit = options.unit;
+      if (options.helpText) metric.helpText = options.helpText;
+      if (options.key) metric.key = options.key;
+      if (options.status) metric.status = options.status;
+    }
+    return metric;
+  }
+
+  function buildModules(summary, workspace) {
+    var modules = [];
+    var totals = summary.totals || {};
+    var health = summary.health || {};
+    var campaigns = safeArray(workspace && workspace.campaigns);
+
+    var identityModule = {
+      key: 'identity',
+      title: 'Identity & Access',
+      icon: 'fas fa-user-shield',
+      description: 'Oversee administrators, user lifecycle, and permissions across Lumina.',
+      status: evaluateMetric('adminCoverage', summary),
+      metrics: [
+        buildMetric('Total Users', totals.users, { unit: '', helpText: 'Users discovered in the centralized directory.' }),
+        buildMetric('Active Workforce', totals.activeUsers, { unit: '', helpText: 'Users marked as active or enabled.' }),
+        buildMetric('Administrators', totals.admins, {
+          unit: '',
+          helpText: 'Users flagged with administrator privileges.',
+          key: 'adminCoverage',
+          status: evaluateMetric('adminCoverage', summary)
+        })
+      ],
+      links: [
+        { label: 'Manage Users', page: 'manageuser', icon: 'fas fa-users-cog' },
+        { label: 'Manage Roles', page: 'manageroles', icon: 'fas fa-user-cog' }
+      ]
+    };
+    modules.push(identityModule);
+
+    var performanceModule = {
+      key: 'performance',
+      title: 'Quality & Performance',
+      icon: 'fas fa-chart-line',
+      description: 'Track QA scoring, attendance, and adherence to elevate customer outcomes.',
+      status: evaluateMetric('qaAverage', summary),
+      metrics: [
+        buildMetric('QA Average', health.qaAverage, {
+          unit: '%',
+          helpText: 'Average QA score across evaluations.',
+          key: 'qaAverage',
+          status: evaluateMetric('qaAverage', summary)
+        }),
+        buildMetric('Attendance Rate', health.attendanceRate, {
+          unit: '%',
+          helpText: 'Present vs. total attendance events.',
+          key: 'attendanceRate',
+          status: evaluateMetric('attendanceRate', summary)
+        }),
+        buildMetric('Adherence Average', health.adherenceAverage, {
+          unit: '%',
+          helpText: 'Average schedule adherence across records.',
+          key: 'adherenceAverage',
+          status: evaluateMetric('adherenceAverage', summary)
+        }),
+        buildMetric('Pending Coaching', health.pendingCoaching, {
+          unit: 'sessions',
+          helpText: 'Coaching sessions awaiting acknowledgement or completion.',
+          key: 'pendingCoaching',
+          status: evaluateMetric('pendingCoaching', summary)
+        })
+      ],
+      links: [
+        { label: 'QA Dashboard', page: 'qadashboard', icon: 'fas fa-clipboard-check' },
+        { label: 'Coaching Dashboard', page: 'coachingdashboard', icon: 'fas fa-chalkboard-teacher' }
+      ]
+    };
+    modules.push(performanceModule);
+
+    var workforceModule = {
+      key: 'workforce',
+      title: 'Workforce Operations',
+      icon: 'fas fa-people-arrows',
+      description: 'Manage scheduling coverage, upcoming shifts, and coaching follow-ups.',
+      status: evaluateMetric('attendanceRate', summary),
+      metrics: [
+        buildMetric('Shifts Today', totals.todayShifts, { unit: 'shifts', helpText: 'Scheduled shifts occurring today.' }),
+        buildMetric('Upcoming Shifts', totals.upcomingShifts, { unit: 'shifts', helpText: 'Future scheduled shifts queued.' }),
+        buildMetric('Coaching Overdue', health.overdueCoaching, {
+          unit: 'sessions',
+          helpText: 'Coaching commitments past due date.',
+          key: 'pendingCoaching',
+          status: evaluateMetric('pendingCoaching', summary)
+        })
+      ],
+      links: [
+        { label: 'Schedule Management', page: 'schedulemanagement', icon: 'fas fa-calendar-alt' },
+        { label: 'Attendance Reports', page: 'attendancereports', icon: 'fas fa-user-clock' }
+      ]
+    };
+    modules.push(workforceModule);
+
+    var collaborationModule = {
+      key: 'collaboration',
+      title: 'Collaboration & Broadcasts',
+      icon: 'fas fa-comments',
+      description: 'Monitor communications velocity and broadcast updates to every campaign.',
+      status: evaluateMetric('collaborationVelocity', summary),
+      metrics: [
+        buildMetric('Messages (Last Snapshot)', totals.collaborationMessages, {
+          unit: 'messages',
+          helpText: 'Recent collaboration entries included in the workspace snapshot.'
+        }),
+        buildMetric('Avg. Messages per Campaign', health.collaborationVelocity, {
+          unit: 'msg/campaign',
+          helpText: 'Engagement signal normalized per active campaign.',
+          key: 'collaborationVelocity',
+          status: evaluateMetric('collaborationVelocity', summary)
+        }),
+        buildMetric('Active Campaigns', totals.campaigns, { unit: '', helpText: 'Campaigns accessible to this administrator.' })
+      ],
+      links: [
+        { label: 'Notifications', page: 'notifications', icon: 'fas fa-bullhorn' },
+        { label: 'Team Chat', page: 'chat', icon: 'fas fa-comments' }
+      ]
+    };
+    modules.push(collaborationModule);
+
+    var platformModule = {
+      key: 'platform',
+      title: 'Platform Governance',
+      icon: 'fas fa-solar-panel',
+      description: 'Orchestrate caches, navigation, and cross-campaign governance.',
+      status: evaluateMetric('adminCoverage', summary),
+      metrics: [
+        buildMetric('Campaign Snapshots', summary.campaignStats.length, {
+          unit: 'campaigns',
+          helpText: 'Campaigns with aggregated stats available in the admin center.'
+        }),
+        buildMetric('QA Records Cached', summary.totals.qaEvaluations, {
+          unit: 'evaluations',
+          helpText: 'Evaluations counted in the latest workspace snapshot.'
+        }),
+        buildMetric('Attendance Events Cached', summary.totals.attendanceEvents, {
+          unit: 'events',
+          helpText: 'Attendance entries contributing to the current health score.'
+        })
+      ],
+      links: [
+        { label: 'Campaign Management', page: 'managecampaign', icon: 'fas fa-bullhorn' },
+        { label: 'Lumina User Guide', page: 'lumina-hq-user-guide', icon: 'fas fa-book-open' }
+      ]
+    };
+    modules.push(platformModule);
+
+    return modules;
+  }
+
+  function buildAiInsights(summary, modules) {
+    var insights = [];
+    var health = summary.health || {};
+    var totals = summary.totals || {};
+
+    if (health.qaAverage !== null && health.qaAverage < 85) {
+      insights.push({
+        title: 'Quality Dip Detected',
+        severity: health.qaAverage < 80 ? 'critical' : 'warning',
+        message: 'Average QA performance has fallen to ' + health.qaAverage + '%. Focus reviews on high-risk campaigns and deploy targeted coaching.',
+        recommendation: 'Prioritize QA remediation workflows within the Quality & Performance module.'
+      });
+    }
+
+    if (health.attendanceRate !== null && health.attendanceRate < 95) {
+      insights.push({
+        title: 'Attendance Risk',
+        severity: health.attendanceRate < 90 ? 'critical' : 'warning',
+        message: 'Attendance rate currently sits at ' + health.attendanceRate + '%. Investigate callouts and schedule adjustments before service levels slip.',
+        recommendation: 'Review Attendance Reports and ensure coverage in Schedule Management.'
+      });
+    }
+
+    if (health.pendingCoaching !== null && health.pendingCoaching > Math.max(5, Math.round(totals.activeUsers * 0.15))) {
+      insights.push({
+        title: 'Coaching Backlog',
+        severity: 'warning',
+        message: health.pendingCoaching + ' coaching sessions are still pending acknowledgement. Agents may be waiting on critical feedback.',
+        recommendation: 'Drive completion via the Coaching Dashboard and send reminders from the Workforce Operations module.'
+      });
+    }
+
+    if (health.adminCoverage !== null && health.adminCoverage < 7) {
+      insights.push({
+        title: 'Low Admin Coverage',
+        severity: 'warning',
+        message: 'Only ' + health.adminCoverage + '% of users hold administrator privileges. Ensure redundancy for critical operations.',
+        recommendation: 'Nominate backup administrators or delegate advanced roles in Identity & Access.'
+      });
+    }
+
+    if (health.collaborationVelocity !== null && health.collaborationVelocity < 5) {
+      insights.push({
+        title: 'Quiet Collaboration Channels',
+        severity: 'info',
+        message: 'Collaboration activity is trending low at ' + health.collaborationVelocity + ' messages per campaign. Consider sharing updates to maintain engagement.',
+        recommendation: 'Publish a broadcast through Notifications or encourage campaign leads to share wins in chat.'
+      });
+    }
+
+    if (!insights.length) {
+      insights.push({
+        title: 'All Systems Steady',
+        severity: 'success',
+        message: 'Key health indicators are within target ranges. Continue monitoring dashboards for early signals.',
+        recommendation: 'Leverage automation controls below to keep caches warm and data flowing.'
+      });
+    }
+
+    return insights;
+  }
+
+  var CONTROL_ACTIONS = [
+    {
+      key: 'identity-refresh-user-cache',
+      moduleKey: 'identity',
+      label: 'Refresh User Directory Cache',
+      description: 'Clears cached user records to ensure the admin center pulls the latest identities.',
+      icon: 'fas fa-sync',
+      variant: 'primary',
+      execute: function () {
+        if (typeof root.invalidateCache === 'function') {
+          var sheetName = (typeof root.USERS_SHEET === 'string' && root.USERS_SHEET) || (G && G.USERS_SHEET) || 'Users';
+          root.invalidateCache(sheetName);
+          return { status: 'ok', message: 'User cache invalidated for "' + sheetName + '".' };
+        }
+        return { status: 'skipped', message: 'Cache service not available in this deployment.' };
+      }
+    },
+    {
+      key: 'performance-refresh-qa-cache',
+      moduleKey: 'performance',
+      label: 'Rebuild QA Snapshot',
+      description: 'Flushes QA evaluation caches and reinitializes the workflow registry.',
+      icon: 'fas fa-clipboard-check',
+      variant: 'secondary',
+      execute: function () {
+        var responses = [];
+        if (typeof root.invalidateCache === 'function') {
+          var qaSheet = (typeof root.QA_RECORDS === 'string' && root.QA_RECORDS) || (G && G.QA_RECORDS) || 'Quality';
+          root.invalidateCache(qaSheet);
+          responses.push('QA cache cleared for "' + qaSheet + '".');
+        }
+        if (root.CallCenterWorkflowService && typeof root.CallCenterWorkflowService.initialize === 'function') {
+          var registry = root.CallCenterWorkflowService.initialize();
+          var keys = registry ? Object.keys(registry) : [];
+          responses.push('Workflow registry refreshed' + (keys.length ? ' (' + keys.length + ' tables).' : '.'));
+        }
+        return {
+          status: responses.length ? 'ok' : 'skipped',
+          message: responses.join(' ')
+        };
+      }
+    },
+    {
+      key: 'workforce-refresh-schedule-cache',
+      moduleKey: 'workforce',
+      label: 'Refresh Schedule Caches',
+      description: 'Clears schedule caches to pull updated shift assignments.',
+      icon: 'fas fa-calendar-week',
+      variant: 'secondary',
+      execute: function () {
+        if (typeof root.invalidateScheduleCaches === 'function') {
+          root.invalidateScheduleCaches();
+          return { status: 'ok', message: 'Schedule caches invalidated successfully.' };
+        }
+        if (typeof root.invalidateCache === 'function') {
+          var scheduleSheet = (typeof G.SCHEDULES_SHEET === 'string' && G.SCHEDULES_SHEET) || 'Schedules';
+          root.invalidateCache(scheduleSheet);
+          return { status: 'ok', message: 'Schedule sheet cache cleared for "' + scheduleSheet + '".' };
+        }
+        return { status: 'skipped', message: 'No schedule cache helpers available.' };
+      }
+    },
+    {
+      key: 'collaboration-clear-notification-cache',
+      moduleKey: 'collaboration',
+      label: 'Clear Broadcast Cache',
+      description: 'Invalidates notification caches so new announcements publish instantly.',
+      icon: 'fas fa-bullhorn',
+      variant: 'secondary',
+      execute: function () {
+        if (typeof root.invalidateCache === 'function') {
+          var sheet = (typeof root.NOTIFICATIONS_SHEET === 'string' && root.NOTIFICATIONS_SHEET) || (G && G.NOTIFICATIONS_SHEET) || 'Notifications';
+          root.invalidateCache(sheet);
+          return { status: 'ok', message: 'Notification cache cleared for "' + sheet + '".' };
+        }
+        return { status: 'skipped', message: 'Notification cache helper unavailable.' };
+      }
+    },
+    {
+      key: 'platform-refresh-navigation-cache',
+      moduleKey: 'platform',
+      label: 'Refresh Navigation Cache',
+      description: 'Invalidates campaign navigation caches to surface new pages immediately.',
+      icon: 'fas fa-compass',
+      variant: 'secondary',
+      execute: function (payload, userId) {
+        var refreshed = 0;
+        if (typeof root.CallCenterWorkflowService === 'object' && root.CallCenterWorkflowService && typeof root.CallCenterWorkflowService.listCampaignAccess === 'function' && userId) {
+          try {
+            var campaigns = root.CallCenterWorkflowService.listCampaignAccess(userId) || [];
+            for (var i = 0; i < campaigns.length; i++) {
+              var cid = campaigns[i] && (campaigns[i].id || campaigns[i].ID || campaigns[i].Id);
+              if (!cid) continue;
+              if (typeof root.invalidateNavigationCache === 'function') {
+                root.invalidateNavigationCache(cid);
+                refreshed += 1;
+              }
+            }
+          } catch (navErr) {
+            try { root.safeWriteError && root.safeWriteError('AdminCenter.navigation', navErr); } catch (_) {}
+          }
+        }
+
+        if (!refreshed && typeof root.invalidateNavigationCache === 'function') {
+          var fallbackCampaign = (payload && payload.campaignId) || (G && G.DEFAULT_CAMPAIGN_ID) || null;
+          if (fallbackCampaign) {
+            root.invalidateNavigationCache(fallbackCampaign);
+            refreshed = 1;
+          }
+        }
+
+        if (typeof root.invalidateCache === 'function') {
+          var sheets = ['PAGES_SHEET', 'CAMPAIGN_PAGES_SHEET', 'PAGE_CATEGORIES_SHEET'];
+          for (var s = 0; s < sheets.length; s++) {
+            var key = sheets[s];
+            var name = (typeof root[key] === 'string' && root[key]) || (G && G[key]) || null;
+            if (name) {
+              try { root.invalidateCache(name); } catch (_) {}
+            }
+          }
+        }
+
+        if (refreshed) {
+          return { status: 'ok', message: 'Navigation caches refreshed for ' + refreshed + ' campaign(s).' };
+        }
+        return { status: 'skipped', message: 'Navigation cache helper unavailable or no campaigns resolved.' };
+      }
+    }
+  ];
+
+  function exportAction(action) {
+    return {
+      key: action.key,
+      moduleKey: action.moduleKey,
+      label: action.label,
+      description: action.description,
+      icon: action.icon,
+      variant: action.variant || 'secondary'
+    };
+  }
+
+  function runControlAction(key, payload, userId) {
+    for (var i = 0; i < CONTROL_ACTIONS.length; i++) {
+      var action = CONTROL_ACTIONS[i];
+      if (action.key === key) {
+        try {
+          var result = action.execute(payload || {}, userId);
+          if (!result || typeof result !== 'object') {
+            return { status: 'ok', message: 'Action executed.' };
+          }
+          return result;
+        } catch (err) {
+          try { root.safeWriteError && root.safeWriteError('AdminCenter.action.' + key, err); } catch (_) {}
+          return { status: 'error', message: err && err.message ? err.message : 'Unexpected error' };
+        }
+      }
+    }
+    return { status: 'error', message: 'Unknown action: ' + key };
+  }
+
+  var AdminCenterService = {
+    getAdminCenterSnapshot: function (userId, options) {
+      var workspace = safeWorkspace(userId, options || {});
+      var campaignStats = safeCampaignStats();
+      var summary = buildSummary(workspace, campaignStats);
+      var modules = buildModules(summary, workspace);
+      var insights = buildAiInsights(summary, modules);
+      return {
+        generatedAt: toIsoString(new Date()),
+        summary: summary,
+        modules: modules,
+        aiInsights: insights,
+        controlActions: CONTROL_ACTIONS.map(exportAction)
+      };
+    },
+    listControlActions: function () {
+      return CONTROL_ACTIONS.map(exportAction);
+    },
+    runControlAction: runControlAction
+  };
+
+  root.AdminCenterService = AdminCenterService;
+  root.clientGetAdminCenterSnapshot = function (userId, options) {
+    return AdminCenterService.getAdminCenterSnapshot(userId, options || {});
+  };
+  root.clientListAdminControlActions = function () {
+    return AdminCenterService.listControlActions();
+  };
+  root.clientRunAdminControlAction = function (actionKey, payload, userId) {
+    return AdminCenterService.runControlAction(actionKey, payload || {}, userId);
+  };
+
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/Code.js
+++ b/Code.js
@@ -3475,6 +3475,14 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       });
     }
 
+    if (
+      page === 'admincenter' ||
+      page === 'lumina-admin' ||
+      page === 'admin-dashboard'
+    ) {
+      return serveAdminPage('AdminCenter', e, baseUrl, user);
+    }
+
     if (page === 'users' || page === 'manageuser') {
       return serveAdminPage('Users', e, baseUrl, user);
     }

--- a/MainUtilities.js
+++ b/MainUtilities.js
@@ -2356,6 +2356,7 @@ function getAllPagesFromActualRouting() {
     { key: 'notifications', title: 'Notifications', icon: 'fas fa-bell', description: 'System notifications and alerts', isSystem: true, requiresAdmin: false, category: 'Communication' },
 
     // ADMINISTRATION
+    { key: 'admincenter', title: 'Lumina Admin Center', icon: 'fas fa-solar-panel', description: 'AI-driven control plane for governance and automation', isSystem: true, requiresAdmin: true, category: 'Administration' },
     { key: 'manageuser', title: 'User Management', icon: 'fas fa-users-cog', description: 'Manage system users and permissions', isSystem: true, requiresAdmin: true, category: 'Administration' },
     { key: 'manageroles', title: 'Role Management', icon: 'fas fa-user-shield', description: 'Manage user roles and permissions', isSystem: true, requiresAdmin: true, category: 'Administration' },
     { key: 'managecampaign', title: 'Campaign Management', icon: 'fas fa-bullhorn', description: 'Manage campaigns and their configurations', isSystem: true, requiresAdmin: true, category: 'Administration' },

--- a/layout.html
+++ b/layout.html
@@ -70,6 +70,7 @@
 
     var __layoutPageDescriptionEntries = {
       'ackform': 'Send coaching acknowledgement links and capture agent sign-off confirmations.',
+      'admincenter': 'AI-orchestrated control plane for Lumina administrators overseeing every service domain.',
       'admin-dashboard': 'Reference security tools, governance policies, and documentation for LuminaHQ administrators.',
       'agent-experience': 'Personalized workspace that surfaces coaching, quality, and productivity insights for agents.',
       'attendancereports': 'Analyze attendance trends, compliance health, and time-off insights across the workforce.',

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -85,6 +85,9 @@
     </a>
 
     <? if (isAdminValue) { ?>
+    <a href="<?= generateLink('admincenter') ?>" class="notification-btn" data-bs-toggle="tooltip" title="Admin Center">
+      <i class="fas fa-solar-panel"></i>
+    </a>
     <a href="<?= generateLink('manageuser') ?>#employment-report" class="notification-btn" data-bs-toggle="tooltip"
       title="Employment Report">
       <i class="fas fa-chart-bar"></i>


### PR DESCRIPTION
## Summary
- introduce an AdminCenterService that composes CallCenterWorkflow snapshots, health scoring, and automation controls
- build a Lumina Admin Center page with AI insights, module dashboards, and action journaling
- register the admin center route, metadata, and topbar shortcut for system administrators

## Testing
- not run (Apps Script UI project)


------
https://chatgpt.com/codex/tasks/task_e_68ea8faa22b08326b424fe2eae191692