### PR TITLE
Enable full user directory view by default

### DIFF
--- a/UserService.js
+++ b/UserService.js
@@ -50,6 +50,7 @@ if (typeof G.CAMPAIGN_USER_PERMISSIONS_HEADERS === 'undefined') {
 
 // HR/Benefits config
 if (typeof G.INSURANCE_MONTHS_AFTER_PROBATION === 'undefined') G.INSURANCE_MONTHS_AFTER_PROBATION = 3;
+if (typeof G.ALLOW_FULL_USER_DIRECTORY_VIEW === 'undefined') G.ALLOW_FULL_USER_DIRECTORY_VIEW = true;
 
 // Optional extra columns we’ll ensure on Users sheet if missing
 const OPTIONAL_USER_COLUMNS = [
@@ -2068,83 +2069,90 @@ function clientGetAllUsers(requestingUserId) {
     }
 
     let filteredUsers = enhancedUsers;
-    const normalizedRequestingId = normalizeManagerUserId(resolvedRequestingUserId);
-    const normalizedCurrentEmail = currentUser
-      ? _normEmail_(currentUser.Email || currentUser.email || currentUser.WorkEmail || currentUser.PrimaryEmail)
-      : '';
-    const fallbackEmailFromId = (normalizedRequestingId && normalizedRequestingId.indexOf('@') !== -1)
-      ? normalizedRequestingId.toLowerCase()
-      : '';
-    const emailCandidates = Array.from(new Set([normalizedCurrentEmail, fallbackEmailFromId].filter(Boolean)));
+    const allowFullDirectoryView = !!G.ALLOW_FULL_USER_DIRECTORY_VIEW;
+    if (!allowFullDirectoryView) {
+      const normalizedRequestingId = normalizeManagerUserId(resolvedRequestingUserId);
+      const normalizedCurrentEmail = currentUser
+        ? _normEmail_(currentUser.Email || currentUser.email || currentUser.WorkEmail || currentUser.PrimaryEmail)
+        : '';
+      const fallbackEmailFromId = (normalizedRequestingId && normalizedRequestingId.indexOf('@') !== -1)
+        ? normalizedRequestingId.toLowerCase()
+        : '';
+      const emailCandidates = Array.from(new Set([normalizedCurrentEmail, fallbackEmailFromId].filter(Boolean)));
 
-    const matchUserById = (collection, targetId) => {
-      if (!targetId) return null;
-      for (let i = 0; i < collection.length; i++) {
-        const candidate = collection[i];
-        if (!candidate) continue;
-        const candidateId = normalizeManagerUserId(candidate.ID || candidate.Id || candidate.id);
-        if (candidateId && candidateId === targetId) {
-          return candidate;
-        }
-      }
-      return null;
-    };
-
-    const matchUserByEmail = (collection, targetEmail) => {
-      if (!targetEmail) return null;
-      for (let i = 0; i < collection.length; i++) {
-        const candidate = collection[i];
-        if (!candidate) continue;
-        const candidateEmail = _normEmail_(
-          candidate.Email || candidate.email || candidate.EmailAddress ||
-          candidate.WorkEmail || candidate.workEmail || candidate.PrimaryEmail || candidate.primaryEmail
-        );
-        if (candidateEmail && candidateEmail === targetEmail) {
-          return candidate;
-        }
-      }
-      return null;
-    };
-
-    const resolveRequestingUser = () => {
-      let found = matchUserById(enhancedUsers, normalizedRequestingId) || matchUserById(users, normalizedRequestingId);
-      if (found) return found;
-      for (let i = 0; i < emailCandidates.length; i++) {
-        const email = emailCandidates[i];
-        if (!email) continue;
-        found = matchUserByEmail(enhancedUsers, email) || matchUserByEmail(users, email);
-        if (found) return found;
-      }
-      return null;
-    };
-
-    if (normalizedRequestingId) {
-      try {
-        const requestingUser = resolveRequestingUser();
-        if (requestingUser) {
-          if (isUserAdmin(requestingUser)) {
-            filteredUsers = enhancedUsers;
-          } else {
-            const managedIds = getManagerVisibleUserIds(normalizedRequestingId, { includeSelf: true });
-            if (managedIds && managedIds.size) {
-              filteredUsers = enhancedUsers.filter(user => managedIds.has(String(user.ID)));
-            } else {
-              filteredUsers = enhancedUsers.filter(user => String(user.ID) === normalizedRequestingId);
-            }
+      const matchUserById = (collection, targetId) => {
+        if (!targetId) return null;
+        for (let i = 0; i < collection.length; i++) {
+          const candidate = collection[i];
+          if (!candidate) continue;
+          const candidateId = normalizeManagerUserId(candidate.ID || candidate.Id || candidate.id);
+          if (candidateId && candidateId === targetId) {
+            return candidate;
           }
-        } else {
-          _userLog_('clientGetAllUsers.requestingUserNotFound', {
-            resolvedRequestingUserId,
-            normalizedRequestingId,
-            emailCandidates
-          }, 'warn');
+        }
+        return null;
+      };
+
+      const matchUserByEmail = (collection, targetEmail) => {
+        if (!targetEmail) return null;
+        for (let i = 0; i < collection.length; i++) {
+          const candidate = collection[i];
+          if (!candidate) continue;
+          const candidateEmail = _normEmail_(
+            candidate.Email || candidate.email || candidate.EmailAddress ||
+            candidate.WorkEmail || candidate.workEmail || candidate.PrimaryEmail || candidate.primaryEmail
+          );
+          if (candidateEmail && candidateEmail === targetEmail) {
+            return candidate;
+          }
+        }
+        return null;
+      };
+
+      const resolveRequestingUser = () => {
+        let found = matchUserById(enhancedUsers, normalizedRequestingId) || matchUserById(users, normalizedRequestingId);
+        if (found) return found;
+        for (let i = 0; i < emailCandidates.length; i++) {
+          const email = emailCandidates[i];
+          if (!email) continue;
+          found = matchUserByEmail(enhancedUsers, email) || matchUserByEmail(users, email);
+          if (found) return found;
+        }
+        return null;
+      };
+
+      if (normalizedRequestingId) {
+        try {
+          const requestingUser = resolveRequestingUser();
+          if (requestingUser) {
+            if (isUserAdmin(requestingUser)) {
+              filteredUsers = enhancedUsers;
+            } else {
+              const managedIds = getManagerVisibleUserIds(normalizedRequestingId, { includeSelf: true });
+              if (managedIds && managedIds.size) {
+                filteredUsers = enhancedUsers.filter(user => managedIds.has(String(user.ID)));
+              } else {
+                filteredUsers = enhancedUsers.filter(user => String(user.ID) === normalizedRequestingId);
+              }
+            }
+          } else {
+            _userLog_('clientGetAllUsers.requestingUserNotFound', {
+              resolvedRequestingUserId,
+              normalizedRequestingId,
+              emailCandidates
+            }, 'warn');
+            filteredUsers = enhancedUsers;
+          }
+        } catch (permissionError) {
           filteredUsers = enhancedUsers;
         }
-      } catch (permissionError) {
+      } else if (resolvedRequestingUserId) {
         filteredUsers = enhancedUsers;
       }
-    } else if (resolvedRequestingUserId) {
-      filteredUsers = enhancedUsers;
+    } else {
+      try {
+        _userLog_('clientGetAllUsers.fullDirectoryView', { count: enhancedUsers.length });
+      } catch (_) { }
     }
     return filteredUsers;
   } catch (globalError) { writeError('clientGetAllUsers', globalError); return []; }


### PR DESCRIPTION
## Summary
- add a configuration flag to enable the full user directory for all requestors by default
- bypass manager-based filtering when the flag is enabled and log activation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1010269ec8326874b54f9582c76be