### PR TITLE
Ensure schedule tools honor active campaign scope

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1847,7 +1847,8 @@
                 try {
                     console.log('👥 Loading users...');
                     const currentUserId = this.getCurrentUserId();
-                    const users = await this.callServerFunction('clientGetScheduleUsers', currentUserId);
+                    const campaignId = this.getCurrentCampaignId();
+                    const users = await this.callServerFunction('clientGetScheduleUsers', currentUserId, campaignId || null);
 
                     this.availableUsers = Array.isArray(users) ? users : [];
                     console.log(`✅ Loaded ${this.availableUsers.length} users`);
@@ -3131,7 +3132,7 @@
                         `;
 
                     // Get attendance users
-                    const users = await this.callServerFunction('clientGetAttendanceUsers', this.getCurrentUserId());
+                    const users = await this.callServerFunction('clientGetAttendanceUsers', this.getCurrentUserId(), this.getCurrentCampaignId() || null);
 
                     if (!users || users.length === 0) {
                         container.innerHTML = `
@@ -4408,6 +4409,74 @@
                 ].filter(id => id);
 
                 return potentialIds.length > 0 ? String(potentialIds[0]) : 'system-user';
+            }
+
+            getCurrentCampaignId() {
+                const candidateValues = [
+                    this.currentUser?.CampaignID,
+                    this.currentUser?.campaignID,
+                    this.currentUser?.CampaignId,
+                    this.currentUser?.campaignId,
+                    this.currentUser?.Campaign,
+                    typeof document !== 'undefined' ? document.documentElement?.getAttribute('data-campaign-id') : null,
+                    typeof document !== 'undefined' ? document.documentElement?.dataset?.campaignId : null,
+                    typeof document !== 'undefined' ? document.body?.getAttribute('data-campaign-id') : null,
+                    typeof document !== 'undefined' ? document.body?.dataset?.campaignId : null,
+                    typeof window !== 'undefined' ? window.__layoutCampaignId : null,
+                    typeof window !== 'undefined' ? window.__LAYOUT_CAMPAIGN_ID : null,
+                    typeof window !== 'undefined' ? window.__LAYOUT_CAMPAIGNID : null,
+                    typeof window !== 'undefined' ? window.__absorbedBannerData?.campaignId : null,
+                    typeof window !== 'undefined' ? window.__absorbedBannerData?.campaignID : null
+                ];
+
+                for (const value of candidateValues) {
+                    const normalized = this.normalizeCampaignIdValue(value);
+                    if (normalized) {
+                        return normalized;
+                    }
+                }
+
+                const sidebarCampaign = document.querySelector('[data-campaign-id]')?.getAttribute('data-campaign-id');
+                const normalizedSidebarCampaign = this.normalizeCampaignIdValue(sidebarCampaign);
+                if (normalizedSidebarCampaign) {
+                    return normalizedSidebarCampaign;
+                }
+
+                return '';
+            }
+
+            normalizeCampaignIdValue(value) {
+                if (value === null || typeof value === 'undefined') {
+                    return '';
+                }
+
+                if (Array.isArray(value)) {
+                    for (const candidate of value) {
+                        const normalizedCandidate = this.normalizeCampaignIdValue(candidate);
+                        if (normalizedCandidate) {
+                            return normalizedCandidate;
+                        }
+                    }
+                    return '';
+                }
+
+                if (typeof value === 'object') {
+                    const objectCandidates = [value.ID, value.Id, value.id, value.campaignId, value.CampaignID, value.value];
+                    for (const candidate of objectCandidates) {
+                        const normalizedCandidate = this.normalizeCampaignIdValue(candidate);
+                        if (normalizedCandidate) {
+                            return normalizedCandidate;
+                        }
+                    }
+                    return '';
+                }
+
+                const text = String(value).trim();
+                if (!text || text.toLowerCase() === 'undefined' || text.toLowerCase() === 'null') {
+                    return '';
+                }
+
+                return text;
             }
 
             formatDate(dateStr) {

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -37,6 +37,190 @@ function scheduleFlagToBool(value) {
   }
 }
 
