### PR TITLE
Fix logout flow to wait for server before clearing auth

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -3735,6 +3735,9 @@
         // ──────────────────────────────────────────────────────────────────────────────
         // SIMPLIFIED LOGOUT FUNCTION
         // ──────────────────────────────────────────────────────────────────────────────
+        let logoutFinalizeTimerId = null;
+        let logoutFinalizeCompleted = false;
+
         function stopSessionHeartbeat(reason) {
             try {
                 if (window.LuminaSessionHeartbeat && typeof window.LuminaSessionHeartbeat.stop === 'function') {
@@ -3757,6 +3760,27 @@
             }
         }
 
+        function finalizeLogout(source) {
+            if (logoutFinalizeCompleted) {
+                console.log('🔁 Logout already finalized, ignoring duplicate finalize from:', source || 'unknown');
+                return;
+            }
+
+            logoutFinalizeCompleted = true;
+
+            try {
+                if (logoutFinalizeTimerId) {
+                    clearTimeout(logoutFinalizeTimerId);
+                    logoutFinalizeTimerId = null;
+                }
+            } catch (timerError) {
+                console.warn('finalizeLogout: unable to clear pending timer', timerError);
+            }
+
+            console.log('🔚 Finalizing logout via:', source || 'unspecified');
+            performLogout();
+        }
+
         function handleLogout() {
             if (!confirm('Are you sure you want to logout?')) return;
 
@@ -3769,15 +3793,25 @@
 
             console.log('🚪 Initiating logout...');
 
-            stopSessionHeartbeat('logout-init');
+            logoutFinalizeCompleted = false;
+            if (logoutFinalizeTimerId) {
+                try {
+                    clearTimeout(logoutFinalizeTimerId);
+                } catch (clearErr) {
+                    console.warn('handleLogout: unable to clear previous logout timer', clearErr);
+                }
+                logoutFinalizeTimerId = null;
+            }
 
-            // Clear browser storage
+            let sessionToken = '';
             try {
-                localStorage.clear();
-                sessionStorage.clear();
-                console.log('🧹 Browser storage cleared');
-            } catch (e) {
-                console.warn('⚠️ Could not clear storage:', e);
+                if (typeof readAuthTokenForGuard === 'function') {
+                    sessionToken = readAuthTokenForGuard() || '';
+                } else if (window.CookieHandler && typeof window.CookieHandler.readAuthToken === 'function') {
+                    sessionToken = window.CookieHandler.readAuthToken() || '';
+                }
+            } catch (tokenError) {
+                console.warn('handleLogout: unable to read session token', tokenError);
             }
 
             try {
@@ -3786,17 +3820,35 @@
                 console.warn('handleLogout: unable to persist manual logout reason', reasonError);
             }
 
+            if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+                try {
+                    logoutFinalizeTimerId = window.setTimeout(function handleLogoutTimeout() {
+                        console.warn('⌛ Logout request timed out; forcing client-side logout.');
+                        finalizeLogout('timeout');
+                    }, 7000);
+                } catch (timerError) {
+                    console.warn('handleLogout: unable to create logout timeout', timerError);
+                    logoutFinalizeTimerId = null;
+                }
+            }
+
+            if (typeof window === 'undefined' || !(window.google && window.google.script && window.google.script.run)) {
+                console.warn('handleLogout: google.script.run unavailable, performing client-only logout.');
+                finalizeLogout('client-only');
+                return;
+            }
+
             // Call server logout
-            google.script.run
+            window.google.script.run
                 .withSuccessHandler(function(result) {
                     console.log('✅ Server logout completed:', result);
-                    performLogout();
+                    finalizeLogout('server-success');
                 })
                 .withFailureHandler(function(err) {
-                    console.warn('⚠️ Server logout failed, but proceeding with client logout:', err);
-                    performLogout();
+                    console.warn('⚠️ Server logout failed, proceeding with client logout:', err);
+                    finalizeLogout('server-failure');
                 })
-                .logout('');
+                .logout(sessionToken || '');
         }
 
         function performLogout() {


### PR DESCRIPTION
## Summary
- defer clearing client auth state until after the server logout finishes so the script connection stays alive
- add a guarded finalizeLogout helper with a timeout fallback to ensure the client still redirects if the server call fails
- keep persisting the manual logout reason while preventing duplicate finalization attempts

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0723906b483268ea45720de38536a