### PR TITLE
Reduce main content spacing around layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1367,11 +1367,11 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 1.5rem) clamp(1.25rem, 4vw, 1.75rem) 1.75rem;
+        margin: calc(var(--topbar-height) + 0.7rem) clamp(0.75rem, 2.6vw, 1.15rem) 1rem;
       }
 
       #sidebar.collapsed~#maincontent {
-        margin-left: clamp(1.25rem, 4vw, 1.75rem);
+        margin-left: clamp(0.75rem, 2.6vw, 1.15rem);
       }
 
       body.sidebar-open #maincontent {
@@ -1399,7 +1399,7 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 1.25rem) clamp(1rem, 5vw, 1.5rem) 1.5rem;
+        margin: calc(var(--topbar-height) + 0.55rem) clamp(0.65rem, 3.5vw, 1.05rem) 0.9rem;
       }
 
       .breadcrumb-nav {
@@ -1416,7 +1416,7 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 1rem) clamp(0.75rem, 6vw, 1.25rem) 1.25rem;
+        margin: calc(var(--topbar-height) + 0.5rem) clamp(0.55rem, 4.5vw, 0.95rem) 0.85rem;
       }
 
       .topbar-toggle {
@@ -1431,16 +1431,16 @@
     }
 
     #maincontent {
-      margin-left: calc(var(--sidebar-width) + 2rem);
-      margin-top: calc(var(--topbar-height) + 2rem);
-      margin-right: 2rem;
-      margin-bottom: 2rem;
+      margin-left: calc(var(--sidebar-width) + 0.75rem);
+      margin-top: calc(var(--topbar-height) + 0.6rem);
+      margin-right: 0.85rem;
+      margin-bottom: 1rem;
       transition: var(--transition-smooth);
-      min-height: calc(100vh - var(--topbar-height) - 4rem);
+      min-height: calc(100vh - var(--topbar-height) - 1.6rem);
     }
 
     #sidebar.collapsed~#maincontent {
-      margin-left: calc(var(--sidebar-collapsed) + 2rem);
+      margin-left: calc(var(--sidebar-collapsed) + 0.75rem);
     }
 
     /* Unified global page banner */


### PR DESCRIPTION
## Summary
- decrease the #maincontent margins across breakpoints so the body sits closer to the sidebar and top bar
- adjust the desktop min-height calculation to align with the tighter vertical spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec884bc1cc83268f652ee02f13119e