### PR TITLE
Improve manager user filtering

### DIFF
--- a/UserService.js
+++ b/UserService.js
@@ -1853,8 +1853,180 @@ function setCampaignUserPermissions(campaignId, userId, permissionLevel, canMana
 // ───────────────────────────────────────────────────────────────────────────────
 // Users: get all (campaign-aware) + safe mappers
 // ───────────────────────────────────────────────────────────────────────────────
+function normalizeManagerUserId(value) {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number' && Number.isFinite(value)) return String(Math.trunc(value));
+  return String(value).trim();
+}
+
+function collectManagerAssignmentsFromRows(rows, managerId, append) {
+  if (!Array.isArray(rows) || typeof append !== 'function' || !managerId) return;
+
+  const wrapCandidate = function (value, meta) {
+    if (!value && (!meta || !meta.email)) return;
+    const candidateMeta = Object.assign({ id: value }, meta || {});
+    append(candidateMeta);
+  };
+
+  if (Array.isArray(rows[0])) {
+    const headers = (rows[0] || []).map(header => String(header || '').trim());
+    const managerIdx = headers.indexOf('ManagerUserID');
+    let userIdx = headers.indexOf('UserID');
+    if (userIdx === -1) userIdx = headers.indexOf('ManagedUserID');
+    const emailIdx = headers.indexOf('UserEmail') !== -1 ? headers.indexOf('UserEmail') : headers.indexOf('ManagedUserEmail');
+    if (managerIdx === -1 || userIdx === -1) return;
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if (!Array.isArray(row)) continue;
+      const managerCandidate = normalizeManagerUserId(row[managerIdx]);
+      const userCandidate = normalizeManagerUserId(row[userIdx]);
+      const emailCandidate = (emailIdx !== -1) ? String(row[emailIdx] || '').trim() : '';
+      if (managerCandidate === managerId && userCandidate && userCandidate !== managerId) {
+        wrapCandidate(userCandidate, { email: emailCandidate });
+      }
+    }
+    return;
+  }
+
+  const normalizeEmail = function (value) {
+    const email = String(value || '').trim().toLowerCase();
+    return email && email.includes('@') ? email : '';
+  };
+
+  rows.forEach(record => {
+    if (!record || typeof record !== 'object') return;
+
+    const managerCandidates = [
+      record.ManagerUserID, record.ManagerUserId, record.managerUserId,
+      record.ManagerID, record.ManagerId, record.managerId, record.manager_id,
+      record.UserManagerID, record.UserManagerId, record.userManagerId
+    ].map(normalizeManagerUserId).filter(Boolean);
+
+    const userCandidates = [
+      record.UserID, record.UserId, record.userId,
+      record.ManagedUserID, record.ManagedUserId, record.managedUserId,
+      record.managed_user_id, record.ManagedID, record.ManagedId
+    ].map(normalizeManagerUserId).filter(Boolean);
+
+    const emailCandidates = [
+      record.UserEmail, record.userEmail, record.UserEmailAddress, record.userEmailAddress,
+      record.ManagedUserEmail, record.managedUserEmail, record.Email, record.email
+    ].map(normalizeEmail).filter(Boolean);
+
+    const managerMatch = managerCandidates.find(candidate => candidate === managerId);
+
+    if (managerMatch && userCandidates.length) {
+      userCandidates.forEach(candidate => {
+        if (candidate && candidate !== managerId) {
+          wrapCandidate(candidate, { email: emailCandidates[0] || '' });
+        }
+      });
+    }
+
+    const reversedManager = userCandidates.find(candidate => candidate === managerId);
+    if (reversedManager && managerCandidates.length) {
+      managerCandidates.forEach(candidate => {
+        if (candidate && candidate !== managerId) {
+          wrapCandidate(candidate);
+        }
+      });
+    }
+  });
+}
+
+function getManagerVisibleUserIds(managerUserId, options) {
+  const opts = Object.assign({ includeSelf: false }, options || {});
+  const normalizedManagerId = normalizeManagerUserId(managerUserId);
+  const visible = new Set();
+
+  if (!normalizedManagerId) {
+    return visible;
+  }
+
+  const append = (value) => {
+    if (!value && value !== 0) return;
+    if (value && typeof value === 'object') {
+      if (Object.prototype.hasOwnProperty.call(value, 'id')) {
+        append(value.id);
+      }
+      return;
+    }
+
+    const normalized = normalizeManagerUserId(value);
+    if (!normalized || normalized === normalizedManagerId) return;
+    if (typeof value === 'string' && value.indexOf('@') !== -1) return;
+    visible.add(normalized);
+  };
+
+  if (opts.includeSelf) {
+    visible.add(normalizedManagerId);
+  }
+
+  let populatedFromHelper = false;
+
+  if (typeof getDirectManagedUserIds === 'function') {
+    try {
+      const directSet = getDirectManagedUserIds(normalizedManagerId);
+      if (directSet && typeof directSet.forEach === 'function') {
+        directSet.forEach(append);
+        populatedFromHelper = populatedFromHelper || directSet.size > 0;
+      }
+    } catch (err) {
+      try { writeError && writeError('getManagerVisibleUserIds.getDirectManagedUserIds', err); } catch (_) { }
+    }
+  }
+
+  const loadAssignments = (rows, label) => {
+    try {
+      collectManagerAssignmentsFromRows(rows, normalizedManagerId, append);
+    } catch (err) {
+      try { writeError && writeError(`getManagerVisibleUserIds.${label}`, err); } catch (_) { }
+    }
+  };
+
+  if (!visible.size || !populatedFromHelper) {
+    if (typeof readManagerAssignments_ === 'function') {
+      loadAssignments(readManagerAssignments_(), 'readManagerAssignments');
+    }
+  }
+
+  if (!visible.size || !populatedFromHelper) {
+    const candidateSheets = Array.from(new Set([
+      (typeof getManagerUsersSheetName_ === 'function') ? getManagerUsersSheetName_() : null,
+      'MANAGER_USERS',
+      'ManagerUsers',
+      'manager_users',
+      'UserManagers'
+    ].filter(Boolean)));
+
+    candidateSheets.forEach(name => {
+      if (!name) return;
+      try {
+        loadAssignments(readSheet(name) || [], `readSheet.${name}`);
+      } catch (err) {
+        try { writeError && writeError(`getManagerVisibleUserIds.readSheet.${name}`, err); } catch (_) { }
+      }
+    });
+  }
+
+  return visible;
+}
+
 function clientGetAllUsers(requestingUserId) {
   try {
+    let resolvedRequestingUserId = requestingUserId;
+    if (!resolvedRequestingUserId) {
+      try {
+        const current = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+        if (current && current.ID) {
+          resolvedRequestingUserId = current.ID;
+        }
+      } catch (currentErr) {
+        try { writeError && writeError('clientGetAllUsers.getCurrentUser', currentErr); } catch (_) { }
+      }
+    }
+
     try {
       ensureUsersHaveIds();
     } catch (ensureError) {
@@ -1925,26 +2097,62 @@ function clientGetAllUsers(requestingUserId) {
     }
 
     let filteredUsers = enhancedUsers;
-    if (requestingUserId) {
+    const normalizedRequestingId = normalizeManagerUserId(resolvedRequestingUserId);
+    if (normalizedRequestingId) {
       try {
-        const requestingUser = users.find(u => String(u.ID) === String(requestingUserId));
+        const requestingUser = enhancedUsers.find(u => String(u.ID) === normalizedRequestingId)
+          || users.find(u => String(u.ID) === normalizedRequestingId);
         if (requestingUser) {
           if (isUserAdmin(requestingUser)) {
             filteredUsers = enhancedUsers;
           } else {
-            const managedCampaigns = getUserManagedCampaigns(requestingUserId) || [];
-            const managedSet = new Set(managedCampaigns.map(c => String(c.ID)));
-            if (managedSet.size > 0) {
-              const managedIds = new Set(Array.from(managedSet).map(String));
-              filteredUsers = enhancedUsers.filter(u => {
-                if (String(u.ID) === String(requestingUserId)) return true;
-                const uCamps = (typeof getUserCampaignsSafe === 'function')
-                  ? (getUserCampaignsSafe(u.ID) || []).map(x => String(x.campaignId))
-                  : (u.CampaignID ? [String(u.CampaignID)] : []);
-                return uCamps.some(cid => managedIds.has(cid));
+            const managedIds = getManagerVisibleUserIds(normalizedRequestingId, { includeSelf: true });
+            const allowedIds = new Set();
+            const allowedEmails = new Set();
+
+            if (managedIds && typeof managedIds.forEach === 'function') {
+              managedIds.forEach(id => {
+                const normalized = normalizeManagerUserId(id);
+                if (normalized) allowedIds.add(String(normalized));
+              });
+            }
+
+            if (typeof getUsersByManager === 'function') {
+              try {
+                const scopedUsers = getUsersByManager(normalizedRequestingId, {
+                  includeManager: true,
+                  fallbackToCampaign: false,
+                  fallbackToAll: false
+                }) || [];
+                if (Array.isArray(scopedUsers) && scopedUsers.length) {
+                  scopedUsers.forEach(scoped => {
+                    if (!scoped) return;
+                    if (scoped.ID) allowedIds.add(String(scoped.ID));
+                    const scopedEmail = String(scoped.Email || scoped.email || '').trim().toLowerCase();
+                    if (scopedEmail && scopedEmail.indexOf('@') !== -1) {
+                      allowedEmails.add(scopedEmail);
+                    }
+                  });
+                }
+              } catch (scopedErr) {
+                try { writeError && writeError('clientGetAllUsers.getUsersByManager', scopedErr); } catch (_) { }
+              }
+            }
+
+            if (!allowedIds.size) {
+              allowedIds.add(normalizedRequestingId);
+            }
+
+            if (allowedIds.size || allowedEmails.size) {
+              filteredUsers = enhancedUsers.filter(user => {
+                if (!user) return false;
+                if (allowedIds.has(String(user.ID))) return true;
+                const normalizedEmail = String(user.Email || user.email || '').trim().toLowerCase();
+                if (!normalizedEmail) return false;
+                return allowedEmails.has(normalizedEmail);
               });
             } else {
-              filteredUsers = enhancedUsers.filter(user => String(user.ID) === String(requestingUserId));
+              filteredUsers = enhancedUsers.filter(user => String(user.ID) === normalizedRequestingId);
             }
           }
         } else {
@@ -1953,6 +2161,8 @@ function clientGetAllUsers(requestingUserId) {
       } catch (permissionError) {
         filteredUsers = enhancedUsers;
       }
+    } else if (resolvedRequestingUserId) {
+      filteredUsers = enhancedUsers;
     }
     return filteredUsers;
   } catch (globalError) { writeError('clientGetAllUsers', globalError); return []; }


### PR DESCRIPTION
## Summary
- enrich manager assignment resolution to capture IDs, emails, and metadata from mapping sources
- expand server-side filtering so managers receive their assigned users even when stored by email or alternative fields
- reuse scoped user resolution for client requests to keep manager views aligned with backend filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0476ef910832687faa7db7dc02355