### PR TITLE
Implement Lumina Admin system owner framework

### DIFF
--- a/AuditService.gs
+++ b/AuditService.gs
@@ -45,6 +45,7 @@
       Action: event.Action || '',
       BeforeJSON: toJson(event.BeforeJSON || event.Before || ''),
       AfterJSON: toJson(event.AfterJSON || event.After || ''),
+      Mode: event.Mode || '',
       IP: event.IP || '',
       UA: event.UA || ''
     };

--- a/IdentityRepository.gs
+++ b/IdentityRepository.gs
@@ -26,9 +26,9 @@
 
   var TABLE_HEADERS = {
     Campaigns: ['CampaignId', 'Name', 'Status', 'ClientOwnerEmail', 'CreatedAt', 'SettingsJSON'],
-    Users: ['UserId', 'Email', 'Username', 'PasswordHash', 'EmailVerified', 'TOTPEnabled', 'TOTPSecretHash', 'Status', 'LastLoginAt', 'CreatedAt'],
+    Users: ['UserId', 'Email', 'Username', 'PasswordHash', 'EmailVerified', 'TOTPEnabled', 'TOTPSecretHash', 'Status', 'LastLoginAt', 'CreatedAt', 'Role', 'CampaignId', 'UpdatedAt', 'FlagsJson', 'Watchlist'],
     UserCampaigns: ['AssignmentId', 'UserId', 'CampaignId', 'Role', 'IsPrimary', 'AddedBy', 'AddedAt', 'Watchlist'],
-    Roles: ['Role', 'Description', 'IsGlobal'],
+    Roles: ['RoleId', 'Role', 'Name', 'Description', 'PermissionsJson', 'DefaultForCampaignManager', 'IsGlobal'],
     RolePermissions: ['PermissionId', 'Role', 'Capability', 'Scope', 'Allowed'],
     OTP: ['Key', 'Email', 'Code', 'Purpose', 'ExpiresAt', 'Attempts', 'LastSentAt', 'ResendCount'],
     Sessions: ['SessionId', 'UserId', 'CampaignId', 'IssuedAt', 'ExpiresAt', 'CSRF', 'IP', 'UA'],
@@ -36,12 +36,19 @@
     Equipment: ['EquipmentId', 'UserId', 'CampaignId', 'Type', 'Serial', 'Condition', 'AssignedAt', 'ReturnedAt', 'Notes', 'Status'],
     EmploymentStatus: ['UserId', 'CampaignId', 'State', 'EffectiveDate', 'Reason', 'Notes'],
     EligibilityRules: ['RuleId', 'Name', 'Scope', 'RuleType', 'ParamsJSON', 'Active'],
-    AuditLog: ['EventId', 'Timestamp', 'ActorUserId', 'ActorRole', 'CampaignId', 'Target', 'Action', 'BeforeJSON', 'AfterJSON', 'IP', 'UA'],
-    FeatureFlags: ['Flag', 'Value', 'Notes', 'UpdatedAt'],
+    AuditLog: ['EventId', 'Timestamp', 'ActorUserId', 'ActorRole', 'CampaignId', 'Target', 'Action', 'BeforeJSON', 'AfterJSON', 'Mode', 'IP', 'UA'],
+    FeatureFlags: ['Key', 'Value', 'Env', 'Description', 'UpdatedAt', 'Flag', 'Notes'],
     Policies: ['PolicyId', 'Name', 'Scope', 'Key', 'Value', 'UpdatedAt'],
     QualityScores: ['RecordId', 'UserId', 'CampaignId', 'Score', 'Date'],
-    Attendance: ['RecordId', 'UserId', 'CampaignId', 'Attendance', 'Status', 'Date'],
-    Performance: ['RecordId', 'UserId', 'CampaignId', 'Metric', 'Score', 'Date']
+    Attendance: ['RecordId', 'UserId', 'CampaignId', 'Date', 'State', 'Start', 'End', 'Productive', 'Minutes'],
+    Performance: ['RecordId', 'UserId', 'CampaignId', 'Metric', 'Score', 'Date'],
+    Shifts: ['ShiftId', 'CampaignId', 'UserId', 'Date', 'StartTime', 'EndTime', 'Status'],
+    QAAudits: ['AuditId', 'UserId', 'CampaignId', 'Score', 'Band', 'AutoFail', 'CreatedAt', 'DetailsUrl'],
+    Coaching: ['CoachId', 'UserId', 'CampaignId', 'Plan', 'DueDate', 'Status'],
+    Benefits: ['UserId', 'Eligible', 'Reason', 'EffectiveDate'],
+    PayrollSync: ['CampaignId', 'RunId', 'Status', 'ErrorsJson', 'StartedAt', 'EndedAt'],
+    SystemMessages: ['MessageId', 'Severity', 'Title', 'Body', 'TargetRole', 'TargetCampaignId', 'Status', 'CreatedAt', 'ResolvedAt', 'CreatedBy', 'MetadataJson'],
+    Jobs: ['JobId', 'Name', 'Schedule', 'LastRunAt', 'LastStatus', 'ConfigJson', 'Enabled', 'RunHash']
   };
 
   var repositoryCache = CacheService ? CacheService.getScriptCache() : null;

--- a/LuminaAdminClient.gs
+++ b/LuminaAdminClient.gs
@@ -1,0 +1,45 @@
+/**
+ * LuminaAdminClient.gs
+ * -----------------------------------------------------------------------------
+ * Lightweight wrappers exposed to HtmlService frontends. Delegates to
+ * LuminaAdmin service for data access and mutations.
+ */
+(function(global) {
+  if (!global) return;
+
+  function ensureService() {
+    if (!global.LuminaAdmin || typeof global.LuminaAdmin.ensureSeeded !== 'function') {
+      throw new Error('LuminaAdmin service not initialized');
+    }
+    global.LuminaAdmin.ensureSeeded();
+    return global.LuminaAdmin;
+  }
+
+  function getMessages() {
+    var service = ensureService();
+    return service.getMessages();
+  }
+
+  function updateMessageStatus(messageId, status) {
+    if (!messageId) {
+      throw new Error('messageId required');
+    }
+    if (!status) {
+      throw new Error('status required');
+    }
+    var service = ensureService();
+    return service.updateMessageStatus(messageId, status);
+  }
+
+  function runJob(jobName) {
+    if (!jobName) {
+      throw new Error('jobName required');
+    }
+    var service = ensureService();
+    return service.runJob(jobName, { mode: 'interactive' });
+  }
+
+  global.LuminaAdminClient_getMessages = getMessages;
+  global.LuminaAdminClient_updateMessageStatus = updateMessageStatus;
+  global.LuminaAdminClient_runJob = runJob;
+})(GLOBAL_SCOPE);

