### PR TITLE
Adjust main content margins for tighter layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2221,7 +2221,9 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 1rem) clamp(0.75rem, 3vw, 1.25rem) 1.25rem;
+        margin: calc(var(--topbar-height) + 0.6rem)
+          clamp(0.5rem, 2.5vw, 1rem)
+          1rem;
       }
 
       #sidebar.collapsed~#maincontent {
@@ -2253,7 +2255,9 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 0.85rem) clamp(0.75rem, 5vw, 1.25rem) 1.25rem;
+        margin: calc(var(--topbar-height) + 0.5rem)
+          clamp(0.5rem, 4vw, 1rem)
+          1rem;
       }
 
       .breadcrumb-nav {
@@ -2270,7 +2274,9 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 0.75rem) clamp(0.5rem, 6vw, 1rem) 1rem;
+        margin: calc(var(--topbar-height) + 0.45rem)
+          clamp(0.4rem, 5vw, 0.85rem)
+          0.85rem;
       }
 
       .topbar-toggle {
@@ -2285,16 +2291,16 @@
     }
 
     #maincontent {
-      margin-left: calc(var(--sidebar-width) + 1.25rem);
-      margin-top: calc(var(--topbar-height) + 1.1rem);
-      margin-right: 1.25rem;
-      margin-bottom: 1.25rem;
+      margin-left: calc(var(--sidebar-width) + 0.75rem);
+      margin-top: calc(var(--topbar-height) + 0.6rem);
+      margin-right: 0.85rem;
+      margin-bottom: 1rem;
       transition: var(--transition-smooth);
-      min-height: calc(100vh - var(--topbar-height) - 2.5rem);
+      min-height: calc(100vh - var(--topbar-height) - 1.6rem);
     }
 
     #sidebar.collapsed~#maincontent {
-      margin-left: calc(var(--sidebar-collapsed) + 1.25rem);
+      margin-left: calc(var(--sidebar-collapsed) + 0.75rem);
     }
 
     /* Unified global page banner */


### PR DESCRIPTION
## Summary
- reduce main content margins across breakpoints so forms and tables sit closer to the sidebar and top bar
- lower the main content min-height to match the tighter vertical spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeaa2abf0483269105afa26f13c24d