### PR TITLE
Enable open-mode authentication fallback

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -520,6 +520,14 @@
       const rememberEl = document.getElementById('rememberMe');
       const returnUrlEl = document.getElementById('returnUrl');
       const togglePasswordEl = document.getElementById('togglePassword');
+      const openModeEnabled = <?!= JSON.stringify(typeof openModeEnabled !== 'undefined' ? openModeEnabled : false) ?>;
+      let openModeRedirectScheduled = false;
+
+      function isGoogleScriptAvailable() {
+        return typeof google !== 'undefined'
+          && !!google.script
+          && !!google.script.run;
+      }
 
       const scriptUrl = <?!= JSON.stringify(scriptUrl || baseUrl || '') ?>;
       const baseUrl = <?!= JSON.stringify(baseUrl || '') ?>;
@@ -735,6 +743,52 @@
         return '';
       }
 
+      function resolveOpenModeRedirect() {
+        const currentHref = (typeof window !== 'undefined' && window.location && window.location.href)
+          ? window.location.href
+          : '';
+        const candidates = [
+          returnUrlEl && returnUrlEl.value ? returnUrlEl.value.trim() : '',
+          scriptUrl,
+          baseUrl,
+          'Landing.html',
+          'Dashboard.html',
+          '/'
+        ];
+
+        for (let index = 0; index < candidates.length; index += 1) {
+          const candidate = candidates[index];
+          if (!candidate) {
+            continue;
+          }
+
+          let resolved = candidate;
+          if (currentHref) {
+            try {
+              resolved = new URL(candidate, currentHref).toString();
+            } catch (err) {
+              if (candidate && candidate.charAt(0) !== '/' && !/^https?:/i.test(candidate)) {
+                try {
+                  const base = new URL(currentHref);
+                  base.pathname = candidate;
+                  base.search = '';
+                  base.hash = '';
+                  resolved = base.toString();
+                } catch (_) { }
+              }
+            }
+          }
+
+          if (currentHref && resolved === currentHref) {
+            continue;
+          }
+
+          return resolved;
+        }
+
+        return currentHref || 'Landing.html';
+      }
+
       function attachTokenToUrl(url, token) {
         const param = sessionTokenParam || 'token';
         if (!token) {
@@ -787,6 +841,32 @@
         persistIdentitySnapshot(null);
         const text = (error && error.message) ? error.message : 'A network error occurred. Please try again.';
         showAlert(errorEl, text, 'danger');
+      }
+
+      function handleOpenModeAccess() {
+        if (openModeRedirectScheduled) {
+          return;
+        }
+        openModeRedirectScheduled = true;
+
+        const identifier = identifierEl && identifierEl.value ? identifierEl.value.trim() : '';
+        if (identifier) {
+          persistLastIdentifier(identifier);
+        }
+        if (rememberEl) {
+          persistRememberPreference(!!rememberEl.checked);
+        }
+
+        clearStoredSession();
+        persistIdentitySnapshot(null);
+        showAlert(errorEl, '', 'danger');
+        showAlert(messageEl, 'Lumina Identity is disabled in this open-source build. Redirecting to the workspace…', 'info');
+        setLoading(true);
+
+        const target = resolveOpenModeRedirect();
+        setTimeout(function () {
+          window.location.href = target;
+        }, 300);
       }
 
       function bootstrapFromExistingSession() {
@@ -845,6 +925,11 @@
           return;
         }
 
+        if (!isGoogleScriptAvailable()) {
+          handleOpenModeAccess();
+          return;
+        }
+
         showAlert(errorEl, '', 'danger');
         showAlert(messageEl, 'Signing you in…', 'info');
         setLoading(true);
@@ -895,6 +980,19 @@
       }
 
       bootstrapFromExistingSession();
+
+      if (!isGoogleScriptAvailable()) {
+        const existing = messageEl && messageEl.textContent ? messageEl.textContent.trim() : '';
+        const notice = openModeEnabled
+          ? 'Lumina Identity is disabled in this open-source build. Redirecting to the workspace…'
+          : 'Lumina Identity is disabled in this open-source build. Select “Log in” to continue directly to the workspace.';
+        const combined = existing ? existing + ' ' + notice : notice;
+        showAlert(messageEl, combined.trim(), 'info');
+      }
+
+      if (openModeEnabled && !isGoogleScriptAvailable()) {
+        setTimeout(function () { handleOpenModeAccess(); }, 120);
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add open-mode detection helpers that seed data and synthesize a default auth state when Lumina Identity is missing
- update requireAuth, login, and logout flows to reuse the open-mode state instead of redirecting to the sign-in page
- auto-redirect the login page to the workspace when running in open mode and Apps Script APIs are unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ead6674c9c8326b67997177f133e1d