### PR TITLE
Restack login hero visual and declutter form styling

### DIFF
--- a/Html/LuminaIdentityLogin.html
+++ b/Html/LuminaIdentityLogin.html
@@ -44,27 +44,36 @@
 
     .page {
       display: grid;
-      grid-template-columns: minmax(320px, 40%) minmax(0, 60%);
+      grid-template-columns: minmax(320px, 48%) minmax(320px, 52%);
       min-height: 100vh;
       width: 100%;
     }
 
     .hero {
-      background:
-        linear-gradient(180deg, rgba(15, 31, 68, 0.88) 0%, rgba(10, 21, 52, 0.95) 100%),
-        url('https://res.cloudinary.com/dr8qd3xfc/image/upload/v1743438226/vlbpo/huowvct9gus48rwy8sfy.svg') center/cover no-repeat;
-      color: #fff;
-      padding: clamp(2.5rem, 4vw, 3rem);
-      position: relative;
+      background: linear-gradient(180deg, rgba(15, 31, 68, 0.95) 0%, rgba(10, 21, 52, 0.98) 100%);
+      color: #f7fbff;
+      padding: clamp(3rem, 5vw, 4rem) clamp(2.8rem, 5vw, 4rem);
       display: flex;
-      flex-direction: column;
+      align-items: flex-start;
       justify-content: center;
-      gap: 1.75rem;
       text-align: left;
     }
 
-    .hero::after {
-      display: none;
+    .hero-content {
+      width: min(100%, 560px);
+      display: flex;
+      flex-direction: column;
+      gap: 1.6rem;
+      align-items: flex-start;
+    }
+
+    .hero-visual {
+      width: clamp(180px, 52%, 240px);
+      align-self: center;
+      margin-top: 1.6rem;
+      aspect-ratio: 3 / 4;
+      background: url('https://res.cloudinary.com/dr8qd3xfc/image/upload/v1743438226/vlbpo/huowvct9gus48rwy8sfy.svg') center/contain no-repeat;
+      filter: drop-shadow(0 16px 34px rgba(29, 55, 126, 0.45));
     }
 
     .hero-header {
@@ -75,7 +84,7 @@
       letter-spacing: 0.24em;
       font-weight: 600;
       text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.7);
+      color: rgba(238, 244, 255, 0.75);
     }
 
     .hero-header::before {
@@ -88,16 +97,17 @@
 
     .hero h1 {
       margin: 0;
-      font-size: clamp(1.8rem, 2.6vw, 2.2rem);
-      line-height: 1.2;
+      font-size: clamp(2rem, 3vw, 2.4rem);
+      line-height: 1.18;
       font-weight: 700;
+      color: #ffffff;
     }
 
     .hero p {
       margin: 0;
-      font-size: 0.95rem;
-      line-height: 1.6;
-      color: rgba(255, 255, 255, 0.78);
+      font-size: 1rem;
+      line-height: 1.65;
+      color: rgba(248, 251, 255, 0.85);
     }
 
     .hero-features {
@@ -120,23 +130,27 @@
       height: 18px;
       margin-top: 0.1rem;
       flex-shrink: 0;
-      color: #77e0ff;
+      color: #9af0ff;
     }
 
     .hero-features strong {
       display: block;
       font-weight: 600;
       margin-bottom: 0.3rem;
-      color: #fff;
+      color: #ffffff;
+    }
+
+    .hero-features span {
+      color: rgba(244, 248, 255, 0.78);
     }
 
     .auth {
-      padding: clamp(2.2rem, 5vw, 4rem);
+      padding: clamp(2.6rem, 5vw, 4.4rem);
       display: grid;
       align-content: center;
-      justify-items: stretch;
-      gap: clamp(1.6rem, 4vw, 2.4rem);
-      background: #ffffff;
+      justify-items: center;
+      gap: clamp(1.8rem, 4vw, 2.6rem);
+      background: linear-gradient(180deg, #ffffff 0%, #f7f9ff 100%);
     }
 
     .brand {
@@ -153,31 +167,34 @@
     .auth-card {
       display: grid;
       gap: 1.6rem;
+      width: min(100%, 430px);
+      padding: clamp(0.5rem, 2.4vw, 1.5rem);
     }
 
     .auth-card h1 {
       margin: 0;
-      font-size: clamp(1.9rem, 2.4vw, 2.2rem);
-      color: var(--blue-900);
+      font-size: clamp(1.8rem, 2.2vw, 2.1rem);
+      color: var(--blue-800);
     }
 
     .auth-card p {
       margin: 0;
-      font-size: 1rem;
-      color: var(--gray-500);
+      font-size: 0.98rem;
+      color: rgba(63, 70, 96, 0.75);
       line-height: 1.6;
     }
 
     form {
       display: grid;
-      gap: 1.25rem;
+      gap: 1.1rem;
+      padding: clamp(0.5rem, 2vw, 1rem);
     }
 
     label {
       display: grid;
       gap: 0.45rem;
       font-weight: 500;
-      color: var(--gray-600);
+      color: rgba(28, 47, 99, 0.82);
       font-size: 0.95rem;
     }
 
@@ -186,10 +203,10 @@
       padding: 0.9rem 1rem;
       border-radius: 14px;
       border: 1px solid var(--border-color);
-      background: #fbfcff;
+      background: #ffffff;
       font-size: 1rem;
       transition: border-color 0.2s ease, box-shadow 0.2s ease;
-      color: var(--blue-900);
+      color: var(--blue-700);
     }
 
     input[type="text"]:focus,
@@ -206,13 +223,14 @@
       justify-content: space-between;
       gap: 1rem;
       font-size: 0.9rem;
+      color: rgba(28, 47, 99, 0.75);
     }
 
     .remember {
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
-      color: var(--gray-500);
+      color: rgba(28, 47, 99, 0.65);
       font-weight: 500;
     }
 
@@ -270,7 +288,7 @@
     .secondary-actions {
       text-align: center;
       font-size: 0.95rem;
-      color: var(--gray-500);
+      color: rgba(63, 70, 96, 0.72);
       display: grid;
       gap: 0.6rem;
     }
@@ -285,13 +303,22 @@
       }
 
       .hero {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        min-height: 420px;
+        padding: clamp(2.4rem, 6vw, 3.2rem) clamp(2rem, 6vw, 3rem);
+        text-align: center;
+      }
+
+      .hero-content {
+        align-items: center;
+        text-align: center;
+      }
+
+      .hero-visual {
+        width: clamp(220px, 62vw, 280px);
       }
 
       .auth {
-        border-top-left-radius: 0;
+        justify-items: stretch;
+        padding: clamp(2.2rem, 6vw, 3.2rem);
       }
     }
 
