### PR TITLE
Add identity cookie support for user context

### DIFF
--- a/CookieHandler.html
+++ b/CookieHandler.html
@@ -2,9 +2,15 @@
 <script>
   (function (global) {
     const COOKIE_NAME = 'authToken';
+    const IDENTITY_COOKIE_NAME = 'luminaIdentity';
     const MIN_MAX_AGE_SECONDS = 300;
     const DEFAULT_SESSION_SECONDS = 60 * 60; // 1 hour fallback
     const DEFAULT_REMEMBER_SECONDS = 24 * 60 * 60; // 24 hours fallback
+    const IDENTITY_MAX_BYTES = 3800;
+    const IDENTITY_ROLE_LIMIT = 6;
+    const IDENTITY_CATEGORY_LIMIT = 8;
+    const IDENTITY_PAGES_PER_CATEGORY_LIMIT = 8;
+    const IDENTITY_UNCATEGORIZED_LIMIT = 10;
 
     function safeParseDate(input) {
       if (!input) return null;
@@ -135,20 +141,372 @@
       clearCookie(COOKIE_NAME, options);
     }
 
+    function safeCookieText(value) {
+      if (value === null || typeof value === 'undefined') {
+        return '';
+      }
+
+      const text = String(value).trim();
+      if (!text || text.toLowerCase() === 'undefined' || text.toLowerCase() === 'null') {
+        return '';
+      }
+
+      return text;
+    }
+
+    function normalizeBoolean(value) {
+      if (value === true || value === false) {
+        return value;
+      }
+
+      if (typeof value === 'string') {
+        const text = value.trim().toLowerCase();
+        if (!text) return false;
+        if (text === 'true' || text === '1' || text === 'yes') return true;
+        if (text === 'false' || text === '0' || text === 'no') return false;
+      }
+
+      if (typeof value === 'number') {
+        if (Number.isNaN(value)) return false;
+        return value !== 0;
+      }
+
+      return false;
+    }
+
+    function sanitizeRoleListForCookie(source) {
+      const roles = [];
+
+      const pushRole = role => {
+        const text = safeCookieText(role);
+        if (!text) {
+          return;
+        }
+
+        const lower = text.toLowerCase();
+        if (roles.some(existing => existing.toLowerCase() === lower)) {
+          return;
+        }
+
+        roles.push(text);
+      };
+
+      if (Array.isArray(source)) {
+        source.forEach(pushRole);
+      } else if (typeof source === 'string') {
+        source.split(/[,;|]/).forEach(pushRole);
+      } else if (source && typeof source === 'object') {
+        Object.keys(source).forEach(key => {
+          if (typeof source[key] === 'string') {
+            pushRole(source[key]);
+          }
+        });
+      }
+
+      return roles.slice(0, IDENTITY_ROLE_LIMIT);
+    }
+
+    function sanitizeNavigationPagesForCookie(pages, limit) {
+      if (!Array.isArray(pages) || !pages.length) {
+        return [];
+      }
+
+      const sanitized = [];
+      for (let i = 0; i < pages.length && sanitized.length < limit; i += 1) {
+        const page = pages[i] || {};
+        const key = safeCookieText(page.PageKey || page.pageKey);
+        const title = safeCookieText(page.PageTitle || page.pageTitle);
+        if (!key || !title) {
+          continue;
+        }
+
+        const entry = {
+          key,
+          title
+        };
+
+        const icon = safeCookieText(page.PageIcon || page.pageIcon);
+        if (icon) {
+          entry.icon = icon;
+        }
+
+        const description = safeCookieText(page.PageDescription || page.pageDescription);
+        if (description) {
+          entry.description = description;
+        }
+
+        sanitized.push(entry);
+      }
+
+      return sanitized;
+    }
+
+    function sanitizeNavigationForCookie(nav) {
+      if (!nav || typeof nav !== 'object') {
+        return null;
+      }
+
+      const sanitized = { categories: [], uncategorized: [] };
+
+      if (Array.isArray(nav.categories)) {
+        for (let i = 0; i < nav.categories.length && sanitized.categories.length < IDENTITY_CATEGORY_LIMIT; i += 1) {
+          const category = nav.categories[i] || {};
+          const pages = sanitizeNavigationPagesForCookie(category.pages || category.Pages, IDENTITY_PAGES_PER_CATEGORY_LIMIT);
+          if (!pages.length) {
+            continue;
+          }
+
+          const catEntry = {
+            name: safeCookieText(category.CategoryName || category.categoryName || 'Category'),
+            pages
+          };
+
+          const icon = safeCookieText(category.CategoryIcon || category.categoryIcon);
+          if (icon) {
+            catEntry.icon = icon;
+          }
+
+          sanitized.categories.push(catEntry);
+        }
+      }
+
+      if (Array.isArray(nav.uncategorizedPages)) {
+        sanitized.uncategorized = sanitizeNavigationPagesForCookie(
+          nav.uncategorizedPages,
+          IDENTITY_UNCATEGORIZED_LIMIT
+        );
+      }
+
+      if (!sanitized.categories.length && !sanitized.uncategorized.length) {
+        return null;
+      }
+
+      return sanitized;
+    }
+
+    function sanitizeIdentityCookiePayload(identity) {
+      if (!identity || typeof identity !== 'object') {
+        return null;
+      }
+
+      const sanitized = {
+        id: safeCookieText(identity.ID || identity.Id || identity.id),
+        userName: safeCookieText(identity.UserName || identity.userName || identity.username),
+        fullName: safeCookieText(identity.FullName || identity.fullName),
+        email: safeCookieText(identity.Email || identity.email),
+        roles: sanitizeRoleListForCookie(identity.roleNames || identity.Roles || identity.roles),
+        isAdmin: normalizeBoolean(identity.IsAdmin || identity.isAdminBool),
+        campaign: {
+          id: safeCookieText(identity.CampaignID || identity.CampaignId || identity.campaignId),
+          name: safeCookieText(identity.CampaignName || identity.campaignName)
+        },
+        persistedAt: new Date().toISOString()
+      };
+
+      const employmentStatus = safeCookieText(identity.EmploymentStatus || identity.employmentStatus);
+      if (employmentStatus) {
+        sanitized.employmentStatus = employmentStatus;
+      }
+
+      const country = safeCookieText(identity.Country || identity.country);
+      if (country) {
+        sanitized.country = country;
+      }
+
+      if (!sanitized.roles.length) {
+        delete sanitized.roles;
+      }
+
+      if (!sanitized.campaign.id) {
+        delete sanitized.campaign.id;
+      }
+      if (!sanitized.campaign.name) {
+        delete sanitized.campaign.name;
+      }
+
+      const scope = identity.CampaignScope || identity.campaignScope || null;
+      if (scope && typeof scope === 'object') {
+        const allowedIds = Array.isArray(scope.allowedCampaignIds)
+          ? scope.allowedCampaignIds.map(safeCookieText).filter(Boolean)
+          : [];
+        if (allowedIds.length) {
+          sanitized.campaign.allowedCampaignIds = allowedIds.slice(0, 12);
+        }
+
+        const activeId = safeCookieText(scope.activeCampaignId);
+        if (activeId) {
+          sanitized.campaign.activeCampaignId = activeId;
+        }
+
+        const defaultId = safeCookieText(scope.defaultCampaignId);
+        if (defaultId) {
+          sanitized.campaign.defaultCampaignId = defaultId;
+        }
+
+        if (scope.needsCampaignAssignment) {
+          sanitized.campaign.needsAssignment = true;
+        }
+      }
+
+      if (Object.keys(sanitized.campaign).length === 0) {
+        delete sanitized.campaign;
+      }
+
+      const navSource = identity.campaignNavigation || identity.navigation || identity.campaignNav;
+      const navigation = sanitizeNavigationForCookie(navSource);
+      if (navigation) {
+        sanitized.navigation = navigation;
+      }
+
+      if (!sanitized.id && !sanitized.userName && !sanitized.email) {
+        return null;
+      }
+
+      return sanitized;
+    }
+
+    function serializeIdentityForCookie(payload) {
+      if (!payload || typeof payload !== 'object') {
+        return '';
+      }
+
+      try {
+        let serialized = JSON.stringify(payload);
+        if (serialized.length <= IDENTITY_MAX_BYTES) {
+          return serialized;
+        }
+
+        if (payload.navigation) {
+          if (Array.isArray(payload.navigation.categories) && payload.navigation.categories.length) {
+            payload.navigation.categories = payload.navigation.categories
+              .slice(0, Math.min(3, payload.navigation.categories.length))
+              .map(category => {
+                const clone = Object.assign({}, category);
+                if (Array.isArray(clone.pages)) {
+                  clone.pages = clone.pages.slice(0, 4);
+                }
+                return clone;
+              });
+          }
+          if (Array.isArray(payload.navigation.uncategorized) && payload.navigation.uncategorized.length) {
+            payload.navigation.uncategorized = payload.navigation.uncategorized.slice(0, 4);
+          }
+
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+
+          delete payload.navigation;
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+        }
+
+        if (Array.isArray(payload.roles) && payload.roles.length) {
+          payload.roles = payload.roles.slice(0, 3);
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+
+          delete payload.roles;
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+        }
+
+        if (payload.campaign && Array.isArray(payload.campaign.allowedCampaignIds)) {
+          payload.campaign.allowedCampaignIds = payload.campaign.allowedCampaignIds.slice(0, 3);
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+
+          delete payload.campaign.allowedCampaignIds;
+          serialized = JSON.stringify(payload);
+          if (serialized.length <= IDENTITY_MAX_BYTES) {
+            return serialized;
+          }
+        }
+
+        if (serialized.length <= IDENTITY_MAX_BYTES) {
+          return serialized;
+        }
+      } catch (err) {
+        console.warn('CookieHandler: unable to serialize identity payload', err);
+        return '';
+      }
+
+      console.warn('CookieHandler: identity payload too large for cookie, skipping');
+      return '';
+    }
+
+    function persistIdentityCookie(identity, options = {}) {
+      if (!identity) {
+        clearCookie(IDENTITY_COOKIE_NAME, options);
+        return null;
+      }
+
+      const sanitized = sanitizeIdentityCookiePayload(identity);
+      if (!sanitized) {
+        clearCookie(IDENTITY_COOKIE_NAME, options);
+        return null;
+      }
+
+      const serialized = serializeIdentityForCookie(sanitized);
+      if (!serialized) {
+        clearCookie(IDENTITY_COOKIE_NAME, options);
+        return sanitized;
+      }
+
+      writeCookie(IDENTITY_COOKIE_NAME, serialized, options);
+      return sanitized;
+    }
+
+    function readIdentityCookie() {
+      const raw = readCookieValue(IDENTITY_COOKIE_NAME);
+      if (!raw) {
+        return null;
+      }
+
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : null;
+      } catch (err) {
+        console.warn('CookieHandler: unable to parse identity cookie', err);
+        return null;
+      }
+    }
+
+    function clearIdentityCookie(options = {}) {
+      clearCookie(IDENTITY_COOKIE_NAME, options);
+    }
+
     const api = {
       AUTH_COOKIE_NAME: COOKIE_NAME,
+      IDENTITY_COOKIE_NAME,
       readCookieValue,
       writeCookie,
       clearCookie,
       readAuthToken,
       persistAuthToken,
       clearAuthToken,
-      resolveMaxAgeSeconds
+      resolveMaxAgeSeconds,
+      sanitizeIdentityCookiePayload,
+      persistIdentityCookie,
+      readIdentityCookie,
+      clearIdentityCookie
     };
 
     global.CookieHandler = api;
     global.readAuthCookie = readAuthToken;
     global.persistAuthCookie = persistAuthToken;
     global.clearAuthCookie = clearAuthToken;
+    global.persistIdentityCookie = persistIdentityCookie;
+    global.readIdentityCookie = readIdentityCookie;
+    global.clearIdentityCookie = clearIdentityCookie;
   })(typeof window !== 'undefined' ? window : this);
 </script>

