### PR TITLE
Persist user identity across sessions

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -1290,6 +1290,10 @@
       rememberExpiry: 'lumina.auth.rememberExpiry',
       lastEmail: 'lumina.auth.lastEmail'
     };
+    const IDENTITY_STORAGE_KEYS = {
+      primary: 'lumina.session.identity',
+      fallback: 'lumina.auth.identity'
+    };
 
     // ───────────────────────────────────────────────────────────────────────────────
     // DOM ELEMENTS AND STATE MANAGEMENT
@@ -2278,10 +2282,202 @@
         console.warn('Unable to clear auth token from sessionStorage', err);
       }
 
+      clearPersistedIdentity('auth-cookie-cleared');
+
       state.authToken = '';
       state.sessionIdleTimeoutMinutes = null;
       state.sessionTtlSeconds = null;
       state.sessionExpiresAt = null;
+    }
+
+    function safeJsonClone(value) {
+      if (!value || typeof value !== 'object') {
+        return value || null;
+      }
+      try {
+        return JSON.parse(JSON.stringify(value));
+      } catch (err) {
+        console.warn('Unable to clone identity payload', err);
+        return null;
+      }
+    }
+
+    function normalizeRoleList(source) {
+      if (!source) {
+        return [];
+      }
+
+      const normalized = [];
+      const pushRole = role => {
+        const value = role == null ? '' : String(role).trim();
+        if (value) {
+          normalized.push(value);
+        }
+      };
+
+      if (Array.isArray(source)) {
+        source.forEach(pushRole);
+      } else if (typeof source === 'string') {
+        source.split(/[,;|]/).forEach(pushRole);
+      } else if (typeof source === 'object') {
+        Object.keys(source).forEach(key => {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            pushRole(source[key]);
+          }
+        });
+      }
+
+      return normalized;
+    }
+
+    function setGlobalIdentity(identity) {
+      try {
+        if (identity) {
+          window.LuminaIdentity = identity;
+          window.__LUMINA_CURRENT_USER = identity;
+        } else {
+          try {
+            delete window.LuminaIdentity;
+          } catch (_) {
+            window.LuminaIdentity = undefined;
+          }
+          try {
+            delete window.__LUMINA_CURRENT_USER;
+          } catch (_) {
+            window.__LUMINA_CURRENT_USER = undefined;
+          }
+        }
+      } catch (err) {
+        console.warn('Unable to update global identity reference', err);
+      }
+    }
+
+    function buildIdentityPayload(user) {
+      if (!user || typeof user !== 'object') {
+        return null;
+      }
+
+      const clone = safeJsonClone(user) || {};
+      const email = ((clone.Email || clone.email || '') + '').trim();
+      const normalizedEmail = email.toLowerCase();
+      const roles = normalizeRoleList(
+        Array.isArray(clone.roleNames) && clone.roleNames.length ? clone.roleNames :
+          (clone.roles || clone.Roles || clone.RoleNames)
+      );
+
+      const campaignScope = safeJsonClone(clone.CampaignScope || clone.campaignScope || null);
+      const resolveCampaignId = () => {
+        if (clone.CampaignID) return clone.CampaignID;
+        if (clone.CampaignId) return clone.CampaignId;
+        if (clone.campaignId) return clone.campaignId;
+        if (campaignScope) {
+          return campaignScope.CampaignID || campaignScope.CampaignId || campaignScope.campaignId || campaignScope.id || '';
+        }
+        return '';
+      };
+      const campaignId = String(resolveCampaignId() || '').trim();
+      const resolveCampaignName = () => {
+        if (clone.CampaignName) return clone.CampaignName;
+        if (clone.campaignName) return clone.campaignName;
+        if (campaignScope) {
+          return campaignScope.campaignName || campaignScope.CampaignName || campaignScope.name || '';
+        }
+        return '';
+      };
+      const campaignName = String(resolveCampaignName() || '').trim();
+
+      const isAdmin = clone.IsAdmin === true || clone.isAdminBool === true ||
+        (typeof clone.IsAdmin === 'string' && clone.IsAdmin.toLowerCase() === 'true');
+
+      const payload = Object.assign({}, clone, {
+        ID: clone.ID || clone.Id || clone.id || null,
+        Id: clone.ID || clone.Id || clone.id || null,
+        id: clone.ID || clone.Id || clone.id || null,
+        Email: email,
+        email: email,
+        normalizedEmail: normalizedEmail,
+        roleNames: roles,
+        Roles: roles.join(', '),
+        CampaignScope: campaignScope || null,
+        campaignScope: campaignScope || null,
+        CampaignID: campaignId,
+        CampaignId: campaignId,
+        campaignId: campaignId,
+        CampaignName: campaignName,
+        campaignName: campaignName,
+        IsAdmin: isAdmin,
+        isAdminBool: isAdmin,
+        FullName: clone.FullName || clone.UserName || clone.fullName || '',
+        UserName: clone.UserName || clone.FullName || clone.userName || clone.displayName || '',
+        identityMeta: Object.assign({}, clone.identityMeta, {
+          persistedAt: new Date().toISOString(),
+          source: clone.identityMeta && clone.identityMeta.source ? clone.identityMeta.source : 'login-page'
+        })
+      });
+
+      const sessionToken = state.authToken || readAuthCookie() || clone.sessionToken || '';
+      payload.sessionToken = sessionToken;
+      payload.sessionExpiresAt = state.sessionExpiresAt || clone.sessionExpiresAt || clone.sessionExpiry || null;
+      payload.sessionIdleTimeoutMinutes = state.sessionIdleTimeoutMinutes || clone.sessionIdleTimeoutMinutes || null;
+
+      return payload;
+    }
+
+    function persistUserIdentity(user) {
+      const payload = buildIdentityPayload(user);
+      if (!payload) {
+        clearPersistedIdentity('persist-empty');
+        return null;
+      }
+
+      const serialized = JSON.stringify(payload);
+
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+          sessionStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+        }
+      } catch (err) {
+        console.warn('Unable to persist identity in sessionStorage', err);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+          localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+        }
+      } catch (err) {
+        console.warn('Unable to persist identity in localStorage', err);
+      }
+
+      setGlobalIdentity(payload);
+      return payload;
+    }
+
+    function clearPersistedIdentity(reason) {
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.removeItem(IDENTITY_STORAGE_KEYS.primary);
+          sessionStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
+        }
+      } catch (err) {
+        console.warn('Unable to clear identity from sessionStorage', err);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.removeItem(IDENTITY_STORAGE_KEYS.primary);
+          localStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
+        }
+      } catch (err) {
+        console.warn('Unable to clear identity from localStorage', err);
+      }
+
+      setGlobalIdentity(null);
+
+      if (reason) {
+        console.log('Cleared persisted identity:', reason);
+      }
     }
 
     function persistSessionToken(token, rememberMe, expiresAtIso, ttlSeconds, idleTimeoutMinutes) {
@@ -2430,6 +2626,10 @@
         result.sessionTtlSeconds,
         result.idleTimeoutMinutes
       );
