### PR TITLE
Add routing and links to the login experience

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -3177,7 +3177,35 @@ function attachTokenToUrl_(url, token, queryParam) {
 }
 
 function renderLoginPage(e, options) {
-  return HtmlService.createHtmlOutput('Authentication is not available.').setTitle('Authentication Unavailable');
+  return createLoginPageOutput_({
+    baseUrl: getBaseUrl(),
+    scriptUrl: SCRIPT_URL,
+    returnUrl: options && options.returnUrl ? options.returnUrl : '',
+    message: options && options.message ? options.message : '',
+    sessionId: options && options.sessionId ? options.sessionId : '',
+    csrfToken: options && options.csrfToken ? options.csrfToken : ''
+  });
+}
+
+function createLoginPageOutput_(context) {
+  try {
+    const tpl = HtmlService.createTemplateFromFile('Html/LuminaIdentityLogin');
+    tpl.baseUrl = (context && context.baseUrl) || '';
+    tpl.scriptUrl = (context && context.scriptUrl) || '';
+    tpl.returnUrl = (context && context.returnUrl) || '';
+    tpl.message = (context && context.message) || '';
+    tpl.sessionId = (context && context.sessionId) || '';
+    tpl.csrfToken = (context && context.csrfToken) || '';
+
+    return tpl
+      .evaluate()
+      .setTitle('Sign in – Lumina Identity')
+      .addMetaTag('viewport', 'width=device-width,initial-scale=1')
+      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+  } catch (err) {
+    console.error('createLoginPageOutput_: failed to render login page', err);
+    return HtmlService.createHtmlOutput('Authentication is not available.').setTitle('Authentication Unavailable');
+  }
 }
 
 
@@ -4212,6 +4240,14 @@ function handlePublicPage(page, e, baseUrl) {
         .setTitle('LuminaHQ User Guide')
         .addMetaTag('viewport', 'width=device-width,initial-scale=1')
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+
+    case 'login':
+      return createLoginPageOutput_({
+        baseUrl: baseUrl,
+        scriptUrl: scriptUrl,
+        returnUrl: (e && e.parameter && (e.parameter.returnUrl || e.parameter.return || e.parameter.redirect)) || '',
+        message: (e && e.parameter && e.parameter.message) || ''
+      });
 
     case 'forgotpassword':
     case 'forgot-password':

--- a/Html/LuminaIdentityLogin.html
+++ b/Html/LuminaIdentityLogin.html
@@ -1,7 +1,17 @@
 <!DOCTYPE html>
+<?
+  var loginBaseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '';
+  var loginScriptUrl = (typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : '';
+  var loginReturnUrl = (typeof returnUrl !== 'undefined' && returnUrl) ? returnUrl : '';
+  var loginMessage = (typeof message !== 'undefined' && message) ? message : '';
+  var loginSessionId = (typeof sessionId !== 'undefined' && sessionId) ? sessionId : '';
+  var loginCsrfToken = (typeof csrfToken !== 'undefined' && csrfToken) ? csrfToken : '';
+?>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <base target="_top">
   <title>Sign in – Lumina Identity</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap">
   <style>
@@ -39,8 +49,8 @@
         Authenticator code
         <input id="totp" type="text" maxlength="6" inputmode="numeric" pattern="\\d{6}">
       </label>
-      <input type="hidden" id="sessionId">
-      <input type="hidden" id="csrf">
+      <input type="hidden" id="sessionId" value="<?= loginSessionId ?>">
+      <input type="hidden" id="csrf" value="<?= loginCsrfToken ?>">
       <button type="submit">Sign in</button>
     </form>
     <div class="alt">
@@ -48,25 +58,66 @@
     </div>
   </div>
   <script>
+    const loginContext = {
+      baseUrl: <?= JSON.stringify(loginBaseUrl) ?>,
+      scriptUrl: <?= JSON.stringify(loginScriptUrl) ?>,
+      returnUrl: <?= JSON.stringify(loginReturnUrl) ?>,
+      message: <?= JSON.stringify(loginMessage) ?>,
+      sessionId: <?= JSON.stringify(loginSessionId) ?>,
+      csrfToken: <?= JSON.stringify(loginCsrfToken) ?>
+    };
+
     const statusEl = document.getElementById('status');
     const otpWrapper = document.getElementById('otp-wrapper');
     const totpWrapper = document.getElementById('totp-wrapper');
     const sessionInput = document.getElementById('sessionId');
     const csrfInput = document.getElementById('csrf');
 
-    function setStatus(message, isError) {
-      statusEl.textContent = message;
-      statusEl.classList.toggle('error', !!isError);
-      statusEl.style.display = message ? 'block' : 'none';
+    function revealSecondFactorsFromMessage(message) {
+      if (!message) {
+        return;
+      }
+      if (/otp|code/i.test(message)) {
+        otpWrapper.style.display = 'block';
+      }
+      if (/totp|authenticator/i.test(message)) {
+        totpWrapper.style.display = 'block';
+      }
     }
 
+    function setStatus(message, isError) {
+      statusEl.textContent = message || '';
+      statusEl.classList.toggle('error', !!isError);
+      statusEl.style.display = message ? 'block' : 'none';
+      if (message) {
+        revealSecondFactorsFromMessage(message);
+      }
+    }
+
+    const endpoint =
+      (loginContext.scriptUrl && loginContext.scriptUrl.trim()) ||
+      (loginContext.baseUrl && loginContext.baseUrl.trim()) ||
+      window.location.href.split('#')[0];
+
     async function api(action, payload) {
-      const response = await fetch('', {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(Object.assign({ action }, payload || {}))
       });
-      return response.json();
+
+      let data = {};
+      try {
+        data = await response.json();
+      } catch (err) {
+        throw new Error('Unexpected response from server');
+      }
+
+      return data;
+    }
+
+    if (loginContext.message) {
+      setStatus(loginContext.message, false);
     }
 
     document.getElementById('login-form').addEventListener('submit', async (event) => {
@@ -80,16 +131,18 @@
           totp: document.getElementById('totp').value || undefined
         };
         const result = await api('auth/login', payload);
-        if (!result.ok) {
-          throw new Error(result.error || 'Unable to sign in');
+        if (!result || result.ok !== true || !result.result) {
+          throw new Error((result && result.error) || 'Unable to sign in');
         }
-        sessionInput.value = result.result.SessionId;
-        csrfInput.value = result.result.CSRF;
+        sessionInput.value = result.result.SessionId || '';
+        csrfInput.value = result.result.CSRF || '';
         setStatus('Success! Redirecting...');
-        setTimeout(() => window.location.href = '?page=dashboard', 900);
+        const redirectTarget = (loginContext.returnUrl && loginContext.returnUrl.trim()) || '?page=dashboard';
+        setTimeout(() => {
+          window.location.href = redirectTarget;
+        }, 900);
       } catch (err) {
-        setStatus(err.message, true);
-        otpWrapper.style.display = 'block';
+        setStatus(err.message || 'Unable to sign in', true);
       }
     });
 
@@ -98,18 +151,21 @@
       try {
         const identity = document.getElementById('identity').value;
         if (!identity) {
-          return setStatus('Enter your email or username first.', true);
+          setStatus('Enter your email or username first.', true);
+          return;
         }
         const response = await api('auth/request-otp', { emailOrUsername: identity, purpose: 'login' });
-        if (!response.ok) {
-          throw new Error(response.error || 'Unable to send code');
+        if (!response || response.ok !== true) {
+          throw new Error((response && response.error) || 'Unable to send code');
         }
         setStatus('Check your email for a six digit code.');
         otpWrapper.style.display = 'block';
       } catch (err) {
-        setStatus(err.message, true);
+        setStatus(err.message || 'Unable to send code', true);
       }
     });
+
+    revealSecondFactorsFromMessage(loginContext.message);
   </script>
 </body>
 </html>

--- a/Landing.html
+++ b/Landing.html
@@ -154,6 +154,36 @@
         padding: 0;
       }
 
