### PR TITLE
Improve user modal tab styling

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -501,53 +501,116 @@
 
     /* Enhanced Tab Navigation */
     .nav-tabs {
-        border-bottom: 2px solid rgba(203, 213, 225, 0.3);
+        border: none;
         margin-bottom: 2rem;
     }
 
-    .nav-tabs .nav-link {
-        border: none;
-        border-bottom: 3px solid transparent;
-        color: var(--gray-600);
-        font-weight: 500;
-        padding: 1rem 1.5rem;
-        transition: var(--transition);
-        border-radius: var(--border-radius-xs) var(--border-radius-xs) 0 0;
-        position: relative;
-        overflow: hidden;
+    #userTabs.nav-tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        background: rgba(148, 163, 184, 0.16);
+        border-radius: 999px;
+        padding: 0.75rem;
+        box-shadow: var(--shadow-md);
     }
 
-    .nav-tabs .nav-link::before {
+    #userTabs .nav-item {
+        margin-bottom: 0;
+    }
+
+    #userTabs .nav-link {
+        border: none;
+        color: var(--gray-600);
+        font-weight: 600;
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        transition: var(--transition-fast);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        background: transparent;
+        position: relative;
+    }
+
+    #userTabs .nav-link::before {
         content: '';
         position: absolute;
         inset: 0;
-        background: linear-gradient(135deg, rgba(59, 130, 246, 0.05), transparent);
+        border-radius: inherit;
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.45), rgba(241, 245, 249, 0.45));
         opacity: 0;
-        transition: var(--transition);
+        transition: var(--transition-fast);
+        z-index: -1;
     }
 
-    .nav-tabs .nav-link:hover::before {
+    #userTabs .nav-link:hover {
+        color: var(--primary-600);
+    }
+
+    #userTabs .nav-link:hover::before {
         opacity: 1;
     }
 
-    .nav-tabs .nav-link.active {
-        background: none;
-        border-bottom-color: var(--primary-500);
-        color: var(--primary-600);
-        position: relative;
+    #userTabs .nav-link i {
+        font-size: 1rem;
+        color: var(--primary-500);
+        transition: var(--transition-fast);
     }
 
-    .nav-tabs .nav-link.active::after {
+    #userTabs .nav-link.active {
+        color: var(--primary-700);
+        box-shadow: var(--shadow-md);
+    }
+
+    #userTabs .nav-link.active::before {
+        opacity: 1;
+        background: white;
+    }
+
+    #userTabs .nav-link.active i {
+        color: var(--primary-600);
+    }
+
+    #userTabs .nav-link:focus-visible {
+        outline: 3px solid rgba(14, 165, 233, 0.35);
+        outline-offset: 2px;
+    }
+
+    #userTabs .nav-link::after {
         content: '';
         position: absolute;
-        bottom: -2px;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 24px;
+        left: 1.5rem;
+        right: 1.5rem;
+        bottom: 0.55rem;
         height: 3px;
-        background: var(--primary-500);
-        border-radius: 2px;
-        box-shadow: 0 2px 8px rgba(59, 130, 246, 0.4);
+        background: linear-gradient(90deg, var(--primary-400), var(--primary-600));
+        border-radius: 999px;
+        opacity: 0;
+        transition: var(--transition-fast);
+    }
+
+    #userTabs .nav-link.active::after {
+        opacity: 1;
+    }
+
+    @media (max-width: 768px) {
+        #userTabs.nav-tabs {
+            border-radius: var(--border-radius-sm);
+            padding: 0.5rem;
+            justify-content: space-between;
+        }
+
+        #userTabs .nav-link {
+            flex: 1 1 calc(50% - 0.5rem);
+            justify-content: center;
+            padding: 0.75rem 1rem;
+        }
+
+        #userTabs .nav-link::after {
+            left: 1rem;
+            right: 1rem;
+        }
     }
 
     /* Enhanced Page Grid */


### PR DESCRIPTION
## Summary
- restyle the user modal tab navigation into a rounded segmented control for better visual hierarchy
- highlight hover, active, and focus states with gradients, shadows, and keyboard-friendly outlines
- add responsive adjustments so the tab group wraps cleanly on smaller screens

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f1ff0532208326b9739ecd79edd75f