### PR TITLE
Ensure schedule management uses logged-in manager context

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -1623,6 +1623,30 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
     <script>
+        (function initializeCurrentUserContext() {
+            try {
+                const injectedUser = <?!= currentUserJson || '{}' ?>;
+                const existingUser = (typeof window !== 'undefined' && window.CURRENT_USER && Object.keys(window.CURRENT_USER).length)
+                    ? window.CURRENT_USER
+                    : null;
+
+                const resolvedUser = existingUser && typeof existingUser === 'object' ? existingUser : injectedUser;
+
+                if (typeof window !== 'undefined') {
+                    window.CURRENT_USER = resolvedUser || {};
+                    window.currentUser = window.currentUser && Object.keys(window.currentUser).length ? window.currentUser : window.CURRENT_USER;
+                    window.user = window.user && Object.keys(window.user).length ? window.user : window.CURRENT_USER;
+                }
+            } catch (error) {
+                console.warn('Unable to initialize current user context for schedule management:', error);
+                if (typeof window !== 'undefined') {
+                    window.CURRENT_USER = window.CURRENT_USER || {};
+                }
+            }
+        })();
+    </script>
+
+    <script>
         // LUMINA Schedule Management System v4.0 - Modern UI Edition with Backend Integration
         class LuminaScheduleManager {
             constructor() {


### PR DESCRIPTION
## Summary
- initialize the schedule management page with the injected current user so the frontend knows which manager is logged in
- fall back to any existing user context while ensuring global user references are populated for manager-scoped queries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef8cc5fdd48326bf46499ea093b089