### PR TITLE
Fix login redirect loops

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2567,8 +2567,10 @@
       return baseUrl.toString();
     }
 
+    const DEFAULT_REDIRECT_PAGE = 'dashboard';
+
     function normalizeRedirectUrl(serverUrl) {
-      let page = 'dashboard';
+      let page = DEFAULT_REDIRECT_PAGE;
       const params = {};
 
       if (serverUrl) {
@@ -2583,6 +2585,11 @@
         } catch (err) {
           console.warn('Unable to parse server redirect URL. Falling back to local page builder.', err);
         }
+      }
+
+      const normalizedPage = (page || '').trim().toLowerCase();
+      if (!normalizedPage || normalizedPage === 'login' || normalizedPage === 'logout') {
+        page = DEFAULT_REDIRECT_PAGE;
       }
 
       return stripTokenFromUrl(buildPageUrl(page, params));


### PR DESCRIPTION
## Summary
- guard login redirects by defaulting to the dashboard when the server suggests login or logout pages
- centralize the default redirect slug so it can be reused for validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed7368b1cc8326bac6a207fb3b2381