### PR TITLE
Fix current user lookup for lowercase email headers

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1010,12 +1010,19 @@ function getBaseUrl() {
 function _findUserByEmail_(email) {
   if (!email) return null;
   try {
-    const CK = 'USR_BY_EMAIL_' + email.toLowerCase();
+    const normalizedEmail = String(email).trim().toLowerCase();
+    if (!normalizedEmail) return null;
+
+    const CK = 'USR_BY_EMAIL_' + normalizedEmail;
     const cached = _cacheGet(CK);
     if (cached) return cached;
 
     const rows = (typeof readSheet === 'function') ? (readSheet('Users') || []) : [];
-    const hit = rows.find(r => String(r.Email || '').trim().toLowerCase() === email.toLowerCase()) || null;
+    const hit = rows.find(function (r) {
+      if (!r) return false;
+      const candidate = String(r.Email || r.email || '').trim().toLowerCase();
+      return candidate === normalizedEmail;
+    }) || null;
     if (hit) _cachePut(CK, hit, 120);
     return hit;
   } catch (e) {


### PR DESCRIPTION
## Summary
- normalize email addresses before caching lookups in `_findUserByEmail_`
- allow matching against both `Email` and `email` sheet columns when resolving the current user

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecd8be86688326b42660516fd83a5b