--- a/Login.html
+++ b/Login.html
@@ -2443,16 +2443,46 @@
 
       try {
         if (window.localStorage) {
-          localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
-          localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
-        }
-      } catch (err) {
-        console.warn('Unable to persist identity in localStorage', err);
+      localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+      localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+    }
+  } catch (err) {
+    console.warn('Unable to persist identity in localStorage', err);
+  }
+
+  try {
+    if (window.CookieHandler && typeof CookieHandler.persistIdentityCookie === 'function') {
+      const cookieOptions = {};
+
+      if (typeof state.sessionTtlSeconds === 'number' && state.sessionTtlSeconds > 0) {
+        cookieOptions.ttlSeconds = Math.floor(state.sessionTtlSeconds);
+        cookieOptions.maxAgeSeconds = Math.max(300, Math.floor(state.sessionTtlSeconds));
+      } else if (typeof state.sessionIdleTimeoutMinutes === 'number' && state.sessionIdleTimeoutMinutes > 0) {
+        cookieOptions.maxAgeSeconds = Math.max(300, Math.floor(state.sessionIdleTimeoutMinutes * 60));
+      } else if (state.lastRememberMe) {
+        cookieOptions.maxAgeSeconds = REMEMBER_COOKIE_MAX_AGE;
+        cookieOptions.rememberMe = true;
+      } else {
+        cookieOptions.maxAgeSeconds = SESSION_COOKIE_MAX_AGE;
       }
 
-      setGlobalIdentity(payload);
-      return payload;
+      if (typeof state.lastRememberMe === 'boolean') {
+        cookieOptions.rememberMe = state.lastRememberMe;
+      }
+
+      if (state.sessionExpiresAt) {
+        cookieOptions.expiresAt = state.sessionExpiresAt;
+      }
+
+      CookieHandler.persistIdentityCookie(payload, cookieOptions);
     }
+  } catch (cookieError) {
+    console.warn('Unable to persist identity cookie', cookieError);
+  }
+
+  setGlobalIdentity(payload);
+  return payload;
+}
 
     function clearPersistedIdentity(reason) {
       try {
@@ -2470,14 +2500,22 @@
           localStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
         }
       } catch (err) {
-        console.warn('Unable to clear identity from localStorage', err);
-      }
+    console.warn('Unable to clear identity from localStorage', err);
+  }
 