+      .nav-actions {
+        display: inline-flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .nav-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.65rem 1.2rem;
+        border-radius: 999px;
+        color: var(--violet);
+        font-weight: 600;
+        text-decoration: none;
+        background: rgba(99, 102, 241, 0.12);
+        transition: var(--transition);
+      }
+
+      .nav-link i {
+        font-size: 0.95rem;
+      }
+
+      .nav-link:hover,
+      .nav-link:focus {
+        color: var(--white);
+        background: linear-gradient(120deg, rgba(99, 102, 241, 0.9), rgba(37, 99, 235, 0.9));
+        box-shadow: 0 18px 32px rgba(79, 70, 229, 0.28);
+      }
+
       nav a {
         text-decoration: none;
         color: var(--stone);
@@ -847,7 +877,14 @@
           flex-wrap: wrap;
         }
 
-        .nav-cta {
+        .nav-actions {
+          width: 100%;
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
+        .nav-actions .nav-link,
+        .nav-actions .nav-cta {
           width: 100%;
           justify-content: center;
         }
@@ -945,10 +982,16 @@
             <li><a href="#insights">Insights</a></li>
           </ul>
         </nav>
-        <a class="nav-cta" href="#cta">
-          <i class="fa-solid fa-paper-plane"></i>
-          Request access
-        </a>
+        <div class="nav-actions">
+          <a class="nav-link" href="?page=login">
+            <i class="fa-solid fa-right-to-bracket"></i>
+            Sign in
+          </a>
+          <a class="nav-cta" href="#cta">
+            <i class="fa-solid fa-paper-plane"></i>
+            Request access
+          </a>
+        </div>
       </div>
     </header>
     <main>
@@ -1283,6 +1326,7 @@
           <a href="?page=landing-about">About</a>
           <a href="?page=landing-capabilities">Capabilities</a>
           <a href="?page=lumina-user-guide">User guide</a>
+          <a href="?page=login">Sign in</a>
           <a href="#cta">Connect with us</a>
         </div>
         <div class="footer-contact">


### PR DESCRIPTION
## Summary
- render the login experience through a reusable template helper used for public routes and auth fallbacks
- enhance the Lumina Identity login page with templated context, return URL handling, and clearer status messaging
- expose a prominent “Sign in” link on the landing page header/footer with responsive styling adjustments

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebb1c81134832682f0d47686f6839a