### PR TITLE
Tighten main content spacing further

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2221,11 +2221,13 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 1rem) clamp(0.75rem, 3vw, 1.25rem) 1.25rem;
+        margin: calc(var(--topbar-height) + 0.4rem)
+          clamp(0.35rem, 2vw, 0.75rem)
+          0.75rem;
       }
 
       #sidebar.collapsed~#maincontent {
-        margin-left: clamp(0.75rem, 3vw, 1.25rem);
+        margin-left: clamp(0.55rem, 2.4vw, 1rem);
       }
 
       body.sidebar-open #maincontent {
@@ -2253,7 +2255,9 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 0.85rem) clamp(0.75rem, 5vw, 1.25rem) 1.25rem;
+        margin: calc(var(--topbar-height) + 0.35rem)
+          clamp(0.35rem, 3.5vw, 0.85rem)
+          0.75rem;
       }
 
       .breadcrumb-nav {
@@ -2270,7 +2274,9 @@
       }
 
       #maincontent {
-        margin: calc(var(--topbar-height) + 0.75rem) clamp(0.5rem, 6vw, 1rem) 1rem;
+        margin: calc(var(--topbar-height) + 0.3rem)
+          clamp(0.3rem, 4.5vw, 0.7rem)
+          0.7rem;
       }
 
       .topbar-toggle {
@@ -2285,16 +2291,16 @@
     }
 
     #maincontent {
-      margin-left: calc(var(--sidebar-width) + 1.25rem);
-      margin-top: calc(var(--topbar-height) + 1.1rem);
-      margin-right: 1.25rem;
-      margin-bottom: 1.25rem;
+      margin-left: calc(var(--sidebar-width) + 0.5rem);
+      margin-top: calc(var(--topbar-height) + 0.35rem);
+      margin-right: 0.6rem;
+      margin-bottom: 0.75rem;
       transition: var(--transition-smooth);
-      min-height: calc(100vh - var(--topbar-height) - 2.5rem);
+      min-height: calc(100vh - var(--topbar-height) - 1.1rem);
     }
 
     #sidebar.collapsed~#maincontent {
-      margin-left: calc(var(--sidebar-collapsed) + 1.25rem);
+      margin-left: calc(var(--sidebar-collapsed) + 0.5rem);
     }
 
     /* Unified global page banner */


### PR DESCRIPTION
## Summary
- pull the main content container tighter to the sidebar, top bar, and right edge across breakpoints
- reduce the collapsed-sidebar gutter and min-height to match the denser spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeaa2abf0483269105afa26f13c24d