-      setGlobalIdentity(null);
+  try {
+    if (window.CookieHandler && typeof CookieHandler.clearIdentityCookie === 'function') {
+      CookieHandler.clearIdentityCookie();
+    }
+  } catch (cookieErr) {
+    console.warn('Unable to clear identity cookie', cookieErr);
+  }
 
-      if (reason) {
-        console.log('Cleared persisted identity:', reason);
-      }
+  setGlobalIdentity(null);
+
+  if (reason) {
+    console.log('Cleared persisted identity:', reason);
+  }
     }
 
     function persistSessionToken(token, rememberMe, expiresAtIso, ttlSeconds, idleTimeoutMinutes) {

--- a/layout.html
+++ b/layout.html
@@ -514,20 +514,66 @@
         console.warn('LuminaIdentity: unable to persist identity in sessionStorage', err);
       }
 
+    try {
+      if (window.localStorage) {
+        localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
+        localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+      }
+    } catch (err) {
+      console.warn('LuminaIdentity: unable to persist identity in localStorage', err);
+    }
+
+    if (options.skipCookie !== true) {
       try {
-        if (window.localStorage) {
-          localStorage.setItem(IDENTITY_STORAGE_KEYS.primary, serialized);
-          localStorage.setItem(IDENTITY_STORAGE_KEYS.fallback, serialized);
+        if (window.CookieHandler && typeof window.CookieHandler.persistIdentityCookie === 'function') {
+          const cookieOptions = {};
+
+          if (typeof options.cookieMaxAgeSeconds === 'number' && options.cookieMaxAgeSeconds > 0) {
+            cookieOptions.maxAgeSeconds = Math.max(SESSION_COOKIE_MIN_SECONDS, Math.floor(options.cookieMaxAgeSeconds));
+          } else if (typeof options.cookieTtlSeconds === 'number' && options.cookieTtlSeconds > 0) {
+            cookieOptions.ttlSeconds = Math.floor(options.cookieTtlSeconds);
+            cookieOptions.maxAgeSeconds = Math.max(SESSION_COOKIE_MIN_SECONDS, cookieOptions.ttlSeconds);
+          } else if (typeof window.__LUMINA_SESSION_MAX_AGE === 'number' && window.__LUMINA_SESSION_MAX_AGE > 0) {
+            cookieOptions.maxAgeSeconds = Math.max(
+              SESSION_COOKIE_MIN_SECONDS,
+              Math.floor(window.__LUMINA_SESSION_MAX_AGE)
+            );
+          } else if (typeof payload.sessionIdleTimeoutMinutes === 'number' && payload.sessionIdleTimeoutMinutes > 0) {
+            cookieOptions.maxAgeSeconds = Math.max(
+              SESSION_COOKIE_MIN_SECONDS,
+              Math.floor(payload.sessionIdleTimeoutMinutes * 60)
+            );
+          }
+
+          if (typeof options.cookieTtlSeconds === 'number' && options.cookieTtlSeconds > 0) {
+            cookieOptions.ttlSeconds = Math.floor(options.cookieTtlSeconds);
+          } else if (typeof payload.sessionTtlSeconds === 'number' && payload.sessionTtlSeconds > 0) {
+            cookieOptions.ttlSeconds = Math.floor(payload.sessionTtlSeconds);
+          }
+
+          const expiresAtCandidate = options.cookieExpiresAt || payload.sessionExpiresAt || payload.sessionExpiry || null;
+          if (expiresAtCandidate) {
+            cookieOptions.expiresAt = expiresAtCandidate;
+          }
+
+          if (typeof options.rememberMe === 'boolean') {
+            cookieOptions.rememberMe = options.rememberMe;
+          } else if (typeof window.__LUMINA_SESSION_REMEMBER === 'boolean') {
+            cookieOptions.rememberMe = window.__LUMINA_SESSION_REMEMBER;
+          }
+
+          window.CookieHandler.persistIdentityCookie(payload, cookieOptions);
         }
-      } catch (err) {
-        console.warn('LuminaIdentity: unable to persist identity in localStorage', err);
+      } catch (cookieError) {
+        console.warn('LuminaIdentity: unable to persist identity cookie', cookieError);
       }
+    }
 
-      if (!options.skipGlobals) {
-        setGlobalIdentity(payload);
-      }
+    if (!options.skipGlobals) {
+      setGlobalIdentity(payload);
+    }
 
-      return payload;
+    return payload;
     }
 
     function readPersistedIdentity() {
@@ -559,12 +605,25 @@
           }
         } catch (err) {
           console.warn('LuminaIdentity: unable to read localStorage identity', err);
-        }
       }
