### PR TITLE
Improve campaign and user context resolution in layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1780,6 +1780,109 @@
 >
   <?
     // Shared layout context so navigation components can stay in sync
+    function __layoutNormalizeText(value) {
+      if (value === null || typeof value === 'undefined') {
+        return '';
+      }
+
+      var text = String(value).trim();
+      return text && text.toLowerCase() !== 'undefined' && text.toLowerCase() !== 'null' ? text : '';
+    }
+
+    function __layoutResolveCampaignId(user) {
+      if (!user || typeof user !== 'object') {
+        return '';
+      }
+
+      var campaignCandidates = [];
+
+      campaignCandidates.push(user.CampaignID, user.campaignId, user.CampaignId);
+
+      if (user.ActiveCampaignId || user.activeCampaignId) {
+        campaignCandidates.push(user.ActiveCampaignId || user.activeCampaignId);
+      }
+
+      if (user.DefaultCampaignId || user.defaultCampaignId) {
+        campaignCandidates.push(user.DefaultCampaignId || user.defaultCampaignId);
+      }
+
+      if (user.CampaignScope && typeof user.CampaignScope === 'object') {
+        campaignCandidates.push(
+          user.CampaignScope.activeCampaignId,
+          user.CampaignScope.defaultCampaignId
+        );
+
+        if (Array.isArray(user.CampaignScope.allowedCampaignIds)) {
+          campaignCandidates = campaignCandidates.concat(user.CampaignScope.allowedCampaignIds);
+        }
+      }
+
+      for (var idx = 0; idx < campaignCandidates.length; idx++) {
+        var candidate = __layoutNormalizeText(campaignCandidates[idx]);
+        if (candidate) {
+          return candidate;
+        }
+      }
+
+      return '';
+    }
+
+    function __layoutResolveCampaignName(user, campaignId) {
+      var candidates = [];
+
+      if (user && typeof user === 'object') {
+        candidates.push(
+          user.campaignName,
+          user.CampaignName,
+          user.campaign,
+          user.Campaign,
+          user.AccountName,
+          user.accountName,
+          user.ClientName,
+          user.clientName
+        );
+
+        if (user.CampaignScope && typeof user.CampaignScope === 'object') {
+          candidates.push(user.CampaignScope.activeCampaignName, user.CampaignScope.defaultCampaignName);
+        }
+      }
+
+      for (var idx = 0; idx < candidates.length; idx++) {
+        var candidate = __layoutNormalizeText(candidates[idx]);
+        if (candidate) {
+          return candidate;
+        }
+      }
+
+      if (!campaignId) {
+        return '';
+      }
+
+      try {
+        if (typeof getCampaignNameSafe === 'function') {
+          var resolved = __layoutNormalizeText(getCampaignNameSafe(campaignId));
+          if (resolved) {
+            return resolved;
+          }
+        }
+      } catch (campaignSafeErr) {
+        console.error('layout: failed to resolve campaign name via getCampaignNameSafe', campaignSafeErr);
+      }
+
+      try {
+        if (typeof getCampaignName === 'function') {
+          var fallbackResolved = __layoutNormalizeText(getCampaignName(campaignId));
+          if (fallbackResolved) {
+            return fallbackResolved;
+          }
+        }
+      } catch (campaignErr) {
+        console.error('layout: failed to resolve campaign name via getCampaignName', campaignErr);
+      }
+
+      return '';
+    }
+
     var __layoutUser = (typeof safeUser !== 'undefined' && safeUser) ? safeUser : (typeof user !== 'undefined' ? user : {});
 
     if (__layoutUser && __layoutUser.ID && typeof createSafeUserObject === 'function') {
@@ -1811,9 +1914,8 @@
       )
     );
 
-    var __layoutCampaignId = (__layoutUser && __layoutUser.CampaignID) ? __layoutUser.CampaignID : '';
-    var __layoutCampaignName = (__layoutUser && (__layoutUser.campaignName || __layoutUser.CampaignName)) ?
-      (__layoutUser.campaignName || __layoutUser.CampaignName) : '';
+    var __layoutCampaignId = __layoutResolveCampaignId(__layoutUser);
+    var __layoutCampaignName = __layoutResolveCampaignName(__layoutUser, __layoutCampaignId);
 
     function __layoutResolveClientName(user) {
       if (!user) {
@@ -1865,6 +1967,26 @@
       }
     } else if (__layoutIsAdmin) {
       __layoutRoleNames = ['System Administrator'];
+    }
+
+    if (!__layoutUser || typeof __layoutUser !== 'object') {
+      __layoutUser = {};
+    }
+
+    if (!__layoutNormalizeText(__layoutUser.FullName) && __layoutNormalizeText(__layoutUser.UserName)) {
+      __layoutUser.FullName = __layoutUser.UserName;
+    }
+
+    if (!__layoutNormalizeText(__layoutUser.DisplayName) && __layoutNormalizeText(__layoutUser.FullName)) {
+      __layoutUser.DisplayName = __layoutUser.FullName;
+    }
+
+    if (!__layoutNormalizeText(__layoutUser.RoleName) && __layoutRoleNames.length) {
+      __layoutUser.RoleName = __layoutRoleNames[0];
+    }
+
+    if (!Array.isArray(__layoutUser.roleNames) || !__layoutUser.roleNames.length) {
+      __layoutUser.roleNames = __layoutRoleNames.slice();
     }
 
     function __layoutFormatEmployment(status) {


### PR DESCRIPTION
## Summary
- add robust helpers to normalize and resolve campaign identifiers and names from the authenticated user context
- fall back to Apps Script campaign lookup utilities when campaign metadata is missing from the session payload
- ensure user objects used by the layout always expose display name and role information for the sidebar and banner components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec58e6e5548326a565fc6c8e52f0e7