+
+      if (result && result.user) {
+        persistUserIdentity(result.user);
+      }
     }
 
     function handleKeepAliveFailure(error) {
@@ -2441,6 +2641,7 @@
     function handleSessionExpired(reason) {
       console.log('Session expired:', reason);
       clearAuthCookie();
+      clearPersistedIdentity('session-expired');
       try {
         showAlert('info', 'Your session has expired. Please sign in again.');
       } catch (err) {
@@ -2474,6 +2675,7 @@
           if (!result || !result.success) {
             if (result && result.expired) {
               clearAuthCookie();
+              clearPersistedIdentity('resume-expired');
               showAlert('info', 'Your previous session has expired. Please sign in again.');
             }
             return;
@@ -2496,6 +2698,7 @@
           hideAllAlerts();
           const resumeInput = result.redirectUrl || (result.redirectSlug ? `?page=${result.redirectSlug}` : '');
           const resumeUrl = normalizeRedirectUrl(resumeInput);
+          persistUserIdentity(resumedUser);
           setupRedirect(resumeUrl, resumedUser);
         })
         .withFailureHandler(error => {
@@ -3247,6 +3450,8 @@
     }
 
     function handleLoginFailure(response, email) {
+      clearAuthCookie();
+      clearPersistedIdentity('login-failed');
       const normalizedEmail = (email || '').trim();
       const displayEmail = normalizedEmail || 'your email address';
 
@@ -3507,6 +3712,10 @@
       const safeUrl = stripTokenFromUrl(url);
       console.log('Setting up redirect to:', safeUrl);
 
+      if (userInfo && typeof userInfo === 'object') {
+        persistUserIdentity(userInfo);
+      }
+
       state.redirectUrl = safeUrl;
       state.isRedirecting = true;
       state.countdownValue = 3;
@@ -3692,6 +3901,8 @@
         response.sessionTtlSeconds,
         response.sessionIdleTimeoutMinutes
       );
+
+      persistUserIdentity(response.user);
 
       const redirectInput = response.redirectUrl || (response.redirectSlug ? `?page=${response.redirectSlug}` : '');
       const destinationUrl = normalizeRedirectUrl(redirectInput);

--- a/layout.html
+++ b/layout.html
@@ -315,6 +315,340 @@
 
     const RETURN_URL = deriveReturnUrl(__RAW_RETURN_URL, PAGE_SLUG);
 
+    const IDENTITY_STORAGE_KEYS = {
+      primary: 'lumina.session.identity',
+      fallback: 'lumina.auth.identity'
+    };
+
+    function safeParseJson(value) {
+      if (!value) {
+        return null;
+      }
+      try {
+        return JSON.parse(value);
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to parse stored identity', err);
+        return null;
+      }
+    }
+
+    function safeJsonClone(value) {
+      if (!value || typeof value !== 'object') {
+        return value || null;
+      }
+      try {
+        return JSON.parse(JSON.stringify(value));
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to clone identity payload', err);
+        return null;
+      }
+    }
+
+    function normalizeIdentityRoles(source) {
+      if (!source) {
+        return [];
+      }
+
+      const roles = [];
+      const push = role => {
+        const value = role == null ? '' : String(role).trim();
+        if (value) {
+          roles.push(value);
+        }
+      };
+
+      if (Array.isArray(source)) {
+        source.forEach(push);
+      } else if (typeof source === 'string') {
+        source.split(/[,;|]/).forEach(push);
+      } else if (typeof source === 'object') {
+        Object.keys(source).forEach(key => {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            push(source[key]);
+          }
+        });
+      }
+
+      return roles;
+    }
+
+    function isPlaceholderUser(candidate) {
+      if (!candidate || typeof candidate !== 'object') {
+        return true;
+      }
+      const email = (candidate.Email || candidate.email || '').trim().toLowerCase();
+      const name = (candidate.FullName || candidate.UserName || candidate.displayName || '').trim().toLowerCase();
+      if (!email && !name) {
+        return true;
+      }
+      if (email === 'lumina@vlbpo.com' || name === 'lumina') {
+        return true;
+      }
+      return false;
+    }
+
+    function setGlobalIdentity(identity) {
+      let previousIdentity = null;
+      try {
+        previousIdentity = window.LuminaIdentity || null;
+      } catch (_) {
+        previousIdentity = null;
+      }
+
+      try {
+        if (identity && typeof identity === 'object') {
+          window.LuminaIdentity = identity;
+          window.__LUMINA_CURRENT_USER = identity;
+
+          if (typeof window.user === 'undefined' || isPlaceholderUser(window.user) || window.user === previousIdentity) {
+            window.user = identity;
+          }
+          if (typeof window.currentUser === 'undefined' || isPlaceholderUser(window.currentUser) || window.currentUser === previousIdentity) {
+            window.currentUser = identity;
+          }
+          if (typeof window.CURRENT_USER === 'undefined' || isPlaceholderUser(window.CURRENT_USER) || window.CURRENT_USER === previousIdentity) {
+            window.CURRENT_USER = identity;
+          }
+        } else {
+          try {
+            delete window.LuminaIdentity;
+          } catch (_) {
+            window.LuminaIdentity = undefined;
+          }
+          try {
+            delete window.__LUMINA_CURRENT_USER;
+          } catch (_) {
+            window.__LUMINA_CURRENT_USER = undefined;
+          }
+
+          const shouldClearUser = isPlaceholderUser(window.user) || window.user === previousIdentity;
+          const shouldClearCurrent = isPlaceholderUser(window.currentUser) || window.currentUser === previousIdentity;
+          const shouldClearUpper = isPlaceholderUser(window.CURRENT_USER) || window.CURRENT_USER === previousIdentity;
+
+          if (shouldClearUser) {
+            window.user = undefined;
+          }
+          if (shouldClearCurrent) {
+            window.currentUser = undefined;
+          }
+          if (shouldClearUpper) {
+            window.CURRENT_USER = undefined;
+          }
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to update global identity', err);
+      }
+    }
+
+    function sanitizeIdentityPayload(user, sourceLabel) {
+      if (!user || typeof user !== 'object') {
+        return null;
+      }
+
+      const clone = safeJsonClone(user) || {};
+      const email = ((clone.Email || clone.email || '') + '').trim();
+      const normalizedEmail = email.toLowerCase();
+      const roles = normalizeIdentityRoles(
+        Array.isArray(clone.roleNames) && clone.roleNames.length ? clone.roleNames :
+          (clone.roles || clone.Roles || clone.RoleNames)
+      );
+
+      const campaignScope = safeJsonClone(clone.CampaignScope || clone.campaignScope || null);
+      const campaignId = String(
+        clone.CampaignID || clone.CampaignId || clone.campaignId ||
+        (campaignScope && (campaignScope.CampaignID || campaignScope.CampaignId || campaignScope.campaignId || campaignScope.id))
+        || ''
+      ).trim();
+      const campaignName = String(
+        clone.CampaignName || clone.campaignName ||
+        (campaignScope && (campaignScope.campaignName || campaignScope.CampaignName || campaignScope.name)) || ''
+      ).trim();
+
+      const isAdmin = clone.IsAdmin === true || clone.isAdminBool === true ||
+        (typeof clone.IsAdmin === 'string' && clone.IsAdmin.toLowerCase() === 'true');
+
+      clone.ID = clone.ID || clone.Id || clone.id || null;
+      clone.Id = clone.ID;
+      clone.id = clone.ID;
+      clone.Email = email;
+      clone.email = email;
+      clone.normalizedEmail = normalizedEmail;
+      clone.roleNames = roles;
+      clone.Roles = roles.join(', ');
+      clone.CampaignScope = campaignScope || null;
+      clone.campaignScope = campaignScope || null;
+      clone.CampaignID = campaignId;
+      clone.CampaignId = campaignId;
+      clone.campaignId = campaignId;
+      clone.CampaignName = campaignName;
+      clone.campaignName = campaignName;
+      clone.IsAdmin = isAdmin;
+      clone.isAdminBool = isAdmin;
+      clone.FullName = clone.FullName || clone.UserName || clone.fullName || '';
+      clone.UserName = clone.UserName || clone.FullName || clone.userName || clone.displayName || '';
+      clone.identityMeta = Object.assign({}, clone.identityMeta, {
+        persistedAt: new Date().toISOString(),
+        source: sourceLabel || (clone.identityMeta && clone.identityMeta.source) || 'layout'
+      });
+
+      return clone;
+    }
+
+    function persistIdentityToStorage(user, options = {}) {
+      const payload = sanitizeIdentityPayload(user, options.source || 'layout');
+      if (!payload) {
+        if (options.clearOnEmpty !== false) {
+          clearPersistedIdentity(options.reason || 'identity-empty');
+        }
+        return null;
+      }
+
+      const serialized = JSON.stringify(payload);
+
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+          sessionStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to persist identity in sessionStorage', err);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+          localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to persist identity in localStorage', err);
+      }
+
+      if (!options.skipGlobals) {
+        setGlobalIdentity(payload);
+      }
+
+      return payload;
+    }
+
+    function readPersistedIdentity() {
+      const keys = [IDENTITY_STORAGE_KEYS.primary, IDENTITY_STORAGE_KEYS.fallback];
+      let raw = null;
+
+      try {
+        if (window.sessionStorage) {
+          for (let i = 0; i < keys.length; i += 1) {
+            raw = sessionStorage.getItem(keys[i]);
+            if (raw) {
+              break;
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to read sessionStorage identity', err);
+      }
+
+      if (!raw) {
+        try {
+          if (window.localStorage) {
+            for (let i = 0; i < keys.length; i += 1) {
+              raw = localStorage.getItem(keys[i]);
+              if (raw) {
+                break;
+              }
+            }
+          }
+        } catch (err) {
+          console.warn('LuminaIdentity: unable to read localStorage identity', err);
+        }
+      }
+
+      const parsed = safeParseJson(raw);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    }
+
+    function clearPersistedIdentity(reason) {
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.removeItem(IDENTITY_STORAGE_KEYS.primary);
+          sessionStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to clear sessionStorage identity', err);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.removeItem(IDENTITY_STORAGE_KEYS.primary);
+          localStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
+        }
+      } catch (err) {
+        console.warn('LuminaIdentity: unable to clear localStorage identity', err);
+      }
+
+      setGlobalIdentity(null);
+
+      if (reason) {
+        console.log('Lumina identity cleared:', reason);
+      }
+    }
+
+    function hydrateIdentityFromStorage(options = {}) {
+      const stored = readPersistedIdentity();
+      if (!stored) {
+        if (options.ensureGlobals !== false) {
+          setGlobalIdentity(null);
+        }
+        return null;
+      }
+
+      const identity = sanitizeIdentityPayload(stored, options.source || 'storage-hydrate');
+      if (!identity) {
+        if (options.clearOnInvalid !== false) {
+          clearPersistedIdentity('hydrate-invalid');
+        }
+        return null;
+      }
+
+      if (options.refreshStorage) {
+        persistIdentityToStorage(identity, { skipGlobals: true, source: 'hydrate-refresh' });
+      }
+
+      if (options.skipGlobals !== true) {
+        setGlobalIdentity(identity);
+      }
+
+      if (options.applyToUi) {
+        try {
+          updateUserDisplaySafely(identity);
+        } catch (err) {
+          console.warn('LuminaIdentity: unable to apply identity to layout', err);
+        }
+      }
+
+      return identity;
+    }
+
+    window.LuminaIdentityManager = {
+      read: readPersistedIdentity,
+      write: (identity, options) => persistIdentityToStorage(identity, options || {}),
+      clear: reason => clearPersistedIdentity(reason || 'manual-clear'),
+      hydrate: options => hydrateIdentityFromStorage(options || {}),
+      setGlobals: setGlobalIdentity
+    };
+
+    hydrateIdentityFromStorage({ applyToUi: false, ensureGlobals: true, source: 'initial-load' });
+
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+      window.addEventListener('storage', function(event) {
+        if (!event) {
+          return;
+        }
+        if (event.key === IDENTITY_STORAGE_KEYS.primary || event.key === IDENTITY_STORAGE_KEYS.fallback) {
+          hydrateIdentityFromStorage({ applyToUi: true, source: 'storage-event', refreshStorage: false });
+        }
+      });
+    }
+
     function buildReturnUrl(extraParams = {}, rawUrl = RETURN_URL) {
       const base = deriveReturnUrl(rawUrl, PAGE_SLUG);
       if (!extraParams || typeof extraParams !== 'object' || Array.isArray(extraParams)) {
@@ -3027,6 +3361,12 @@
                 }
             }
 
+            try {
+                persistIdentityToStorage(user, { source: 'display-update' });
+            } catch (persistError) {
+                console.warn('LuminaIdentity: unable to persist identity from display update', persistError);
+            }
+
             window.__userHydrated = true;
             console.log('User display updated successfully');
         }
