### PR TITLE
Restrict user lists to active campaign context

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1600,12 +1600,15 @@
         if (users.length === 0) {
           try {
             console.log('Loading user list from server...');
-            users = await this.callServerFunction('clientGetAssignedAgentNames', [window.MANAGER_USER_ID], { timeoutMs: 10000 });
+            const campaignArg = (typeof window !== 'undefined' && window.__LAYOUT_CAMPAIGN_ID)
+              ? window.__LAYOUT_CAMPAIGN_ID
+              : (window.MANAGER_USER_ID || '');
+            users = await this.callServerFunction('clientGetAssignedAgentNames', [campaignArg], { timeoutMs: 10000 });
 
             if (!Array.isArray(users) || users.length === 0) {
               console.log('No users from clientGetAssignedAgentNames, trying fallback...');
               try {
-                const userData = await this.callServerFunction('getUsers', [], { timeoutMs: 8000 });
+                const userData = await this.callServerFunction('getUsers', [{ campaignId: campaignArg, excludeGuests: true }], { timeoutMs: 8000 });
                 if (Array.isArray(userData)) {
                   users = userData.map(u => u.FullName || u.UserName || u.name || u.Email).filter(Boolean);
                 }
@@ -2966,11 +2969,14 @@
         } else {
           console.log('Export manager calling server for user list...');
           try {
-            this.userList = await this.callServerFunction('clientGetAssignedAgentNames', [window.MANAGER_USER_ID], { timeoutMs: 8000 });
+            const campaignArg = (typeof window !== 'undefined' && window.__LAYOUT_CAMPAIGN_ID)
+              ? window.__LAYOUT_CAMPAIGN_ID
+              : (window.MANAGER_USER_ID || '');
+            this.userList = await this.callServerFunction('clientGetAssignedAgentNames', [campaignArg], { timeoutMs: 8000 });
 
             if (!Array.isArray(this.userList) || this.userList.length === 0) {
               console.log('No users from clientGetAssignedAgentNames, trying getUsers fallback...');
-              const userData = await this.callServerFunction('getUsers', [], { timeoutMs: 6000 });
+              const userData = await this.callServerFunction('getUsers', [{ campaignId: campaignArg, excludeGuests: true }], { timeoutMs: 6000 });
               if (Array.isArray(userData)) {
                 this.userList = userData.map(u => u.FullName || u.UserName || u.name || u.Email).filter(Boolean);
               } else {

--- a/QualityForm.html
+++ b/QualityForm.html
@@ -2639,7 +2639,7 @@
     }
 
     try {
-      const users = await run('getUsers');
+      const users = await run('getUsers', { campaignId: cid, excludeGuests: true });
       if (Array.isArray(users) && users.length > 0) {
         userList = users.slice();
         populateAgentSelect(users);

--- a/luminaIdentity.js
+++ b/luminaIdentity.js
@@ -504,6 +504,13 @@ var LuminaIdentity = (function () {
     }
 
     try {
+      if (typeof _readUsersSheetSafe_ === 'function') {
+        var scoped = _readUsersSheetSafe_({ excludeGuests: true });
+        if (Array.isArray(scoped) && scoped.length) {
+          return scoped;
+        }
+      }
+
       if (typeof readSheet === 'function') {
         var sheetData = readSheet('Users') || [];
         if (Array.isArray(sheetData) && sheetData.length) {


### PR DESCRIPTION
## Summary
- add campaign-aware helper utilities and filtering in Code.js to keep user queries scoped to the active tenant and omit guest accounts
- update user-facing helpers and fallbacks to honor the resolved campaign while retaining graceful degradation paths
- ensure UI calls in AttendanceReports and QualityForm pass the current campaign id when requesting users and tighten lumina identity fallbacks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0ecfa29908326ac31f53f68e3f236