-
-      const parsed = safeParseJson(raw);
-      return parsed && typeof parsed === 'object' ? parsed : null;
     }
+
+    if (!raw) {
+      try {
+        if (window.CookieHandler && typeof window.CookieHandler.readIdentityCookie === 'function') {
+          const cookieIdentity = window.CookieHandler.readIdentityCookie();
+          if (cookieIdentity && typeof cookieIdentity === 'object') {
+            return cookieIdentity;
+          }
+        }
+      } catch (cookieReadError) {
+        console.warn('LuminaIdentity: unable to read identity cookie', cookieReadError);
+      }
+    }
+
+    const parsed = safeParseJson(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  }
 
     function clearPersistedIdentity(reason) {
       try {
@@ -582,14 +641,22 @@
           localStorage.removeItem(IDENTITY_STORAGE_KEYS.fallback);
         }
       } catch (err) {
-        console.warn('LuminaIdentity: unable to clear localStorage identity', err);
-      }
+      console.warn('LuminaIdentity: unable to clear localStorage identity', err);
+    }
 
-      setGlobalIdentity(null);
-
-      if (reason) {
-        console.log('Lumina identity cleared:', reason);
+    try {
+      if (window.CookieHandler && typeof window.CookieHandler.clearIdentityCookie === 'function') {
+        window.CookieHandler.clearIdentityCookie();
       }
+    } catch (cookieErr) {
+      console.warn('LuminaIdentity: unable to clear identity cookie', cookieErr);
+    }
+
+    setGlobalIdentity(null);
+
+    if (reason) {
+      console.log('Lumina identity cleared:', reason);
+    }
   }
 
   const SESSION_COOKIE_DEFAULT_SECONDS = 60 * 60; // 1 hour
