### PR TITLE
Add Lumina Identity authentication and RBAC platform

### DIFF
--- a/AuditService.gs
+++ b/AuditService.gs
@@ -1,0 +1,71 @@
+/**
+ * AuditService.gs
+ * -----------------------------------------------------------------------------
+ * Immutable audit logging helper. Every administrative or security-sensitive
+ * event must be written to the AuditLog sheet using the schema from the Lumina
+ * Identity specification.
+ */
+(function bootstrapAuditService(global) {
+  if (!global) return;
+  if (global.AuditService && typeof global.AuditService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var Utilities = global.Utilities;
+
+  if (!IdentityRepository) {
+    throw new Error('AuditService requires IdentityRepository bootstrap');
+  }
+
+  function toJson(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    if (typeof value === 'string') return value;
+    try {
+      return JSON.stringify(value);
+    } catch (err) {
+      return String(value);
+    }
+  }
+
+  function log(event) {
+    if (!event) {
+      throw new Error('Audit event payload is required');
+    }
+    var payload = {
+      EventId: event.EventId || Utilities.getUuid(),
+      Timestamp: event.Timestamp || new Date().toISOString(),
+      ActorUserId: event.ActorUserId || '',
+      ActorRole: event.ActorRole || '',
+      CampaignId: event.CampaignId || '',
+      Target: event.Target || '',
+      Action: event.Action || '',
+      BeforeJSON: toJson(event.BeforeJSON || event.Before || ''),
+      AfterJSON: toJson(event.AfterJSON || event.After || ''),
+      IP: event.IP || '',
+      UA: event.UA || ''
+    };
+    IdentityRepository.append('AuditLog', payload);
+    return payload;
+  }
+
+  function list(filters) {
+    var rows = IdentityRepository.list('AuditLog');
+    if (!filters) {
+      return rows;
+    }
+    return rows.filter(function(row) {
+      if (filters.campaignId && row.CampaignId !== filters.campaignId) return false;
+      if (filters.target && row.Target !== filters.target) return false;
+      if (filters.action && row.Action !== filters.action) return false;
+      if (filters.from && new Date(row.Timestamp).getTime() < new Date(filters.from).getTime()) return false;
+      if (filters.to && new Date(row.Timestamp).getTime() > new Date(filters.to).getTime()) return false;
+      return true;
+    });
+  }
+
+  global.AuditService = {
+    log: log,
+    list: list
+  };
+})(GLOBAL_SCOPE);

--- a/AuthService.gs
+++ b/AuthService.gs
@@ -1,0 +1,444 @@
+/**
+ * AuthService.gs
+ * -----------------------------------------------------------------------------
+ * Comprehensive authentication and verification service for Lumina Identity.
+ */
+(function bootstrapAuthService(global) {
+  if (!global) return;
+  if (global.AuthService && typeof global.AuthService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var SessionService = global.SessionService;
+  var AuditService = global.AuditService;
+  var Utilities = global.Utilities;
+  var MailApp = global.MailApp;
+  var PropertiesService = global.PropertiesService;
+  var EnterpriseSecurity = global.EnterpriseSecurity;
+
+  if (!IdentityRepository || !SessionService || !AuditService) {
+    throw new Error('AuthService requires repository, session, and audit services');
+  }
+
+  var PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+  var OTP_TTL_MS = 5 * 60 * 1000;
+  var OTP_MAX_RESENDS = 3;
+  var OTP_MAX_ATTEMPTS = 5;
+  var LOGIN_RATE_LIMIT_1M = 5;
+  var LOGIN_RATE_LIMIT_15M = 20;
+
+  function getSecuritySalt() {
+    var scriptProperties = PropertiesService && PropertiesService.getScriptProperties();
+    if (!scriptProperties) {
+      throw new Error('Script properties unavailable');
+    }
+    var salt = scriptProperties.getProperty('IDENTITY_PASSWORD_SALT');
+    if (!salt) {
+      salt = Utilities.base64Encode(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, Utilities.getUuid()));
+      scriptProperties.setProperty('IDENTITY_PASSWORD_SALT', salt);
+    }
+    return salt;
+  }
+
+  function hashPassword(password) {
+    if (!password) {
+      throw new Error('Password required');
+    }
+    var salt = getSecuritySalt();
+    var digest = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_512, salt + '|' + password);
+    return Utilities.base64Encode(digest);
+  }
+
+  function validatePassword(password) {
+    if (!PASSWORD_REGEX.test(password)) {
+      throw new Error('Password does not meet complexity requirements');
+    }
+  }
+
+  function constantTimeEquals(a, b) {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    var strA = String(a);
+    var strB = String(b);
+    if (strA.length !== strB.length) {
+      return false;
+    }
+    var diff = 0;
+    for (var i = 0; i < strA.length; i++) {
+      diff |= strA.charCodeAt(i) ^ strB.charCodeAt(i);
+    }
+    return diff === 0;
+  }
+
+  function findUser(emailOrUsername) {
+    if (!emailOrUsername) return null;
+    var normalized = String(emailOrUsername).toLowerCase();
+    var users = IdentityRepository.list('Users');
+    return users.find(function(user) {
+      return String(user.Email || '').toLowerCase() === normalized || String(user.Username || '').toLowerCase() === normalized;
+    }) || null;
+  }
+
+  function generateOtpCode() {
+    var code = Math.floor(100000 + Math.random() * 900000);
+    return String(code);
+  }
+
+  function otpCacheKey(email, purpose) {
+    return String(email).toLowerCase() + '::' + purpose;
+  }
+
+  function createOtp(email, purpose) {
+    var now = Date.now();
+    var key = otpCacheKey(email, purpose);
+    var record = {
+      Key: key,
+      Email: email,
+      Code: generateOtpCode(),
+      Purpose: purpose,
+      ExpiresAt: new Date(now + OTP_TTL_MS).toISOString(),
+      Attempts: 0,
+      LastSentAt: new Date(now).toISOString(),
+      ResendCount: 0
+    };
+    IdentityRepository.upsert('OTP', 'Key', record);
+    return record;
+  }
+
+  function sendOtpEmail(email, code, purpose) {
+    if (!MailApp) {
+      console.log('MailApp unavailable – OTP code: ' + code);
+      return;
+    }
+    MailApp.sendEmail({
+      to: email,
+      subject: 'Your Lumina Identity verification code',
+      htmlBody: '<p>Your verification code is <strong>' + code + '</strong> (valid for 5 minutes) for ' + purpose + '.</p>'
+    });
+  }
+
+  function enforceOtpRateLimit(email, purpose) {
+    var existing = IdentityRepository.find('OTP', function(row) {
+      return row.Key === otpCacheKey(email, purpose);
+    });
+    if (!existing) {
+      return;
+    }
+    var lastSent = new Date(existing.LastSentAt).getTime();
+    if (Date.now() - lastSent < 60 * 1000) {
+      throw new Error('OTP recently sent. Please wait before requesting another code.');
+    }
+    if (Number(existing.ResendCount || 0) >= OTP_MAX_RESENDS) {
+      throw new Error('Maximum OTP resends reached. Contact support.');
+    }
+  }
+
+  function requestOtp(emailOrUsername, purpose, context) {
+    purpose = purpose || 'login';
+    var user = findUser(emailOrUsername);
+    if (!user) {
+      throw new Error('User not found');
+    }
+    enforceLoginRateLimit(emailOrUsername, context && context.ip);
+    enforceOtpRateLimit(user.Email, purpose);
+    var otp = createOtp(user.Email, purpose);
+    sendOtpEmail(user.Email, otp.Code, purpose);
+    IdentityRepository.upsert('OTP', 'Key', Object.assign({}, otp, {
+      ResendCount: Number(otp.ResendCount || 0) + 1
+    }));
+    AuditService.log({
+      ActorUserId: user.UserId,
+      ActorRole: 'SYSTEM',
+      CampaignId: '',
+      Target: user.Email,
+      Action: 'OTP_SENT',
+      IP: context && context.ip,
+      UA: context && context.ua
+    });
+    return { success: true };
+  }
+
+  function verifyOtp(email, code, purpose, context) {
+    var key = otpCacheKey(email, purpose);
+    var record = IdentityRepository.find('OTP', function(row) {
+      return row.Key === key;
+    });
+    if (!record) {
+      throw new Error('OTP not requested.');
+    }
+    var now = Date.now();
+    if (new Date(record.ExpiresAt).getTime() < now) {
+      IdentityRepository.remove('OTP', 'Key', key);
+      throw new Error('OTP expired.');
+    }
+    if (Number(record.Attempts || 0) >= OTP_MAX_ATTEMPTS) {
+      throw new Error('Maximum OTP attempts exceeded.');
+    }
+    if (!constantTimeEquals(record.Code, code)) {
+      IdentityRepository.upsert('OTP', 'Key', Object.assign({}, record, {
+        Attempts: Number(record.Attempts || 0) + 1
+      }));
+      AuditService.log({
+        ActorUserId: '',
+        ActorRole: 'SYSTEM',
+        CampaignId: '',
+        Target: email,
+        Action: 'OTP_INVALID',
+        IP: context && context.ip,
+        UA: context && context.ua
+      });
+      throw new Error('Invalid OTP code.');
+    }
+    IdentityRepository.remove('OTP', 'Key', key);
+    return true;
+  }
+
+  function enforceLoginRateLimit(identifier, ip) {
+    var row = IdentityRepository.find('LoginAttempts', function(item) {
+      return item.EmailOrUsername === identifier;
+    }) || {
+      EmailOrUsername: identifier,
+      Count1m: 0,
+      Count15m: 0,
+      LastAttemptAt: new Date(0).toISOString(),
+      LockedUntil: ''
+    };
+    var now = Date.now();
+    var lockedUntil = row.LockedUntil ? new Date(row.LockedUntil).getTime() : 0;
+    if (lockedUntil && lockedUntil > now) {
+      throw new Error('Temporarily locked — try again later.');
+    }
+    var lastAttempt = new Date(row.LastAttemptAt).getTime();
+    var within1m = (now - lastAttempt) < 60 * 1000;
+    var within15m = (now - lastAttempt) < 15 * 60 * 1000;
+    row.Count1m = within1m ? Number(row.Count1m || 0) + 1 : 1;
+    row.Count15m = within15m ? Number(row.Count15m || 0) + 1 : 1;
+    row.LastAttemptAt = new Date(now).toISOString();
+    if (row.Count1m > LOGIN_RATE_LIMIT_1M || row.Count15m > LOGIN_RATE_LIMIT_15M) {
+      row.LockedUntil = new Date(now + 5 * 60 * 1000).toISOString();
+      IdentityRepository.upsert('LoginAttempts', 'EmailOrUsername', row);
+      AuditService.log({
+        ActorUserId: '',
+        ActorRole: 'SYSTEM',
+        CampaignId: '',
+        Target: identifier,
+        Action: 'LOGIN_RATE_LIMITED',
+        IP: ip || ''
+      });
+      throw new Error('Temporarily locked — try again at ' + new Date(row.LockedUntil).toLocaleTimeString());
+    }
+    IdentityRepository.upsert('LoginAttempts', 'EmailOrUsername', row);
+  }
+
+  function resetLoginAttempts(identifier) {
+    IdentityRepository.remove('LoginAttempts', 'EmailOrUsername', identifier);
+  }
+
+  function login(payload, context) {
+    context = context || {};
+    var identifier = payload.emailOrUsername;
+    enforceLoginRateLimit(identifier, context.ip);
+    var user = findUser(identifier);
+    if (!user) {
+      throw new Error('Invalid credentials');
+    }
+    if (user.Status === 'Locked') {
+      throw new Error('Account locked. Contact administrator.');
+    }
+    if (!payload.password) {
+      throw new Error('Password required');
+    }
+    var hashed = hashPassword(payload.password);
+    if (!constantTimeEquals(user.PasswordHash, hashed)) {
+      AuditService.log({
+        ActorUserId: user.UserId,
+        ActorRole: 'SYSTEM',
+        CampaignId: '',
+        Target: user.UserId,
+        Action: 'LOGIN_FAILED',
+        IP: context.ip,
+        UA: context.ua
+      });
+      throw new Error('Invalid credentials');
+    }
+    if (payload.otp) {
+      verifyOtp(user.Email, payload.otp, 'login', context);
+    }
+    if (user.TOTPEnabled === 'Y') {
+      if (!payload.totp) {
+        throw new Error('TOTP required');
+      }
+      if (!verifyTotp(user, payload.totp)) {
+        throw new Error('Invalid TOTP');
+      }
+    }
+    resetLoginAttempts(identifier);
+    IdentityRepository.upsert('Users', 'UserId', Object.assign({}, user, {
+      LastLoginAt: new Date().toISOString()
+    }));
+    var primaryCampaign = getPrimaryCampaign(user.UserId);
+    var session = SessionService.issueSession(user, primaryCampaign ? primaryCampaign.CampaignId : '', context.ip, context.ua);
+    AuditService.log({
+      ActorUserId: user.UserId,
+      ActorRole: primaryCampaign ? primaryCampaign.Role : '',
+      CampaignId: primaryCampaign ? primaryCampaign.CampaignId : '',
+      Target: user.UserId,
+      Action: 'LOGIN_SUCCESS',
+      IP: context.ip,
+      UA: context.ua,
+      After: { sessionId: session.SessionId }
+    });
+    return session;
+  }
+
+  function getPrimaryCampaign(userId) {
+    var assignments = IdentityRepository.list('UserCampaigns').filter(function(row) {
+      return row.UserId === userId;
+    });
+    if (!assignments.length) {
+      return null;
+    }
+    var primary = assignments.find(function(row) { return row.IsPrimary === 'Y' || row.IsPrimary === true; });
+    return primary || assignments[0];
+  }
+
+  function enableTotp(user, secret, code) {
+    if (!secret) {
+      throw new Error('TOTP secret required');
+    }
+    if (!code) {
+      throw new Error('Verification code required');
+    }
+    if (!verifyTotpCode(secret, code)) {
+      throw new Error('Unable to verify TOTP code');
+    }
+    var record = Object.assign({}, user, {
+      TOTPEnabled: 'Y',
+      TOTPSecretHash: encryptTotpSecret(user.UserId, secret)
+    });
+    IdentityRepository.upsert('Users', 'UserId', record);
+    AuditService.log({
+      ActorUserId: user.UserId,
+      ActorRole: 'SYSTEM',
+      CampaignId: '',
+      Target: user.UserId,
+      Action: 'TOTP_ENABLED'
+    });
+    return true;
+  }
+
+  function disableTotp(user) {
+    var record = Object.assign({}, user, {
+      TOTPEnabled: 'N',
+      TOTPSecretHash: ''
+    });
+    IdentityRepository.upsert('Users', 'UserId', record);
+    AuditService.log({
+      ActorUserId: user.UserId,
+      ActorRole: 'SYSTEM',
+      CampaignId: '',
+      Target: user.UserId,
+      Action: 'TOTP_DISABLED'
+    });
+  }
+
+  function base32Decode(secret) {
+    var alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    var padding = '=';
+    secret = String(secret || '').replace(new RegExp(padding, 'g'), '').toUpperCase();
+    var bits = '';
+    for (var i = 0; i < secret.length; i++) {
+      var val = alphabet.indexOf(secret.charAt(i));
+      if (val === -1) {
+        continue;
+      }
+      bits += ('00000' + val.toString(2)).slice(-5);
+    }
+    var result = [];
+    for (var j = 0; j + 8 <= bits.length; j += 8) {
+      result.push(parseInt(bits.slice(j, j + 8), 2));
+    }
+    return result;
+  }
+
+  function decryptTotpSecret(user) {
+    if (!user.TOTPSecretHash) {
+      return null;
+    }
+    if (EnterpriseSecurity && EnterpriseSecurity.isEncryptedValue(user.TOTPSecretHash)) {
+      return EnterpriseSecurity.decryptValue(user.TOTPSecretHash, { tenant: user.UserId, purpose: 'TOTP' });
+    }
+    return user.TOTPSecretHash;
+  }
+
+  function encryptTotpSecret(userId, secret) {
+    if (!EnterpriseSecurity) {
+      return secret;
+    }
+    return EnterpriseSecurity.encryptValue(secret, { tenant: userId, purpose: 'TOTP' });
+  }
+
+  function verifyTotp(user, token) {
+    var secret = decryptTotpSecret(user);
+    if (!secret) {
+      return false;
+    }
+    return verifyTotpCode(secret, token);
+  }
+
+  function verifyTotpCode(secret, token) {
+    if (!secret || !token) {
+      return false;
+    }
+    var secretBytes = base32Decode(secret);
+    var timestep = Math.floor(Date.now() / 30000);
+    for (var offset = -1; offset <= 1; offset++) {
+      var counter = timestep + offset;
+      var bytes = new Array(8);
+      for (var i = 7; i >= 0; i--) {
+        bytes[i] = counter & 0xff;
+        counter = counter >> 8;
+      }
+      var hmac = Utilities.computeHmacSha1Signature(bytes, secretBytes);
+      var offsetBits = hmac[hmac.length - 1] & 0x0f;
+      var binary = ((hmac[offsetBits] & 0x7f) << 24) |
+        ((hmac[offsetBits + 1] & 0xff) << 16) |
+        ((hmac[offsetBits + 2] & 0xff) << 8) |
+        (hmac[offsetBits + 3] & 0xff);
+      var generated = (binary % 1000000).toString();
+      while (generated.length < 6) {
+        generated = '0' + generated;
+      }
+      if (constantTimeEquals(generated, token)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function logout(sessionId, context) {
+    SessionService.invalidateSession(sessionId);
+    AuditService.log({
+      ActorUserId: context && context.userId,
+      ActorRole: context && context.role,
+      CampaignId: context && context.campaignId,
+      Target: context && context.userId,
+      Action: 'LOGOUT',
+      IP: context && context.ip,
+      UA: context && context.ua
+    });
+  }
+
+  global.AuthService = {
+    validatePassword: validatePassword,
+    hashPassword: hashPassword,
+    requestOtp: requestOtp,
+    verifyOtp: verifyOtp,
+    login: login,
+    enableTotp: enableTotp,
+    disableTotp: disableTotp,
+    logout: logout,
+    verifyTotpCode: verifyTotpCode
+  };
+})(GLOBAL_SCOPE);

--- a/Code.js
+++ b/Code.js
@@ -3580,6 +3580,10 @@ function doGet(e) {
   try {
     const baseUrl = getBaseUrl();
 
+    if (e && e.parameter && e.parameter.api === 'identity') {
+      return IdentityRouter.handleGet(e);
+    }
+
     if (e.parameter.page === 'proxy') {
       console.log('doGet: Handling proxy request');
       return serveEnhancedProxy(e);

--- a/EligibilityService.gs
+++ b/EligibilityService.gs
@@ -1,0 +1,207 @@
+/**
+ * EligibilityService.gs
+ * -----------------------------------------------------------------------------
+ * Evaluates eligibility hints and lifecycle suggestions using the Eligibility
+ * rules defined in Sheets.
+ */
+(function bootstrapEligibilityService(global) {
+  if (!global) return;
+  if (global.EligibilityService && typeof global.EligibilityService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var PolicyService = global.PolicyService;
+
+  if (!IdentityRepository || !PolicyService) {
+    throw new Error('EligibilityService requires IdentityRepository and PolicyService');
+  }
+
+  function parseJson(value) {
+    if (!value) return {};
+    if (typeof value === 'object') return value;
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      return {};
+    }
+  }
+
+  function evaluateEligibility(userId, campaignId) {
+    var rules = PolicyService.listEligibilityRules(campaignId).filter(function(rule) {
+      return rule.Active === 'Y' || rule.Active === true;
+    });
+    var employmentHistory = IdentityRepository.list('EmploymentStatus').filter(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    var hints = [];
+    rules.forEach(function(rule) {
+      var params = parseJson(rule.ParamsJSON);
+      switch (rule.RuleType) {
+        case 'Insurance':
+          hints.push(evaluateInsuranceRule(employmentHistory, params));
+          break;
+        case 'Promo':
+        case 'Promotion':
+          hints.push(evaluatePromotionRule(userId, campaignId, params));
+          break;
+        case 'Terminate':
+          hints.push(evaluateTerminationRule(userId, campaignId, params));
+          break;
+        case 'Watch':
+          hints.push(evaluateWatchRule(userId, campaignId, params));
+          break;
+        default:
+          break;
+      }
+    });
+    return hints.filter(Boolean);
+  }
+
+  function evaluateInsuranceRule(history, params) {
+    params = params || {};
+    var minTenureDays = params.minTenureDays || 90;
+    if (!history || !history.length) {
+      return {
+        category: 'Insurance',
+        status: 'Ineligible',
+        reason: 'No employment records found.'
+      };
+    }
+    var hired = history.find(function(record) {
+      return record.State === 'Hired' || record.State === 'Active';
+    });
+    if (!hired) {
+      return {
+        category: 'Insurance',
+        status: 'Ineligible',
+        reason: 'No active employment status.'
+      };
+    }
+    var hiredDate = new Date(hired.EffectiveDate);
+    var today = new Date();
+    var tenureDays = Math.floor((today.getTime() - hiredDate.getTime()) / (1000 * 60 * 60 * 24));
+    if (tenureDays >= minTenureDays) {
+      return {
+        category: 'Insurance',
+        status: 'Eligible',
+        reason: 'Minimum tenure satisfied (' + tenureDays + ' days).'
+      };
+    }
+    return {
+      category: 'Insurance',
+      status: 'Pending',
+      reason: 'Tenure ' + tenureDays + '/' + minTenureDays + ' days. Next review on ' + formatFutureDate(minTenureDays - tenureDays) + '.'
+    };
+  }
+
+  function evaluatePromotionRule(userId, campaignId, params) {
+    params = params || {};
+    var qaScores = IdentityRepository.list('QualityScores').filter(function(score) {
+      return score.UserId === userId && score.CampaignId === campaignId;
+    });
+    var attendance = IdentityRepository.list('Attendance').filter(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    var watchlist = IdentityRepository.list('UserCampaigns').some(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId && row.Watchlist === 'Y';
+    });
+    var qaTarget = params.qaTarget || 90;
+    var attendanceTarget = params.attendanceTarget || 95;
+    var windowDays = params.windowDays || 60;
+    var qaOk = averageRecentScores(qaScores, windowDays) >= qaTarget;
+    var attendanceOk = averageRecentScores(attendance, windowDays, 'Attendance') >= attendanceTarget;
+    if (qaOk && attendanceOk && !watchlist) {
+      return {
+        category: 'Promotion',
+        status: 'Eligible',
+        reason: 'QA and attendance targets met over last ' + windowDays + ' days.'
+      };
+    }
+    return {
+      category: 'Promotion',
+      status: 'Not Ready',
+      reason: 'Targets unmet or watchlist flag present.'
+    };
+  }
+
+  function evaluateTerminationRule(userId, campaignId, params) {
+    params = params || {};
+    var attendance = IdentityRepository.list('Attendance').filter(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    var threshold = params.absenceThreshold || 3;
+    var lookback = params.lookbackDays || 30;
+    var consecutiveMisses = countConsecutiveAbsences(attendance, lookback);
+    if (consecutiveMisses >= threshold) {
+      return {
+        category: 'Termination',
+        status: 'Review',
+        reason: 'Repeated absences detected (' + consecutiveMisses + ' in last ' + lookback + ' days).'
+      };
+    }
+    return null;
+  }
+
+  function evaluateWatchRule(userId, campaignId, params) {
+    params = params || {};
+    if (!params.kpiThreshold) {
+      return null;
+    }
+    var kpi = IdentityRepository.list('Performance').filter(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    var belowThreshold = kpi.some(function(row) {
+      return Number(row.Score || 0) < params.kpiThreshold;
+    });
+    if (belowThreshold) {
+      return {
+        category: 'Watch',
+        status: 'Flagged',
+        reason: 'Performance metrics below threshold of ' + params.kpiThreshold
+      };
+    }
+    return null;
+  }
+
+  function averageRecentScores(rows, windowDays, valueKey) {
+    if (!rows || !rows.length) {
+      return 0;
+    }
+    var cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - (windowDays || 30));
+    var total = 0;
+    var count = 0;
+    rows.forEach(function(row) {
+      var date = new Date(row.Date || row.EffectiveDate || row.Timestamp);
+      if (date >= cutoff) {
+        total += Number(row.Score || row[valueKey || 'Score'] || 0);
+        count++;
+      }
+    });
+    return count ? Math.round((total / count) * 100) / 100 : 0;
+  }
+
+  function countConsecutiveAbsences(rows, lookbackDays) {
+    var cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - (lookbackDays || 30));
+    var misses = 0;
+    rows.forEach(function(row) {
+      var date = new Date(row.Date || row.EffectiveDate || row.Timestamp);
+      if (date >= cutoff && row.Status === 'Absent') {
+        misses++;
+      }
+    });
+    return misses;
+  }
+
+  function formatFutureDate(daysAhead) {
+    var date = new Date();
+    date.setDate(date.getDate() + Math.max(daysAhead, 0));
+    return date.toISOString().split('T')[0];
+  }
+
+  global.EligibilityService = {
+    evaluateEligibility: evaluateEligibility
+  };
+})(GLOBAL_SCOPE);

--- a/EquipmentService.gs
+++ b/EquipmentService.gs
@@ -1,0 +1,93 @@
+/**
+ * EquipmentService.gs
+ * -----------------------------------------------------------------------------
+ * Handles assignment and reclamation of company assets.
+ */
+(function bootstrapEquipmentService(global) {
+  if (!global) return;
+  if (global.EquipmentService && typeof global.EquipmentService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var RBACService = global.RBACService;
+  var AuditService = global.AuditService;
+  var Utilities = global.Utilities;
+
+  if (!IdentityRepository || !RBACService || !AuditService) {
+    throw new Error('EquipmentService dependencies missing');
+  }
+
+  function assignEquipment(actor, payload) {
+    RBACService.assertPermission(actor.UserId, payload.CampaignId, RBACService.CAPABILITIES.MANAGE_EQUIPMENT, actor.Roles);
+    var record = {
+      EquipmentId: payload.EquipmentId || Utilities.getUuid(),
+      UserId: payload.UserId,
+      CampaignId: payload.CampaignId,
+      Type: payload.Type,
+      Serial: payload.Serial,
+      Condition: payload.Condition || 'Good',
+      AssignedAt: payload.AssignedAt || new Date().toISOString(),
+      ReturnedAt: payload.ReturnedAt || '',
+      Notes: payload.Notes || '',
+      Status: payload.Status || 'Assigned'
+    };
+    IdentityRepository.upsert('Equipment', 'EquipmentId', record);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: payload.CampaignId,
+      Target: 'Equipment:' + record.EquipmentId,
+      Action: 'EQUIPMENT_ASSIGN',
+      After: record
+    });
+    return record;
+  }
+
+  function updateEquipment(actor, equipmentId, updates) {
+    var record = IdentityRepository.find('Equipment', function(row) { return row.EquipmentId === equipmentId; });
+    if (!record) {
+      throw new Error('Equipment not found');
+    }
+    RBACService.assertPermission(actor.UserId, record.CampaignId, RBACService.CAPABILITIES.MANAGE_EQUIPMENT, actor.Roles);
+    var updated = Object.assign({}, record, updates, {
+      ReturnedAt: updates.ReturnedAt || record.ReturnedAt,
+      Status: updates.Status || record.Status
+    });
+    IdentityRepository.upsert('Equipment', 'EquipmentId', updated);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: record.CampaignId,
+      Target: 'Equipment:' + equipmentId,
+      Action: 'EQUIPMENT_UPDATE',
+      Before: record,
+      After: updated
+    });
+    return updated;
+  }
+
+  function listEquipment(actor, filters) {
+    var rows = IdentityRepository.list('Equipment');
+    if (filters && filters.campaignId) {
+      rows = rows.filter(function(row) { return row.CampaignId === filters.campaignId; });
+    }
+    if (filters && filters.userId) {
+      rows = rows.filter(function(row) { return row.UserId === filters.userId; });
+    }
+    return rows;
+  }
+
+  function hasOutstandingEquipment(userId, campaignId) {
+    return IdentityRepository.list('Equipment').some(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId && (!row.ReturnedAt || row.Status === 'Assigned');
+    });
+  }
+
+  global.EquipmentService = {
+    assignEquipment: assignEquipment,
+    updateEquipment: updateEquipment,
+    listEquipment: listEquipment,
+    hasOutstandingEquipment: hasOutstandingEquipment
+  };
+})(GLOBAL_SCOPE);

--- a/Html/LuminaIdentityApp.html
+++ b/Html/LuminaIdentityApp.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lumina Identity Workspace</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; font-family: 'Inter', sans-serif; background: #060811; color: #e9ecff; }
+    header { padding: 1.2rem 2.2rem; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(255,255,255,0.08); position: sticky; top: 0; backdrop-filter: blur(8px); background: rgba(6,8,17,0.85); }
+    .workspace { display: grid; grid-template-columns: 260px 1fr; min-height: calc(100vh - 72px); }
+    nav { border-right: 1px solid rgba(255,255,255,0.05); padding: 1.5rem; background: rgba(7,11,28,0.85); }
+    nav button { display: block; width: 100%; text-align: left; background: transparent; border: 0; color: inherit; padding: 0.7rem 1rem; border-radius: 10px; margin-bottom: 0.4rem; cursor: pointer; }
+    nav button.active { background: linear-gradient(135deg,#5f2ded,#8a62ff); }
+    main { padding: 2rem 2.5rem; overflow-y: auto; }
+    h2 { margin-top: 0; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; background: rgba(255,255,255,0.04); border-radius: 12px; overflow: hidden; }
+    th, td { padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid rgba(255,255,255,0.06); }
+    th { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: #9aa2e6; }
+    tr:last-child td { border-bottom: 0; }
+    .tag { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.6rem; border-radius: 999px; font-size: 0.75rem; background: rgba(95,45,237,0.25); color: #cbbdff; }
+    .hint { margin-top: 1rem; padding: 1rem 1.2rem; border-radius: 12px; background: rgba(36,226,158,0.16); color: #59f2b6; }
+    .panel { margin-top: 2rem; padding: 1.6rem; border-radius: 14px; background: rgba(255,255,255,0.04); }
+    .panel h3 { margin-top: 0; }
+    .audit-log { max-height: 220px; overflow-y: auto; }
+    .audit-log li { list-style: none; padding: 0.6rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <strong>Lumina Identity</strong>
+      <span style="color:#7f89c9; margin-left:0.6rem;">Campaign: <span id="campaign-name">Loading...</span></span>
+    </div>
+    <button id="logout" style="background: rgba(255,255,255,0.08); border:0; color:#f2f5ff; padding:0.55rem 1.2rem; border-radius:10px;">Logout</button>
+  </header>
+  <div class="workspace">
+    <nav>
+      <button data-view="directory" class="active">User directory</button>
+      <button data-view="equipment">Equipment</button>
+      <button data-view="policies">Policies & Flags</button>
+      <button data-view="audit">Audit</button>
+    </nav>
+    <main>
+      <section id="view-directory">
+        <h2>Campaign directory</h2>
+        <table id="user-table">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Watch</th>
+              <th>Eligibility</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+      <section id="view-equipment" style="display:none;">
+        <h2>Equipment assignments</h2>
+        <div id="equipment-list" class="panel">No equipment records yet.</div>
+      </section>
+      <section id="view-policies" style="display:none;">
+        <h2>Policies</h2>
+        <div id="policy-list" class="panel">Loading policies...</div>
+      </section>
+      <section id="view-audit" style="display:none;">
+        <h2>Recent audit log</h2>
+        <ul id="audit-log" class="audit-log"></ul>
+      </section>
+    </main>
+  </div>
+  <script>
+    const state = { sessionId: null, csrf: null, campaignId: null };
+    const views = document.querySelectorAll('nav button');
+    views.forEach(btn => btn.addEventListener('click', () => switchView(btn.dataset.view)));
+
+    async function api(action, payload) {
+      const response = await fetch('', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(Object.assign({ action, sessionId: state.sessionId, csrf: state.csrf }, payload || {}))
+      });
+      return response.json();
+    }
+
+    function switchView(view) {
+      views.forEach(btn => btn.classList.toggle('active', btn.dataset.view === view));
+      document.querySelectorAll('main section').forEach(section => {
+        section.style.display = section.id === 'view-' + view ? 'block' : 'none';
+      });
+      if (view === 'directory') loadDirectory();
+      if (view === 'equipment') loadEquipment();
+      if (view === 'policies') loadPolicies();
+      if (view === 'audit') loadAudit();
+    }
+
+    async function bootstrap() {
+      const sessionData = window.__IDENTITY_SESSION__ || {};
+      state.sessionId = sessionData.sessionId;
+      state.csrf = sessionData.csrf;
+      state.campaignId = sessionData.campaignId;
+      document.getElementById('campaign-name').textContent = sessionData.campaignName || 'Unknown';
+      await loadDirectory();
+    }
+
+    async function loadDirectory() {
+      const result = await api('users/list', { campaignId: state.campaignId });
+      if (!result.ok) return;
+      const tbody = document.querySelector('#user-table tbody');
+      tbody.innerHTML = '';
+      (result.result || []).forEach(user => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${user.Email}</td>
+          <td>${user.Role}</td>
+          <td><span class="tag">${user.Status}</span></td>
+          <td>${user.Watchlist === 'Y' ? '⚠️' : ''}</td>
+          <td>${(user.Eligibility || []).map(e => e.status).join(', ') || '—'}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    async function loadEquipment() {
+      const container = document.getElementById('equipment-list');
+      const result = await api('equipment/list', { campaignId: state.campaignId });
+      if (!result.ok) return container.textContent = result.error || 'Unable to load equipment.';
+      const items = result.result || [];
+      if (!items.length) {
+        container.textContent = 'No equipment assigned.';
+        return;
+      }
+      container.innerHTML = items.map(item => `<div class="hint">${item.Type} – ${item.Serial} (${item.Status})</div>`).join('');
+    }
+
+    async function loadPolicies() {
+      const container = document.getElementById('policy-list');
+      const result = await api('policies/list', { scope: state.campaignId });
+      if (!result.ok) return container.textContent = result.error || 'Unable to load policies.';
+      container.innerHTML = result.result.map(item => `<div class="hint">${item.Name}: <strong>${item.Value}</strong></div>`).join('');
+    }
+
+    async function loadAudit() {
+      const list = document.getElementById('audit-log');
+      const result = await api('audit/list', { campaignId: state.campaignId });
+      if (!result.ok) return;
+      list.innerHTML = '';
+      (result.result || []).slice(-15).reverse().forEach(event => {
+        const li = document.createElement('li');
+        li.textContent = `${event.Timestamp} — ${event.Action} (${event.ActorRole || 'n/a'})`;
+        list.appendChild(li);
+      });
+    }
+
+    document.getElementById('logout').addEventListener('click', async () => {
+      await api('auth/logout', {});
+      window.location.href = '?page=login';
+    });
+
+    bootstrap();
+  </script>
+</body>
+</html>

--- a/Html/LuminaIdentityLanding.html
+++ b/Html/LuminaIdentityLanding.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lumina Identity</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  <style>
+    body { font-family: 'Inter', sans-serif; margin: 0; background: #0b1026; color: #f2f5ff; }
+    header { padding: 3rem 2rem; text-align: center; background: linear-gradient(135deg,#1b3fd4,#5f2ded); }
+    main { max-width: 720px; margin: -4rem auto 0 auto; background: #101638; border-radius: 16px; padding: 3rem; box-shadow: 0 20px 45px rgba(0,0,0,0.35); }
+    h1 { margin-top: 0; font-size: 2.6rem; }
+    p.lead { font-size: 1.1rem; line-height: 1.7; color: #c6c9ff; }
+    .cta { margin-top: 2rem; display: inline-flex; align-items: center; gap: 0.6rem; padding: 0.9rem 1.6rem; border-radius: 999px; background: #5f2ded; color: #fff; text-decoration: none; font-weight: 600; box-shadow: 0 12px 32px rgba(95,45,237,0.45); }
+    .grid { display: grid; gap: 1.6rem; margin-top: 2.4rem; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); }
+    .card { background: rgba(255,255,255,0.04); padding: 1.4rem; border-radius: 12px; border: 1px solid rgba(255,255,255,0.08); }
+    .card h3 { margin-top: 0; font-size: 1.1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Lumina Identity</h1>
+    <p class="lead">Tenant-aware authentication, authorization, and lifecycle control for every Lumina campaign.</p>
+    <a class="cta" href="?page=login">Sign in to continue</a>
+  </header>
+  <main>
+    <section>
+      <h2>Security-first identity</h2>
+      <p class="lead">Email + password, OTP, and TOTP in a single workflow. Sessions expire automatically and every action is audited.</p>
+      <div class="grid">
+        <div class="card">
+          <h3>Campaign isolation</h3>
+          <p>All reads and writes enforce campaign boundaries so client data always stays segregated.</p>
+        </div>
+        <div class="card">
+          <h3>RBAC + guests</h3>
+          <p>Fine-grained permissions for managers, analysts, and guests with read-only views.</p>
+        </div>
+        <div class="card">
+          <h3>Lifecycle governance</h3>
+          <p>Track employment state, transfers, watchlists, and equipment compliance in one pane of glass.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/Html/LuminaIdentityLogin.html
+++ b/Html/LuminaIdentityLogin.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sign in – Lumina Identity</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
+  <style>
+    body { margin: 0; font-family: 'Inter', sans-serif; display: grid; place-items: center; min-height: 100vh; background: radial-gradient(circle at top,#2a3cff,#070b24); color: #f7f7ff; }
+    .shell { width: min(480px, calc(100% - 2rem)); background: rgba(12,18,52,0.9); border-radius: 18px; padding: 3rem 2.6rem; box-shadow: 0 30px 60px rgba(10,12,38,0.5); backdrop-filter: blur(14px); }
+    h1 { margin-top: 0; font-size: 2rem; }
+    form { display: grid; gap: 1.2rem; margin-top: 1.8rem; }
+    label { display: grid; gap: 0.35rem; font-weight: 600; }
+    input { padding: 0.8rem 1rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.18); background: rgba(7,10,32,0.9); color: inherit; }
+    button { padding: 0.85rem 1rem; border: 0; border-radius: 12px; background: linear-gradient(135deg,#5f2ded,#a65cff); color: #fff; font-weight: 600; cursor: pointer; box-shadow: 0 12px 30px rgba(95,45,237,0.35); }
+    .alt { text-align: center; margin-top: 1.4rem; font-size: 0.95rem; color: #b8bbf2; }
+    .status { margin-top: 1rem; padding: 0.75rem; border-radius: 10px; background: rgba(25,200,120,0.15); color: #5bf2a5; display: none; }
+    .status.error { background: rgba(255,71,87,0.1); color: #ff7990; }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <h1>Welcome back</h1>
+    <p>Use your Lumina credentials. OTP and TOTP will be requested automatically when your campaign policy requires it.</p>
+    <div class="status" id="status"></div>
+    <form id="login-form">
+      <label>
+        Email or Username
+        <input id="identity" type="text" autocomplete="username" required>
+      </label>
+      <label>
+        Password
+        <input id="password" type="password" autocomplete="current-password" required>
+      </label>
+      <label id="otp-wrapper" style="display:none;">
+        Verification code
+        <input id="otp" type="text" maxlength="6" inputmode="numeric" pattern="\\d{6}">
+      </label>
+      <label id="totp-wrapper" style="display:none;">
+        Authenticator code
+        <input id="totp" type="text" maxlength="6" inputmode="numeric" pattern="\\d{6}">
+      </label>
+      <input type="hidden" id="sessionId">
+      <input type="hidden" id="csrf">
+      <button type="submit">Sign in</button>
+    </form>
+    <div class="alt">
+      Need a one-time code? <a href="#" id="request-otp" style="color:#8da2ff;">Send OTP</a>
+    </div>
+  </div>
+  <script>
+    const statusEl = document.getElementById('status');
+    const otpWrapper = document.getElementById('otp-wrapper');
+    const totpWrapper = document.getElementById('totp-wrapper');
+    const sessionInput = document.getElementById('sessionId');
+    const csrfInput = document.getElementById('csrf');
+
+    function setStatus(message, isError) {
+      statusEl.textContent = message;
+      statusEl.classList.toggle('error', !!isError);
+      statusEl.style.display = message ? 'block' : 'none';
+    }
+
+    async function api(action, payload) {
+      const response = await fetch('', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(Object.assign({ action }, payload || {}))
+      });
+      return response.json();
+    }
+
+    document.getElementById('login-form').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      setStatus('Signing in...');
+      try {
+        const payload = {
+          emailOrUsername: document.getElementById('identity').value,
+          password: document.getElementById('password').value,
+          otp: document.getElementById('otp').value || undefined,
+          totp: document.getElementById('totp').value || undefined
+        };
+        const result = await api('auth/login', payload);
+        if (!result.ok) {
+          throw new Error(result.error || 'Unable to sign in');
+        }
+        sessionInput.value = result.result.SessionId;
+        csrfInput.value = result.result.CSRF;
+        setStatus('Success! Redirecting...');
+        setTimeout(() => window.location.href = '?page=dashboard', 900);
+      } catch (err) {
+        setStatus(err.message, true);
+        otpWrapper.style.display = 'block';
+      }
+    });
+
+    document.getElementById('request-otp').addEventListener('click', async (event) => {
+      event.preventDefault();
+      try {
+        const identity = document.getElementById('identity').value;
+        if (!identity) {
+          return setStatus('Enter your email or username first.', true);
+        }
+        const response = await api('auth/request-otp', { emailOrUsername: identity, purpose: 'login' });
+        if (!response.ok) {
+          throw new Error(response.error || 'Unable to send code');
+        }
+        setStatus('Check your email for a six digit code.');
+        otpWrapper.style.display = 'block';
+      } catch (err) {
+        setStatus(err.message, true);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/IdentityRepository.gs
+++ b/IdentityRepository.gs
@@ -1,0 +1,231 @@
+/**
+ * IdentityRepository.gs
+ * -----------------------------------------------------------------------------
+ * Shared data-access helpers for the Lumina Identity platform. Provides typed
+ * wrappers around the Sheets-based data model defined in the Lumina Identity
+ * specification. Every table is represented by a sheet whose header row matches
+ * the contract from the design document. The repository automatically ensures
+ * header integrity, provides optimistic locking semantics, and exposes helpers
+ * to read/write strongly typed objects.
+ */
+(function bootstrapIdentityRepository(global) {
+  if (!global) return;
+  if (global.IdentityRepository && typeof global.IdentityRepository === 'object') {
+    return;
+  }
+
+  var SpreadsheetApp = global.SpreadsheetApp;
+  var PropertiesService = global.PropertiesService;
+  var CacheService = global.CacheService;
+  var LockService = global.LockService;
+  var Utilities = global.Utilities;
+
+  var SPREADSHEET_ID_PROPERTY = 'IDENTITY_SPREADSHEET_ID';
+  var CACHE_TTL_SECONDS = 60;
+  var HEADER_ROW = 1;
+
+  var TABLE_HEADERS = {
+    Campaigns: ['CampaignId', 'Name', 'Status', 'ClientOwnerEmail', 'CreatedAt', 'SettingsJSON'],
+    Users: ['UserId', 'Email', 'Username', 'PasswordHash', 'EmailVerified', 'TOTPEnabled', 'TOTPSecretHash', 'Status', 'LastLoginAt', 'CreatedAt'],
+    UserCampaigns: ['AssignmentId', 'UserId', 'CampaignId', 'Role', 'IsPrimary', 'AddedBy', 'AddedAt', 'Watchlist'],
+    Roles: ['Role', 'Description', 'IsGlobal'],
+    RolePermissions: ['PermissionId', 'Role', 'Capability', 'Scope', 'Allowed'],
+    OTP: ['Key', 'Email', 'Code', 'Purpose', 'ExpiresAt', 'Attempts', 'LastSentAt', 'ResendCount'],
+    Sessions: ['SessionId', 'UserId', 'CampaignId', 'IssuedAt', 'ExpiresAt', 'CSRF', 'IP', 'UA'],
+    LoginAttempts: ['EmailOrUsername', 'Count1m', 'Count15m', 'LastAttemptAt', 'LockedUntil'],
+    Equipment: ['EquipmentId', 'UserId', 'CampaignId', 'Type', 'Serial', 'Condition', 'AssignedAt', 'ReturnedAt', 'Notes', 'Status'],
+    EmploymentStatus: ['UserId', 'CampaignId', 'State', 'EffectiveDate', 'Reason', 'Notes'],
+    EligibilityRules: ['RuleId', 'Name', 'Scope', 'RuleType', 'ParamsJSON', 'Active'],
+    AuditLog: ['EventId', 'Timestamp', 'ActorUserId', 'ActorRole', 'CampaignId', 'Target', 'Action', 'BeforeJSON', 'AfterJSON', 'IP', 'UA'],
+    FeatureFlags: ['Flag', 'Value', 'Notes', 'UpdatedAt'],
+    Policies: ['PolicyId', 'Name', 'Scope', 'Key', 'Value', 'UpdatedAt'],
+    QualityScores: ['RecordId', 'UserId', 'CampaignId', 'Score', 'Date'],
+    Attendance: ['RecordId', 'UserId', 'CampaignId', 'Attendance', 'Status', 'Date'],
+    Performance: ['RecordId', 'UserId', 'CampaignId', 'Metric', 'Score', 'Date']
+  };
+
+  var repositoryCache = CacheService ? CacheService.getScriptCache() : null;
+  var spreadsheetCache = null;
+
+  function getSpreadsheetId() {
+    var scriptProperties = PropertiesService && PropertiesService.getScriptProperties();
+    if (!scriptProperties) {
+      throw new Error('Script properties unavailable – configure IDENTITY_SPREADSHEET_ID.');
+    }
+    var id = scriptProperties.getProperty(SPREADSHEET_ID_PROPERTY);
+    if (!id) {
+      throw new Error('Missing script property: IDENTITY_SPREADSHEET_ID');
+    }
+    return id;
+  }
+
+  function getSpreadsheet() {
+    if (spreadsheetCache) {
+      return spreadsheetCache;
+    }
+    if (!SpreadsheetApp) {
+      throw new Error('SpreadsheetApp unavailable');
+    }
+    spreadsheetCache = SpreadsheetApp.openById(getSpreadsheetId());
+    return spreadsheetCache;
+  }
+
+  function normalizeHeaders(values) {
+    return (values || []).map(function(value) {
+      return String(value || '').trim();
+    });
+  }
+
+  function ensureSheet(name) {
+    var ss = getSpreadsheet();
+    var sheet = ss.getSheetByName(name);
+    if (!sheet) {
+      sheet = ss.insertSheet(name);
+    }
+    var headers = sheet.getRange(HEADER_ROW, 1, 1, sheet.getLastColumn() || TABLE_HEADERS[name].length).getValues()[0];
+    var normalized = normalizeHeaders(headers);
+    var expected = TABLE_HEADERS[name];
+    var needsWrite = expected.length !== normalized.length || expected.some(function(header, idx) {
+      return normalized[idx] !== header;
+    });
+
+    if (needsWrite) {
+      sheet.clear();
+      sheet.getRange(HEADER_ROW, 1, 1, expected.length).setValues([expected]);
+    }
+    return sheet;
+  }
+
+  function withLock(name, callback) {
+    var lock = LockService ? LockService.getScriptLock() : null;
+    if (!lock) {
+      return callback();
+    }
+    lock.waitLock(30000);
+    try {
+      return callback();
+    } finally {
+      lock.releaseLock();
+    }
+  }
+
+  function list(name) {
+    var cacheKey = 'identity-table-' + name;
+    if (repositoryCache) {
+      var cached = repositoryCache.get(cacheKey);
+      if (cached) {
+        try {
+          return JSON.parse(cached);
+        } catch (err) {
+          repositoryCache.remove(cacheKey);
+        }
+      }
+    }
+
+    var sheet = ensureSheet(name);
+    var range = sheet.getDataRange();
+    var values = range.getValues();
+    if (values.length <= 1) {
+      return [];
+    }
+    var headers = values[0];
+    var rows = [];
+    for (var i = 1; i < values.length; i++) {
+      var row = values[i];
+      if (row.join('').trim() === '') {
+        continue;
+      }
+      var obj = {};
+      headers.forEach(function(header, idx) {
+        obj[String(header)] = row[idx];
+      });
+      rows.push(obj);
+    }
+
+    if (repositoryCache) {
+      repositoryCache.put(cacheKey, JSON.stringify(rows), CACHE_TTL_SECONDS);
+    }
+    return rows;
+  }
+
+  function write(name, rows) {
+    var sheet = ensureSheet(name);
+    var headers = TABLE_HEADERS[name];
+    var values = [headers];
+    rows.forEach(function(row) {
+      var arr = headers.map(function(header) {
+        return (row && Object.prototype.hasOwnProperty.call(row, header)) ? row[header] : '';
+      });
+      values.push(arr);
+    });
+    sheet.clearContents();
+    sheet.getRange(1, 1, values.length, headers.length).setValues(values);
+    if (repositoryCache) {
+      repositoryCache.remove('identity-table-' + name);
+    }
+  }
+
+  function upsert(name, key, payload) {
+    if (!payload || !key) {
+      throw new Error('Invalid upsert payload for ' + name);
+    }
+    return withLock('identity-upsert-' + name, function() {
+      var rows = list(name);
+      var found = false;
+      for (var i = 0; i < rows.length; i++) {
+        if (rows[i][key] === payload[key]) {
+          rows[i] = Object.assign({}, rows[i], payload);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        rows.push(payload);
+      }
+      write(name, rows);
+      return payload;
+    });
+  }
+
+  function remove(name, key, value) {
+    return withLock('identity-remove-' + name, function() {
+      var rows = list(name).filter(function(row) {
+        return row[key] !== value;
+      });
+      write(name, rows);
+    });
+  }
+
+  function append(name, payload) {
+    var sheet = ensureSheet(name);
+    var headers = TABLE_HEADERS[name];
+    var row = headers.map(function(header) {
+      return (payload && Object.prototype.hasOwnProperty.call(payload, header)) ? payload[header] : '';
+    });
+    sheet.appendRow(row);
+    if (repositoryCache) {
+      repositoryCache.remove('identity-table-' + name);
+    }
+    return payload;
+  }
+
+  function find(name, predicate) {
+    var rows = list(name);
+    for (var i = 0; i < rows.length; i++) {
+      if (predicate(rows[i])) {
+        return rows[i];
+      }
+    }
+    return null;
+  }
+
+  global.IdentityRepository = {
+    list: list,
+    append: append,
+    upsert: upsert,
+    remove: remove,
+    find: find,
+    ensureSheet: ensureSheet,
+    TABLE_HEADERS: TABLE_HEADERS
+  };
+})(GLOBAL_SCOPE);

--- a/PolicyService.gs
+++ b/PolicyService.gs
@@ -1,0 +1,90 @@
+/**
+ * PolicyService.gs
+ * -----------------------------------------------------------------------------
+ * Provides read/write helpers for Policies, FeatureFlags, and EligibilityRules.
+ */
+(function bootstrapPolicyService(global) {
+  if (!global) return;
+  if (global.PolicyService && typeof global.PolicyService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var RBACService = global.RBACService;
+  var Utilities = global.Utilities;
+
+  if (!IdentityRepository || !RBACService) {
+    throw new Error('PolicyService requires IdentityRepository and RBACService');
+  }
+
+  function listPolicies(scope) {
+    var rows = IdentityRepository.list('Policies');
+    if (!scope) {
+      return rows;
+    }
+    return rows.filter(function(row) {
+      return row.Scope === scope || row.Scope === 'Global';
+    });
+  }
+
+  function upsertPolicy(actor, payload) {
+    RBACService.assertPermission(actor.UserId, payload.CampaignId || '', RBACService.CAPABILITIES.MANAGE_POLICIES, actor.Roles);
+    var record = {
+      PolicyId: payload.PolicyId || Utilities.getUuid(),
+      Name: payload.Name,
+      Scope: payload.Scope || (payload.CampaignId ? payload.CampaignId : 'Global'),
+      Key: payload.Key,
+      Value: payload.Value,
+      UpdatedAt: new Date().toISOString()
+    };
+    IdentityRepository.upsert('Policies', 'PolicyId', record);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: payload.CampaignId || '',
+      Target: 'Policy:' + record.Key,
+      Action: 'POLICY_UPSERT',
+      After: record
+    });
+    return record;
+  }
+
+  function listFeatureFlags() {
+    return IdentityRepository.list('FeatureFlags');
+  }
+
+  function setFeatureFlag(actor, flag, value) {
+    RBACService.assertPermission(actor.UserId, actor.CampaignId || '', RBACService.CAPABILITIES.MANAGE_POLICIES, actor.Roles);
+    var record = {
+      Flag: flag,
+      Value: value,
+      Notes: '',
+      UpdatedAt: new Date().toISOString()
+    };
+    IdentityRepository.upsert('FeatureFlags', 'Flag', record);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: actor.CampaignId || '',
+      Target: 'FeatureFlag:' + flag,
+      Action: 'FLAG_UPDATE',
+      After: record
+    });
+    return record;
+  }
+
+  function listEligibilityRules(campaignId) {
+    var rows = IdentityRepository.list('EligibilityRules');
+    return rows.filter(function(row) {
+      return row.Scope === 'Global' || row.Scope === campaignId;
+    });
+  }
+
+  global.PolicyService = {
+    listPolicies: listPolicies,
+    upsertPolicy: upsertPolicy,
+    listFeatureFlags: listFeatureFlags,
+    setFeatureFlag: setFeatureFlag,
+    listEligibilityRules: listEligibilityRules
+  };
+})(GLOBAL_SCOPE);

--- a/RBACService.gs
+++ b/RBACService.gs
@@ -1,0 +1,120 @@
+/**
+ * RBACService.gs
+ * -----------------------------------------------------------------------------
+ * Centralized role-based access control provider for Lumina Identity. Roles and
+ * capabilities are loaded from the RolePermissions sheet. The service exposes
+ * helpers to determine whether an actor is authorised to perform a capability
+ * within a given scope.
+ */
+(function bootstrapRBACService(global) {
+  if (!global) return;
+  if (global.RBACService && typeof global.RBACService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+
+  if (!IdentityRepository) {
+    throw new Error('RBACService requires IdentityRepository bootstrap');
+  }
+
+  var CAPABILITIES = {
+    VIEW_USERS: 'VIEW_USERS',
+    MANAGE_USERS: 'MANAGE_USERS',
+    ASSIGN_ROLES: 'ASSIGN_ROLES',
+    TRANSFER_USERS: 'TRANSFER_USERS',
+    TERMINATE_USERS: 'TERMINATE_USERS',
+    MANAGE_EQUIPMENT: 'MANAGE_EQUIPMENT',
+    VIEW_AUDIT: 'VIEW_AUDIT',
+    MANAGE_POLICIES: 'MANAGE_POLICIES'
+  };
+
+  function getRolePermissions(role) {
+    return IdentityRepository.list('RolePermissions').filter(function(row) {
+      return row.Role === role;
+    });
+  }
+
+  function isAllowed(role, capability, campaignContext) {
+    var permissions = getRolePermissions(role);
+    var allowed = permissions.some(function(permission) {
+      if (permission.Capability !== capability) {
+        return false;
+      }
+      return permission.Allowed === 'Y' || permission.Allowed === true;
+    });
+    if (!allowed) {
+      return false;
+    }
+    if (!campaignContext) {
+      return true;
+    }
+    if (role === 'System Admin' || role === 'CEO' || role === 'CTO') {
+      return true;
+    }
+    if (permissionScopeAllowsCampaign(permissions, capability, campaignContext.scope)) {
+      return true;
+    }
+    return false;
+  }
+
+  function permissionScopeAllowsCampaign(permissions, capability, scope) {
+    var relevant = permissions.filter(function(permission) {
+      return permission.Capability === capability;
+    });
+    if (!relevant.length) {
+      return false;
+    }
+    return relevant.some(function(permission) {
+      if (!permission.Scope) {
+        return false;
+      }
+      var normalized = String(permission.Scope).toLowerCase();
+      if (normalized === 'global') {
+        return true;
+      }
+      if (!scope) {
+        return false;
+      }
+      if (normalized === 'campaign') {
+        return scope === 'campaign';
+      }
+      if (normalized === 'team') {
+        return scope === 'team';
+      }
+      return false;
+    });
+  }
+
+  function campaignScopeForUser(userId, campaignId) {
+    var assignments = IdentityRepository.list('UserCampaigns').filter(function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    if (!assignments.length) {
+      return null;
+    }
+    return assignments.map(function(assignment) {
+      return assignment.Role;
+    });
+  }
+
+  function assertPermission(userId, campaignId, capability, actorRoles) {
+    var roles = actorRoles || campaignScopeForUser(userId, campaignId);
+    if (!roles || !roles.length) {
+      throw new Error('User lacks campaign assignment');
+    }
+    var granted = roles.some(function(role) {
+      return isAllowed(role, capability, { scope: 'campaign', campaignId: campaignId });
+    });
+    if (!granted) {
+      throw new Error('Permission denied: ' + capability);
+    }
+  }
+
+  global.RBACService = {
+    CAPABILITIES: CAPABILITIES,
+    isAllowed: isAllowed,
+    assertPermission: assertPermission,
+    campaignScopeForUser: campaignScopeForUser
+  };
+})(GLOBAL_SCOPE);

--- a/Router.gs
+++ b/Router.gs
@@ -1,0 +1,161 @@
+/**
+ * Router.gs
+ * -----------------------------------------------------------------------------
+ * Minimal API router for Lumina Identity actions. The router expects an action
+ * parameter and JSON body on POST requests. Responses are always JSON.
+ */
+var IdentityRouter = (function createIdentityRouter(global) {
+  var SessionService = global.SessionService;
+  var AuthService = global.AuthService;
+  var UserService = global.UserService;
+  var EquipmentService = global.EquipmentService;
+  var PolicyService = global.PolicyService;
+  var AuditService = global.AuditService;
+  var IdentityRepository = global.IdentityRepository;
+
+  function parseRequest(e) {
+    var body = {};
+    if (e && e.postData && e.postData.contents) {
+      try {
+        body = JSON.parse(e.postData.contents);
+      } catch (err) {
+        throw new Error('Invalid JSON body');
+      }
+    }
+    return {
+      action: (e.parameter && e.parameter.action) || body.action,
+      body: body,
+      sessionId: (e.parameter && e.parameter.sessionId) || body.sessionId,
+      csrf: (e.parameter && e.parameter.csrf) || body.csrf,
+      campaignId: (e.parameter && e.parameter.campaignId) || body.campaignId,
+      query: e.parameter || {},
+      ip: (e && e.context && e.context.clientIp) || '',
+      ua: (e && e.headers && e.headers['User-Agent']) || ''
+    };
+  }
+
+  function jsonResponse(payload, status) {
+    var output = ContentService.createTextOutput(JSON.stringify(payload));
+    output.setMimeType(ContentService.MimeType.JSON);
+    if (status) {
+      output.setContent(JSON.stringify(Object.assign({ status: status }, payload)));
+    }
+    return output;
+  }
+
+  function handlePost(e) {
+    try {
+      var request = parseRequest(e);
+      var result = dispatch(request, e);
+      return jsonResponse({ ok: true, result: result });
+    } catch (err) {
+      console.error('IdentityRouter error', err);
+      return jsonResponse({ ok: false, error: err.message || 'Request failed' });
+    }
+  }
+
+  function handleGet(e) {
+    try {
+      var action = e.parameter && e.parameter.action;
+      if (action === 'health') {
+        return jsonResponse({ ok: true, version: '1.0.0', timestamp: new Date().toISOString() });
+      }
+      return jsonResponse({ ok: false, error: 'Unsupported GET action' });
+    } catch (err) {
+      return jsonResponse({ ok: false, error: err.message || 'Request failed' });
+    }
+  }
+
+  function dispatch(request, rawEvent) {
+    var action = (request.action || '').toLowerCase();
+    switch (action) {
+      case 'auth/request-otp':
+        return AuthService.requestOtp(request.body.emailOrUsername, request.body.purpose, { ip: request.ip, ua: request.ua });
+      case 'auth/login':
+        return AuthService.login(request.body, { ip: request.ip, ua: request.ua });
+      case 'auth/verify-otp':
+        return AuthService.verifyOtp(request.body.email, request.body.code, request.body.purpose || 'login', { ip: request.ip, ua: request.ua });
+      case 'auth/enable-totp':
+        return AuthService.enableTotp(requireUserContext(request, rawEvent), request.body.secret, request.body.code);
+      case 'auth/disable-totp':
+        return AuthService.disableTotp(requireUserContext(request, rawEvent));
+      case 'auth/logout':
+        var context = requireSession(request);
+        AuthService.logout(request.sessionId, { userId: context.user.UserId, role: '', campaignId: context.session.CampaignId, ip: request.ip, ua: request.ua });
+        return true;
+      case 'users/list':
+        var actor = requireActor(request, rawEvent);
+        return UserService.listUsers(actor, request.body.campaignId || actor.CampaignId);
+      case 'users/create':
+        return UserService.createUser(requireActor(request, rawEvent), request.body);
+      case 'users/update':
+        return UserService.updateUser(requireActor(request, rawEvent), request.body.userId, request.body);
+      case 'users/transfer':
+        return UserService.transferUser(requireActor(request, rawEvent), request.body.userId, request.body.toCampaignId);
+      case 'users/lifecycle':
+        return UserService.updateLifecycle(requireActor(request, rawEvent), request.body.userId, request.body);
+      case 'equipment/assign':
+        return EquipmentService.assignEquipment(requireActor(request, rawEvent), request.body);
+      case 'equipment/update':
+        return EquipmentService.updateEquipment(requireActor(request, rawEvent), request.body.equipmentId, request.body);
+      case 'equipment/list':
+        return EquipmentService.listEquipment(requireActor(request, rawEvent), request.body);
+      case 'policies/list':
+        return PolicyService.listPolicies(request.body.scope || 'Global');
+      case 'audit/list':
+        return AuditService.list(request.body);
+      case 'health':
+        return { ok: true, version: '1.0.0' };
+      default:
+        throw new Error('Unsupported action: ' + action);
+    }
+  }
+
+  function requireActor(request, rawEvent) {
+    var context = requireSession(request);
+    var assignments = IdentityRepository.list('UserCampaigns').filter(function(row) {
+      return row.UserId === context.user.UserId;
+    });
+    var primary = assignments.find(function(row) { return row.IsPrimary === 'Y' || row.IsPrimary === true; });
+    return {
+      UserId: context.user.UserId,
+      Roles: assignments.map(function(row) { return row.Role; }),
+      PrimaryRole: primary ? primary.Role : '',
+      CampaignId: primary ? primary.CampaignId : '',
+      session: context.session
+    };
+  }
+
+  function requireUserContext(request) {
+    var context = requireSession(request);
+    return context.user;
+  }
+
+  function requireSession(request) {
+    if (!request.sessionId) {
+      throw new Error('Session required');
+    }
+    if (!SessionService.validateCsrf(request.sessionId, request.csrf)) {
+      throw new Error('Invalid CSRF token');
+    }
+    var session = SessionService.readSession(request.sessionId);
+    if (!session) {
+      throw new Error('Session expired');
+    }
+    var user = IdentityRepository.find('Users', function(row) { return row.UserId === session.UserId; });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    var renewed = SessionService.renewSession(session.SessionId);
+    return { session: renewed || session, user: user };
+  }
+
+  return {
+    handlePost: handlePost,
+    handleGet: handleGet
+  };
+})(GLOBAL_SCOPE);
+
+function doPost(e) {
+  return IdentityRouter.handlePost(e);
+}

--- a/SeedData.js
+++ b/SeedData.js
@@ -159,6 +159,202 @@ const SEED_LUMINA_ADMIN_PROFILE = {
   seedLabel: 'Lumina Administrator'
 };
 
+const IDENTITY_ROLE_SEED = [
+  { role: 'System Admin', description: 'Bootstrap superuser', isGlobal: 'Y', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_USERS', scope: 'Global' },
+    { capability: 'ASSIGN_ROLES', scope: 'Global' },
+    { capability: 'TRANSFER_USERS', scope: 'Global' },
+    { capability: 'TERMINATE_USERS', scope: 'Global' },
+    { capability: 'MANAGE_EQUIPMENT', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' },
+    { capability: 'MANAGE_POLICIES', scope: 'Global' }
+  ] },
+  { role: 'CEO', description: 'Executive leadership', isGlobal: 'Y', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'COO', description: 'Operations executive', isGlobal: 'Y', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_USERS', scope: 'Global' },
+    { capability: 'TRANSFER_USERS', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'CFO', description: 'Finance leadership', isGlobal: 'Y', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'CTO', description: 'Technology leadership', isGlobal: 'Y', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_POLICIES', scope: 'Global' }
+  ] },
+  { role: 'Call Center Director', description: 'Multi-campaign operations leader', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_USERS', scope: 'Global' },
+    { capability: 'ASSIGN_ROLES', scope: 'Global' },
+    { capability: 'TRANSFER_USERS', scope: 'Global' },
+    { capability: 'TERMINATE_USERS', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'Operations Manager', description: 'Multi-campaign operations manager', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_USERS', scope: 'Global' },
+    { capability: 'ASSIGN_ROLES', scope: 'Global' },
+    { capability: 'TRANSFER_USERS', scope: 'Global' },
+    { capability: 'TERMINATE_USERS', scope: 'Global' },
+    { capability: 'MANAGE_EQUIPMENT', scope: 'Global' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'Account Manager', description: 'Client-facing operations lead', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Global' },
+    { capability: 'MANAGE_USERS', scope: 'Campaign' },
+    { capability: 'ASSIGN_ROLES', scope: 'Campaign' },
+    { capability: 'TRANSFER_USERS', scope: 'Campaign' },
+    { capability: 'TERMINATE_USERS', scope: 'Campaign' },
+    { capability: 'VIEW_AUDIT', scope: 'Campaign' }
+  ] },
+  { role: 'Workforce Manager', description: 'Workforce management', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' }
+  ] },
+  { role: 'Quality Assurance Manager', description: 'QA manager', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' }
+  ] },
+  { role: 'Training Manager', description: 'Training oversight', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' }
+  ] },
+  { role: 'Team Supervisor', description: 'Team-level supervisor', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Team' }
+  ] },
+  { role: 'Floor Supervisor', description: 'Floor supervisor', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Team' }
+  ] },
+  { role: 'Escalations Manager', description: 'Escalations oversight', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'TRANSFER_USERS', scope: 'Campaign' }
+  ] },
+  { role: 'Client Success Manager', description: 'Client delivery partner', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'VIEW_AUDIT', scope: 'Campaign' }
+  ] },
+  { role: 'Compliance Manager', description: 'Compliance oversight', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'MANAGE_POLICIES', scope: 'Campaign' },
+    { capability: 'VIEW_AUDIT', scope: 'Global' }
+  ] },
+  { role: 'IT Support Manager', description: 'IT device support', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'MANAGE_EQUIPMENT', scope: 'Campaign' }
+  ] },
+  { role: 'Reporting Analyst / Metrics Lead', description: 'Reporting & analytics', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'VIEW_AUDIT', scope: 'Campaign' }
+  ] },
+  { role: 'Campaign Manager', description: 'Primary campaign manager', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' },
+    { capability: 'MANAGE_USERS', scope: 'Campaign' },
+    { capability: 'ASSIGN_ROLES', scope: 'Campaign' },
+    { capability: 'TRANSFER_USERS', scope: 'Campaign' },
+    { capability: 'TERMINATE_USERS', scope: 'Campaign' },
+    { capability: 'MANAGE_EQUIPMENT', scope: 'Campaign' },
+    { capability: 'VIEW_AUDIT', scope: 'Campaign' }
+  ] },
+  { role: 'Guest (Client Owner)', description: 'Read-only client access', isGlobal: 'N', permissions: [
+    { capability: 'VIEW_USERS', scope: 'Campaign' }
+  ] }
+];
+
+const IDENTITY_CAMPAIGN_SEED = [
+  { CampaignId: 'lumina-hq', Name: 'Lumina HQ', Status: 'Active', ClientOwnerEmail: 'executive@lumina.com' },
+  { CampaignId: 'credit-suite', Name: 'Credit Suite', Status: 'Active', ClientOwnerEmail: 'client@creditsuite.com' }
+];
+
+function seedLuminaIdentity() {
+  if (typeof IdentityRepository === 'undefined' || typeof AuthService === 'undefined') {
+    throw new Error('Load IdentityRepository and AuthService before seeding identity data.');
+  }
+  var utilitiesService = (typeof globalThis !== 'undefined' && globalThis.Utilities) ? globalThis.Utilities
+    : (typeof Utilities !== 'undefined' ? Utilities : null);
+  if (!utilitiesService) {
+    throw new Error('Utilities service unavailable');
+  }
+  var now = new Date().toISOString();
+
+  IDENTITY_CAMPAIGN_SEED.forEach(function(campaign) {
+    IdentityRepository.upsert('Campaigns', 'CampaignId', Object.assign({
+      CreatedAt: now,
+      SettingsJSON: '{}'
+    }, campaign));
+  });
+
+  IDENTITY_ROLE_SEED.forEach(function(roleSeed) {
+    IdentityRepository.upsert('Roles', 'Role', {
+      Role: roleSeed.role,
+      Description: roleSeed.description,
+      IsGlobal: roleSeed.isGlobal
+    });
+    roleSeed.permissions.forEach(function(permission) {
+      IdentityRepository.upsert('RolePermissions', 'PermissionId', {
+        PermissionId: roleSeed.role + '::' + permission.capability + '::' + permission.scope,
+        Role: roleSeed.role,
+        Capability: permission.capability,
+        Scope: permission.scope,
+        Allowed: 'Y'
+      });
+    });
+  });
+
+  var adminEmail = 'identity.admin@lumina.com';
+  var existingAdmin = IdentityRepository.find('Users', function(row) {
+    return row.Email === adminEmail;
+  });
+  var tempPassword = 'ChangeMe!1!';
+  var adminId = existingAdmin ? existingAdmin.UserId : utilitiesService.getUuid();
+  var adminRecord = {
+    UserId: adminId,
+    Email: adminEmail,
+    Username: 'lumina.identity',
+    PasswordHash: AuthService.hashPassword(tempPassword),
+    EmailVerified: 'Y',
+    TOTPEnabled: 'N',
+    TOTPSecretHash: '',
+    Status: 'Active',
+    LastLoginAt: '',
+    CreatedAt: now
+  };
+  IdentityRepository.upsert('Users', 'UserId', adminRecord);
+
+  var assignment = {
+    AssignmentId: utilitiesService.getUuid(),
+    UserId: adminId,
+    CampaignId: 'lumina-hq',
+    Role: 'System Admin',
+    IsPrimary: 'Y',
+    AddedBy: 'seed',
+    AddedAt: now,
+    Watchlist: 'N'
+  };
+  IdentityRepository.upsert('UserCampaigns', 'AssignmentId', assignment);
+
+  var employmentExists = IdentityRepository.list('EmploymentStatus').some(function(row) {
+    return row.UserId === adminId && row.CampaignId === 'lumina-hq' && row.State === 'Active';
+  });
+  if (!employmentExists) {
+    IdentityRepository.append('EmploymentStatus', {
+      UserId: adminId,
+      CampaignId: 'lumina-hq',
+      State: 'Active',
+      EffectiveDate: now,
+      Reason: 'Seed data',
+      Notes: 'Seeded system administrator'
+    });
+  }
+
+  return {
+    adminEmail: adminEmail,
+    tempPassword: tempPassword
+  };
+}
+
 
 /**
  * Public entry point. Returns a structured summary of what was ensured.

--- a/SessionService.gs
+++ b/SessionService.gs
@@ -1,0 +1,200 @@
+/**
+ * SessionService.gs
+ * -----------------------------------------------------------------------------
+ * Encapsulates session handling for the Lumina Identity platform. Sessions are
+ * issued after successful authentication and persisted via CacheService with a
+ * fallback to PropertiesService to satisfy the 10–30 minute sliding expiration
+ * requirement.
+ */
+(function bootstrapSessionService(global) {
+  if (!global) return;
+  if (global.SessionService && typeof global.SessionService === 'object') {
+    return;
+  }
+
+  var CacheService = global.CacheService;
+  var PropertiesService = global.PropertiesService;
+  var Utilities = global.Utilities;
+  var IdentityRepository = global.IdentityRepository;
+  var DEFAULT_TTL_SECONDS = 20 * 60; // 20 minutes
+  var MIN_TTL_SECONDS = 10 * 60;
+  var MAX_TTL_SECONDS = 30 * 60;
+  var SESSION_PREFIX = 'session::';
+  var CSRF_PREFIX = 'csrf::';
+
+  if (!IdentityRepository) {
+    throw new Error('SessionService requires IdentityRepository bootstrap');
+  }
+
+  var cache = CacheService ? CacheService.getUserCache() : null;
+  var scriptProperties = PropertiesService ? PropertiesService.getScriptProperties() : null;
+
+  function now() {
+    return new Date().getTime();
+  }
+
+  function clampTtl(ttlSeconds) {
+    if (!ttlSeconds) {
+      return DEFAULT_TTL_SECONDS;
+    }
+    return Math.max(MIN_TTL_SECONDS, Math.min(MAX_TTL_SECONDS, ttlSeconds));
+  }
+
+  function generateId(prefix) {
+    var uuid = Utilities.getUuid();
+    return prefix ? prefix + uuid : uuid;
+  }
+
+  function persistSession(session) {
+    IdentityRepository.upsert('Sessions', 'SessionId', session);
+  }
+
+  function toCachePayload(session) {
+    return JSON.stringify(session);
+  }
+
+  function putCache(key, payload, ttlSeconds) {
+    if (!cache) {
+      return;
+    }
+    cache.put(key, payload, ttlSeconds);
+  }
+
+  function readCache(key) {
+    if (!cache) {
+      return null;
+    }
+    var cached = cache.get(key);
+    return cached || null;
+  }
+
+  function writeFallback(key, payload) {
+    if (!scriptProperties) {
+      return;
+    }
+    scriptProperties.setProperty(key, payload);
+  }
+
+  function readFallback(key) {
+    if (!scriptProperties) {
+      return null;
+    }
+    return scriptProperties.getProperty(key);
+  }
+
+  function deleteFallback(key) {
+    if (!scriptProperties) {
+      return;
+    }
+    scriptProperties.deleteProperty(key);
+  }
+
+  function issueSession(user, campaignId, ip, ua, ttlSeconds) {
+    var issuedAt = now();
+    var expiresAt = issuedAt + clampTtl(ttlSeconds) * 1000;
+    var session = {
+      SessionId: generateId('SID-'),
+      UserId: user.UserId,
+      CampaignId: campaignId,
+      IssuedAt: issuedAt,
+      ExpiresAt: expiresAt,
+      CSRF: generateCsrfToken(),
+      IP: ip || '',
+      UA: ua || ''
+    };
+    var payload = toCachePayload(session);
+    putCache(SESSION_PREFIX + session.SessionId, payload, clampTtl(ttlSeconds));
+    writeFallback(SESSION_PREFIX + session.SessionId, payload);
+    persistSession(session);
+    return session;
+  }
+
+  function generateCsrfToken() {
+    var randomBytes = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, Utilities.getUuid());
+    return Utilities.base64Encode(randomBytes).replace(/[^a-zA-Z0-9]/g, '').slice(0, 40);
+  }
+
+  function issueCsrf(sessionId) {
+    var token = generateCsrfToken();
+    putCache(CSRF_PREFIX + sessionId, token, clampTtl());
+    writeFallback(CSRF_PREFIX + sessionId, token);
+    return token;
+  }
+
+  function readSession(sessionId) {
+    if (!sessionId) {
+      return null;
+    }
+    var payload = readCache(SESSION_PREFIX + sessionId) || readFallback(SESSION_PREFIX + sessionId);
+    if (!payload) {
+      return null;
+    }
+    try {
+      var session = JSON.parse(payload);
+      if (session.ExpiresAt && session.ExpiresAt < now()) {
+        invalidateSession(sessionId);
+        return null;
+      }
+      return session;
+    } catch (err) {
+      invalidateSession(sessionId);
+      return null;
+    }
+  }
+
+  function validateCsrf(sessionId, token) {
+    if (!sessionId || !token) {
+      return false;
+    }
+    var expected = readCache(CSRF_PREFIX + sessionId) || readFallback(CSRF_PREFIX + sessionId);
+    return expected && expected === token;
+  }
+
+  function renewSession(sessionId, ttlSeconds) {
+    var session = readSession(sessionId);
+    if (!session) {
+      return null;
+    }
+    var issuedAt = now();
+    session.IssuedAt = issuedAt;
+    session.ExpiresAt = issuedAt + clampTtl(ttlSeconds) * 1000;
+    var payload = toCachePayload(session);
+    putCache(SESSION_PREFIX + sessionId, payload, clampTtl(ttlSeconds));
+    writeFallback(SESSION_PREFIX + sessionId, payload);
+    IdentityRepository.upsert('Sessions', 'SessionId', session);
+    return session;
+  }
+
+  function invalidateSession(sessionId) {
+    if (!sessionId) {
+      return;
+    }
+    if (cache) {
+      cache.remove(SESSION_PREFIX + sessionId);
+      cache.remove(CSRF_PREFIX + sessionId);
+    }
+    deleteFallback(SESSION_PREFIX + sessionId);
+    deleteFallback(CSRF_PREFIX + sessionId);
+    IdentityRepository.remove('Sessions', 'SessionId', sessionId);
+  }
+
+  function invalidateUserSessions(userId) {
+    var sessions = IdentityRepository.list('Sessions').filter(function(row) {
+      return row.UserId === userId;
+    });
+    sessions.forEach(function(session) {
+      invalidateSession(session.SessionId);
+    });
+  }
+
+  global.SessionService = {
+    issueSession: issueSession,
+    renewSession: renewSession,
+    invalidateSession: invalidateSession,
+    invalidateUserSessions: invalidateUserSessions,
+    readSession: readSession,
+    issueCsrf: issueCsrf,
+    validateCsrf: validateCsrf,
+    DEFAULT_TTL_SECONDS: DEFAULT_TTL_SECONDS
+  };
+})(GLOBAL_SCOPE);

--- a/UserService.gs
+++ b/UserService.gs
@@ -1,0 +1,231 @@
+/**
+ * UserService.gs
+ * -----------------------------------------------------------------------------
+ * User administration, lifecycle, and transfer management.
+ */
+(function bootstrapUserService(global) {
+  if (!global) return;
+  if (global.UserService && typeof global.UserService === 'object') {
+    return;
+  }
+
+  var IdentityRepository = global.IdentityRepository;
+  var RBACService = global.RBACService;
+  var AuthService = global.AuthService;
+  var EquipmentService = global.EquipmentService;
+  var AuditService = global.AuditService;
+  var EligibilityService = global.EligibilityService;
+  var Utilities = global.Utilities;
+
+  if (!IdentityRepository || !RBACService || !AuthService || !AuditService) {
+    throw new Error('UserService dependencies missing');
+  }
+
+  function listUsers(actor, campaignId) {
+    RBACService.assertPermission(actor.UserId, campaignId, RBACService.CAPABILITIES.VIEW_USERS, actor.Roles);
+    return IdentityRepository.list('UserCampaigns')
+      .filter(function(row) { return row.CampaignId === campaignId; })
+      .map(function(row) {
+        var user = IdentityRepository.find('Users', function(item) { return item.UserId === row.UserId; });
+        if (!user) {
+          return null;
+        }
+        var eligibility = EligibilityService ? EligibilityService.evaluateEligibility(row.UserId, campaignId) : [];
+        return {
+          AssignmentId: row.AssignmentId,
+          UserId: user.UserId,
+          Email: user.Email,
+          Username: user.Username,
+          Role: row.Role,
+          Status: user.Status,
+          Watchlist: row.Watchlist,
+          Eligibility: eligibility
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function createUser(actor, payload) {
+    RBACService.assertPermission(actor.UserId, payload.CampaignId, RBACService.CAPABILITIES.MANAGE_USERS, actor.Roles);
+    AuthService.validatePassword(payload.password);
+    var now = new Date().toISOString();
+    var userId = payload.UserId || Utilities.getUuid();
+    var record = {
+      UserId: userId,
+      Email: payload.Email,
+      Username: payload.Username || payload.Email,
+      PasswordHash: AuthService.hashPassword(payload.password),
+      EmailVerified: payload.EmailVerified ? 'Y' : 'N',
+      TOTPEnabled: 'N',
+      TOTPSecretHash: '',
+      Status: payload.Status || 'Active',
+      LastLoginAt: '',
+      CreatedAt: now
+    };
+    IdentityRepository.upsert('Users', 'UserId', record);
+    addUserCampaignAssignment(actor, userId, payload.CampaignId, payload.Role, payload.IsPrimary);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: payload.CampaignId,
+      Target: userId,
+      Action: 'USER_CREATED',
+      After: record
+    });
+    return record;
+  }
+
+  function addUserCampaignAssignment(actor, userId, campaignId, role, isPrimary) {
+    RBACService.assertPermission(actor.UserId, campaignId, RBACService.CAPABILITIES.ASSIGN_ROLES, actor.Roles);
+    var record = {
+      AssignmentId: Utilities.getUuid(),
+      UserId: userId,
+      CampaignId: campaignId,
+      Role: role,
+      IsPrimary: isPrimary ? 'Y' : 'N',
+      AddedBy: actor.UserId,
+      AddedAt: new Date().toISOString(),
+      Watchlist: 'N'
+    };
+    IdentityRepository.upsert('UserCampaigns', 'AssignmentId', record);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: campaignId,
+      Target: userId,
+      Action: 'ROLE_ASSIGNED',
+      After: record
+    });
+  }
+
+  function updateUser(actor, userId, updates) {
+    var user = IdentityRepository.find('Users', function(row) { return row.UserId === userId; });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    RBACService.assertPermission(actor.UserId, updates.CampaignId, RBACService.CAPABILITIES.MANAGE_USERS, actor.Roles);
+    var updated = Object.assign({}, user, updates);
+    if (updates.password) {
+      AuthService.validatePassword(updates.password);
+      updated.PasswordHash = AuthService.hashPassword(updates.password);
+    }
+    IdentityRepository.upsert('Users', 'UserId', updated);
+    if (typeof updates.Watchlist !== 'undefined') {
+      updateWatchlist(userId, updates.CampaignId, updates.Watchlist, actor);
+    }
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: updates.CampaignId,
+      Target: userId,
+      Action: 'USER_UPDATED',
+      Before: user,
+      After: updated
+    });
+    return updated;
+  }
+
+  function updateWatchlist(userId, campaignId, value, actor) {
+    var assignment = IdentityRepository.find('UserCampaigns', function(row) {
+      return row.UserId === userId && row.CampaignId === campaignId;
+    });
+    if (!assignment) {
+      throw new Error('User is not assigned to campaign');
+    }
+    var updated = Object.assign({}, assignment, {
+      Watchlist: value ? 'Y' : 'N'
+    });
+    IdentityRepository.upsert('UserCampaigns', 'AssignmentId', updated);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: campaignId,
+      Target: userId,
+      Action: value ? 'WATCHLIST_ADDED' : 'WATCHLIST_REMOVED'
+    });
+  }
+
+  function transferUser(actor, userId, toCampaignId) {
+    var existing = IdentityRepository.list('UserCampaigns').filter(function(row) { return row.UserId === userId; });
+    if (!existing.length) {
+      throw new Error('User has no assignments');
+    }
+    RBACService.assertPermission(actor.UserId, toCampaignId, RBACService.CAPABILITIES.TRANSFER_USERS, actor.Roles);
+    var roleToCarry = existing[0].Role;
+    existing.forEach(function(assignment) {
+      IdentityRepository.remove('UserCampaigns', 'AssignmentId', assignment.AssignmentId);
+    });
+    addUserCampaignAssignment(actor, userId, toCampaignId, roleToCarry || 'Team Member', true);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: toCampaignId,
+      Target: userId,
+      Action: 'USER_TRANSFERRED',
+      Before: existing,
+      After: { campaignId: toCampaignId }
+    });
+  }
+
+  function updateLifecycle(actor, userId, payload) {
+    var campaignId = payload.CampaignId;
+    RBACService.assertPermission(actor.UserId, campaignId, RBACService.CAPABILITIES.MANAGE_USERS, actor.Roles);
+    if (['Terminated', 'Resigned'].indexOf(payload.State) >= 0 && !payload.Override && EquipmentService.hasOutstandingEquipment(userId, campaignId)) {
+      throw new Error('Outstanding equipment must be returned before termination.');
+    }
+    var existingUser = IdentityRepository.find('Users', function(row) { return row.UserId === userId; });
+    var record = {
+      UserId: userId,
+      CampaignId: campaignId,
+      State: payload.State,
+      EffectiveDate: payload.EffectiveDate || new Date().toISOString(),
+      Reason: payload.Reason || '',
+      Notes: payload.Notes || ''
+    };
+    if (existingUser) {
+      var nextStatus = existingUser.Status;
+      if (payload.State === 'Terminated' || payload.State === 'Resigned') {
+        nextStatus = 'Locked';
+      }
+      IdentityRepository.upsert('Users', 'UserId', Object.assign({}, existingUser, { Status: nextStatus }));
+    }
+    IdentityRepository.append('EmploymentStatus', record);
+    AuditService.log({
+      ActorUserId: actor.UserId,
+      ActorRole: actor.PrimaryRole,
+      CampaignId: campaignId,
+      Target: userId,
+      Action: 'LIFECYCLE_UPDATE',
+      After: record
+    });
+    return record;
+  }
+
+  function getUserProfile(actor, userId, campaignId) {
+    RBACService.assertPermission(actor.UserId, campaignId, RBACService.CAPABILITIES.VIEW_USERS, actor.Roles);
+    var user = IdentityRepository.find('Users', function(row) { return row.UserId === userId; });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    var assignments = IdentityRepository.list('UserCampaigns').filter(function(row) {
+      return row.UserId === userId;
+    });
+    var equipment = EquipmentService.listEquipment(actor, { userId: userId, campaignId: campaignId });
+    var eligibility = EligibilityService ? EligibilityService.evaluateEligibility(userId, campaignId) : [];
+    return {
+      user: user,
+      assignments: assignments,
+      equipment: equipment,
+      eligibility: eligibility
+    };
+  }
+
+  global.UserService = {
+    listUsers: listUsers,
+    createUser: createUser,
+    updateUser: updateUser,
+    transferUser: transferUser,
+    updateLifecycle: updateLifecycle,
+    getUserProfile: getUserProfile
+  };
+})(GLOBAL_SCOPE);

