### PR TITLE
Fix missing session token persistence after login redirect

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -637,6 +637,100 @@
       }
     }
 
+    function persistClientSessionToken(token, options = {}) {
+      const normalizedToken = typeof token === 'string' ? token.trim() : '';
+      if (!normalizedToken) {
+        return '';
+      }
+
+      try {
+        if (typeof window !== 'undefined') {
+          window.__LUMINA_SESSION_TOKEN__ = normalizedToken;
+        }
+      } catch (assignError) {
+        console.warn('persistClientSessionToken: unable to assign global token reference', assignError);
+      }
+
+      try {
+        if (typeof window !== 'undefined'
+          && window.CookieHandler
+          && typeof window.CookieHandler.persistAuthToken === 'function') {
+          window.CookieHandler.persistAuthToken(normalizedToken, options);
+        }
+      } catch (cookieError) {
+        console.warn('persistClientSessionToken: unable to persist auth cookie', cookieError);
+      }
+
+      const storageKeys = Array.isArray(SESSION_TOKEN_STORAGE_KEYS) ? SESSION_TOKEN_STORAGE_KEYS : [];
+
+      storageKeys.forEach(key => {
+        try {
+          if (typeof window !== 'undefined' && window.localStorage) {
+            window.localStorage.setItem(key, normalizedToken);
+          }
+        } catch (localError) {
+          console.warn('persistClientSessionToken: unable to persist token in localStorage', { key, error: localError });
+        }
+
+        try {
+          if (typeof window !== 'undefined' && window.sessionStorage) {
+            window.sessionStorage.setItem(key, normalizedToken);
+          }
+        } catch (sessionError) {
+          console.warn('persistClientSessionToken: unable to persist token in sessionStorage', { key, error: sessionError });
+        }
+      });
+
+      try {
+        broadcastSessionTokenChange(normalizedToken);
+      } catch (broadcastError) {
+        console.warn('persistClientSessionToken: unable to broadcast token update', broadcastError);
+      }
+
+      return normalizedToken;
+    }
+
+    function captureSessionTokenFromUrl() {
+      if (typeof window === 'undefined' || !window.location) {
+        return '';
+      }
+
+      try {
+        const currentUrl = new URL(window.location.href);
+        const tokenFromQuery = (currentUrl.searchParams.get(SESSION_TOKEN_QUERY_PARAM) || '').trim();
+
+        if (!tokenFromQuery) {
+          return '';
+        }
+
+        const persistedToken = persistClientSessionToken(tokenFromQuery);
+
+        const params = new URLSearchParams(currentUrl.search);
+        params.delete(SESSION_TOKEN_QUERY_PARAM);
+        ['sessionTtlSeconds', 'sessionExpiresAt', 'idleTimeoutMinutes', 'rememberMe'].forEach(param => {
+          if (params.has(param)) {
+            params.delete(param);
+          }
+        });
+
+        const sanitizedSearch = params.toString();
+        const cleanedUrl = `${currentUrl.pathname}${sanitizedSearch ? `?${sanitizedSearch}` : ''}${currentUrl.hash || ''}`;
+
+        if (window.history && typeof window.history.replaceState === 'function') {
+          window.history.replaceState({}, document.title, cleanedUrl);
+        }
+
+        console.log('🔐 Session token persisted from URL parameter');
+
+        return persistedToken;
+      } catch (err) {
+        console.warn('captureSessionTokenFromUrl: unable to process session token from URL', err);
+        return '';
+      }
+    }
+
+    const INITIAL_URL_SESSION_TOKEN = captureSessionTokenFromUrl();
+
     function setLogoutReason(reason) {
       try {
         if (!window.sessionStorage) {


### PR DESCRIPTION
## Summary
- persist session tokens found in redirect URLs when loading authenticated layouts
- store the session token across cookie, local storage, and session storage, and notify listeners
- clean up the URL after persisting the token to avoid leaking sensitive parameters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68edd66111988326af8c33d37cc55192