@@ -3053,6 +3393,12 @@
                 }
             } catch (storageError) {
                 console.warn('stopSessionHeartbeat: unable to clear fallback storage', storageError);
+            }
+
+            try {
+                clearPersistedIdentity(reason || 'logout');
+            } catch (identityError) {
+                console.warn('stopSessionHeartbeat: unable to clear persisted identity', identityError);
             }
         }
 
@@ -3238,6 +3584,12 @@
             } catch (sessionStorageError) {
                 console.warn('AuthGuard: unable to clear sessionStorage tokens', sessionStorageError);
             }
+
+            try {
+                clearPersistedIdentity(reason || 'auth-guard');
+            } catch (identityError) {
+                console.warn('AuthGuard: unable to clear persisted identity', identityError);
+            }
         }
 
         function redirectToLogin() {
@@ -3306,6 +3658,12 @@
         // ──────────────────────────────────────────────────────────────────────────────
         document.addEventListener('DOMContentLoaded', function() {
             console.log('🚀 VLBPO Dashboard initializing...');
+
+            try {
+                hydrateIdentityFromStorage({ applyToUi: true, source: 'dom-ready', refreshStorage: false });
+            } catch (identityError) {
+                console.warn('LuminaIdentity: unable to hydrate identity on DOM ready', identityError);
+            }
 
             const absorbed = absorbLocalBanners();
 


### PR DESCRIPTION
## Summary
- persist the authenticated user's identity details when logging in or resuming a session so role and campaign context is available across pages
- hydrate the shared layout from stored identity data, expose a global identity manager, and clear identity details when sessions expire or users log out

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68ec87baabe88326a73db5bdd96f29d5