--- a/LuminaAdminMessages.html
+++ b/LuminaAdminMessages.html
@@ -1,0 +1,135 @@
+<?!= includeOnce('ResponsiveStyles') ?>
+<section class="container py-5" id="luminaAdminMessages">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+      <h1 class="h3 mb-1"><i class="fas fa-bell me-2 text-warning"></i>Lumina Admin Messages Center</h1>
+      <p class="text-muted mb-0">Review, acknowledge, and resolve autonomous alerts issued by the Lumina Admin system owner.</p>
+    </div>
+    <div>
+      <button class="btn btn-outline-primary" id="refreshMessagesBtn"><i class="fas fa-rotate me-2"></i>Refresh</button>
+    </div>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle mb-0" id="messagesTable">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Severity</th>
+              <th scope="col">Title</th>
+              <th scope="col">Status</th>
+              <th scope="col">Created</th>
+              <th scope="col" class="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="messagesTableBody">
+            <tr>
+              <td colspan="5" class="text-center py-4 text-muted"><i class="fas fa-circle-notch fa-spin me-2"></i>Loading messages…</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  (function() {
+    const tableBody = document.getElementById('messagesTableBody');
+    const refreshBtn = document.getElementById('refreshMessagesBtn');
+
+    function renderRows(messages) {
+      if (!messages || !messages.length) {
+        tableBody.innerHTML = '<tr><td colspan="5" class="text-center py-4 text-muted">No messages found.</td></tr>';
+        return;
+      }
+      tableBody.innerHTML = messages.map(renderRow).join('');
+    }
+
+    function renderRow(message) {
+      const severityBadge = buildSeverityBadge(message.Severity);
+      const created = new Date(message.CreatedAt || Date.now());
+      const actions = buildActions(message);
+      return `
+        <tr data-message-id="${message.MessageId}">
+          <td>${severityBadge}</td>
+          <td>
+            <div class="fw-semibold">${escapeHtml(message.Title)}</div>
+            <div class="small text-muted">${escapeHtml(message.Body)}</div>
+          </td>
+          <td><span class="badge rounded-pill bg-secondary-subtle text-secondary">${escapeHtml(message.Status)}</span></td>
+          <td>${created.toLocaleString()}</td>
+          <td class="text-end">${actions}</td>
+        </tr>`;
+    }
+
+    function buildSeverityBadge(severity) {
+      const normalized = String(severity || 'INFO').toUpperCase();
+      const classes = {
+        CRITICAL: 'bg-danger',
+        WARNING: 'bg-warning text-dark',
+        NOTICE: 'bg-info text-dark',
+        INFO: 'bg-primary'
+      };
+      const badgeClass = classes[normalized] || 'bg-secondary';
+      return `<span class="badge ${badgeClass}"><i class="fas fa-exclamation-triangle me-1"></i>${normalized}</span>`;
+    }
+
+    function buildActions(message) {
+      const actions = [];
+      if (message.Status !== 'Resolved') {
+        actions.push(`<button class="btn btn-sm btn-outline-success" data-action="resolve">Resolve</button>`);
+      }
+      if (message.Status === 'Open') {
+        actions.push(`<button class="btn btn-sm btn-outline-secondary ms-2" data-action="ack">Acknowledge</button>`);
+      }
+      return actions.join('');
+    }
+
+    function escapeHtml(text) {
+      return String(text || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function fetchMessages() {
+      refreshBtn.disabled = true;
+      google.script.run.withSuccessHandler(function(result) {
+        refreshBtn.disabled = false;
+        renderRows(result || []);
+      }).withFailureHandler(function(error) {
+        refreshBtn.disabled = false;
+        tableBody.innerHTML = `<tr><td colspan="5" class="text-danger text-center py-4">${escapeHtml(error.message || error)}</td></tr>`;
+      }).LuminaAdminClient_getMessages();
+    }
+
+    function updateMessageStatus(messageId, status) {
+      google.script.run.withSuccessHandler(function() {
+        fetchMessages();
+      }).withFailureHandler(function(error) {
+        alert('Failed to update message: ' + (error.message || error));
+      }).LuminaAdminClient_updateMessageStatus(messageId, status);
+    }
+
+    tableBody.addEventListener('click', function(event) {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const row = button.closest('tr[data-message-id]');
+      if (!row) return;
+      const messageId = row.getAttribute('data-message-id');
+      const action = button.getAttribute('data-action');
+      if (action === 'ack') {
+        updateMessageStatus(messageId, 'Acknowledged');
+      } else if (action === 'resolve') {
+        updateMessageStatus(messageId, 'Resolved');
+      }
+    });
+
+    refreshBtn.addEventListener('click', fetchMessages);
+    fetchMessages();
+  })();
+</script>

--- a/LuminaAdminService.gs
+++ b/LuminaAdminService.gs
@@ -1,0 +1,728 @@
+/**
+ * LuminaAdminService.gs
+ * -----------------------------------------------------------------------------
+ * System-owner automation, telemetry, and policy enforcement for Lumina Sheets.
+ * Provides bootstrap seeding, RBAC/ABAC helpers, background job orchestration,
+ * and global navigation registry for the lumina-admin@system superuser.
+ */
+(function bootstrapLuminaAdmin(global) {
+  if (!global) return;
+  if (global.LuminaAdmin && typeof global.LuminaAdmin === 'object') {
+    return;
+  }
+
+  var Utilities = global.Utilities;
+  var ScriptApp = global.ScriptApp;
+  var MailApp = global.MailApp;
+  var LockService = global.LockService;
+
+  function getRepository() {
+    var repo = global.IdentityRepository;
+    if (!repo || typeof repo.list !== 'function') {
+      throw new Error('IdentityRepository not initialized');
+    }
+    return repo;
+  }
+
+  function getAuditService() {
+    var audit = global.AuditService;
+    if (!audit || typeof audit.log !== 'function') {
+      throw new Error('AuditService not initialized');
+    }
+    return audit;
+  }
+
+  var SYSTEM_OWNER = {
+    USER_ID: 'LUMINA-SYSTEM-OWNER',
+    USERNAME: 'lumina-admin',
+    EMAIL: 'lumina-admin@system',
+    ROLE: 'SystemOwner'
+  };
+
+  var DEFAULT_FEATURE_FLAGS = [
+    { Key: 'autonomous_mode', Value: 'true', Env: 'prod', Description: 'Enable Lumina Admin autonomous agent', UpdatedAt: new Date().toISOString(), Flag: 'autonomous_mode', Notes: 'SystemOwner bootstrap default' },
+    { Key: 'notify_email', Value: 'true', Env: 'prod', Description: 'Send email notifications for Lumina Admin messages', UpdatedAt: new Date().toISOString(), Flag: 'notify_email', Notes: 'SystemOwner bootstrap default' },
+    { Key: 'notify_inapp', Value: 'true', Env: 'prod', Description: 'Enable in-app SystemMessages banner', UpdatedAt: new Date().toISOString(), Flag: 'notify_inapp', Notes: 'SystemOwner bootstrap default' },
+    { Key: 'risky_auto_actions', Value: 'false', Env: 'prod', Description: 'Allow autonomous corrective actions without approval', UpdatedAt: new Date().toISOString(), Flag: 'risky_auto_actions', Notes: 'Disabled by default' }
+  ];
+
+  var DEFAULT_JOBS = [
+    { JobId: 'integrity_scan', Name: 'integrity_scan', Schedule: 'every5m', Enabled: 'true' },
+    { JobId: 'rollup_attendance', Name: 'rollup_attendance', Schedule: 'hourly', Enabled: 'true' },
+    { JobId: 'qa_monitor', Name: 'qa_monitor', Schedule: 'hourly', Enabled: 'true' },
+    { JobId: 'policy_enforcer', Name: 'policy_enforcer', Schedule: 'hourly', Enabled: 'true' },
+    { JobId: 'benefits_eligibility', Name: 'benefits_eligibility', Schedule: 'daily-0200', Enabled: 'true' },
+    { JobId: 'integration_health', Name: 'integration_health', Schedule: 'hourly', Enabled: 'true' },
+    { JobId: 'featureflag_audit', Name: 'featureflag_audit', Schedule: 'daily-0205', Enabled: 'true' }
+  ];
+
+  var CATEGORY_REGISTRY = {
+    Overview: ['Admin Dashboard', 'System Health', 'Audit Trail'],
+    People: ['User Directory', 'Roles & Policies', 'Equipment Ledger', 'Lifecycle Actions'],
+    Scheduling: ['Shifts', 'Adherence', 'Attendance'],
+    Quality: ['QA Audits', 'Coaching', 'Scorecards'],
+    Operations: ['Tickets', 'Tasks', 'Knowledge Base'],
+    Finance: ['Payroll Hooks', 'Deductions', 'Benefits Eligibility'],
+    Integrations: ['Google', 'Mail', 'Cloudinary', 'iCoPAY'],
+    System: ['Config', 'Feature Flags', 'Backups', 'Jobs', 'Logs']
+  };
+
+  var BACKGROUND_SEVERITIES = ['INFO', 'NOTICE', 'WARNING', 'CRITICAL', 'KUDOS'];
+
+  var JOB_HANDLERS = {
+    integrity_scan: runIntegrityScan,
+    policy_enforcer: runPolicyEnforcer,
+    rollup_attendance: runAttendanceRollup,
+    qa_monitor: runQaMonitor,
+    benefits_eligibility: runBenefitsEligibility,
+    integration_health: runIntegrationHealth,
+    featureflag_audit: runFeatureFlagAudit
+  };
+
+  function clone(value) {
+    if (value === null || typeof value === 'undefined') return value;
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (err) {
+      return value;
+    }
+  }
+
+  function nowIso() {
+    return new Date().toISOString();
+  }
+
+  function ensureSystemOwnerUser() {
+    var repo = getRepository();
+    var users = repo.list('Users');
+    var existing = users.find(function(row) { return row.UserId === SYSTEM_OWNER.USER_ID || String(row.Email || '').toLowerCase() === SYSTEM_OWNER.EMAIL; });
+    var flagsJson = JSON.stringify({ BackgroundAgent: true, PII_RedactionDefault: true });
+    var payload = {
+      UserId: SYSTEM_OWNER.USER_ID,
+      Email: SYSTEM_OWNER.EMAIL,
+      Username: SYSTEM_OWNER.USERNAME,
+      Status: 'Active',
+      CreatedAt: existing ? (existing.CreatedAt || nowIso()) : nowIso(),
+      UpdatedAt: nowIso(),
+      Role: SYSTEM_OWNER.ROLE,
+      CampaignId: '*',
+      FlagsJson: flagsJson,
+      Watchlist: 'false'
+    };
+    repo.upsert('Users', 'UserId', payload);
+    repo.upsert('UserCampaigns', 'AssignmentId', {
+      AssignmentId: SYSTEM_OWNER.USER_ID + '::GLOBAL',
+      UserId: SYSTEM_OWNER.USER_ID,
+      CampaignId: '*',
+      Role: SYSTEM_OWNER.ROLE,
+      IsPrimary: 'true',
+      AddedBy: SYSTEM_OWNER.USER_ID,
+      AddedAt: nowIso(),
+      Watchlist: 'false'
+    });
+    return payload;
+  }
+
+  function ensureRoles() {
+    var repo = getRepository();
+    var roles = repo.list('Roles');
+    var roleIndex = {};
+    roles.forEach(function(role) {
+      roleIndex[String(role.Name || role.Role || '').toLowerCase()] = role;
+    });
+    var desired = [
+      { Name: 'SystemOwner', Permissions: ['*'], DefaultForCampaignManager: false, IsGlobal: 'Y' },
+      { Name: 'CampaignManager', Permissions: ['manage_campaign', 'manage_people', 'view_reports'], DefaultForCampaignManager: true, IsGlobal: 'N' },
+      { Name: 'Agent', Permissions: ['view_tasks', 'submit_updates'], DefaultForCampaignManager: false, IsGlobal: 'N' },
+      { Name: 'GuestClient', Permissions: ['view_reports_readonly'], DefaultForCampaignManager: false, IsGlobal: 'N' }
+    ];
+
+    desired.forEach(function(role) {
+      var key = role.Name.toLowerCase();
+      var existing = roleIndex[key];
+      var payload = {
+        RoleId: role.Name.toUpperCase(),
+        Role: role.Name,
+        Name: role.Name,
+        Description: role.Name + ' role',
+        PermissionsJson: JSON.stringify(role.Permissions),
+        DefaultForCampaignManager: String(role.DefaultForCampaignManager),
+        IsGlobal: role.IsGlobal || 'N'
+      };
+      repo.upsert('Roles', 'RoleId', payload);
+      if (role.Name === 'SystemOwner') {
+        repo.upsert('RolePermissions', 'PermissionId', {
+          PermissionId: 'SystemOwner::*',
+          Role: 'SystemOwner',
+          Capability: '*',
+          Scope: 'Global',
+          Allowed: 'Y'
+        });
+      }
+    });
+  }
+
+  function ensureFeatureFlags() {
+    var repo = getRepository();
+    var existing = repo.list('FeatureFlags');
+    var index = {};
+    existing.forEach(function(flag) {
+      index[String(flag.Key || flag.Flag || '').toLowerCase()] = flag;
+    });
+    DEFAULT_FEATURE_FLAGS.forEach(function(flag) {
+      var key = String(flag.Key).toLowerCase();
+      if (index[key]) {
+        return;
+      }
+      repo.upsert('FeatureFlags', 'Key', flag);
+    });
+  }
+
+  function ensureJobs() {
+    var repo = getRepository();
+    var existing = repo.list('Jobs');
+    var index = {};
+    existing.forEach(function(job) {
+      index[String(job.JobId || job.Name || '').toLowerCase()] = job;
+    });
+    DEFAULT_JOBS.forEach(function(job) {
+      var key = String(job.JobId).toLowerCase();
+      if (index[key]) {
+        return;
+      }
+      var payload = Object.assign({
+        LastRunAt: '',
+        LastStatus: 'NEVER',
+        ConfigJson: '{}',
+        RunHash: ''
+      }, job);
+      repo.upsert('Jobs', 'JobId', payload);
+    });
+  }
+
+  function ensureSeeded() {
+    var lock = LockService ? LockService.getScriptLock() : null;
+    if (lock) {
+      lock.waitLock(30000);
+    }
+    try {
+      ensureSystemOwnerUser();
+      ensureRoles();
+      ensureFeatureFlags();
+      ensureJobs();
+    } finally {
+      if (lock) {
+        lock.releaseLock();
+      }
+    }
+  }
+
+  function categoryRegistry() {
+    return clone(CATEGORY_REGISTRY);
+  }
+
+  function isSystemOwnerUser(user) {
+    if (!user) return false;
+    if (String(user.UserId || user.userId || '').toUpperCase() === SYSTEM_OWNER.USER_ID) return true;
+    if (String(user.Email || user.email || '').toLowerCase() === SYSTEM_OWNER.EMAIL) return true;
+    if (String(user.Role || user.role || '') === 'SystemOwner') return true;
+    return false;
+  }
+
+  function buildSystemOwnerNavigation() {
+    var nav = { categories: [], uncategorizedPages: [] };
+    Object.keys(CATEGORY_REGISTRY).forEach(function(category) {
+      var pages = CATEGORY_REGISTRY[category] || [];
+      nav.categories.push({
+        CategoryName: category,
+        CategoryIcon: inferCategoryIcon(category),
+        pages: pages.map(function(page) {
+          return {
+            PageTitle: page,
+            PageKey: slugify(page),
+            PageIcon: inferPageIcon(page)
+          };
+        })
+      });
+    });
+    return nav;
+  }
+
+  function inferCategoryIcon(category) {
+    var lower = String(category || '').toLowerCase();
+    if (lower === 'overview') return 'fas fa-chart-pie';
+    if (lower === 'people') return 'fas fa-users';
+    if (lower === 'scheduling') return 'fas fa-calendar-check';
+    if (lower === 'quality') return 'fas fa-star';
+    if (lower === 'operations') return 'fas fa-tasks';
+    if (lower === 'finance') return 'fas fa-coins';
+    if (lower === 'integrations') return 'fas fa-plug';
+    if (lower === 'system') return 'fas fa-cog';
+    return 'fas fa-folder-open';
+  }
+
+  function inferPageIcon(page) {
+    var lower = String(page || '').toLowerCase();
+    if (/dashboard/.test(lower)) return 'fas fa-chart-line';
+    if (/health/.test(lower)) return 'fas fa-heartbeat';
+    if (/audit/.test(lower)) return 'fas fa-clipboard-check';
+    if (/user/.test(lower)) return 'fas fa-user-cog';
+    if (/roles/.test(lower)) return 'fas fa-user-shield';
+    if (/equipment/.test(lower)) return 'fas fa-laptop';
+    if (/lifecycle/.test(lower)) return 'fas fa-random';
+    if (/shift|schedule/.test(lower)) return 'fas fa-clock';
+    if (/qa|quality/.test(lower)) return 'fas fa-check-circle';
+    if (/coaching/.test(lower)) return 'fas fa-chalkboard-teacher';
+    if (/ticket|task/.test(lower)) return 'fas fa-inbox';
+    if (/knowledge/.test(lower)) return 'fas fa-book';
+    if (/payroll|benefit/.test(lower)) return 'fas fa-money-check';
+    if (/integration/.test(lower)) return 'fas fa-project-diagram';
+    if (/config|flag/.test(lower)) return 'fas fa-sliders-h';
+    if (/backup/.test(lower)) return 'fas fa-database';
+    if (/job/.test(lower)) return 'fas fa-robot';
+    if (/log/.test(lower)) return 'fas fa-scroll';
+    return 'fas fa-file-alt';
+  }
+
+  function slugify(text) {
+    return String(text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function publishMessage(severity, title, body, target) {
+    if (BACKGROUND_SEVERITIES.indexOf(severity) === -1) {
+      throw new Error('Invalid severity: ' + severity);
+    }
+    var repo = getRepository();
+    var metadata = (target && target.metadata) || {};
+    var sanitizedBody = redactSensitiveText(body, target && target.allowPII);
+    var payload = {
+      MessageId: Utilities.getUuid(),
+      Severity: severity,
+      Title: title,
+      Body: sanitizedBody,
+      TargetRole: target && target.role ? target.role : '',
+      TargetCampaignId: target && target.campaignId ? target.campaignId : '',
+      Status: 'Open',
+      CreatedAt: nowIso(),
+      ResolvedAt: '',
+      CreatedBy: target && target.createdBy ? target.createdBy : SYSTEM_OWNER.USER_ID,
+      MetadataJson: JSON.stringify(metadata)
+    };
+    repo.append('SystemMessages', payload);
+    if (shouldSendEmail()) {
+      trySendEmailNotification(payload);
+    }
+    return payload;
+  }
+
+  function shouldSendEmail() {
+    var repo = getRepository();
+    var flags = repo.list('FeatureFlags');
+    return flags.some(function(flag) {
+      var key = String(flag.Key || flag.Flag || '').toLowerCase();
+      var value = String(flag.Value || flag.value || '').toLowerCase();
+      return key === 'notify_email' && (value === 'true' || value === '1');
+    });
+  }
+
+  function trySendEmailNotification(message) {
+    if (!MailApp) {
+      return;
+    }
+    var subject = '[Lumina Admin] ' + message.Severity + ' • ' + message.Title;
+    var htmlBody = '<p>' + escapeHtml(message.Body) + '</p>';
+    MailApp.sendEmail({ to: SYSTEM_OWNER.EMAIL, subject: subject, htmlBody: htmlBody });
+  }
+
+  function escapeHtml(text) {
+    return String(text || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function redactSensitiveText(text, allowPII) {
+    if (allowPII) {
+      return text;
+    }
+    return String(text || '').replace(/([A-Z][a-z]+)\s+([A-Z])[a-z]*/g, '$1 $2.');
+  }
+
+  function logAudit(action, resourceType, resourceId, before, after, mode) {
+    getAuditService().log({
+      ActorUserId: SYSTEM_OWNER.USER_ID,
+      ActorRole: SYSTEM_OWNER.ROLE,
+      CampaignId: resourceType === 'Campaign' ? resourceId : '',
+      Target: resourceType + '::' + resourceId,
+      Action: action,
+      Before: before,
+      After: after,
+      Timestamp: nowIso(),
+      Mode: mode || 'Autonomous'
+    });
+  }
+
+  function runJob(jobName, context) {
+    ensureSeeded();
+    var repo = getRepository();
+    var job = repo.list('Jobs').find(function(row) {
+      return String(row.JobId || row.Name || '').toLowerCase() === String(jobName).toLowerCase();
+    });
+    if (!job) {
+      throw new Error('Unknown job: ' + jobName);
+    }
+    if (String(job.Enabled).toLowerCase() === 'false') {
+      return { skipped: true, reason: 'Job disabled' };
+    }
+    var handler = JOB_HANDLERS[job.Name];
+    if (!handler) {
+      throw new Error('No handler registered for job ' + job.Name);
+    }
+    var result = handler(context || {}) || {};
+    var hashSource = result.metrics || result;
+    var newHash = Utilities.base64Encode(Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, JSON.stringify(hashSource || {})));
+    if (job.RunHash && job.RunHash === newHash) {
+      return { skipped: true, reason: 'No changes detected', hash: newHash };
+    }
+    var messages = Array.isArray(result.messages) ? result.messages : [];
+    messages.forEach(function(message) {
+      publishMessage(message.severity || 'INFO', message.title || 'Lumina Admin Notice', message.body || '', message.target || {});
+    });
+    repo.upsert('Jobs', 'JobId', Object.assign({}, job, {
+      LastRunAt: nowIso(),
+      LastStatus: (result && result.status) || 'SUCCESS',
+      RunHash: newHash
+    }));
+    return Object.assign({}, result, {
+      hash: newHash,
+      messagesPublished: messages.length
+    });
+  }
+
+  function registerTriggers() {
+    if (!ScriptApp) {
+      return { installed: false, reason: 'ScriptApp unavailable in this environment' };
+    }
+    var existing = ScriptApp.getProjectTriggers();
+    var required = {
+      every5m: { type: 'timeBased', minutes: 5, handler: 'LuminaAdmin_runIntegrity' },
+      hourly: { type: 'timeBased', minutes: 60, handler: 'LuminaAdmin_runHourly' },
+      daily: { type: 'timeBased', hours: 24, handler: 'LuminaAdmin_runDaily' }
+    };
+    Object.keys(required).forEach(function(key) {
+      var config = required[key];
+      var present = existing.some(function(trigger) {
+        return trigger.getHandlerFunction && trigger.getHandlerFunction() === config.handler;
+      });
+      if (present) {
+        return;
+      }
+      var builder = ScriptApp.newTrigger(config.handler).timeBased();
+      if (config.minutes === 5) builder.everyMinutes(5);
+      else if (config.minutes === 60) builder.everyHours(1);
+      else builder.atHour(2).everyDays(1);
+      builder.create();
+    });
+    return { installed: true };
+  }
+
+  function runIntegrityScan() {
+    var repo = getRepository();
+    var orphanedEquipment = repo.list('Equipment').filter(function(eq) {
+      return !eq.UserId;
+    });
+    var messages = [];
+    if (orphanedEquipment.length) {
+      messages.push({
+        severity: 'WARNING',
+        title: 'Equipment without custodian',
+        body: orphanedEquipment.length + ' assets require review.',
+        target: { role: 'SystemOwner' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { orphanedEquipment: orphanedEquipment.length },
+      messages: messages
+    };
+  }
+
+  function runPolicyEnforcer() {
+    var repo = getRepository();
+    var shifts = repo.list('Shifts');
+    var uncovered = shifts.filter(function(shift) {
+      return !shift.UserId || String(shift.Status || '').toLowerCase() === 'uncovered';
+    });
+    var messages = [];
+    if (uncovered.length) {
+      messages.push({
+        severity: 'CRITICAL',
+        title: 'Uncovered shifts detected',
+        body: uncovered.length + ' shifts are missing coverage.',
+        target: { role: 'CampaignManager' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { uncoveredShifts: uncovered.length },
+      messages: messages
+    };
+  }
+
+  function runAttendanceRollup() {
+    var repo = getRepository();
+    var attendance = repo.list('Attendance');
+    var overtime = attendance.filter(function(record) {
+      return Number(record.Minutes || 0) > 40 * 60;
+    });
+    var messages = [];
+    if (overtime.length) {
+      messages.push({
+        severity: 'NOTICE',
+        title: 'Weekly overtime review',
+        body: overtime.length + ' agents exceeded 40 hours.',
+        target: { role: 'SystemOwner' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { overtimeRecords: overtime.length },
+      messages: messages
+    };
+  }
+
+  function runQaMonitor() {
+    var repo = getRepository();
+    var audits = repo.list('QAAudits');
+    var recent = audits.slice(-20);
+    var belowThreshold = recent.filter(function(audit) {
+      return Number(audit.Score || 0) < 80;
+    });
+    var messages = [];
+    if (belowThreshold.length) {
+      messages.push({
+        severity: 'NOTICE',
+        title: 'QA score dip detected',
+        body: belowThreshold.length + ' recent audits fell below 80%.',
+        target: { role: 'Quality' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { lowScores: belowThreshold.length },
+      messages: messages
+    };
+  }
+
+  function runBenefitsEligibility() {
+    var repo = getRepository();
+    var benefits = repo.list('Benefits');
+    var needingReview = benefits.filter(function(row) {
+      return String(row.Eligible || '').toLowerCase() === 'false';
+    });
+    var messages = [];
+    if (needingReview.length) {
+      messages.push({
+        severity: 'NOTICE',
+        title: 'Benefits eligibility review',
+        body: needingReview.length + ' team members need eligibility review.',
+        target: { role: 'CampaignManager' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { pending: needingReview.length },
+      messages: messages
+    };
+  }
+
+  function runIntegrationHealth() {
+    var repo = getRepository();
+    var jobs = repo.list('Jobs');
+    var failures = jobs.filter(function(job) {
+      return String(job.LastStatus || '').toUpperCase() === 'FAILED';
+    });
+    var messages = [];
+    if (failures.length) {
+      messages.push({
+        severity: 'WARNING',
+        title: 'Integration job failures',
+        body: failures.length + ' background jobs reported failures.',
+        target: { role: 'SystemOwner' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { failingJobs: failures.length },
+      messages: messages
+    };
+  }
+
+  function runFeatureFlagAudit() {
+    var repo = getRepository();
+    var flags = repo.list('FeatureFlags');
+    var risky = flags.filter(function(flag) {
+      var key = String(flag.Key || flag.Flag || '').toLowerCase();
+      var value = String(flag.Value || '').toLowerCase();
+      return key === 'risky_auto_actions' && value === 'true';
+    });
+    var messages = [];
+    if (risky.length) {
+      messages.push({
+        severity: 'WARNING',
+        title: 'Risky automation enabled',
+        body: 'Risky autonomous actions are enabled. Confirm this is intentional.',
+        target: { role: 'SystemOwner' }
+      });
+    }
+    return {
+      status: 'SUCCESS',
+      metrics: { riskyFlags: risky.length },
+      messages: messages
+    };
+  }
+
+  function lifecycleAction(action, payload, actor) {
+    ensureSeeded();
+    var repo = getRepository();
+    var before;
+    var after;
+    if (action === 'hire') {
+      var userId = payload.UserId || Utilities.getUuid();
+      before = null;
+      after = Object.assign({
+        UserId: userId,
+        Status: 'Active',
+        CreatedAt: nowIso(),
+        UpdatedAt: nowIso()
+      }, payload);
+      repo.upsert('Users', 'UserId', after);
+      publishMessage('INFO', 'New hire onboarded', redactSensitiveText('User ' + (payload.DisplayName || payload.Username || 'New Hire') + ' created for campaign ' + (payload.CampaignId || ''), false), { role: 'SystemOwner' });
+    } else if (action === 'transfer') {
+      before = repo.list('Users').find(function(row) { return row.UserId === payload.UserId; });
+      after = Object.assign({}, before, { CampaignId: payload.TargetCampaignId, UpdatedAt: nowIso() });
+      repo.upsert('Users', 'UserId', after);
+      publishMessage('NOTICE', 'Transfer completed', 'User transferred to campaign ' + payload.TargetCampaignId + '.', { role: 'SystemOwner' });
+    } else if (action === 'promote') {
+      before = repo.list('Users').find(function(row) { return row.UserId === payload.UserId; });
+      after = Object.assign({}, before, { Role: payload.Role, UpdatedAt: nowIso() });
+      repo.upsert('Users', 'UserId', after);
+      publishMessage('KUDOS', 'Promotion recorded', 'User promoted to ' + payload.Role + '.', { role: 'SystemOwner' });
+    } else if (action === 'terminate') {
+      before = repo.list('Users').find(function(row) { return row.UserId === payload.UserId; });
+      after = Object.assign({}, before, { Status: 'Inactive', UpdatedAt: nowIso() });
+      repo.upsert('Users', 'UserId', after);
+      publishMessage('CRITICAL', 'Access revoked', 'User access revoked for security compliance.', { role: 'SystemOwner' });
+    } else {
+      throw new Error('Unsupported lifecycle action: ' + action);
+    }
+    logAudit(action.toUpperCase(), 'User', payload.UserId || (after && after.UserId) || '', before, after, actor && actor.mode);
+    return { success: true };
+  }
+
+  function getMessages(filters) {
+    var rows = getRepository().list('SystemMessages');
+    if (!filters) return rows;
+    return rows.filter(function(row) {
+      if (filters.status && String(row.Status).toLowerCase() !== String(filters.status).toLowerCase()) return false;
+      if (filters.severity && String(row.Severity).toUpperCase() !== String(filters.severity).toUpperCase()) return false;
+      return true;
+    });
+  }
+
+  function updateMessageStatus(messageId, status) {
+    var repo = getRepository();
+    var rows = repo.list('SystemMessages');
+    var existing = rows.find(function(row) { return row.MessageId === messageId; });
+    if (!existing) {
+      throw new Error('Message not found: ' + messageId);
+    }
+    var updated = Object.assign({}, existing, {
+      Status: status,
+      ResolvedAt: status === 'Resolved' ? nowIso() : existing.ResolvedAt
+    });
+    repo.upsert('SystemMessages', 'MessageId', updated);
+    logAudit('MESSAGE_STATUS', 'SystemMessage', messageId, existing, updated, 'Interactive');
+    return updated;
+  }
+
+  function ensureTotpSecret(userId) {
+    var repo = getRepository();
+    var users = repo.list('Users');
+    var user = users.find(function(row) { return row.UserId === userId; });
+    if (!user) {
+      throw new Error('User not found for TOTP enrollment');
+    }
+    if (user.TOTPSecretHash) {
+      return user.TOTPSecretHash;
+    }
+    var secret = Utilities.base64Encode(Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, Utilities.getUuid()));
+    repo.upsert('Users', 'UserId', Object.assign({}, user, {
+      TOTPSecretHash: secret,
+      TOTPEnabled: 'true',
+      UpdatedAt: nowIso()
+    }));
+    logAudit('TOTP_ENROLL', 'User', userId, user, Object.assign({}, user, { TOTPSecretHash: secret, TOTPEnabled: 'true' }), 'Interactive');
+    return secret;
+  }
+
+  function isAutonomousModeEnabled() {
+    var repo = getRepository();
+    var flags = repo.list('FeatureFlags');
+    return flags.some(function(flag) {
+      var key = String(flag.Key || flag.Flag || '').toLowerCase();
+      var value = String(flag.Value || '').toLowerCase();
+      return key === 'autonomous_mode' && (value === 'true' || value === '1');
+    });
+  }
+
+  function ensureAutonomousRun(jobName) {
+    if (!isAutonomousModeEnabled()) {
+      return { skipped: true, reason: 'Autonomous mode disabled' };
+    }
+    return runJob(jobName || 'integrity_scan', { mode: 'autonomous' });
+  }
+
+  global.LuminaAdmin = {
+    ensureSeeded: ensureSeeded,
+    ensureTriggers: registerTriggers,
+    isSystemOwner: isSystemOwnerUser,
+    getCategoryRegistry: categoryRegistry,
+    buildSystemOwnerNavigation: buildSystemOwnerNavigation,
+    publishMessage: publishMessage,
+    runJob: runJob,
+    ensureAutonomousRun: ensureAutonomousRun,
+    lifecycleAction: lifecycleAction,
+    getMessages: getMessages,
+    updateMessageStatus: updateMessageStatus,
+    ensureTotpSecret: ensureTotpSecret
+  };
+
+  if (typeof global.LuminaAdmin_runIntegrity !== 'function') {
+    global.LuminaAdmin_runIntegrity = function() {
+      return ensureAutonomousRun('integrity_scan');
+    };
+  }
+
+  if (typeof global.LuminaAdmin_runHourly !== 'function') {
+    global.LuminaAdmin_runHourly = function() {
+      ensureAutonomousRun('rollup_attendance');
+      ensureAutonomousRun('qa_monitor');
+      ensureAutonomousRun('policy_enforcer');
+      ensureAutonomousRun('integration_health');
+    };
+  }
+
+  if (typeof global.LuminaAdmin_runDaily !== 'function') {
+    global.LuminaAdmin_runDaily = function() {
+      ensureAutonomousRun('benefits_eligibility');
+      ensureAutonomousRun('featureflag_audit');
+    };
+  }
+
+})(GLOBAL_SCOPE);

--- a/PolicyService.gs
+++ b/PolicyService.gs
@@ -76,12 +76,15 @@
     var rbac = getRBACService();
     rbac.assertPermission(actor.UserId, actor.CampaignId || '', rbac.CAPABILITIES.MANAGE_POLICIES, actor.Roles);
     var record = {
+      Key: flag,
       Flag: flag,
       Value: value,
+      Env: actor && actor.Environment ? actor.Environment : 'prod',
+      Description: '',
       Notes: '',
       UpdatedAt: new Date().toISOString()
     };
-    getIdentityRepository().upsert('FeatureFlags', 'Flag', record);
+    getIdentityRepository().upsert('FeatureFlags', 'Key', record);
     getAuditService().log({
       ActorUserId: actor.UserId,
       ActorRole: actor.PrimaryRole,

--- a/SeedData.js
+++ b/SeedData.js
@@ -391,6 +391,10 @@ function seedDefaultData() {
     const luminaAdminInfo = ensureLuminaAdminUser(roleIdsByName, campaignIdsByName, pageCatalog);
     summary.luminaAdmin = luminaAdminInfo;
 
+    if (typeof LuminaAdmin === 'object' && LuminaAdmin && typeof LuminaAdmin.ensureSeeded === 'function') {
+      LuminaAdmin.ensureSeeded();
+    }
+
     return {
       success: true,
       message: 'Seed data ensured successfully.',
@@ -407,6 +411,13 @@ function seedDefaultData() {
       details: summary
     };
   }
+}
+
+function seedLuminaSystemOwner() {
+  if (typeof LuminaAdmin === 'object' && LuminaAdmin && typeof LuminaAdmin.ensureSeeded === 'function') {
+    return LuminaAdmin.ensureSeeded();
+  }
+  throw new Error('LuminaAdmin bootstrap unavailable');
 }
 
 /**

--- a/docs/lumina-admin.md
+++ b/docs/lumina-admin.md
@@ -1,0 +1,59 @@
+# Lumina Admin System Owner
+
+The Lumina Admin module provisions a system-owned superuser and a fully automated governance framework for Lumina Sheets deployments. This guide explains the core concepts, how to enable or disable autonomous mode, and how to extend categories, jobs, and policies.
+
+## System Owner Identity
+
+* **User ID:** `LUMINA-SYSTEM-OWNER`
+* **Username:** `lumina-admin`
+* **Email:** `lumina-admin@system`
+* **Role:** `SystemOwner`
+
+The account is immutable and bypasses tenant scoping. Seeding occurs automatically through `LuminaAdmin.ensureSeeded()` which is invoked during `seedDefaultData()` and exposed as `seedLuminaSystemOwner()`.
+
+## Access Control Model
+
+The SystemOwner role receives the wildcard capability (`*`) which grants read/write to every campaign. Other roles include `CampaignManager`, `Agent`, and `GuestClient`. Attribute-based checks rely on the `CampaignId` field: non-SystemOwner users must have the campaign in their assignment list.
+
+## Sidebar Registry
+
+`LuminaAdmin.buildSystemOwnerNavigation()` produces a global sidebar grouped by category. Update the registry in `LuminaAdminService.gs` (the `CATEGORY_REGISTRY` constant) to add new categories or pages.
+
+## Background Jobs
+
+Autonomous operations rely on the Jobs sheet. Default jobs include integrity scans, policy enforcement, QA monitoring, benefits eligibility checks, integration health, and feature flag audits. Each job is idempotent by persisting a `RunHash` of the last results.
+
+* Call `LuminaAdmin.ensureTriggers()` after deployment to register Apps Script time-based triggers.
+* Manually run jobs with `LuminaAdmin.runJob('integrity_scan')` or via the HTML client helper `LuminaAdminClient_runJob`.
+
+## Notifications and Messages
+
+Alerts persist to the `SystemMessages` sheet. Severities include `INFO`, `NOTICE`, `WARNING`, and `CRITICAL`. The Messages Center UI (`LuminaAdminMessages.html`) allows acknowledge/resolve actions which append to the audit log.
+
+Email delivery honors the `notify_email` feature flag. In-app banners should read from the same sheet for realtime dashboards.
+
+## Lifecycle Actions
+
+Use `LuminaAdmin.lifecycleAction(action, payload, actor)` for hires, transfers, promotions, and terminations. Each action logs to `AuditLog` with before/after snapshots.
+
+## TOTP and Security
+
+`LuminaAdmin.ensureTotpSecret(userId)` provisions a TOTP shared secret and enables multifactor authentication for the specified user. Use this when onboarding privileged administrators.
+
+## Extensibility
+
+* **Add categories/pages:** edit `CATEGORY_REGISTRY`.
+* **Add jobs:** push new definitions into `DEFAULT_JOBS` and add handlers in `JOB_HANDLERS`.
+* **Add policies:** extend job handlers to evaluate additional constraints and publish messages.
+
+Disable autonomous mode by setting the `autonomous_mode` feature flag to `false`. This skips scheduled jobs while still allowing interactive runs.
+
+## .NET Adapter Hooks
+
+If the optional ASP.NET Core services are deployed, expose API endpoints that forward to Apps Script webhooks:
+
+* `POST /api/admin/jobs/run` → `LuminaAdmin.runJob`
+* `GET /api/system/messages` → `LuminaAdmin.getMessages`
+* `GET /api/audit` → `AuditService.list`
+
+Use service accounts with read-only scopes for telemetry scans and limit write access to auditable flows.

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -51,6 +51,21 @@
   var campaignIdValue = (typeof campaignId !== 'undefined' && campaignId) ? campaignId : '';
   var campaignNameValue = (typeof campaignName !== 'undefined' && campaignName) ? campaignName : '';
   var navigationConfig = navigation && typeof navigation === 'object' ? navigation : { categories: [], uncategorizedPages: [] };
+  var luminaAdminNav = null;
+  try {
+    if (typeof LuminaAdmin !== 'undefined' && LuminaAdmin && typeof LuminaAdmin.isSystemOwner === 'function' && LuminaAdmin.isSystemOwner(sidebarUser)) {
+      if (typeof LuminaAdmin.buildSystemOwnerNavigation === 'function') {
+        luminaAdminNav = LuminaAdmin.buildSystemOwnerNavigation();
+      }
+    }
+  } catch (err) {
+    if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+      console.log('LuminaAdmin navigation error', err);
+    }
+  }
+  if (luminaAdminNav) {
+    navigationConfig = luminaAdminNav;
+  }
   var employmentMetaValue = employmentMeta && typeof employmentMeta === 'object' ? employmentMeta : { status: '', cls: '', icon: 'fas fa-briefcase' };
 
   function safeUserString(value) {


### PR DESCRIPTION
## Summary
- add a LuminaAdmin service that seeds the system-owner account, manages global navigation, orchestrates autonomous jobs, and exposes lifecycle, messaging, and MFA helpers
- expand repository schema, seeding, and policy utilities to support system messages, jobs, feature flags, and audit mode tracking
- surface a system-owner sidebar experience, message center UI, and client helpers, and document how to operate the Lumina Admin module

## Testing
- not run (Apps Script environment)

------
https://chatgpt.com/codex/tasks/task_e_68ebc97e848c8326a389efcbe9426fba