@@ -302,16 +329,15 @@
       }
 
       .page {
-        border-radius: 0;
         min-height: 100vh;
       }
 
       .hero {
-        padding: 2.5rem 1.8rem;
+        padding: 2.4rem 1.6rem 2.6rem;
       }
 
       .auth {
-        padding: 2.2rem 1.6rem 3rem;
+        padding: 2.1rem 1.4rem 2.8rem;
       }
     }
   </style>
@@ -319,7 +345,7 @@
 <body>
   <div class="page">
     <section class="hero" aria-label="LuminaHQ platform overview">
-      <div>
+      <div class="hero-content">
         <span class="hero-header">LuminaHQ Platform</span>
         <h1>Clarity for every customer conversation</h1>
         <p>Monitor performance, coach your teams, and orchestrate quality programs in one collaborative workspace.</p>
@@ -352,6 +378,7 @@
             </div>
           </li>
         </ul>
+        <div class="hero-visual" aria-hidden="true"></div>
       </div>
     </section>
     <section class="auth" aria-label="LuminaHQ login">


### PR DESCRIPTION
## Summary
- restack the Lumina Identity hero so the illustration sits beneath the headline copy with brightened typography
- remove the card treatment from the login form while keeping the compact width through padding adjustments

## Testing
- not run (static HTML/CSS changes)

------
https://chatgpt.com/codex/tasks/task_e_68ebdd7e8a9c8326902f60c8176c4098