@@ -745,7 +812,13 @@
 
     let identity = null;
     if (result.user) {
-      identity = persistIdentityToStorage(result.user, { source: options.source || 'session-result' });
+      identity = persistIdentityToStorage(result.user, {
+        source: options.source || 'session-result',
+        rememberMe: tokenInfo.rememberMe,
+        cookieMaxAgeSeconds: tokenInfo.maxAgeSeconds,
+        cookieTtlSeconds: tokenInfo.ttlSeconds,
+        cookieExpiresAt: tokenInfo.expiresAt
+      });
       if (identity && options.applyToUi !== false && typeof updateUserDisplaySafely === 'function') {
         try {
           updateUserDisplaySafely(identity);
@@ -892,7 +965,16 @@
       }
 
       if (options.refreshStorage) {
-        persistIdentityToStorage(identity, { skipGlobals: true, source: 'hydrate-refresh' });
+        persistIdentityToStorage(identity, {
+          skipGlobals: true,
+          source: 'hydrate-refresh',
+          cookieMaxAgeSeconds: (typeof window.__LUMINA_SESSION_MAX_AGE === 'number'
+            ? window.__LUMINA_SESSION_MAX_AGE
+            : undefined),
+          rememberMe: (typeof window.__LUMINA_SESSION_REMEMBER === 'boolean'
+            ? window.__LUMINA_SESSION_REMEMBER
+            : undefined)
+        });
       }
 
       if (options.skipGlobals !== true) {
@@ -3659,7 +3741,15 @@
             }
 
             try {
-                persistIdentityToStorage(user, { source: 'display-update' });
+                persistIdentityToStorage(user, {
+                    source: 'display-update',
+                    cookieMaxAgeSeconds: (typeof window.__LUMINA_SESSION_MAX_AGE === 'number'
+                        ? window.__LUMINA_SESSION_MAX_AGE
+                        : undefined),
+                    rememberMe: (typeof window.__LUMINA_SESSION_REMEMBER === 'boolean'
+                        ? window.__LUMINA_SESSION_REMEMBER
+                        : undefined)
+                });
             } catch (persistError) {
                 console.warn('LuminaIdentity: unable to persist identity from display update', persistError);
             }


### PR DESCRIPTION
## Summary
- add identity cookie helpers to persist user profile and navigation details alongside the auth token
- update layout identity handling to write/read the new cookie so campaign and role metadata stay available
- update login flow to keep the identity cookie in sync when sessions start or end

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecdc304ff48326989b2dd5382167d5