### PR TITLE
Add employment report user list and filtering

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -4454,6 +4454,7 @@
   }
 
   // ---------- Employment report ----------
+  let employmentReportCurrentFilter = '__all';
   function showEmploymentReport() {
     const modal = new bootstrap.Modal(document.getElementById('employmentReportModal'));
     modal.show();
@@ -4491,33 +4492,143 @@
     }
 
     const statusData = validList.map(status => {
-      const count = statusCounts[status] || 0;
-      const percentage = totalUsers > 0 ? ((count / totalUsers) * 100).toFixed(1) : '0.0';
-      return { status, count, percentage };
+      const label = safeTrim(status) || 'Unspecified';
+      const count = (typeof statusCounts[label] === 'number')
+        ? statusCounts[label]
+        : (typeof statusCounts[status] === 'number' ? statusCounts[status] : 0);
+      const percentage = totalUsers > 0 ? (count / totalUsers) * 100 : 0;
+      const key = safeLower(label) || 'unspecified';
+      return {
+        status: label,
+        key,
+        count,
+        percentage,
+        percentageLabel: percentage.toFixed(1)
+      };
     }).sort((a, b) => b.count - a.count);
 
+    const statusOrder = {};
+    statusData.forEach((item, index) => {
+      statusOrder[item.key] = index;
+    });
+
+    const userListRaw = Array.isArray(data.users) ? data.users : [];
+    const normalizedUsers = userListRaw.map(user => {
+      const rawStatus = user?.employmentStatus || user?.EmploymentStatus || user?.status || '';
+      const normalizedStatus = typeof normalizeEmploymentStatusClient === 'function'
+        ? normalizeEmploymentStatusClient(rawStatus)
+        : safeTrim(rawStatus);
+      const statusLabel = normalizedStatus || 'Unspecified';
+      const statusKey = safeLower(statusLabel) || 'unspecified';
+
+      const email = safeTrim(user?.email || user?.Email || '');
+      const rawName = user?.name || user?.fullName || user?.FullName || user?.UserName
+        || user?.userName || user?.username || '';
+      const name = safeTrim(rawName, email || 'Unnamed user');
+
+      const campaign = safeTrim(user?.campaignName || user?.campaign || user?.CampaignName || user?.Campaign || '');
+      const hireDate = safeTrim(user?.hireDate || user?.HireDate || '');
+      const hireDisplay = hireDate ? formatHireVisual(hireDate) : '';
+
+      const roleSet = new Set();
+      const roleSources = [user?.roles, user?.roleNames, user?.Roles, user?.csvRoles];
+      roleSources.forEach(source => {
+        if (!source) return;
+        if (Array.isArray(source)) {
+          source.forEach(role => {
+            const trimmed = safeTrim(role);
+            if (trimmed) roleSet.add(trimmed);
+          });
+        } else if (typeof source === 'string') {
+          source.split(',').forEach(part => {
+            const trimmed = safeTrim(part);
+            if (trimmed) roleSet.add(trimmed);
+          });
+        }
+      });
+
+      return {
+        id: safeTrim(user?.id || user?.ID || ''),
+        name,
+        email,
+        status: statusLabel,
+        statusKey,
+        campaign,
+        hireDate,
+        hireDisplay,
+        roles: Array.from(roleSet)
+      };
+    });
+
+    const sortedUsers = normalizedUsers.slice().sort((a, b) => {
+      const aOrder = Object.prototype.hasOwnProperty.call(statusOrder, a.statusKey)
+        ? statusOrder[a.statusKey]
+        : statusData.length;
+      const bOrder = Object.prototype.hasOwnProperty.call(statusOrder, b.statusKey)
+        ? statusOrder[b.statusKey]
+        : statusData.length;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+
+    const filterKey = employmentReportCurrentFilter || '__all';
+    const initialVisibleCount = filterKey === '__all'
+      ? sortedUsers.length
+      : sortedUsers.filter(user => user.statusKey === filterKey).length;
+
+    const statusRowsHtml = statusData.map(item => `
+        <tr>
+          <td><strong>${escapeHtml(item.status)}</strong></td>
+          <td>${item.count}</td>
+          <td>${item.percentageLabel}%</td>
+          <td>
+            <div class="progress" style="height: 20px;">
+              <div class="progress-bar ${getStatusColorClass(item.status)}" role="progressbar"
+                   style="width: ${item.percentageLabel}%"
+                   aria-valuenow="${item.percentageLabel}" aria-valuemin="0" aria-valuemax="100">
+              </div>
+            </div>
+          </td>
+        </tr>`).join('');
+
+    const filterOptionsHtml = [`<option value="__all"${filterKey === '__all' ? ' selected' : ''}>All statuses (${sortedUsers.length})</option>`]
+      .concat(statusData.map(item => {
+        const selected = filterKey === item.key ? ' selected' : '';
+        return `<option value="${escapeHtml(item.key)}"${selected}>${escapeHtml(item.status)} (${item.count})</option>`;
+      })).join('');
+
+    const userRowsHtml = sortedUsers.map(user => {
+      const badgeClass = getStatusBadgeClass(user.status);
+      const emailHtml = user.email ? `<div class="small text-muted">${escapeHtml(user.email)}</div>` : '';
+      const campaignHtml = user.campaign ? escapeHtml(user.campaign) : '<span class="text-muted">—</span>';
+      const hireHtml = user.hireDisplay ? escapeHtml(user.hireDisplay) : '<span class="text-muted">—</span>';
+      const rolesHtml = user.roles.length
+        ? user.roles.map(role => `<span class="badge bg-light text-dark border me-1">${escapeHtml(role)}</span>`).join('')
+        : '<span class="text-muted">—</span>';
+      return `
+        <tr data-report-user-row data-status-key="${escapeHtml(user.statusKey)}">
+          <td>
+            <div class="fw-semibold">${escapeHtml(user.name)}</div>
+            ${emailHtml}
+          </td>
+          <td><span class="badge rounded-pill ${badgeClass}">${escapeHtml(user.status)}</span></td>
+          <td>${campaignHtml}</td>
+          <td>${rolesHtml}</td>
+          <td>${hireHtml}</td>
+        </tr>`;
+    }).join('');
+
+    const hasUsers = sortedUsers.length > 0;
+
     content.innerHTML = `
-    <div class="row">
+    <div class="row g-4">
       <div class="col-md-8">
         <h6 class="fw-bold"><i class="fas fa-chart-pie me-2"></i>Employment Status Distribution</h6>
         <div class="table-responsive">
           <table class="table table-sm">
             <thead><tr><th>Status</th><th>Count</th><th>Percentage</th><th>Visual</th></tr></thead>
             <tbody>
-              ${statusData.map(item => `
-                <tr>
-                  <td><strong>${escapeHtml(item.status)}</strong></td>
-                  <td>${item.count}</td>
-                  <td>${item.percentage}%</td>
-                  <td>
-                    <div class="progress" style="height: 20px;">
-                      <div class="progress-bar ${getStatusColorClass(item.status)}" role="progressbar"
-                           style="width: ${item.percentage}%"
-                           aria-valuenow="${item.percentage}" aria-valuemin="0" aria-valuemax="100">
-                      </div>
-                    </div>
-                  </td>
-                </tr>`).join('')}
+              ${statusRowsHtml}
             </tbody>
           </table>
         </div>
@@ -4550,7 +4661,74 @@
         </div>
       </div>
     </div>
+    <div class="mt-4">
+      <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+        <h6 class="fw-bold mb-0"><i class="fas fa-users me-2"></i>Users by Status</h6>
+        <div class="d-flex align-items-center gap-2">
+          <select id="employmentReportStatusFilter" class="form-select form-select-sm w-auto">
+            ${filterOptionsHtml}
+          </select>
+          <span class="small text-muted" id="employmentReportUserCount">${initialVisibleCount} ${initialVisibleCount === 1 ? 'user' : 'users'}</span>
+        </div>
+      </div>
+      ${hasUsers ? `
+        <div class="table-responsive" id="employmentReportTableWrapper">
+          <table class="table table-hover table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Status</th>
+                <th>Campaign</th>
+                <th>Roles</th>
+                <th>Hire Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${userRowsHtml}
+            </tbody>
+          </table>
+        </div>` : ''}
+      <div id="employmentReportEmptyState" class="text-center text-muted py-4${hasUsers ? ' d-none' : ''}">
+        <i class="fas fa-users-slash fa-2x mb-2"></i>
+        <div>No users found for the selected status.</div>
+      </div>
+    </div>
   `;
+
+    const filterSelect = content.querySelector('#employmentReportStatusFilter');
+    const userCountEl = content.querySelector('#employmentReportUserCount');
+    const emptyStateEl = content.querySelector('#employmentReportEmptyState');
+    const tableWrapper = content.querySelector('#employmentReportTableWrapper');
+    const rows = Array.from(content.querySelectorAll('[data-report-user-row]'));
+
+    const applyFilter = (key) => {
+      const normalizedKey = key && key !== '__all' ? key : '__all';
+      let visible = 0;
+      rows.forEach(row => {
+        const rowKey = row.getAttribute('data-status-key') || '';
+        const matches = normalizedKey === '__all' || rowKey === normalizedKey;
+        row.style.display = matches ? '' : 'none';
+        if (matches) visible++;
+      });
+      if (userCountEl) {
+        userCountEl.textContent = `${visible} ${visible === 1 ? 'user' : 'users'}`;
+      }
+      if (emptyStateEl) {
+        emptyStateEl.classList.toggle('d-none', visible > 0);
+      }
+      if (tableWrapper) {
+        tableWrapper.classList.toggle('d-none', rows.length > 0 && visible === 0);
+      }
+    };
+
+    if (filterSelect) {
+      filterSelect.addEventListener('change', () => {
+        const selectedKey = filterSelect.value || '__all';
+        employmentReportCurrentFilter = selectedKey;
+        applyFilter(selectedKey);
+      });
+      applyFilter(filterSelect.value || '__all');
+    }
   }
   function getStatusColorClass(status) {
     const s = (status || '').toLowerCase();
@@ -4569,6 +4747,13 @@
     if (s.includes('retired')) return 'bg-secondary';
     if (s.includes('intern')) return 'bg-info';
     return 'bg-secondary';
+  }
+  function getStatusBadgeClass(status) {
+    const base = getStatusColorClass(status) || 'bg-secondary';
+    if (base.startsWith('bg-')) {
+      return `text-bg-${base.slice(3)}`;
+    }
+    return 'text-bg-secondary';
   }
 
   // ---------- Permissions & Pages for a user ----------


### PR DESCRIPTION
## Summary
- extend the employment status report service to return normalized user summaries, groupings, and recent change notes
- render the employment report modal with a user table, status filter, and badge styling alongside existing summary data

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f1817fc0888326a5e83ec6131995b1