### PR TITLE
Fix CampaignService syntax error

### DIFF
--- a/CampaignService.js
+++ b/CampaignService.js
@@ -699,8 +699,7 @@ function csGetAllCampaigns() {
         description: c.Description || '',
         createdAt: c.CreatedAt ? new Date(c.CreatedAt).toISOString() : null,
         updatedAt: c.UpdatedAt ? new Date(c.UpdatedAt).toISOString() : null
-      }))
-      });
+      }));
 
     const visible = hasCampaignManagementPrivileges(identity)
       ? mapped


### PR DESCRIPTION
## Summary
- correct the campaign mapping block in `CampaignService.js` by removing an extra closing bracket
- ensure `csGetAllCampaigns` returns campaigns without triggering a syntax error

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed47b91b4c8326ad8c908de7d4b925