+function normalizeCampaignIdValue(value) {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const normalized = normalizeCampaignIdValue(value[i]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    const objectCandidates = [
+      value.ID,
+      value.Id,
+      value.id,
+      value.CampaignID,
+      value.campaignID,
+      value.CampaignId,
+      value.campaignId,
+      value.value
+    ];
+
+    for (let i = 0; i < objectCandidates.length; i++) {
+      const normalized = normalizeCampaignIdValue(objectCandidates[i]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+
+    return '';
+  }
+
+  const text = String(value).trim();
+  if (!text || text.toLowerCase() === 'undefined' || text.toLowerCase() === 'null') {
+    return '';
+  }
+
+  return text;
+}
+
+function doesUserBelongToCampaign(user, campaignId) {
+  const normalizedCampaignId = normalizeCampaignIdValue(campaignId);
+  if (!normalizedCampaignId || !user) {
+    return false;
+  }
+
+  const candidateValues = [
+    user.CampaignID,
+    user.campaignID,
+    user.CampaignId,
+    user.campaignId,
+    user.Campaign,
+    user.campaign,
+    user.primaryCampaignId,
+    user.PrimaryCampaignId,
+    user.primaryCampaignID,
+    user.PrimaryCampaignID
+  ];
+
+  for (let i = 0; i < candidateValues.length; i++) {
+    const candidate = normalizeCampaignIdValue(candidateValues[i]);
+    if (candidate && candidate === normalizedCampaignId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function collectUserRoleCandidates(user) {
+  const roles = [];
+
+  const appendValue = (value) => {
+    if (value === null || typeof value === 'undefined') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(appendValue);
+      return;
+    }
+
+    if (typeof value === 'object') {
+      appendValue(value.name || value.Name || value.roleName || value.RoleName);
+      appendValue(value.value);
+      return;
+    }
+
+    const text = String(value);
+    if (!text) {
+      return;
+    }
+
+    text.split(/[,;/|]+/).forEach((part) => {
+      const trimmed = part.trim();
+      if (trimmed) {
+        roles.push(trimmed);
+      }
+    });
+  };
+
+  appendValue(user && user.roleNames);
+  appendValue(user && user.RoleNames);
+  appendValue(user && user.roles);
+  appendValue(user && user.Roles);
+  appendValue(user && user.role);
+  appendValue(user && user.Role);
+  appendValue(user && user.primaryRole);
+  appendValue(user && user.PrimaryRole);
+  appendValue(user && user.primaryRoles);
+  appendValue(user && user.PrimaryRoles);
+  appendValue(user && user.csvRoles);
+  appendValue(user && user.CsvRoles);
+  appendValue(user && user.RoleName);
+  appendValue(user && user.roleName);
+
+  return roles;
+}
+
+function isScheduleRoleRestricted(user) {
+  const restrictedRoles = ['client', 'guest'];
+  const roleNames = collectUserRoleCandidates(user)
+    .map(role => String(role || '').trim().toLowerCase())
+    .filter(Boolean);
+
+  return roleNames.some(role => restrictedRoles.includes(role));
+}
+
+function isScheduleNameRestricted(user) {
+  const restrictedNames = ['client', 'guest'];
+  const nameCandidates = [
+    user && user.UserName,
+    user && user.Username,
+    user && user.username,
+    user && user.FullName,
+    user && user.Name,
+    user && user.DisplayName
+  ];
+
+  return nameCandidates.some(name => {
+    if (!name) {
+      return false;
+    }
+    const normalized = String(name).trim().toLowerCase();
+    return normalized && restrictedNames.includes(normalized);
+  });
+}
+
+function filterUsersByCampaign(users, campaignId) {
+  const normalizedCampaignId = normalizeCampaignIdValue(campaignId);
+  if (!normalizedCampaignId) {
+    return Array.isArray(users) ? users.slice() : [];
+  }
+
+  let filteredUsers = Array.isArray(users) ? users.filter(Boolean) : [];
+
+  try {
+    if (typeof getUsersByCampaign === 'function') {
+      const campaignUsers = getUsersByCampaign(normalizedCampaignId) || [];
+      if (Array.isArray(campaignUsers) && campaignUsers.length) {
+        const campaignUserIds = new Set(
+          campaignUsers
+            .map(user => normalizeUserIdValue(user && user.ID))
+            .filter(Boolean)
+        );
+
+        if (campaignUserIds.size) {
+          filteredUsers = filteredUsers.filter(user => campaignUserIds.has(normalizeUserIdValue(user && user.ID)));
+          return filteredUsers;
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to resolve campaign membership via getUsersByCampaign:', normalizedCampaignId, error);
+  }
+
+  return filteredUsers.filter(user => doesUserBelongToCampaign(user, normalizedCampaignId));
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // USER MANAGEMENT FUNCTIONS - Integrated with MainUtilities
 // ────────────────────────────────────────────────────────────────────────────
@@ -47,7 +231,8 @@ function scheduleFlagToBool(value) {
  */
 function clientGetScheduleUsers(requestingUserId, campaignId = null) {
   try {
-    console.log('🔍 Getting schedule users for:', requestingUserId, 'campaign:', campaignId);
+    const normalizedCampaignId = normalizeCampaignIdValue(campaignId);
+    console.log('🔍 Getting schedule users for:', requestingUserId, 'campaign:', normalizedCampaignId || '(not provided)');
 
     // Use MainUtilities to get all users
     const allUsers = readSheet(USERS_SHEET) || [];
@@ -56,34 +241,59 @@ function clientGetScheduleUsers(requestingUserId, campaignId = null) {
       return [];
     }
 
+    const normalizedManagerId = normalizeUserIdValue(requestingUserId);
+    let requestingUser = null;
+    if (normalizedManagerId) {
+      requestingUser = allUsers.find(u => normalizeUserIdValue(u && u.ID) === normalizedManagerId) || null;
+    }
+
+    let effectiveCampaignId = normalizedCampaignId;
+    if (!effectiveCampaignId && requestingUser) {
+      const managerCampaignCandidates = [
+        requestingUser.CampaignID,
+        requestingUser.campaignID,
+        requestingUser.CampaignId,
+        requestingUser.campaignId,
+        requestingUser.Campaign,
+        requestingUser.campaign
+      ];
+
+      for (let i = 0; i < managerCampaignCandidates.length; i++) {
+        const candidate = normalizeCampaignIdValue(managerCampaignCandidates[i]);
+        if (candidate) {
+          effectiveCampaignId = candidate;
+          break;
+        }
+      }
+    }
+
     let filteredUsers = allUsers;
 
     // Filter by campaign if specified - use MainUtilities campaign functions
-    if (campaignId) {
-      const campaignUsers = getUsersByCampaign(campaignId);
-      const campaignUserIds = new Set(campaignUsers.map(u => u.ID));
-      filteredUsers = allUsers.filter(user => campaignUserIds.has(user.ID));
+    if (effectiveCampaignId) {
+      filteredUsers = filterUsersByCampaign(allUsers, effectiveCampaignId);
     }
 
     // Apply manager permissions using MainUtilities functions
-    if (requestingUserId) {
-      const normalizedManagerId = normalizeUserIdValue(requestingUserId);
-      const requestingUser = allUsers.find(u => normalizeUserIdValue(u.ID) === normalizedManagerId);
-
+    if (normalizedManagerId) {
       if (requestingUser) {
         const isAdmin = scheduleFlagToBool(requestingUser.IsAdmin);
 
         if (!isAdmin) {
           const managedUserIds = buildManagedUserSet(normalizedManagerId);
 
-          filteredUsers = filteredUsers.filter(user => managedUserIds.has(normalizeUserIdValue(user.ID)));
+          filteredUsers = filteredUsers.filter(user => managedUserIds.has(normalizeUserIdValue(user && user.ID)));
         }
+      } else {
+        console.warn('Requesting user not found when applying manager filter:', requestingUserId);
       }
     }
 
     // Transform to schedule-friendly format
     const scheduleUsers = filteredUsers
       .filter(user => user && user.ID && (user.UserName || user.FullName))
+      .filter(user => !isScheduleNameRestricted(user))
+      .filter(user => !isScheduleRoleRestricted(user))
       .filter(user => isUserConsideredActive(user))
       .map(user => {
         const campaignName = getCampaignById(user.CampaignID)?.Name || '';

--- a/layout.html
+++ b/layout.html
@@ -422,8 +422,53 @@
 
     const __PAGE_SLUG_SOURCES = <?!= JSON.stringify(__layoutSlugSources) ?>;
     const __RAW_RETURN_URL = <?!= JSON.stringify(__layoutRawReturnUrl) ?>;
+    const __LAYOUT_CAMPAIGN_ID = <?!= JSON.stringify(__layoutCampaignId || '') ?>;
     const __LAYOUT_CAMPAIGN_NAME = <?!= JSON.stringify(__layoutCampaignName || '') ?>;
     const __LAYOUT_CLIENT_NAME = <?!= JSON.stringify(__layoutClientName || '') ?>;
+
+    if (typeof window !== 'undefined') {
+      window.__LAYOUT_CAMPAIGN_ID = __LAYOUT_CAMPAIGN_ID;
+      window.__LAYOUT_CAMPAIGN_NAME = __LAYOUT_CAMPAIGN_NAME;
+    }
+
+    if (typeof document !== 'undefined' && document.documentElement) {
+      const root = document.documentElement;
+      if (__LAYOUT_CAMPAIGN_ID) {
+        root.setAttribute('data-campaign-id', __LAYOUT_CAMPAIGN_ID);
+      } else {
+        root.removeAttribute('data-campaign-id');
+      }
+
+      if (__LAYOUT_CAMPAIGN_NAME) {
+        root.setAttribute('data-campaign-name', __LAYOUT_CAMPAIGN_NAME);
+      } else {
+        root.removeAttribute('data-campaign-name');
+      }
+
+      const applyBodyCampaignAttributes = () => {
+        if (!document.body) {
+          return;
+        }
+
+        if (__LAYOUT_CAMPAIGN_ID) {
+          document.body.setAttribute('data-campaign-id', __LAYOUT_CAMPAIGN_ID);
+        } else {
+          document.body.removeAttribute('data-campaign-id');
+        }
+
+        if (__LAYOUT_CAMPAIGN_NAME) {
+          document.body.setAttribute('data-campaign-name', __LAYOUT_CAMPAIGN_NAME);
+        } else {
+          document.body.removeAttribute('data-campaign-name');
+        }
+      };
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', applyBodyCampaignAttributes, { once: true });
+      } else {
+        applyBodyCampaignAttributes();
+      }
+    }
 
     const __invalidPanelPattern = /usercodeapppanel/i;
 

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -53,6 +53,9 @@
   var navigationConfig = navigation && typeof navigation === 'object' ? navigation : { categories: [], uncategorizedPages: [] };
   var employmentMetaValue = employmentMeta && typeof employmentMeta === 'object' ? employmentMeta : { status: '', cls: '', icon: 'fas fa-briefcase' };
 
+  var campaignIdAttrValue = escapeHtml(campaignIdValue);
+  var campaignNameAttrValue = escapeHtml(campaignNameValue);
+
   function safeUserString(value) {
     if (value === null || typeof value === 'undefined') {
       return '';
@@ -392,7 +395,10 @@
   }
 </style>
 
-<nav id="sidebar" data-current-page='<?= currentPageAttrValue ?>'>
+<nav id="sidebar"
+  data-current-page='<?= currentPageAttrValue ?>'
+  data-campaign-id="<?= campaignIdAttrValue ?>"
+  data-campaign-name="<?= campaignNameAttrValue ?>">
   <!-- Enhanced Logo Section -->
   <div class="sidebar-logo" id="sidebarToggle">
     <img


### PR DESCRIPTION
## Summary
- expose the active campaign identifier and name via global variables and data attributes in the shared layout
- stamp the navigation sidebar with sanitized campaign metadata for downstream scripts
- have the schedule manager read campaign identifiers from the new layout attributes before loading data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee66fcf2348326abe9732c7146b0b2