### PR TITLE
Ensure default redirect is initialized before sanitizer

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -1007,6 +1007,11 @@
   </div>
 
   <script>
+    const DEFAULT_REDIRECT_PAGE = 'dashboard';
+    if (typeof window !== 'undefined') {
+      window.DEFAULT_REDIRECT_PAGE = DEFAULT_REDIRECT_PAGE;
+    }
+
     const SERVER_OBSERVED_METADATA = <?!= serverMetadataJson ?>;
     const INITIAL_RETURN_URL = <?!= JSON.stringify(initialReturnUrl || '') ?>;
     // ───────────────────────────────────────────────────────────────────────────────
@@ -2568,7 +2573,7 @@
     }
 
     function normalizeRedirectUrl(serverUrl) {
-      let page = 'dashboard';
+      let page = DEFAULT_REDIRECT_PAGE;
       const params = {};
 
       if (serverUrl) {
@@ -2583,6 +2588,11 @@
         } catch (err) {
           console.warn('Unable to parse server redirect URL. Falling back to local page builder.', err);
         }
+      }
+
+      const normalizedPage = (page || '').trim().toLowerCase();
+      if (!normalizedPage || normalizedPage === 'login' || normalizedPage === 'logout') {
+        page = DEFAULT_REDIRECT_PAGE;
       }
 
       return stripTokenFromUrl(buildPageUrl(page, params));


### PR DESCRIPTION
## Summary
- expose the dashboard redirect slug immediately when the login script loads so redirect sanitization cannot observe an uninitialized binding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed7368b1cc8326bac6a207fb3b2381