### PR TITLE
Improve schedule spreadsheet resolution and error reporting

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -280,10 +280,15 @@ function clientCreateShiftSlot(slotData) {
 
   } catch (error) {
     console.error('❌ Error creating shift slot:', error);
-    safeWriteError('clientCreateShiftSlot', error);
+    if (typeof safeWriteError === 'function') {
+      safeWriteError('clientCreateShiftSlot', error);
+    }
+    const errorMessage = error && error.message
+      ? error.message
+      : (typeof error === 'string' ? error : (error && error.toString ? error.toString() : 'Unknown error'));
     return {
       success: false,
-      error: error.message
+      error: errorMessage || 'Unknown error while creating shift slot'
     };
   }
 }


### PR DESCRIPTION
## Summary
- extend schedule spreadsheet lookup to gather IDs from script properties, global config, and active spreadsheet fallbacks
- surface clearer configuration data for schedule spreadsheets and improve error handling when creation fails

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68ee06b1f5ac832684ba6291753d7dfb