### PR TITLE
Improve shift slot handling in schedule management

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1611,6 +1611,7 @@
                 this.currentUser = window.user || window.currentUser || window.CURRENT_USER || {};
                 this.availableUsers = [];
                 this.availableCampaigns = [];
+                this.availableShiftSlots = [];
                 this.attendanceChart = null;
                 this.pendingImportSchedules = [];
                 this.pendingImportSummary = null;
@@ -1848,6 +1849,48 @@
                 });
             }
 
+            updateShiftSlotDropdown(slots = this.availableShiftSlots) {
+                const dropdown = document.getElementById('scheduleShiftSlots');
+                if (!dropdown) return;
+
+                const selectedValues = Array.from(dropdown.selectedOptions || []).map(option => option.value);
+
+                if (!Array.isArray(slots) || slots.length === 0) {
+                    dropdown.innerHTML = '<option value="" disabled>No shift slots available</option>';
+                    dropdown.selectedIndex = -1;
+                    dropdown.disabled = true;
+                    return;
+                }
+
+                dropdown.disabled = false;
+
+                const buildTimeLabel = (slot) => {
+                    const start = this.formatTimeValue(slot.StartTime || slot.startTime || '');
+                    const end = this.formatTimeValue(slot.EndTime || slot.endTime || '');
+                    if (start && end) {
+                        return `${start} - ${end}`;
+                    }
+                    if (start || end) {
+                        return start || end;
+                    }
+                    return 'Time not set';
+                };
+
+                dropdown.innerHTML = slots.map(slot => {
+                    const timeLabel = buildTimeLabel(slot);
+                    const department = slot.Department || slot.department || 'General';
+                    const name = slot.Name || slot.name || 'Unnamed Shift';
+                    return `<option value="${slot.ID}">${name} • ${timeLabel} • ${department}</option>`;
+                }).join('');
+
+                selectedValues.forEach(value => {
+                    const option = dropdown.querySelector(`option[value="${value}"]`);
+                    if (option) {
+                        option.selected = true;
+                    }
+                });
+            }
+
             updateUsersList() {
                 const container = document.getElementById('usersList');
                 if (!container) return;
@@ -1954,12 +1997,20 @@
                     console.log('🕒 Loading shift slots...');
                     const slots = await this.callServerFunction('clientGetAllShiftSlots');
 
-                    this.displayShiftSlots(Array.isArray(slots) ? slots : []);
-                    document.getElementById('totalSlots').textContent = Array.isArray(slots) ? slots.length : 0;
+                    const normalizedSlots = Array.isArray(slots) ? slots : [];
+                    this.availableShiftSlots = normalizedSlots;
+                    this.updateShiftSlotDropdown(normalizedSlots);
+                    this.displayShiftSlots(normalizedSlots);
+                    const totalSlotsElement = document.getElementById('totalSlots');
+                    if (totalSlotsElement) {
+                        totalSlotsElement.textContent = normalizedSlots.length;
+                    }
 
-                    console.log(`✅ Loaded ${Array.isArray(slots) ? slots.length : 0} shift slots`);
+                    console.log(`✅ Loaded ${normalizedSlots.length} shift slots`);
                 } catch (error) {
                     console.error('❌ Error loading shift slots:', error);
+                    this.availableShiftSlots = [];
+                    this.updateShiftSlotDropdown([]);
                     this.displayShiftSlots([]);
                     this.showToast('Failed to load shift slots. You may need to create some first.', 'warning');
                 }
@@ -2178,6 +2229,7 @@
                         formData.startDate,
                         formData.endDate,
                         formData.users,
+                        formData.shiftSlots,
                         formData.templateId,
                         formData.generatedBy,
                         formData.options
@@ -2203,8 +2255,13 @@
             getScheduleGenerationData() {
                 const startDate = document.getElementById('scheduleStartDate').value;
                 const endDate = document.getElementById('scheduleEndDate').value;
-                const userSelections = Array.from(document.getElementById('scheduleUsers').selectedOptions);
+                const userSelect = document.getElementById('scheduleUsers');
+                const userSelections = userSelect ? Array.from(userSelect.selectedOptions) : [];
                 const users = userSelections.map(option => option.value);
+                const shiftSlotSelect = document.getElementById('scheduleShiftSlots');
+                const shiftSlotSelections = shiftSlotSelect
+                    ? Array.from(shiftSlotSelect.selectedOptions).map(option => option.value).filter(Boolean)
+                    : [];
                 const campaignId = document.getElementById('campaignFilter').value || null;
                 const priority = parseInt(document.getElementById('schedulePriority').value);
                 const detectConflicts = document.getElementById('detectConflicts').checked;
@@ -2214,6 +2271,7 @@
                     startDate,
                     endDate,
                     users: users.length > 0 ? users : null,
+                    shiftSlots: shiftSlotSelections.length > 0 ? shiftSlotSelections : null,
                     templateId: null,
                     generatedBy: this.getCurrentUserId() || 'System',
                     options: {
@@ -2391,6 +2449,39 @@
                 } catch (error) {
                     console.error('❌ Error creating shift slot:', error);
                     this.showToast('Failed to create shift slot: ' + error.message, 'danger');
+                } finally {
+                    this.showLoading(false);
+                }
+            }
+
+            async deleteShiftSlot(slotId) {
+                if (!slotId) {
+                    this.showToast('Invalid shift slot selected for deletion.', 'warning');
+                    return;
+                }
+
+                if (typeof window.confirm === 'function') {
+                    const confirmed = window.confirm('Are you sure you want to delete this shift slot? This action cannot be undone.');
+                    if (!confirmed) {
+                        return;
+                    }
+                }
+
+                try {
+                    this.showLoading(true);
+                    console.log('🗑️ Deleting shift slot:', slotId);
+
+                    const result = await this.callServerFunction('clientDeleteShiftSlot', slotId);
+
+                    if (result && result.success) {
+                        this.showToast(result.message || 'Shift slot deleted successfully!', 'success');
+                        await this.loadShiftSlots();
+                    } else {
+                        throw new Error(result?.error || 'Failed to delete shift slot');
+                    }
+                } catch (error) {
+                    console.error('❌ Error deleting shift slot:', error);
+                    this.showToast('Failed to delete shift slot: ' + error.message, 'danger');
                 } finally {
                     this.showLoading(false);
                 }
@@ -4296,6 +4387,12 @@
                     `;
 
                 window.scheduleManager.showToast(`Shift Preview: ${preview}`, 'info');
+            }
+        }
+
+        function deleteShiftSlot(slotId) {
+            if (window.scheduleManager) {
+                window.scheduleManager.deleteShiftSlot(slotId);
             }
         }
 


### PR DESCRIPTION
## Summary
- update the schedule management UI to cache shift slots, populate the multiselect, and preserve selections
- send selected shift slot IDs to the enhanced scheduler and expose a delete action in the UI
- add a backend helper to remove shift slots from the sheet and invalidate cached data

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee01e2d1d8832687d7f5b1eb4b6b80