### PR TITLE
Restrict schedule data to assigned manager users

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1934,18 +1934,63 @@
                 const container = document.getElementById('usersList');
                 if (!container) return;
 
-                if (this.availableUsers.length === 0) {
+                if (!Array.isArray(this.availableUsers) || this.availableUsers.length === 0) {
                     container.innerHTML = '<div class="text-muted text-center py-4">No users found. Please check user data and permissions.</div>';
+                    this.updateManagerStats();
                     return;
                 }
 
-                container.innerHTML = this.availableUsers.map(user => `
+                const groupedByManager = new Map();
+
+                this.availableUsers.forEach(user => {
+                    const managerNames = Array.isArray(user.assignedManagerNames) && user.assignedManagerNames.length
+                        ? user.assignedManagerNames
+                        : ['Unassigned'];
+
+                    const userKey = user.ID || user.Id || user.id || user.UserName || user.UserID || user.Email;
+
+                    managerNames.forEach(name => {
+                        const managerLabel = name && name.trim() ? name.trim() : 'Unassigned';
+                        if (!groupedByManager.has(managerLabel)) {
+                            groupedByManager.set(managerLabel, new Map());
+                        }
+
+                        const usersMap = groupedByManager.get(managerLabel);
+                        if (!usersMap.has(userKey)) {
+                            usersMap.set(userKey, user);
+                        }
+                    });
+                });
+
+                const sortedManagers = Array.from(groupedByManager.entries()).sort((a, b) => {
+                    const nameA = a[0].toLowerCase();
+                    const nameB = b[0].toLowerCase();
+                    if (nameA === 'unassigned' && nameB !== 'unassigned') return 1;
+                    if (nameB === 'unassigned' && nameA !== 'unassigned') return -1;
+                    return nameA.localeCompare(nameB);
+                });
+
+                container.innerHTML = sortedManagers.map(([managerName, usersMap]) => {
+                    const users = Array.from(usersMap.values());
+                    const managerBadge = managerName === 'Unassigned'
+                        ? '<span class="badge bg-secondary ms-2">Unassigned</span>'
+                        : '';
+
+                    const managerHeader = `
+                        <div class="d-flex align-items-center mb-2">
+                            <h6 class="fw-semibold mb-0 text-primary">${managerName}</h6>
+                            ${managerBadge}
+                            <span class="badge bg-light text-dark ms-auto">${users.length} ${users.length === 1 ? 'user' : 'users'}</span>
+                        </div>
+                    `;
+
+                    const userCards = users.map(user => `
                         <div class="d-flex justify-content-between align-items-center mb-3 p-3 border rounded interactive-item">
                             <div>
                                 <strong class="d-block">${user.FullName || user.UserName}</strong>
                                 <small class="text-muted">
-                                    ${user.Email || 'No email'} • 
-                                    ${user.campaignName || 'No campaign'} • 
+                                    ${user.Email || 'No email'} •
+                                    ${user.campaignName || 'No campaign'} •
                                     ${user.EmploymentStatus || 'Active'}
                                 </small>
                             </div>
@@ -1955,15 +2000,45 @@
                         </div>
                     `).join('');
 
-                this.updateManagerStats();
+                    return `
+                        <div class="manager-group mb-4">
+                            ${managerHeader}
+                            ${userCards || '<div class="text-muted small">No users assigned.</div>'}
+                        </div>
+                    `;
+                }).join('');
+
+                this.updateManagerStats(groupedByManager);
             }
 
-            updateManagerStats() {
+            updateManagerStats(groupedByManager = null) {
                 const container = document.getElementById('managerStats');
                 if (!container) return;
 
                 const activeUsers = this.availableUsers.filter(u => u.isActive).length;
                 const withCampaigns = this.availableUsers.filter(u => u.CampaignID).length;
+                const managerIds = new Set();
+                this.availableUsers.forEach(user => {
+                    const assignedIds = Array.isArray(user.assignedManagerIds) ? user.assignedManagerIds : [];
+                    assignedIds.forEach(id => {
+                        if (id) {
+                            managerIds.add(String(id));
+                        }
+                    });
+                });
+
+                const managerCount = managerIds.size;
+                let unassignedCount = this.availableUsers.filter(user => {
+                    const assignedIds = Array.isArray(user.assignedManagerIds) ? user.assignedManagerIds : [];
+                    return assignedIds.length === 0;
+                }).length;
+
+                if (groupedByManager instanceof Map && groupedByManager.has('Unassigned')) {
+                    const unassignedGroup = groupedByManager.get('Unassigned');
+                    if (unassignedGroup && typeof unassignedGroup.size === 'number') {
+                        unassignedCount = unassignedGroup.size;
+                    }
+                }
 
                 container.innerHTML = `
                         <div class="row g-3">
@@ -1983,12 +2058,14 @@
                                 <div class="metric-card">
                                     <div class="metric-number text-info">${withCampaigns}</div>
                                     <div class="metric-label">With Campaigns</div>
+                                    <small class="text-muted">Campaigns tracked: ${this.availableCampaigns.length}</small>
                                 </div>
                             </div>
                             <div class="col-6">
                                 <div class="metric-card">
-                                    <div class="metric-number text-warning">${this.availableCampaigns.length}</div>
-                                    <div class="metric-label">Campaigns</div>
+                                    <div class="metric-number text-warning">${managerCount}</div>
+                                    <div class="metric-label">Managers Assigned</div>
+                                    <small class="text-muted">Unassigned users: ${unassignedCount}</small>
                                 </div>
                             </div>
                         </div>
@@ -2109,7 +2186,9 @@
 
                     const dashboard = await this.callServerFunction('clientGetAttendanceDashboard',
                         startDate.toISOString().split('T')[0],
-                        endDate.toISOString().split('T')[0]
+                        endDate.toISOString().split('T')[0],
+                        null,
+                        this.getCurrentUserId()
                     );
 
                     if (dashboard && dashboard.success) {
@@ -2703,7 +2782,8 @@
                         startDate: document.getElementById('filterStartDate')?.value,
                         endDate: document.getElementById('filterEndDate')?.value,
                         userName: document.getElementById('filterUser')?.value,
-                        status: document.getElementById('filterStatus')?.value
+                        status: document.getElementById('filterStatus')?.value,
+                        managerId: this.getCurrentUserId()
                     };
 
                     const result = await this.callServerFunction('clientGetAllSchedules', filters);
@@ -3214,7 +3294,8 @@
                             replaceExisting,
                             summary
                         },
-                        schedules
+                        schedules,
+                        managerUserId: this.getCurrentUserId()
                     };
 
                     const result = await this.callServerFunction('clientImportSchedules', payload);

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -25,64 +25,132 @@ const SCHEDULE_CONFIG = {
  * Get users for schedule management with manager filtering
  * Uses MainUtilities user functions with campaign support
  */
-function clientGetScheduleUsers(requestingUserId, campaignId = null) {
+function clientGetScheduleUsers(requestingUserId, campaignIdOrOptions) {
   try {
-    console.log('🔍 Getting schedule users for:', requestingUserId, 'campaign:', campaignId);
+    var rawOptions = {};
+    var managerId = requestingUserId;
+    var campaignFilter = null;
 
-    // Use MainUtilities to get all users
-    const allUsers = readSheet(USERS_SHEET) || [];
-    if (allUsers.length === 0) {
-      console.warn('No users found in Users sheet');
-      return [];
-    }
-
-    let filteredUsers = allUsers;
-
-    // Filter by campaign if specified - use MainUtilities campaign functions
-    if (campaignId) {
-      const campaignUsers = getUsersByCampaign(campaignId);
-      const campaignUserIds = new Set(campaignUsers.map(u => u.ID));
-      filteredUsers = allUsers.filter(user => campaignUserIds.has(user.ID));
-    }
-
-    // Apply manager permissions using MainUtilities functions
-    if (requestingUserId) {
-      const normalizedManagerId = normalizeUserIdValue(requestingUserId);
-      const requestingUser = allUsers.find(u => normalizeUserIdValue(u.ID) === normalizedManagerId);
-
-      if (requestingUser) {
-        const isAdmin = requestingUser.IsAdmin === true || String(requestingUser.IsAdmin).toUpperCase() === 'TRUE';
-
-        if (!isAdmin) {
-          const managedUserIds = buildManagedUserSet(normalizedManagerId);
-
-          filteredUsers = filteredUsers.filter(user => managedUserIds.has(normalizeUserIdValue(user.ID)));
-        }
+    if (typeof campaignIdOrOptions === 'object' && campaignIdOrOptions !== null) {
+      rawOptions = campaignIdOrOptions;
+      if (typeof rawOptions.campaignId !== 'undefined' && rawOptions.campaignId !== null) {
+        campaignFilter = _normStr_(rawOptions.campaignId);
       }
+      if (!managerId && typeof rawOptions.managerUserId !== 'undefined' && rawOptions.managerUserId !== null) {
+        managerId = rawOptions.managerUserId;
+      }
+    } else if (typeof campaignIdOrOptions !== 'undefined' && campaignIdOrOptions !== null) {
+      campaignFilter = _normStr_(campaignIdOrOptions);
     }
 
-    // Transform to schedule-friendly format
-    const scheduleUsers = filteredUsers
-      .filter(user => user && user.ID && (user.UserName || user.FullName))
-      .filter(user => isUserConsideredActive(user))
-      .map(user => {
-        const campaignName = getCampaignById(user.CampaignID)?.Name || '';
-        return {
-          ID: user.ID,
-          UserName: user.UserName || user.FullName,
-          FullName: user.FullName || user.UserName,
-          Email: user.Email || '',
-          CampaignID: user.CampaignID || '',
-          campaignName: campaignName,
-          EmploymentStatus: user.EmploymentStatus || 'Active',
-          HireDate: user.HireDate || '',
-          canLogin: user.CanLogin === 'TRUE' || user.CanLogin === true,
-          isActive: isUserConsideredActive(user)
-        };
-      });
+    var fetchOptions = Object.assign({
+      includeManager: true,
+      fallbackToCampaign: false,
+      fallbackToAll: false
+    }, rawOptions || {});
 
-    console.log(`✅ Returning ${scheduleUsers.length} schedule users`);
-    return scheduleUsers;
+    delete fetchOptions.campaignId;
+    delete fetchOptions.managerUserId;
+
+    var users = getUser(managerId, fetchOptions) || [];
+    if (!Array.isArray(users)) {
+      users = [];
+    }
+
+    if (campaignFilter) {
+      users = users.filter(function (user) {
+        var userCampaignId = _normStr_(user && (user.CampaignID || user.campaignId));
+        return userCampaignId === campaignFilter;
+      });
+    }
+
+    var assignmentRows = [];
+    try {
+      assignmentRows = _readManagerUsersSheetSafe_();
+    } catch (assignmentError) {
+      console.warn('clientGetScheduleUsers: unable to read MANAGER_USERS sheet', assignmentError);
+    }
+
+    var userAssignments = new Map();
+    assignmentRows.forEach(function (rel) {
+      if (!rel) return;
+      var userId = _normStr_(rel.UserID || rel.userId || rel.UserId);
+      var mgrId = _normStr_(rel.ManagerUserID || rel.managerUserId || rel.ManagerID || rel.managerId);
+      if (!userId || !mgrId) return;
+      var existing = userAssignments.get(userId);
+      if (!existing) {
+        existing = new Set();
+        userAssignments.set(userId, existing);
+      }
+      existing.add(mgrId);
+    });
+
+    var allUsers = _readUsersSheetSafe_();
+    var managerLookup = new Map();
+    allUsers.forEach(function (row) {
+      if (!row) return;
+      var id = _normStr_(row.ID || row.Id || row.id);
+      if (!id) return;
+      managerLookup.set(id, {
+        id: id,
+        fullName: _normStr_(row.FullName || row.fullName),
+        userName: _normStr_(row.UserName || row.userName || row.Username),
+        email: _normStr_(row.Email || row.email || row.EmailAddress || ''),
+        campaignId: _normStr_(row.CampaignID || row.campaignId || ''),
+        displayName: function () {
+          return this.fullName || this.userName || this.email || this.id;
+        }
+      });
+    });
+
+    var campaignNameMap = _campaignNameMap_();
+    var managerIdStr = managerId ? _normStr_(managerId) : '';
+
+    var enriched = users.map(function (user) {
+      var safeUser = Object.assign({}, user);
+      var userId = _normStr_(safeUser.ID || safeUser.Id || safeUser.id);
+      var campaignId = _normStr_(safeUser.CampaignID || safeUser.campaignId || '');
+      if (!safeUser.campaignName && campaignId) {
+        safeUser.campaignName = campaignNameMap[campaignId] || safeUser.campaignName || '';
+      }
+
+      var assignedSet = userAssignments.get(userId);
+      var assignedIds = assignedSet ? Array.from(assignedSet) : [];
+      if (!assignedIds.length && managerIdStr) {
+        assignedIds = [managerIdStr];
+      }
+
+      var assignedManagers = assignedIds
+        .map(function (mgrId) {
+          var details = managerLookup.get(mgrId);
+          if (!details) return null;
+          return {
+            id: details.id,
+            fullName: details.fullName,
+            userName: details.userName,
+            email: details.email,
+            campaignId: details.campaignId,
+            displayName: details.displayName()
+          };
+        })
+        .filter(Boolean);
+
+      var uniqueAssignedIds = Array.from(new Set(assignedManagers.map(function (mgr) { return mgr.id; })));
+      var uniqueManagerNames = Array.from(new Set(assignedManagers.map(function (mgr) { return mgr.displayName; }).filter(Boolean)));
+      var uniqueManagerEmails = Array.from(new Set(assignedManagers
+        .map(function (mgr) { return mgr.email; })
+        .filter(function (email) { return !!email; })));
+
+      safeUser.assignedManagers = assignedManagers;
+      safeUser.assignedManagerIds = uniqueAssignedIds;
+      safeUser.assignedManagerNames = uniqueManagerNames;
+      safeUser.assignedManagerEmails = uniqueManagerEmails;
+
+      return safeUser;
+    });
+
+    console.log('✅ Returning', enriched.length, 'schedule users scoped by manager assignments');
+    return enriched;
 
   } catch (error) {
     console.error('❌ Error getting schedule users:', error);
@@ -892,6 +960,61 @@ function clientGetAllSchedules(filters = {}) {
 
     let filteredSchedules = schedules;
 
+    const managerScope = resolveScheduleManagerScope(filters && filters.managerId);
+    if (managerScope.shouldFilter) {
+      const allowedIds = managerScope.allowedIds;
+      const allowedKeys = managerScope.allowedKeys;
+
+      filteredSchedules = filteredSchedules.filter(schedule => {
+        if (!schedule || typeof schedule !== 'object') {
+          return false;
+        }
+
+        const idCandidates = [
+          schedule.UserID,
+          schedule.UserId,
+          schedule.userId,
+          schedule.AgentID,
+          schedule.AgentId,
+          schedule.agentId
+        ]
+          .map(value => (value === undefined || value === null) ? '' : String(value))
+          .filter(value => value);
+
+        for (let i = 0; i < idCandidates.length; i++) {
+          if (allowedIds.has(idCandidates[i])) {
+            return true;
+          }
+        }
+
+        const nameCandidates = [
+          schedule.UserName,
+          schedule.User,
+          schedule['User Name'],
+          schedule.Agent,
+          schedule.AgentName,
+          schedule['Agent Name'],
+          schedule.Name,
+          schedule.FullName,
+          schedule.Assignee,
+          schedule.AssignedTo,
+          schedule.userName,
+          schedule.fullName,
+          schedule.Email,
+          schedule.UserEmail
+        ];
+
+        for (let i = 0; i < nameCandidates.length; i++) {
+          const key = normalizeUserKey(nameCandidates[i]);
+          if (key && allowedKeys.has(key)) {
+            return true;
+          }
+        }
+
+        return false;
+      });
+    }
+
     // Apply filters
     if (filters.startDate) {
       const startDate = new Date(filters.startDate);
@@ -958,7 +1081,12 @@ function clientImportSchedules(importRequest = {}) {
     const now = new Date();
     const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
 
-    const userLookup = buildScheduleUserLookup();
+    const importManagerId = importRequest.managerUserId || metadata.importedBy || null;
+    const lookupOptions = {};
+    if (metadata && metadata.campaignId) {
+      lookupOptions.campaignId = metadata.campaignId;
+    }
+    const userLookup = buildScheduleUserLookup(importManagerId, lookupOptions);
     const normalizedNew = schedules
       .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
       .filter(record => record);
@@ -1105,7 +1233,12 @@ function clientImportSchedules(importRequest = {}) {
     const now = new Date();
     const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
 
-    const userLookup = buildScheduleUserLookup();
+    const importManagerId = importRequest.managerUserId || metadata.importedBy || null;
+    const lookupOptions = {};
+    if (metadata && metadata.campaignId) {
+      lookupOptions.campaignId = metadata.campaignId;
+    }
+    const userLookup = buildScheduleUserLookup(importManagerId, lookupOptions);
     const normalizedNew = schedules
       .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
       .filter(record => record);
@@ -1252,7 +1385,12 @@ function clientImportSchedules(importRequest = {}) {
     const now = new Date();
     const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
 
-    const userLookup = buildScheduleUserLookup();
+    const importManagerId = importRequest.managerUserId || metadata.importedBy || null;
+    const lookupOptions = {};
+    if (metadata && metadata.campaignId) {
+      lookupOptions.campaignId = metadata.campaignId;
+    }
+    const userLookup = buildScheduleUserLookup(importManagerId, lookupOptions);
     const normalizedNew = schedules
       .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
       .filter(record => record);
@@ -1399,7 +1537,12 @@ function clientImportSchedules(importRequest = {}) {
     const now = new Date();
     const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
 
-    const userLookup = buildScheduleUserLookup();
+    const importManagerId = importRequest.managerUserId || metadata.importedBy || null;
+    const lookupOptions = {};
+    if (metadata && metadata.campaignId) {
+      lookupOptions.campaignId = metadata.campaignId;
+    }
+    const userLookup = buildScheduleUserLookup(importManagerId, lookupOptions);
     const normalizedNew = schedules
       .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
       .filter(record => record);
@@ -1526,30 +1669,94 @@ function clientImportSchedules(importRequest = {}) {
 /**
  * Get comprehensive attendance dashboard data with AI insights
  */
-function clientGetAttendanceDashboard(startDate, endDate, campaignId = null) {
+function clientGetAttendanceDashboard(startDate, endDate, campaignId = null, managerUserId) {
   try {
     console.log('📊 Generating attendance dashboard');
 
-    // Use ScheduleUtilities to read attendance data
     const attendanceData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
-    
-    // Filter by date range
+
     const filteredData = attendanceData.filter(record => {
-      if (!record.Date) return false;
+      if (!record || !record.Date) return false;
       const recordDate = new Date(record.Date);
       const start = new Date(startDate);
       const end = new Date(endDate);
       return recordDate >= start && recordDate <= end;
     });
 
-    // Get users for context using our enhanced user functions
-    const users = clientGetScheduleUsers('system', campaignId);
-    const userMap = new Map(users.map(u => [u.UserName, u]));
+    const managerScope = resolveScheduleManagerScope(managerUserId, campaignId ? { campaignId: campaignId } : {});
 
-    // Calculate metrics
-    const metrics = calculateAttendanceMetrics(filteredData);
-    const userStats = calculateUserAttendanceStats(filteredData, userMap);
-    const trends = calculateAttendanceTrends(filteredData);
+    const managerFilteredData = managerScope.shouldFilter
+      ? filteredData.filter(record => {
+        if (!record || typeof record !== 'object') {
+          return false;
+        }
+
+        const idCandidates = [
+          record.UserID,
+          record.UserId,
+          record.userId,
+          record.AgentID,
+          record.AgentId,
+          record.agentId
+        ]
+          .map(value => (value === undefined || value === null) ? '' : String(value))
+          .filter(value => value);
+
+        for (let i = 0; i < idCandidates.length; i++) {
+          if (managerScope.allowedIds.has(idCandidates[i])) {
+            return true;
+          }
+        }
+
+        const nameCandidates = [
+          record.UserName,
+          record.User,
+          record['User Name'],
+          record.Agent,
+          record.AgentName,
+          record['Agent Name'],
+          record.Name,
+          record.FullName,
+          record.Assignee,
+          record.AssignedTo,
+          record.userName,
+          record.fullName,
+          record.Email,
+          record.UserEmail
+        ];
+
+        for (let i = 0; i < nameCandidates.length; i++) {
+          const key = normalizeUserKey(nameCandidates[i]);
+          if (key && managerScope.allowedKeys.has(key)) {
+            return true;
+          }
+        }
+
+        return false;
+      })
+      : filteredData;
+
+    const users = managerScope.users;
+    const userMap = new Map();
+    users.forEach(user => {
+      const candidates = [user.UserName, user.FullName, user.Email, user.userName, user.fullName, user.email];
+      candidates.forEach(candidate => {
+        if (!candidate) {
+          return;
+        }
+        const key = normalizeUserKey(candidate);
+        if (candidate && !userMap.has(candidate)) {
+          userMap.set(candidate, user);
+        }
+        if (key && !userMap.has(key)) {
+          userMap.set(key, user);
+        }
+      });
+    });
+
+    const metrics = calculateAttendanceMetrics(managerFilteredData);
+    const userStats = calculateUserAttendanceStats(managerFilteredData, userMap);
+    const trends = calculateAttendanceTrends(managerFilteredData);
     const aiInsights = generateAIInsights(metrics, userStats, trends);
 
     return {
@@ -1557,7 +1764,7 @@ function clientGetAttendanceDashboard(startDate, endDate, campaignId = null) {
       dashboard: {
         period: { startDate, endDate },
         totalUsers: users.length,
-        totalRecords: filteredData.length,
+        totalRecords: managerFilteredData.length,
         metrics: metrics,
         userStats: userStats,
         trends: trends,
@@ -1930,6 +2137,34 @@ function clientMarkAttendanceStatus(userName, date, status, notes = '') {
     // Use ScheduleUtilities to ensure proper sheet structure
     const sheet = ensureScheduleSheetWithHeaders(ATTENDANCE_STATUS_SHEET, ATTENDANCE_STATUS_HEADERS);
 
+    const managerScope = resolveScheduleManagerScope();
+    let resolvedUserId = null;
+    try {
+      resolvedUserId = getUserIdByName(userName);
+    } catch (lookupError) {
+      console.warn('clientMarkAttendanceStatus: unable to resolve user ID via getUserIdByName', lookupError);
+      resolvedUserId = userName;
+    }
+
+    const resolvedUserIdString = resolvedUserId === undefined || resolvedUserId === null ? '' : String(resolvedUserId);
+    if (managerScope.shouldFilter) {
+      let authorized = false;
+      if (resolvedUserIdString && managerScope.allowedIds.has(resolvedUserIdString)) {
+        authorized = true;
+      }
+
+      if (!authorized) {
+        const normalizedUserName = normalizeUserKey(userName);
+        if (normalizedUserName && managerScope.allowedKeys.has(normalizedUserName)) {
+          authorized = true;
+        }
+      }
+
+      if (!authorized) {
+        throw new Error('You are not authorized to manage attendance for this user.');
+      }
+    }
+
     // Check if entry already exists
     const existingData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
     const existingEntry = existingData.find(entry =>
@@ -1955,7 +2190,7 @@ function clientMarkAttendanceStatus(userName, date, status, notes = '') {
       // Create new entry using proper header order
       const entry = {
         ID: Utilities.getUuid(),
-        UserID: getUserIdByName(userName) || userName,
+        UserID: resolvedUserIdString || userName,
         UserName: userName,
         Date: date,
         Status: status,
@@ -2115,7 +2350,7 @@ function clientRunSystemDiagnostics() {
 
     // Test attendance system
     try {
-      const dashboard = clientGetAttendanceDashboard('2025-01-01', '2025-01-31');
+      const dashboard = clientGetAttendanceDashboard('2025-01-01', '2025-01-31', null, null);
       diagnostics.attendance = {
         working: dashboard.success,
         hasData: dashboard.success && dashboard.dashboard.totalRecords > 0,
@@ -2203,7 +2438,7 @@ function clientRunSystemDiagnostics() {
 function clientApproveSchedules(scheduleIds, approvingUserId, notes = '') {
   try {
     console.log('✅ Approving schedules:', scheduleIds);
-    
+
     const sheet = getScheduleSpreadsheet().getSheetByName(SCHEDULE_GENERATION_SHEET);
     if (!sheet) {
       throw new Error('Schedules sheet not found');
@@ -2214,12 +2449,46 @@ function clientApproveSchedules(scheduleIds, approvingUserId, notes = '') {
     const statusCol = headers.indexOf('Status') + 1;
     const approvedByCol = headers.indexOf('ApprovedBy') + 1;
     const updatedAtCol = headers.indexOf('UpdatedAt') + 1;
+    const userIdIndex = headers.indexOf('UserID');
+    const userNameIndex = headers.indexOf('UserName');
 
     let updated = 0;
 
+    const managerScope = resolveScheduleManagerScope(approvingUserId);
+
+    const isScheduleVisible = function (row) {
+      if (!managerScope.shouldFilter) {
+        return true;
+      }
+
+      const idCandidates = [];
+      if (userIdIndex >= 0) {
+        const candidate = row[userIdIndex];
+        if (candidate !== undefined && candidate !== null && candidate !== '') {
+          idCandidates.push(String(candidate));
+        }
+      }
+
+      for (let i = 0; i < idCandidates.length; i++) {
+        if (managerScope.allowedIds.has(idCandidates[i])) {
+          return true;
+        }
+      }
+
+      if (userNameIndex >= 0) {
+        const name = row[userNameIndex];
+        const key = normalizeUserKey(name);
+        if (key && managerScope.allowedKeys.has(key)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
     for (let i = 1; i < data.length; i++) {
       const scheduleId = data[i][0]; // ID is first column
-      if (scheduleIds.includes(scheduleId)) {
+      if (scheduleIds.includes(scheduleId) && isScheduleVisible(data[i])) {
         sheet.getRange(i + 1, statusCol).setValue('APPROVED');
         sheet.getRange(i + 1, approvedByCol).setValue(approvingUserId || 'System');
         sheet.getRange(i + 1, updatedAtCol).setValue(new Date());
@@ -2252,7 +2521,7 @@ function clientApproveSchedules(scheduleIds, approvingUserId, notes = '') {
 function clientRejectSchedules(scheduleIds, rejectingUserId, reason = '') {
   try {
     console.log('❌ Rejecting schedules:', scheduleIds);
-    
+
     const sheet = getScheduleSpreadsheet().getSheetByName(SCHEDULE_GENERATION_SHEET);
     if (!sheet) {
       throw new Error('Schedules sheet not found');
@@ -2263,12 +2532,46 @@ function clientRejectSchedules(scheduleIds, rejectingUserId, reason = '') {
     const statusCol = headers.indexOf('Status') + 1;
     const notesCol = headers.indexOf('Notes') + 1;
     const updatedAtCol = headers.indexOf('UpdatedAt') + 1;
+    const userIdIndex = headers.indexOf('UserID');
+    const userNameIndex = headers.indexOf('UserName');
 
     let updated = 0;
 
+    const managerScope = resolveScheduleManagerScope(rejectingUserId);
+
+    const isScheduleVisible = function (row) {
+      if (!managerScope.shouldFilter) {
+        return true;
+      }
+
+      const idCandidates = [];
+      if (userIdIndex >= 0) {
+        const candidate = row[userIdIndex];
+        if (candidate !== undefined && candidate !== null && candidate !== '') {
+          idCandidates.push(String(candidate));
+        }
+      }
+
+      for (let i = 0; i < idCandidates.length; i++) {
+        if (managerScope.allowedIds.has(idCandidates[i])) {
+          return true;
+        }
+      }
+
+      if (userNameIndex >= 0) {
+        const name = row[userNameIndex];
+        const key = normalizeUserKey(name);
+        if (key && managerScope.allowedKeys.has(key)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
     for (let i = 1; i < data.length; i++) {
       const scheduleId = data[i][0]; // ID is first column
-      if (scheduleIds.includes(scheduleId)) {
+      if (scheduleIds.includes(scheduleId) && isScheduleVisible(data[i])) {
         sheet.getRange(i + 1, statusCol).setValue('REJECTED');
         if (reason) {
           const existingNotes = data[i][notesCol - 1] || '';
@@ -2363,6 +2666,10 @@ function normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, time
   const userKey = normalizeUserKey(userName);
   const matchedUser = userLookup[userKey];
 
+  if (!matchedUser) {
+    return null;
+  }
+
   const notes = [];
   if (metadata && metadata.sourceMonth) {
     const monthName = getMonthNameFromNumber(metadata.sourceMonth);
@@ -2421,9 +2728,117 @@ function normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, time
   };
 }
 
-function buildScheduleUserLookup() {
+function resolveScheduleManagerScope(managerUserId, rawOptions) {
+  let explicitManagerId = managerUserId;
+  let options = rawOptions;
+
+  if (typeof explicitManagerId === 'object' && explicitManagerId !== null && typeof options === 'undefined') {
+    options = explicitManagerId;
+    explicitManagerId = undefined;
+  }
+
+  let currentUser = null;
   try {
-    const users = clientGetScheduleUsers('system') || [];
+    if (typeof getCurrentUser === 'function') {
+      currentUser = getCurrentUser();
+    }
+  } catch (currentUserError) {
+    console.warn('resolveScheduleManagerScope: unable to resolve current user', currentUserError);
+  }
+
+  let managerId = explicitManagerId;
+  if (!managerId && currentUser && currentUser.ID) {
+    managerId = currentUser.ID;
+  }
+
+  let isAdmin = false;
+  try {
+    if (typeof isUserAdmin === 'function') {
+      isAdmin = isUserAdmin(currentUser);
+    }
+  } catch (adminCheckError) {
+    console.warn('resolveScheduleManagerScope: admin check failed', adminCheckError);
+  }
+
+  const fetchOptions = Object.assign({
+    includeManager: true,
+    fallbackToCampaign: false,
+    fallbackToAll: isAdmin
+  }, options || {});
+
+  let scheduleUsers = [];
+  try {
+    scheduleUsers = clientGetScheduleUsers(managerId, fetchOptions) || [];
+  } catch (scopeError) {
+    console.warn('resolveScheduleManagerScope: clientGetScheduleUsers failed, falling back to getUser', scopeError);
+    try {
+      scheduleUsers = getUser(managerId, fetchOptions) || [];
+    } catch (fallbackError) {
+      console.error('resolveScheduleManagerScope: unable to resolve schedule users', fallbackError);
+      scheduleUsers = [];
+    }
+  }
+
+  if (!Array.isArray(scheduleUsers)) {
+    scheduleUsers = [];
+  }
+
+  const allowedIds = new Set();
+  const allowedKeys = new Set();
+
+  scheduleUsers.forEach(user => {
+    if (!user) {
+      return;
+    }
+
+    const idCandidates = [user.ID, user.Id, user.id];
+    idCandidates.forEach(candidate => {
+      if (candidate === undefined || candidate === null || candidate === '') {
+        return;
+      }
+      allowedIds.add(String(candidate));
+    });
+
+    const nameCandidates = [
+      user.UserName,
+      user.User,
+      user.userName,
+      user.FullName,
+      user.fullName,
+      user.Email,
+      user.email
+    ];
+    nameCandidates.forEach(name => {
+      const key = normalizeUserKey(name);
+      if (key) {
+        allowedKeys.add(key);
+      }
+    });
+  });
+
+  const normalizedManagerId = managerId ? String(managerId) : '';
+  if (normalizedManagerId) {
+    allowedIds.add(normalizedManagerId);
+  }
+
+  const hasManagerContext = normalizedManagerId && normalizedManagerId.toLowerCase() !== 'system';
+  const shouldFilter = hasManagerContext && !isAdmin;
+
+  return {
+    managerId: normalizedManagerId,
+    isAdmin: isAdmin,
+    users: scheduleUsers,
+    allowedIds: allowedIds,
+    allowedKeys: allowedKeys,
+    currentUser: currentUser,
+    shouldFilter: shouldFilter
+  };
+}
+
+function buildScheduleUserLookup(managerUserId, options) {
+  try {
+    const scope = resolveScheduleManagerScope(managerUserId, options);
+    const users = scope.users || [];
     const lookup = {};
 
     users.forEach(user => {


### PR DESCRIPTION
## Summary
- scope schedule retrieval and attendance analytics in ScheduleService to the logged-in manager's assignments, including approvals, rejections, imports, and attendance updates via a shared manager-context helper
- require imported schedules to match managed users and enrich helper lookups so unauthorized names are ignored
- send the current manager ID from the Schedule Management UI when loading schedules, attendance dashboards, and imports so backend filters apply correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee32d70668832690aef89903ef8c8e