--- a/tests/IdentityTests.gs
+++ b/tests/IdentityTests.gs
@@ -1,0 +1,121 @@
+/**
+ * tests/IdentityTests.gs
+ * -----------------------------------------------------------------------------
+ * Lightweight unit tests for critical Lumina Identity flows. Execute
+ * `runIdentityTests()` from the Apps Script editor to validate OTP/TOTP,
+ * RBAC, and lifecycle safeguards after deployment.
+ */
+function runIdentityTests() {
+  var results = [];
+  results.push(testTotpVerification());
+  results.push(testRbacEnforcement());
+  results.push(testLifecycleTerminationGuard());
+  return results;
+}
+
+function testTotpVerification() {
+  var secret = 'JBSWY3DPEHPK3PXP'; // Base32 for "Hello!"
+  var originalNow = Date.now;
+  try {
+    Date.now = function() { return 0; };
+    var expectedCode = generateTotp(secret, 0);
+    var passed = AuthService.verifyTotpCode(secret, expectedCode);
+    return formatTestResult('TOTP verification accepts valid codes', passed);
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+function testRbacEnforcement() {
+  var originalList = IdentityRepository.list;
+  try {
+    IdentityRepository.list = function(name) {
+      if (name === 'RolePermissions') {
+        return [
+          { Role: 'Campaign Manager', Capability: 'VIEW_USERS', Scope: 'Campaign', Allowed: 'Y' },
+          { Role: 'Guest (Client Owner)', Capability: 'VIEW_USERS', Scope: 'Campaign', Allowed: 'Y' }
+        ];
+      }
+      if (name === 'UserCampaigns') {
+        return [
+          { AssignmentId: '1', UserId: 'user-1', CampaignId: 'camp-1', Role: 'Campaign Manager', IsPrimary: 'Y', Watchlist: 'N' }
+        ];
+      }
+      return [];
+    };
+    var managerAllowed = RBACService.isAllowed('Campaign Manager', RBACService.CAPABILITIES.MANAGE_USERS, { scope: 'campaign' });
+    var guestAllowed = RBACService.isAllowed('Guest (Client Owner)', RBACService.CAPABILITIES.MANAGE_USERS, { scope: 'campaign' });
+    var passed = managerAllowed === false && guestAllowed === false;
+    return formatTestResult('RBAC denies MANAGE_USERS for guests', passed);
+  } finally {
+    IdentityRepository.list = originalList;
+  }
+}
+
+function testLifecycleTerminationGuard() {
+  var originalAssert = RBACService.assertPermission;
+  var originalEquipment = EquipmentService.hasOutstandingEquipment;
+  var originalAppend = IdentityRepository.append;
+  var originalAudit = AuditService.log;
+  try {
+    RBACService.assertPermission = function() { return true; };
+    EquipmentService.hasOutstandingEquipment = function() { return true; };
+    IdentityRepository.append = function() { throw new Error('Should not append when blocked'); };
+    AuditService.log = function() {};
+    var threw = false;
+    try {
+      UserService.updateLifecycle({ UserId: 'actor-1', Roles: ['Campaign Manager'], PrimaryRole: 'Campaign Manager' }, 'user-1', {
+        CampaignId: 'camp-1',
+        State: 'Terminated',
+        EffectiveDate: new Date().toISOString()
+      });
+    } catch (err) {
+      threw = err && err.message && err.message.indexOf('Outstanding equipment') >= 0;
+    }
+    return formatTestResult('Lifecycle termination blocked when equipment outstanding', threw);
+  } finally {
+    RBACService.assertPermission = originalAssert;
+    EquipmentService.hasOutstandingEquipment = originalEquipment;
+    IdentityRepository.append = originalAppend;
+    AuditService.log = originalAudit;
+  }
+}
+
+function generateTotp(secret, timestamp) {
+  var counter = Math.floor(timestamp / 30000);
+  var bytes = [];
+  for (var i = 7; i >= 0; i--) {
+    bytes[i] = counter & 0xff;
+    counter = Math.floor(counter / 256);
+  }
+  var keyBytes = (function base32Decode(value) {
+    var alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    value = value.replace(/=+$/, '').toUpperCase();
+    var bits = '';
+    for (var i = 0; i < value.length; i++) {
+      var idx = alphabet.indexOf(value.charAt(i));
+      if (idx < 0) continue;
+      bits += ('00000' + idx.toString(2)).slice(-5);
+    }
+    var out = [];
+    for (var j = 0; j + 8 <= bits.length; j += 8) {
+      out.push(parseInt(bits.slice(j, j + 8), 2));
+    }
+    return out;
+  })(secret);
+  var hmac = Utilities.computeHmacSha1Signature(bytes, keyBytes);
+  var offset = hmac[hmac.length - 1] & 0x0f;
+  var binary = ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  var otp = (binary % 1000000).toString();
+  while (otp.length < 6) {
+    otp = '0' + otp;
+  }
+  return otp;
+}
+
+function formatTestResult(message, passed) {
+  return { message: message, passed: !!passed };
+}


### PR DESCRIPTION
## Summary
- add dedicated identity repository and services covering authentication, sessions, RBAC, lifecycle, equipment, policies, and audits
- wire a JSON API router plus HtmlService landing, login, and campaign workspace views for the new identity experience
- document setup and seeding for Lumina Identity and provide Apps Script unit tests for critical flows

## Testing
- not run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb85aafb988326a6b963d75e4b5c0b