### PR TITLE
Refine password utility usage across services

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -1895,15 +1895,29 @@ var AuthenticationService = (function () {
   }
 
   function constantTimeEquals(a, b) {
-    if (typeof a !== 'string' || typeof b !== 'string') {
+    try {
+      const utils = getPasswordUtils();
+      if (utils && typeof utils.constantTimeEquals === 'function') {
+        return utils.constantTimeEquals(
+          utils.normalizePasswordInput(a),
+          utils.normalizePasswordInput(b)
+        );
+      }
+    } catch (utilsError) {
+      console.warn('constantTimeEquals: password utilities unavailable, falling back', utilsError);
+    }
+
+    if (a == null || b == null) {
       return false;
     }
-    if (a.length !== b.length) {
+    const strA = String(a);
+    const strB = String(b);
+    if (strA.length !== strB.length) {
       return false;
     }
     let result = 0;
-    for (let i = 0; i < a.length; i++) {
-      result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    for (let i = 0; i < strA.length; i++) {
+      result |= strA.charCodeAt(i) ^ strB.charCodeAt(i);
     }
     return result === 0;
   }


### PR DESCRIPTION
## Summary
- route AuthenticationService constant-time comparisons through the shared PasswordUtilities module with a safe fallback
- hash IdentityService reset tokens using PasswordUtilities.digestToHex when available
- add password utility helpers in UserService and reuse them for generating admin reset token hashes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed5f8aef788326b001f6d55a1c50e5