### PR TITLE
Mirror seeded admin to legacy Users sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ HTML front-ends inside `Html/`.
 
 ### Bootstrap & seed data
 
-- Run `seedLuminaIdentity()` (see `SeedData.js`) to insert the baseline roles,
-  campaigns, and a `System Admin` account with 2FA disabled. Update the default
+- Run `seedDefaultData()` to bootstrap the workspace. The helper now also calls
+  `seedLuminaIdentity()` under the hood so the identity roles, permissions, and
+  `System Admin` account are provisioned automatically. Update the default
   password immediately after the first login.
+- The bootstrap flow now mirrors the seeded administrator into the legacy
+  `Users` directory tab so the default Apps Script container sheet immediately
+  shows the account and its assigned metadata.
 - Use the `/auth/request-otp` endpoint (exposed via the router) to verify email
   delivery through Apps Script `MailApp` or your preferred SMTP relay.
 


### PR DESCRIPTION
## Summary
- ensure the seed administrator is mirrored into the legacy Users sheet so the default Apps Script container shows the account
- add utilities that resolve the Users sheet schema and upsert the bootstrap record when seeding
- document that the seeding flow now populates the Users tab in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec12288b6883269a34036e68a5648b