### PR TITLE
Clarify login session token expiration messaging

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -3889,6 +3889,7 @@
       const error = urlParams.get('error');
       const logoutReason = (state.lastLogoutReason || '').toLowerCase();
       const shouldShowAutoTimeout = !error && !message && logoutReason === 'auto';
+      const shouldShowManualLogout = !error && !message && logoutReason === 'manual';
 
       let shouldReplaceUrl = false;
 
@@ -3921,8 +3922,8 @@
 
       const resumed = attemptSessionResume();
 
-      if (!resumed && shouldShowAutoTimeout) {
-        showAlert('info', 'Your session timed out after 30 minutes of inactivity. Please sign in again to continue.');
+      if (!resumed && (shouldShowAutoTimeout || shouldShowManualLogout)) {
+        showAlert('info', 'Session tokens expire when you log out or after 30 minutes of inactivity. Please sign in again to continue.');
       }
 
       // Auto-focus email field when not redirecting


### PR DESCRIPTION
## Summary
- show a consistent notice on the login page when a session token expires
- explain that tokens are invalidated on logout or after 30 minutes of inactivity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f070caa8dc83269fa108b14aa4b397