### PR TITLE
Prevent redirect constant redeclaration on repeated loads

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -1007,13 +1007,19 @@
   </div>
 
   <script>
-    var DEFAULT_REDIRECT_PAGE = 'dashboard';
-    if (typeof window !== 'undefined') {
-      if (typeof window.DEFAULT_REDIRECT_PAGE === 'string' && window.DEFAULT_REDIRECT_PAGE.trim()) {
-        DEFAULT_REDIRECT_PAGE = window.DEFAULT_REDIRECT_PAGE;
-      } else {
-        window.DEFAULT_REDIRECT_PAGE = DEFAULT_REDIRECT_PAGE;
+    function getDefaultRedirectPage() {
+      if (typeof window === 'undefined') {
+        return 'dashboard';
       }
+
+      var existing = window.DEFAULT_REDIRECT_PAGE;
+      if (typeof existing === 'string' && existing.trim()) {
+        return existing;
+      }
+
+      var fallback = 'dashboard';
+      window.DEFAULT_REDIRECT_PAGE = fallback;
+      return fallback;
     }
 
     const SERVER_OBSERVED_METADATA = <?!= serverMetadataJson ?>;
@@ -2577,7 +2583,7 @@
     }
 
     function normalizeRedirectUrl(serverUrl) {
-      let page = DEFAULT_REDIRECT_PAGE;
+      let page = getDefaultRedirectPage();
       const params = {};
 
       if (serverUrl) {
@@ -2596,7 +2602,7 @@
 
       const normalizedPage = (page || '').trim().toLowerCase();
       if (!normalizedPage || normalizedPage === 'login' || normalizedPage === 'logout') {
-        page = DEFAULT_REDIRECT_PAGE;
+        page = getDefaultRedirectPage();
       }
 
       return stripTokenFromUrl(buildPageUrl(page, params));

--- a/Login.html
+++ b/Login.html
@@ -1007,6 +1007,15 @@
   </div>
 
   <script>
+    var DEFAULT_REDIRECT_PAGE = 'dashboard';
+    if (typeof window !== 'undefined') {
+      if (typeof window.DEFAULT_REDIRECT_PAGE === 'string' && window.DEFAULT_REDIRECT_PAGE.trim()) {
+        DEFAULT_REDIRECT_PAGE = window.DEFAULT_REDIRECT_PAGE;
+      } else {
+        window.DEFAULT_REDIRECT_PAGE = DEFAULT_REDIRECT_PAGE;
+      }
+    }
+
     const SERVER_OBSERVED_METADATA = <?!= serverMetadataJson ?>;
     const INITIAL_RETURN_URL = <?!= JSON.stringify(initialReturnUrl || '') ?>;
     // ───────────────────────────────────────────────────────────────────────────────
@@ -2568,7 +2577,7 @@
     }
 
     function normalizeRedirectUrl(serverUrl) {
-      let page = 'dashboard';
+      let page = DEFAULT_REDIRECT_PAGE;
       const params = {};
 
       if (serverUrl) {
@@ -2583,6 +2592,11 @@
         } catch (err) {
           console.warn('Unable to parse server redirect URL. Falling back to local page builder.', err);
         }
+      }
+
+      const normalizedPage = (page || '').trim().toLowerCase();
+      if (!normalizedPage || normalizedPage === 'login' || normalizedPage === 'logout') {
+        page = DEFAULT_REDIRECT_PAGE;
       }
 
       return stripTokenFromUrl(buildPageUrl(page, params));


### PR DESCRIPTION
## Summary
- guard the default redirect initialization so repeated script loads reuse the existing window value instead of redeclaring the identifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed7368b1cc8326bac6a207fb3b2381