### PR TITLE
Expose session context for hierarchy-aware services

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -1184,6 +1184,20 @@ var AuthenticationService = (function () {
       userPayload.NeedsCampaignAssignment = userPayload.CampaignScope
         ? !!userPayload.CampaignScope.needsCampaignAssignment
         : false;
+
+      try {
+        if (typeof AuthorizationRegistry !== 'undefined'
+          && AuthorizationRegistry
+          && typeof AuthorizationRegistry.registerAuthorizationSnapshot === 'function') {
+          AuthorizationRegistry.registerAuthorizationSnapshot(userPayload, {
+            sessionToken: sessionToken,
+            tenantPayload: tenantPayload,
+            rawScope: rawScope
+          });
+        }
+      } catch (registryError) {
+        console.warn('buildSessionUserContext: failed to register authorization snapshot', registryError);
+      }
     }
 
     return {
@@ -3366,6 +3380,758 @@ var AuthenticationService = (function () {
     }
   }
 
+  function getLocalRoleHierarchyDefaults() {
+    try {
+      if (typeof AuthorizationRegistry !== 'undefined'
+        && AuthorizationRegistry
+        && typeof AuthorizationRegistry.getDefaultRoleHierarchyRules === 'function') {
+        const defaults = AuthorizationRegistry.getDefaultRoleHierarchyRules();
+        if (Array.isArray(defaults) && defaults.length) {
+          return defaults;
+        }
+      }
+    } catch (registryError) {
+      console.warn('AuthenticationService: unable to load defaults from AuthorizationRegistry', registryError);
+    }
+
+    return [
+      {
+        key: 'SYSTEM_ADMIN',
+        label: 'System Administrator',
+        weight: 2200,
+        aliases: ['system administrator', 'system admin', 'administrator', 'admin'],
+        capabilities: { isSystemAdmin: true, isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'CEO',
+        label: 'Chief Executive Officer',
+        weight: 2100,
+        aliases: ['ceo', 'chief executive officer'],
+        capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'COO',
+        label: 'Chief Operating Officer',
+        weight: 2050,
+        aliases: ['coo', 'chief operating officer'],
+        capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'CFO',
+        label: 'Chief Financial Officer',
+        weight: 2000,
+        aliases: ['cfo', 'chief financial officer'],
+        capabilities: { isExecutive: true, canManagePages: true }
+      },
+      {
+        key: 'CTO',
+        label: 'Chief Technology Officer',
+        weight: 1950,
+        aliases: ['cto', 'chief technology officer'],
+        capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'DIRECTOR',
+        label: 'Director',
+        weight: 1800,
+        aliases: ['director'],
+        capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'OPERATIONS_MANAGER',
+        label: 'Operations Manager',
+        weight: 1700,
+        aliases: ['operations manager', 'ops manager'],
+        capabilities: { isManager: true, canManageUsers: true, canManagePages: true }
+      },
+      {
+        key: 'ACCOUNT_MANAGER',
+        label: 'Account Manager',
+        weight: 1650,
+        aliases: ['account manager'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'WORKFORCE_MANAGER',
+        label: 'Workforce Manager',
+        weight: 1600,
+        aliases: ['workforce manager'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'QUALITY_ASSURANCE_MANAGER',
+        label: 'Quality Assurance Manager',
+        weight: 1550,
+        aliases: ['quality assurance manager', 'qa manager'],
+        capabilities: { isManager: true, canManagePages: true }
+      },
+      {
+        key: 'TRAINING_MANAGER',
+        label: 'Training Manager',
+        weight: 1500,
+        aliases: ['training manager'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'TEAM_SUPERVISOR',
+        label: 'Team Supervisor',
+        weight: 1400,
+        aliases: ['team supervisor', 'team lead'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'FLOOR_SUPERVISOR',
+        label: 'Floor Supervisor',
+        weight: 1350,
+        aliases: ['floor supervisor'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'ESCALATIONS_MANAGER',
+        label: 'Escalations Manager',
+        weight: 1300,
+        aliases: ['escalations manager'],
+        capabilities: { isManager: true, canManagePages: true }
+      },
+      {
+        key: 'CLIENT_SUCCESS_MANAGER',
+        label: 'Client Success Manager',
+        weight: 1250,
+        aliases: ['client success manager', 'customer success manager'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'COMPLIANCE_MANAGER',
+        label: 'Compliance Manager',
+        weight: 1200,
+        aliases: ['compliance manager'],
+        capabilities: { isManager: true, canManagePages: true }
+      },
+      {
+        key: 'IT_SUPPORT_MANAGER',
+        label: 'IT Support Manager',
+        weight: 1150,
+        aliases: ['it support manager', 'it manager', 'technology manager'],
+        capabilities: { isManager: true, canManagePages: true }
+      },
+      {
+        key: 'REPORTING_ANALYST',
+        label: 'Reporting Analyst',
+        weight: 900,
+        aliases: ['reporting analyst', 'analyst'],
+        capabilities: { canManagePages: true }
+      },
+      {
+        key: 'QUALITY',
+        label: 'Quality',
+        weight: 850,
+        aliases: ['quality', 'qa'],
+        capabilities: { canManagePages: true }
+      },
+      {
+        key: 'MANAGER',
+        label: 'Manager',
+        weight: 1450,
+        aliases: ['manager', 'supervisor'],
+        capabilities: { isManager: true, canManageUsers: true }
+      },
+      {
+        key: 'AGENT',
+        label: 'Agent',
+        weight: 400,
+        aliases: ['agent', 'associate'],
+        capabilities: {}
+      },
+      {
+        key: 'GUEST',
+        label: 'Guest',
+        weight: 100,
+        aliases: ['guest', 'viewer'],
+        capabilities: {}
+      }
+    ];
+  }
+
+  const ROLE_HIERARCHY_RULES = (function resolveRoleHierarchyRules() {
+    const defaults = getLocalRoleHierarchyDefaults();
+    try {
+      if (typeof AuthorizationRegistry !== 'undefined' && AuthorizationRegistry) {
+        if (typeof AuthorizationRegistry.ensureRoleHierarchyRules === 'function') {
+          const ensured = AuthorizationRegistry.ensureRoleHierarchyRules(defaults);
+          if (Array.isArray(ensured) && ensured.length) {
+            return ensured;
+          }
+        }
+        if (typeof AuthorizationRegistry.getRoleHierarchyRules === 'function') {
+          const external = AuthorizationRegistry.getRoleHierarchyRules(defaults);
+          if (Array.isArray(external) && external.length) {
+            return external;
+          }
+        }
+      }
+    } catch (registryError) {
+      console.warn('AuthenticationService: failed to resolve role hierarchy from AuthorizationRegistry', registryError);
+    }
+    return defaults;
+  })();
+
+  function escapeRegExp(str) {
+    return String(str || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function aliasMatchesRole(lowerName, alias) {
+    const normalizedAlias = String(alias || '').trim().toLowerCase();
+    if (!normalizedAlias) return false;
+    if (lowerName === normalizedAlias) return true;
+
+    try {
+      const pattern = new RegExp('(^|\\b)' + escapeRegExp(normalizedAlias) + '(?=\\b|$)');
+      return pattern.test(lowerName);
+    } catch (err) {
+      console.warn('aliasMatchesRole: failed to evaluate alias pattern', alias, err);
+      return false;
+    }
+  }
+
+  function cloneCapabilities(capabilities) {
+    const clone = {};
+    if (!capabilities || typeof capabilities !== 'object') {
+      return clone;
+    }
+    Object.keys(capabilities).forEach(function (key) {
+      clone[key] = !!capabilities[key];
+    });
+    return clone;
+  }
+
+  function resolveRoleClassification(name) {
+    const original = String(name || '').trim();
+    const lower = original.toLowerCase();
+    if (!lower) {
+      return { key: 'UNSPECIFIED', label: original || '', weight: 0, matched: null, capabilities: {} };
+    }
+
+    for (let i = 0; i < ROLE_HIERARCHY_RULES.length; i++) {
+      const rule = ROLE_HIERARCHY_RULES[i];
+      try {
+        if (rule.matcher && rule.matcher.test(lower)) {
+          return {
+            key: rule.key,
+            label: rule.label,
+            weight: rule.weight,
+            matched: rule.matcher.source,
+            capabilities: cloneCapabilities(rule.capabilities)
+          };
+        }
+        if (rule.aliases && rule.aliases.some(function (alias) { return aliasMatchesRole(lower, alias); })) {
+          return {
+            key: rule.key,
+            label: rule.label,
+            weight: rule.weight,
+            matched: 'alias',
+            capabilities: cloneCapabilities(rule.capabilities)
+          };
+        }
+      } catch (err) {
+        console.warn('resolveRoleClassification: matcher failed for role', original, err);
+      }
+    }
+
+    return { key: 'CUSTOM', label: original, weight: 100, matched: null, capabilities: {} };
+  }
+
+  function aggregateRoleCapabilities(roleHierarchy) {
+    const snapshot = {
+      isSystemAdmin: false,
+      isExecutive: false,
+      isManager: false,
+      canManageUsers: false,
+      canManagePages: false
+    };
+
+    if (!Array.isArray(roleHierarchy)) {
+      return snapshot;
+    }
+
+    roleHierarchy.forEach(function (role) {
+      if (!role || !role.capabilities) return;
+      if (role.capabilities.isSystemAdmin) snapshot.isSystemAdmin = true;
+      if (role.capabilities.isExecutive) snapshot.isExecutive = true;
+      if (role.capabilities.isManager) snapshot.isManager = true;
+      if (role.capabilities.canManageUsers) snapshot.canManageUsers = true;
+      if (role.capabilities.canManagePages) snapshot.canManagePages = true;
+    });
+
+    return snapshot;
+  }
+
+  function buildUserClaims(payload, authorization) {
+    const claims = [];
+    const seen = {};
+
+    function addClaim(value) {
+      const claim = String(value || '').trim();
+      if (!claim || seen[claim]) return;
+      seen[claim] = true;
+      claims.push(claim);
+    }
+
+    const userId = normalizeString(payload && (payload.ID || payload.Id || payload.id));
+    const userName = normalizeString(payload && payload.UserName);
+
+    addClaim('lumina:session:active');
+    if (userId) addClaim('lumina:user:' + userId);
+
+    const currentUserId = normalizeString(payload && (payload.CurrentUserId || payload.CurrentUserID));
+    if (currentUserId) {
+      addClaim('lumina:session:current-user');
+      addClaim('lumina:session:current-user:' + currentUserId);
+    }
+    if (userName) addClaim('lumina:username:' + userName.toLowerCase());
+
+    const email = normalizeString(payload && payload.Email);
+    if (email) addClaim('lumina:email:' + email.toLowerCase());
+
+    if (payload && toBool(payload.EmailConfirmed)) {
+      addClaim('lumina:identity:email-confirmed');
+    } else {
+      addClaim('lumina:identity:email-unconfirmed');
+    }
+
+    if (payload && toBool(payload.CanLogin)) {
+      addClaim('lumina:identity:login-enabled');
+    } else {
+      addClaim('lumina:identity:login-disabled');
+    }
+
+    if (payload && toBool(payload.IsAdmin)) addClaim('lumina:user:admin-flag');
+    if (payload && toBool(payload.IsSystemAdmin)) addClaim('lumina:system:admin');
+    if (payload && toBool(payload.IsGlobalAdmin)) addClaim('lumina:tenant:global-admin');
+    if (payload && toBool(payload.IsManager)) addClaim('lumina:role:manager');
+    if (payload && toBool(payload.IsExecutive)) addClaim('lumina:role:executive');
+
+    if (payload && toBool(payload.CanManageUsers)) addClaim('lumina:capability:manage-users');
+    if (payload && toBool(payload.CanManagePages)) addClaim('lumina:capability:manage-pages');
+
+    if (payload && payload.RoleCapabilities) {
+      if (payload.RoleCapabilities.isManager) addClaim('lumina:capability:team-supervision');
+      if (payload.RoleCapabilities.canManageUsers) addClaim('lumina:capability:team-admin');
+      if (payload.RoleCapabilities.canManagePages) addClaim('lumina:capability:content-admin');
+    }
+
+    if (authorization && Array.isArray(authorization.permissionLevels)) {
+      authorization.permissionLevels.forEach(function (level) {
+        const normalizedLevel = normalizeString(level).toUpperCase();
+        if (normalizedLevel) {
+          addClaim('lumina:permission-level:' + normalizedLevel.toLowerCase());
+        }
+      });
+    }
+
+    if (authorization && Array.isArray(authorization.roleHierarchy)) {
+      authorization.roleHierarchy.forEach(function (role) {
+        if (!role) return;
+        const roleKey = normalizeString(role.level).toLowerCase();
+        const roleLabel = normalizeString(role.label).toLowerCase();
+        if (roleKey) addClaim('lumina:role:' + roleKey);
+        if (roleLabel) addClaim('lumina:role-label:' + roleLabel);
+      });
+    }
+
+    if (authorization && authorization.highestRole && authorization.highestRole.level) {
+      addClaim('lumina:role:primary-' + authorization.highestRole.level.toLowerCase());
+    }
+
+    const campaignScope = payload && payload.CampaignScope ? payload.CampaignScope : {};
+    const defaultCampaignId = normalizeCampaignId(campaignScope.defaultCampaignId);
+    const activeCampaignId = normalizeCampaignId(payload && (payload.ActiveCampaignId || payload.CurrentCampaignId));
+
+    const currentCampaignId = normalizeCampaignId(payload && payload.CurrentCampaignId);
+    if (currentCampaignId) {
+      addClaim('lumina:session:current-campaign');
+      addClaim('lumina:session:current-campaign:' + currentCampaignId);
+    }
+
+    if (defaultCampaignId) addClaim('lumina:campaign:default:' + defaultCampaignId);
+    if (activeCampaignId) addClaim('lumina:campaign:active:' + activeCampaignId);
+
+    const allowedCampaigns = Array.isArray(payload && payload.AllowedCampaignIds) ? payload.AllowedCampaignIds : [];
+    allowedCampaigns.forEach(function (id) {
+      const normalized = normalizeCampaignId(id);
+      if (normalized) addClaim('lumina:campaign:access:' + normalized);
+    });
+
+    const managedCampaigns = Array.isArray(payload && payload.ManagedCampaignIds) ? payload.ManagedCampaignIds : [];
+    managedCampaigns.forEach(function (id) {
+      const normalized = normalizeCampaignId(id);
+      if (normalized) addClaim('lumina:campaign:manage:' + normalized);
+    });
+
+    const adminCampaigns = Array.isArray(payload && payload.AdminCampaignIds) ? payload.AdminCampaignIds : [];
+    adminCampaigns.forEach(function (id) {
+      const normalized = normalizeCampaignId(id);
+      if (normalized) addClaim('lumina:campaign:admin:' + normalized);
+    });
+
+    if (Array.isArray(payload && payload.CampaignPermissions)) {
+      payload.CampaignPermissions.forEach(function (perm) {
+        if (!perm) return;
+        const campaignId = normalizeCampaignId(perm.campaignId || perm.CampaignId);
+        if (!campaignId) return;
+        if (perm.canManageUsers) addClaim('lumina:campaign:' + campaignId + ':manage-users');
+        if (perm.canManagePages) addClaim('lumina:campaign:' + campaignId + ':manage-pages');
+        if (perm.permissionLevel) {
+          addClaim('lumina:campaign:' + campaignId + ':level:' + String(perm.permissionLevel).toLowerCase());
+        }
+      });
+    }
+
+    const managedUserIds = Array.isArray(payload && payload.ManagedUserIds) ? payload.ManagedUserIds : [];
+    if (managedUserIds.length) {
+      addClaim('lumina:assignment:has-team');
+      managedUserIds.forEach(function (id) {
+        const normalized = normalizeString(id);
+        if (normalized) addClaim('lumina:assignment:manages:' + normalized);
+      });
+    }
+
+    const directManagerId = normalizeString(payload && payload.DirectManagerId);
+    if (directManagerId) {
+      addClaim('lumina:assignment:reports-to');
+      addClaim('lumina:assignment:reports-to:' + directManagerId);
+    }
+
+    if (authorization && authorization.manager && Array.isArray(authorization.manager.directReports)) {
+      authorization.manager.directReports.forEach(function (id) {
+        const normalized = normalizeString(id);
+        if (normalized) addClaim('lumina:assignment:direct-report:' + normalized);
+      });
+    }
+
+    if (campaignScope && toBool(campaignScope.needsCampaignAssignment)) {
+      addClaim('lumina:campaign:needs-assignment');
+    }
+
+    addClaim('lumina:claims:version:1');
+
+    return claims;
+  }
+
+  function getManagerUsersSheetName() {
+    try {
+      if (typeof getManagerUsersSheetName_ === 'function') {
+        const name = getManagerUsersSheetName_();
+        if (name) return String(name);
+      }
+    } catch (err) {
+      console.warn('getManagerUsersSheetName: helper lookup failed', err);
+    }
+
+    try {
+      if (typeof G !== 'undefined' && G && G.MANAGER_USERS_SHEET) {
+        return String(G.MANAGER_USERS_SHEET);
+      }
+    } catch (err) {
+      console.warn('getManagerUsersSheetName: global lookup failed', err);
+    }
+
+    if (typeof MANAGER_USERS_SHEET === 'string') {
+      return MANAGER_USERS_SHEET;
+    }
+
+    return 'MANAGER_USERS';
+  }
+
+  function loadManagerAssignments() {
+    const name = getManagerUsersSheetName();
+    if (!name || typeof readSheet !== 'function') {
+      return [];
+    }
+    try {
+      const rows = readSheet(name) || [];
+      return Array.isArray(rows) ? rows : [];
+    } catch (err) {
+      console.warn('loadManagerAssignments: unable to read manager assignments', err);
+      return [];
+    }
+  }
+
+  function mapUserSummary(record) {
+    if (!record || typeof record !== 'object') {
+      return null;
+    }
+    return {
+      id: record.ID || record.Id || record.id || null,
+      userName: record.UserName || record.username || '',
+      fullName: record.FullName || record.fullName || record.UserName || '',
+      email: record.Email || record.email || '',
+      campaignId: record.CampaignID || record.CampaignId || record.campaignId || ''
+    };
+  }
+
+  function loadUsersIndex() {
+    if (typeof readSheet !== 'function') {
+      return {};
+    }
+    try {
+      const sheetName = (typeof USERS_SHEET === 'string' && USERS_SHEET) ? USERS_SHEET : 'Users';
+      const rows = readSheet(sheetName) || [];
+      const index = {};
+      rows.forEach(function (row) {
+        if (!row || typeof row !== 'object') return;
+        const key = String(row.ID || row.Id || row.id || '').trim();
+        if (!key) return;
+        index[key] = row;
+      });
+      return index;
+    } catch (err) {
+      console.warn('loadUsersIndex: unable to read users sheet', err);
+      return {};
+    }
+  }
+
+  function buildManagerProfile(userId) {
+    const normalizedId = normalizeString(userId);
+    if (!normalizedId) {
+      return {
+        isManager: false,
+        managedUserIds: [],
+        managedUsers: [],
+        hasAssignments: false,
+        directManagerId: null,
+        directManager: null,
+        directReports: []
+      };
+    }
+
+    const assignments = loadManagerAssignments();
+    if (!assignments.length) {
+      return {
+        isManager: false,
+        managedUserIds: [],
+        managedUsers: [],
+        hasAssignments: false,
+        directManagerId: null,
+        directManager: null,
+        directReports: []
+      };
+    }
+
+    const managedUserIds = [];
+    let directManagerId = null;
+
+    assignments.forEach(function (assignment) {
+      if (!assignment) return;
+      const managerId = normalizeString(assignment.ManagerUserID || assignment.managerUserId || assignment.ManagerID);
+      const targetId = normalizeString(assignment.UserID || assignment.userId || assignment.TargetUserID);
+      if (!managerId || !targetId) {
+        return;
+      }
+      if (managerId === normalizedId) {
+        if (managedUserIds.indexOf(targetId) === -1) {
+          managedUserIds.push(targetId);
+        }
+      }
+      if (targetId === normalizedId && !directManagerId) {
+        directManagerId = managerId;
+      }
+    });
+
+    const usersIndex = loadUsersIndex();
+    const managedUsers = managedUserIds
+      .map(function (id) { return mapUserSummary(usersIndex[id]); })
+      .filter(Boolean);
+
+    const directManager = directManagerId ? mapUserSummary(usersIndex[directManagerId]) : null;
+
+    return {
+      isManager: managedUserIds.length > 0,
+      managedUserIds: managedUserIds,
+      managedUsers: managedUsers,
+      hasAssignments: managedUserIds.length > 0,
+      directManagerId: directManagerId,
+      directManager: directManager,
+      directReports: managedUserIds.slice()
+    };
+  }
+
+  function buildCampaignPermissionProfile(userId, tenantPayload) {
+    const normalizedId = normalizeString(userId);
+    const profile = {
+      permissionLevels: [],
+      campaignPermissions: [],
+      activeCampaignPermission: null
+    };
+
+    if (!normalizedId) {
+      return profile;
+    }
+
+    let permissions = [];
+    try {
+      if (typeof readCampaignPermsSafely_ === 'function') {
+        permissions = readCampaignPermsSafely_();
+      } else if (typeof readSheet === 'function') {
+        const sheetName = (typeof G !== 'undefined' && G && G.CAMPAIGN_USER_PERMISSIONS_SHEET)
+          ? G.CAMPAIGN_USER_PERMISSIONS_SHEET
+          : 'CampaignUserPermissions';
+        permissions = readSheet(sheetName) || [];
+      }
+    } catch (err) {
+      console.warn('buildCampaignPermissionProfile: unable to load permissions', err);
+      permissions = [];
+    }
+
+    const userPermissions = (permissions || []).filter(function (perm) {
+      if (!perm || typeof perm !== 'object') return false;
+      const permUserId = normalizeString(perm.UserID || perm.UserId || perm.userId);
+      return permUserId === normalizedId;
+    }).map(function (perm) {
+      const permissionLevel = String(perm.PermissionLevel || perm.permissionLevel || 'USER').toUpperCase();
+      const canManageUsers = toBool(perm.CanManageUsers || perm.canManageUsers);
+      const canManagePages = toBool(perm.CanManagePages || perm.canManagePages);
+      const campaignId = normalizeCampaignId(perm.CampaignID || perm.CampaignId || perm.campaignId);
+      return {
+        id: perm.ID || perm.Id || perm.id || null,
+        campaignId: campaignId,
+        permissionLevel: permissionLevel,
+        canManageUsers: canManageUsers,
+        canManagePages: canManagePages,
+        createdAt: perm.CreatedAt || perm.createdAt || null,
+        updatedAt: perm.UpdatedAt || perm.updatedAt || null
+      };
+    });
+
+    const seenLevels = {};
+    userPermissions.forEach(function (perm) {
+      if (!perm) return;
+      if (!seenLevels[perm.permissionLevel]) {
+        profile.permissionLevels.push(perm.permissionLevel);
+        seenLevels[perm.permissionLevel] = true;
+      }
+    });
+
+    const activeCampaignId = tenantPayload && tenantPayload.activeCampaignId
+      ? String(tenantPayload.activeCampaignId)
+      : '';
+    if (activeCampaignId) {
+      profile.activeCampaignPermission = userPermissions.find(function (perm) {
+        return perm.campaignId === activeCampaignId;
+      }) || null;
+    }
+
+    profile.campaignPermissions = userPermissions;
+    return profile;
+  }
+
+  function resolveUserAuthorizationProfile(user, tenantPayload) {
+    const userId = normalizeString(user && (user.ID || user.Id || user.id));
+    if (!userId) {
+      return null;
+    }
+
+    let roles = [];
+    try {
+      if (typeof getUserRolesSafe === 'function') {
+        roles = getUserRolesSafe(userId) || [];
+      }
+    } catch (err) {
+      console.warn('resolveUserAuthorizationProfile: unable to load roles', err);
+      roles = [];
+    }
+
+    const roleEntries = [];
+    const roleNames = [];
+    const roleHierarchy = [];
+    const seenRoleIds = {};
+    const seenRoleNames = {};
+
+    roles.forEach(function (role) {
+      if (!role || typeof role !== 'object') return;
+      const id = String(role.id || role.ID || '').trim();
+      const name = String(role.name || role.Name || '').trim();
+      if (!name) return;
+      const normalizedName = name.toLowerCase();
+      if (id && seenRoleIds[id]) {
+        return;
+      }
+      if (normalizedName && seenRoleNames[normalizedName]) {
+        return;
+      }
+      if (id) seenRoleIds[id] = true;
+      if (normalizedName) seenRoleNames[normalizedName] = true;
+
+      const classification = resolveRoleClassification(name);
+      roleEntries.push({
+        id: id || null,
+        name: name,
+        normalizedName: normalizedName,
+        level: classification.key,
+        levelLabel: classification.label,
+        weight: classification.weight,
+        capabilities: classification.capabilities
+      });
+      roleNames.push(name);
+      roleHierarchy.push({
+        name: name,
+        level: classification.key,
+        label: classification.label,
+        weight: classification.weight,
+        capabilities: classification.capabilities
+      });
+    });
+
+    roleHierarchy.sort(function (a, b) { return (b.weight || 0) - (a.weight || 0); });
+
+    const roleCapabilities = aggregateRoleCapabilities(roleHierarchy);
+
+    const campaignProfile = buildCampaignPermissionProfile(userId, tenantPayload || {});
+    const managerProfile = buildManagerProfile(userId);
+
+    const permissionLevels = campaignProfile.permissionLevels.slice();
+    if (toBool(user && user.IsAdmin) && permissionLevels.indexOf('ADMIN') === -1) {
+      permissionLevels.push('ADMIN');
+    }
+
+    const highestRole = roleHierarchy.length ? roleHierarchy[0] : null;
+
+    const canManageUsersFromPerms = campaignProfile.campaignPermissions.some(function (perm) {
+      return perm && (perm.canManageUsers || perm.permissionLevel === 'MANAGER' || perm.permissionLevel === 'ADMIN');
+    });
+    const canManagePagesFromPerms = campaignProfile.campaignPermissions.some(function (perm) {
+      return perm && (perm.canManagePages || perm.permissionLevel === 'MANAGER' || perm.permissionLevel === 'ADMIN');
+    });
+
+    const flags = {
+      isSystemAdmin: !!(toBool(user && user.IsAdmin) || roleCapabilities.isSystemAdmin),
+      isManager: !!(managerProfile.isManager || canManageUsersFromPerms || roleCapabilities.isManager),
+      isExecutive: !!roleCapabilities.isExecutive,
+      canManageUsers: false,
+      canManagePages: false
+    };
+
+    flags.canManageUsers = !!(flags.isSystemAdmin || canManageUsersFromPerms || roleCapabilities.canManageUsers);
+    flags.canManagePages = !!(flags.isSystemAdmin || canManagePagesFromPerms || roleCapabilities.canManagePages);
+
+    if (flags.isSystemAdmin && permissionLevels.indexOf('ADMIN') === -1) {
+      permissionLevels.push('ADMIN');
+    }
+
+    return {
+      userId: userId,
+      roles: roleEntries,
+      roleNames: roleNames,
+      roleHierarchy: roleHierarchy,
+      highestRole: highestRole,
+      flags: flags,
+      roleCapabilities: roleCapabilities,
+      permissionLevels: permissionLevels,
+      campaignPermissions: campaignProfile.campaignPermissions,
+      activeCampaignPermission: campaignProfile.activeCampaignPermission,
+      manager: managerProfile
+    };
+  }
+
   function buildUserPayload(user, tenantPayload) {
     if (!user) return null;
 
@@ -3410,6 +4176,68 @@ var AuthenticationService = (function () {
       payload.IsGlobalAdmin = payload.CampaignScope.isGlobalAdmin || payload.IsAdmin;
       payload.NeedsCampaignAssignment = payload.CampaignScope.needsCampaignAssignment;
 
+    }
+
+    const authorization = resolveUserAuthorizationProfile(user, payload.CampaignScope || tenantPayload || {});
+    if (authorization) {
+      payload.Authorization = authorization;
+      payload.Roles = authorization.roles.slice();
+      payload.RoleNames = authorization.roleNames.slice();
+      payload.RoleHierarchy = authorization.roleHierarchy.slice();
+      payload.HighestRole = authorization.highestRole;
+      payload.PermissionLevels = authorization.permissionLevels.slice();
+      payload.CampaignPermissions = authorization.campaignPermissions.slice();
+      payload.ActiveCampaignPermission = authorization.activeCampaignPermission;
+      payload.ManagedUserIds = authorization.manager.managedUserIds.slice();
+      payload.ManagedUsers = authorization.manager.managedUsers.slice();
+      payload.DirectManagerId = authorization.manager.directManagerId;
+      payload.DirectManager = authorization.manager.directManager;
+      payload.IsManager = !!authorization.flags.isManager;
+      payload.IsExecutive = !!authorization.flags.isExecutive;
+      payload.CanManageUsers = !!authorization.flags.canManageUsers;
+      payload.CanManagePages = !!authorization.flags.canManagePages;
+      payload.IsSystemAdmin = !!(authorization.flags.isSystemAdmin || payload.IsAdmin);
+      payload.RoleCapabilities = Object.assign({
+        isSystemAdmin: false,
+        isExecutive: false,
+        isManager: false,
+        canManageUsers: false,
+        canManagePages: false
+      }, authorization.roleCapabilities || {});
+    } else {
+      payload.Roles = [];
+      payload.RoleNames = [];
+      payload.RoleHierarchy = [];
+      payload.PermissionLevels = [];
+      payload.CampaignPermissions = [];
+      payload.ActiveCampaignPermission = null;
+      payload.ManagedUserIds = [];
+      payload.ManagedUsers = [];
+      payload.DirectManagerId = null;
+      payload.DirectManager = null;
+      payload.IsManager = false;
+      payload.IsExecutive = false;
+      payload.CanManageUsers = payload.IsGlobalAdmin || payload.IsAdmin;
+      payload.CanManagePages = payload.IsGlobalAdmin || payload.IsAdmin;
+      payload.IsSystemAdmin = payload.IsAdmin;
+      payload.RoleCapabilities = {
+        isSystemAdmin: !!payload.IsSystemAdmin,
+        isExecutive: false,
+        isManager: false,
+        canManageUsers: !!payload.CanManageUsers,
+        canManagePages: !!payload.CanManagePages
+      };
+    }
+
+    payload.CurrentCampaignId = payload.ActiveCampaignId;
+    payload.CurrentUserId = payload.ID;
+
+    const claims = buildUserClaims(payload, authorization);
+    payload.Claims = claims.slice();
+    payload.AuthorizationClaims = claims.slice();
+    if (payload.Authorization) {
+      payload.Authorization.claims = claims.slice();
+      payload.Authorization.roleCapabilities = payload.RoleCapabilities;
     }
 
     return payload;
@@ -4561,7 +5389,31 @@ var AuthenticationService = (function () {
 
       const entry = findSessionEntry(sessionToken);
       if (entry) {
+        let userIdForRegistry = null;
+        try {
+          if (entry.record) {
+            userIdForRegistry = getRecordValue(entry.record, 'UserId')
+              || getRecordValue(entry.record, 'userId')
+              || null;
+          }
+        } catch (registryLookupError) {
+          console.warn('logout: unable to extract userId for authorization cleanup', registryLookupError);
+        }
+
         removeSessionEntry(entry);
+
+        try {
+          if (typeof AuthorizationRegistry !== 'undefined'
+            && AuthorizationRegistry
+            && typeof AuthorizationRegistry.clearAuthorizationSnapshot === 'function') {
+            AuthorizationRegistry.clearAuthorizationSnapshot({
+              userId: userIdForRegistry,
+              sessionToken: sessionToken
+            });
+          }
+        } catch (registryError) {
+          console.warn('logout: failed to clear authorization snapshot', registryError);
+        }
       }
 
       clearActiveSessionState();

--- a/AuthorizationRegistry.js
+++ b/AuthorizationRegistry.js
@@ -1,0 +1,1020 @@
+/**
+ * AuthorizationRegistry.js
+ * -----------------------------------------------------------------------------
+ * Central repository for authorization metadata so the entire system can resolve
+ * role hierarchy rules, capability flags, and user authorization snapshots.
+ *
+ * The registry keeps a normalized copy of the role hierarchy, exposes helpers to
+ * compare levels, and persists authorization snapshots keyed by both user ID and
+ * session token.  Other modules can query these snapshots to enforce hierarchy
+ * rules without having to rebuild the authorization profile on every request.
+ */
+
+var AuthorizationRegistry = (function () {
+  var PROFILE_CACHE_TTL_SECONDS = 10 * 60; // 10 minutes
+  var PROFILE_CACHE_PREFIX = 'AUTHZ_PROFILE:';
+  var SESSION_CACHE_PREFIX = 'AUTHZ_SESSION:';
+  var ROLE_RULES_PROPERTY_KEY = 'AUTHZ_ROLE_RULES';
+  var PROFILE_PROPERTY_PREFIX = 'AUTHZ_PROFILE:';
+  var SESSION_PROPERTY_PREFIX = 'AUTHZ_SESSION:';
+  var ROLE_INDEX_CACHE_KEY = 'AUTHZ_ROLE_INDEX';
+
+  function nowIsoString() {
+    try {
+      return new Date().toISOString();
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function getScriptCache() {
+    try {
+      if (typeof CacheService !== 'undefined' && CacheService.getScriptCache) {
+        return CacheService.getScriptCache();
+      }
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to access CacheService', err);
+    }
+    return null;
+  }
+
+  function getScriptProperties() {
+    try {
+      if (typeof PropertiesService !== 'undefined' && PropertiesService.getScriptProperties) {
+        return PropertiesService.getScriptProperties();
+      }
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to access PropertiesService', err);
+    }
+    return null;
+  }
+
+  function safeCachePut(cache, key, value, ttl) {
+    if (!cache || !key) return;
+    try {
+      cache.put(key, value, ttl || PROFILE_CACHE_TTL_SECONDS);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: cache.put failed for key', key, err);
+    }
+  }
+
+  function safeCacheRemove(cache, key) {
+    if (!cache || !key) return;
+    try {
+      cache.remove(key);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: cache.remove failed for key', key, err);
+    }
+  }
+
+  function cloneCapabilities(capabilities) {
+    var clone = {
+      isSystemAdmin: false,
+      isExecutive: false,
+      isManager: false,
+      canManageUsers: false,
+      canManagePages: false
+    };
+
+    if (!capabilities || typeof capabilities !== 'object') {
+      return clone;
+    }
+
+    Object.keys(clone).forEach(function (key) {
+      if (typeof capabilities[key] !== 'undefined') {
+        clone[key] = !!capabilities[key];
+      }
+    });
+
+    return clone;
+  }
+
+  function normalizeAliases(rawAliases) {
+    if (!Array.isArray(rawAliases)) return [];
+    var aliases = [];
+    rawAliases.forEach(function (alias) {
+      var normalized = '';
+      if (alias || alias === 0) {
+        normalized = String(alias).trim().toLowerCase();
+      }
+      if (normalized && aliases.indexOf(normalized) === -1) {
+        aliases.push(normalized);
+      }
+    });
+    return aliases;
+  }
+
+  function cloneRule(rule) {
+    if (!rule || typeof rule !== 'object') {
+      return null;
+    }
+    return {
+      key: String(rule.key || rule.level || '').trim().toUpperCase(),
+      label: String(rule.label || rule.title || rule.key || '').trim() || '',
+      weight: Number(rule.weight || 0),
+      aliases: normalizeAliases(rule.aliases),
+      capabilities: cloneCapabilities(rule.capabilities)
+    };
+  }
+
+  function sanitizeRules(rules) {
+    var list = Array.isArray(rules) ? rules : [];
+    var sanitized = [];
+
+    list.forEach(function (rule, index) {
+      var cloned = cloneRule(rule) || {};
+      if (!cloned.key) {
+        var fallback = (cloned.label || 'CUSTOM_' + index).toUpperCase().replace(/[^A-Z0-9_]/g, '_');
+        cloned.key = fallback || ('CUSTOM_' + index);
+      }
+      if (!cloned.label) {
+        cloned.label = cloned.key;
+      }
+      if (typeof cloned.weight !== 'number' || isNaN(cloned.weight)) {
+        cloned.weight = 0;
+      }
+      sanitized.push(cloned);
+    });
+
+    return sanitized;
+  }
+
+  var DEFAULT_ROLE_RULES = sanitizeRules([
+    {
+      key: 'SYSTEM_ADMIN',
+      label: 'System Administrator',
+      weight: 2200,
+      aliases: ['system administrator', 'system admin', 'administrator', 'admin'],
+      capabilities: { isSystemAdmin: true, isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'CEO',
+      label: 'Chief Executive Officer',
+      weight: 2100,
+      aliases: ['ceo', 'chief executive officer'],
+      capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'COO',
+      label: 'Chief Operating Officer',
+      weight: 2050,
+      aliases: ['coo', 'chief operating officer'],
+      capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'CFO',
+      label: 'Chief Financial Officer',
+      weight: 2000,
+      aliases: ['cfo', 'chief financial officer'],
+      capabilities: { isExecutive: true, canManagePages: true }
+    },
+    {
+      key: 'CTO',
+      label: 'Chief Technology Officer',
+      weight: 1950,
+      aliases: ['cto', 'chief technology officer'],
+      capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'DIRECTOR',
+      label: 'Director',
+      weight: 1800,
+      aliases: ['director'],
+      capabilities: { isExecutive: true, isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'OPERATIONS_MANAGER',
+      label: 'Operations Manager',
+      weight: 1700,
+      aliases: ['operations manager', 'ops manager'],
+      capabilities: { isManager: true, canManageUsers: true, canManagePages: true }
+    },
+    {
+      key: 'ACCOUNT_MANAGER',
+      label: 'Account Manager',
+      weight: 1650,
+      aliases: ['account manager'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'WORKFORCE_MANAGER',
+      label: 'Workforce Manager',
+      weight: 1600,
+      aliases: ['workforce manager'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'QUALITY_ASSURANCE_MANAGER',
+      label: 'Quality Assurance Manager',
+      weight: 1550,
+      aliases: ['quality assurance manager', 'qa manager'],
+      capabilities: { isManager: true, canManagePages: true }
+    },
+    {
+      key: 'TRAINING_MANAGER',
+      label: 'Training Manager',
+      weight: 1500,
+      aliases: ['training manager'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'TEAM_SUPERVISOR',
+      label: 'Team Supervisor',
+      weight: 1400,
+      aliases: ['team supervisor', 'team lead'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'FLOOR_SUPERVISOR',
+      label: 'Floor Supervisor',
+      weight: 1350,
+      aliases: ['floor supervisor'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'ESCALATIONS_MANAGER',
+      label: 'Escalations Manager',
+      weight: 1300,
+      aliases: ['escalations manager'],
+      capabilities: { isManager: true, canManagePages: true }
+    },
+    {
+      key: 'CLIENT_SUCCESS_MANAGER',
+      label: 'Client Success Manager',
+      weight: 1250,
+      aliases: ['client success manager', 'customer success manager'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'COMPLIANCE_MANAGER',
+      label: 'Compliance Manager',
+      weight: 1200,
+      aliases: ['compliance manager'],
+      capabilities: { isManager: true, canManagePages: true }
+    },
+    {
+      key: 'IT_SUPPORT_MANAGER',
+      label: 'IT Support Manager',
+      weight: 1150,
+      aliases: ['it support manager', 'it manager', 'technology manager'],
+      capabilities: { isManager: true, canManagePages: true }
+    },
+    {
+      key: 'REPORTING_ANALYST',
+      label: 'Reporting Analyst',
+      weight: 900,
+      aliases: ['reporting analyst', 'analyst'],
+      capabilities: { canManagePages: true }
+    },
+    {
+      key: 'QUALITY',
+      label: 'Quality',
+      weight: 850,
+      aliases: ['quality', 'qa'],
+      capabilities: { canManagePages: true }
+    },
+    {
+      key: 'MANAGER',
+      label: 'Manager',
+      weight: 1450,
+      aliases: ['manager', 'supervisor'],
+      capabilities: { isManager: true, canManageUsers: true }
+    },
+    {
+      key: 'AGENT',
+      label: 'Agent',
+      weight: 400,
+      aliases: ['agent', 'associate'],
+      capabilities: {}
+    },
+    {
+      key: 'GUEST',
+      label: 'Guest',
+      weight: 100,
+      aliases: ['guest', 'viewer'],
+      capabilities: {}
+    }
+  ]);
+
+  function getStoredRoleRules() {
+    var props = getScriptProperties();
+    if (!props) {
+      return DEFAULT_ROLE_RULES.slice();
+    }
+
+    try {
+      var stored = props.getProperty(ROLE_RULES_PROPERTY_KEY);
+      if (!stored) {
+        props.setProperty(ROLE_RULES_PROPERTY_KEY, JSON.stringify(DEFAULT_ROLE_RULES));
+        return DEFAULT_ROLE_RULES.slice();
+      }
+
+      var parsed = JSON.parse(stored);
+      var sanitized = sanitizeRules(parsed);
+      return sanitized.length ? sanitized : DEFAULT_ROLE_RULES.slice();
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to parse stored role rules', err);
+      try {
+        props.setProperty(ROLE_RULES_PROPERTY_KEY, JSON.stringify(DEFAULT_ROLE_RULES));
+      } catch (persistError) {
+        console.warn('AuthorizationRegistry: failed to persist default rules', persistError);
+      }
+      return DEFAULT_ROLE_RULES.slice();
+    }
+  }
+
+  function persistRoleRules(rules) {
+    var props = getScriptProperties();
+    if (!props) {
+      return;
+    }
+    try {
+      props.setProperty(ROLE_RULES_PROPERTY_KEY, JSON.stringify(rules));
+    } catch (err) {
+      console.warn('AuthorizationRegistry: failed to persist role rules', err);
+    }
+  }
+
+  function buildRoleIndex(rules) {
+    var index = {};
+    if (!Array.isArray(rules)) {
+      return index;
+    }
+
+    rules.forEach(function (rule) {
+      if (!rule || !rule.key) return;
+      var key = String(rule.key).trim().toUpperCase();
+      if (!key) return;
+      index[key] = {
+        key: key,
+        label: rule.label || key,
+        weight: Number(rule.weight || 0),
+        capabilities: cloneCapabilities(rule.capabilities)
+      };
+    });
+
+    return index;
+  }
+
+  function getRoleIndex() {
+    var cache = getScriptCache();
+    if (cache) {
+      try {
+        var cached = cache.get(ROLE_INDEX_CACHE_KEY);
+        if (cached) {
+          return JSON.parse(cached);
+        }
+      } catch (err) {
+        console.warn('AuthorizationRegistry: failed to read role index cache', err);
+      }
+    }
+
+    var rules = getStoredRoleRules();
+    var index = buildRoleIndex(rules);
+
+    if (cache) {
+      try {
+        cache.put(ROLE_INDEX_CACHE_KEY, JSON.stringify(index), PROFILE_CACHE_TTL_SECONDS);
+      } catch (err) {
+        console.warn('AuthorizationRegistry: unable to cache role index', err);
+      }
+    }
+
+    return index;
+  }
+
+  function compareRoleLevels(levelA, levelB) {
+    var index = getRoleIndex();
+    var normalizedA = String(levelA || '').trim().toUpperCase();
+    var normalizedB = String(levelB || '').trim().toUpperCase();
+    var weightA = normalizedA && index[normalizedA] ? Number(index[normalizedA].weight || 0) : 0;
+    var weightB = normalizedB && index[normalizedB] ? Number(index[normalizedB].weight || 0) : 0;
+    return weightA - weightB;
+  }
+
+  function roleIsAtLeast(level, requiredLevel) {
+    if (!requiredLevel && requiredLevel !== 0) {
+      return true;
+    }
+    return compareRoleLevels(level, requiredLevel) >= 0;
+  }
+
+  function uniqStrings(list) {
+    if (!Array.isArray(list)) return [];
+    var seen = {};
+    var result = [];
+    list.forEach(function (item) {
+      if (!item && item !== 0) return;
+      var normalized = String(item).trim();
+      if (!normalized) return;
+      if (seen[normalized]) return;
+      seen[normalized] = true;
+      result.push(normalized);
+    });
+    return result;
+  }
+
+  function sanitizeUserReference(user) {
+    if (!user || typeof user !== 'object') return null;
+    var ref = {};
+    if (user.ID || user.Id || user.id) {
+      ref.id = String(user.ID || user.Id || user.id).trim();
+    }
+    if (user.UserId || user.userId) {
+      ref.userId = String(user.UserId || user.userId).trim();
+      if (!ref.id) ref.id = ref.userId;
+    }
+    if (user.UserName || user.username) {
+      ref.userName = String(user.UserName || user.username).trim();
+    }
+    if (user.FullName || user.fullName || user.name) {
+      ref.fullName = String(user.FullName || user.fullName || user.name).trim();
+    }
+    if (user.Email || user.email) {
+      ref.email = String(user.Email || user.email).trim();
+    }
+    return Object.keys(ref).length ? ref : null;
+  }
+
+  function normalizeSnapshotId(value) {
+    if (!value && value !== 0) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function deriveCurrentCampaignId(userPayload, snapshotCampaign) {
+    var fromPayload = '';
+    if (userPayload && typeof userPayload === 'object') {
+      fromPayload = normalizeSnapshotId(
+        userPayload.CurrentCampaignId
+          || userPayload.ActiveCampaignId
+          || (userPayload.CampaignScope && userPayload.CampaignScope.activeCampaignId)
+          || (userPayload.CampaignID || userPayload.campaignId)
+      );
+    }
+
+    if (fromPayload) {
+      return fromPayload;
+    }
+
+    if (snapshotCampaign && snapshotCampaign.activeCampaignId) {
+      return normalizeSnapshotId(snapshotCampaign.activeCampaignId);
+    }
+
+    return '';
+  }
+
+  function deriveCurrentUserId(userPayload, fallbackUserId) {
+    if (userPayload && typeof userPayload === 'object') {
+      var current = normalizeSnapshotId(
+        userPayload.CurrentUserId
+          || userPayload.UserId
+          || userPayload.userId
+          || userPayload.ID
+          || userPayload.Id
+          || userPayload.id
+      );
+      if (current) {
+        return current;
+      }
+    }
+    return normalizeSnapshotId(fallbackUserId);
+  }
+
+  function buildSessionDetails(userPayload, sessionToken) {
+    var expiresAt = null;
+    var lastActivityAt = null;
+    var idleTimeoutMinutes = null;
+
+    if (userPayload && typeof userPayload === 'object') {
+      expiresAt = normalizeSnapshotId(userPayload.sessionExpiresAt || userPayload.sessionExpiry);
+      lastActivityAt = normalizeSnapshotId(userPayload.sessionLastActivityAt);
+      if (typeof userPayload.sessionIdleTimeoutMinutes === 'number' && !isNaN(userPayload.sessionIdleTimeoutMinutes)) {
+        idleTimeoutMinutes = userPayload.sessionIdleTimeoutMinutes;
+      }
+    }
+
+    return {
+      token: normalizeSnapshotId(sessionToken) || null,
+      expiresAt: expiresAt || null,
+      lastActivityAt: lastActivityAt || null,
+      idleTimeoutMinutes: idleTimeoutMinutes
+    };
+  }
+
+  function buildAuthorizationSnapshot(userPayload, options) {
+    if (!userPayload || typeof userPayload !== 'object') {
+      return null;
+    }
+
+    var userId = '';
+    if (userPayload.ID || userPayload.Id || userPayload.id) {
+      userId = String(userPayload.ID || userPayload.Id || userPayload.id).trim();
+    }
+    if (!userId && userPayload.UserId) {
+      userId = String(userPayload.UserId).trim();
+    }
+    if (!userId) {
+      return null;
+    }
+
+    var sessionToken = '';
+    if (options && options.sessionToken) {
+      sessionToken = String(options.sessionToken).trim();
+    } else if (userPayload.sessionToken) {
+      sessionToken = String(userPayload.sessionToken).trim();
+    }
+
+    var claims = Array.isArray(userPayload.AuthorizationClaims) ? userPayload.AuthorizationClaims.slice()
+      : Array.isArray(userPayload.Claims) ? userPayload.Claims.slice()
+      : [];
+
+    var uniqueClaims = uniqStrings(claims);
+
+    var roleHierarchy = Array.isArray(userPayload.RoleHierarchy) ? userPayload.RoleHierarchy : [];
+    var normalizedRoles = roleHierarchy.map(function (role) {
+      var normalized = cloneRule(role) || {};
+      normalized.name = String(role && (role.name || role.label || '') || '').trim();
+      return normalized;
+    });
+
+    var highestRole = null;
+    if (userPayload.HighestRole && typeof userPayload.HighestRole === 'object') {
+      highestRole = cloneRule(userPayload.HighestRole);
+      if (highestRole) {
+        highestRole.name = String(userPayload.HighestRole.name || userPayload.HighestRole.label || '').trim();
+      }
+    }
+
+    var directReports = uniqStrings(userPayload.ManagedUserIds || []);
+    var managedUsers = Array.isArray(userPayload.ManagedUsers)
+      ? userPayload.ManagedUsers.map(sanitizeUserReference).filter(Boolean)
+      : [];
+
+    var snapshot = {
+      userId: userId,
+      sessionToken: sessionToken || null,
+      userName: String(userPayload.UserName || '').trim(),
+      fullName: String(userPayload.FullName || '').trim(),
+      email: String(userPayload.Email || '').trim().toLowerCase(),
+      highestRole: highestRole,
+      roles: normalizedRoles,
+      claims: uniqueClaims,
+      roleCapabilities: cloneCapabilities(userPayload.RoleCapabilities || (userPayload.Authorization && userPayload.Authorization.roleCapabilities)),
+      flags: {
+        isSystemAdmin: !!userPayload.IsSystemAdmin,
+        isExecutive: !!userPayload.IsExecutive,
+        isManager: !!userPayload.IsManager,
+        canManageUsers: !!userPayload.CanManageUsers,
+        canManagePages: !!userPayload.CanManagePages
+      },
+      permissionLevels: uniqStrings(userPayload.PermissionLevels || []),
+      campaign: {
+        activeCampaignId: String(userPayload.ActiveCampaignId || userPayload.CurrentCampaignId || '').trim(),
+        defaultCampaignId: String(userPayload.DefaultCampaignId || '').trim(),
+        allowedCampaignIds: uniqStrings(userPayload.AllowedCampaignIds || []),
+        managedCampaignIds: uniqStrings(userPayload.ManagedCampaignIds || []),
+        adminCampaignIds: uniqStrings(userPayload.AdminCampaignIds || []),
+        activePermission: userPayload.ActiveCampaignPermission ? JSON.parse(JSON.stringify(userPayload.ActiveCampaignPermission)) : null
+      },
+      directReports: directReports,
+      managedUsers: managedUsers,
+      directManagerId: userPayload.DirectManagerId ? String(userPayload.DirectManagerId).trim() : null,
+      directManager: sanitizeUserReference(userPayload.DirectManager),
+      timestamp: nowIsoString()
+    };
+
+    snapshot.session = buildSessionDetails(userPayload, snapshot.sessionToken);
+
+    snapshot.currentUserId = deriveCurrentUserId(userPayload, snapshot.userId) || snapshot.userId;
+    snapshot.currentCampaignId = deriveCurrentCampaignId(userPayload, snapshot.campaign);
+    snapshot.campaign.currentCampaignId = snapshot.currentCampaignId;
+    snapshot.currentCampaignPermission = snapshot.campaign.activePermission || null;
+
+    if (options && options.tenantPayload) {
+      try {
+        snapshot.tenant = JSON.parse(JSON.stringify(options.tenantPayload));
+      } catch (err) {
+        snapshot.tenant = null;
+      }
+    }
+
+    if (options && options.rawScope) {
+      try {
+        snapshot.rawScope = JSON.parse(JSON.stringify(options.rawScope));
+      } catch (err) {
+        snapshot.rawScope = null;
+      }
+    }
+
+    return snapshot;
+  }
+
+  function storeSnapshot(snapshot) {
+    if (!snapshot || !snapshot.userId) {
+      return null;
+    }
+
+    var json;
+    try {
+      json = JSON.stringify(snapshot);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to serialize snapshot for user', snapshot.userId, err);
+      return null;
+    }
+
+    var cache = getScriptCache();
+    if (cache) {
+      safeCachePut(cache, PROFILE_CACHE_PREFIX + snapshot.userId, json, PROFILE_CACHE_TTL_SECONDS);
+      if (snapshot.sessionToken) {
+        safeCachePut(cache, SESSION_CACHE_PREFIX + snapshot.sessionToken, json, PROFILE_CACHE_TTL_SECONDS);
+      }
+    }
+
+    var props = getScriptProperties();
+    if (props) {
+      try {
+        props.setProperty(PROFILE_PROPERTY_PREFIX + snapshot.userId, json);
+        if (snapshot.sessionToken) {
+          props.setProperty(SESSION_PROPERTY_PREFIX + snapshot.sessionToken, json);
+        }
+      } catch (err) {
+        console.warn('AuthorizationRegistry: failed to persist snapshot for user', snapshot.userId, err);
+      }
+    }
+
+    return snapshot;
+  }
+
+  function parseSnapshot(serialized) {
+    if (!serialized) return null;
+    try {
+      return JSON.parse(serialized);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to parse stored snapshot', err);
+      return null;
+    }
+  }
+
+  function getSnapshotFromCache(key) {
+    var cache = getScriptCache();
+    if (!cache) return null;
+    try {
+      var serialized = cache.get(key);
+      return parseSnapshot(serialized);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: cache lookup failed for key', key, err);
+      return null;
+    }
+  }
+
+  function getSnapshotFromProperties(key) {
+    var props = getScriptProperties();
+    if (!props) return null;
+    try {
+      var serialized = props.getProperty(key);
+      return parseSnapshot(serialized);
+    } catch (err) {
+      console.warn('AuthorizationRegistry: properties lookup failed for key', key, err);
+      return null;
+    }
+  }
+
+  function getAuthorizationSnapshotForUser(userId) {
+    if (!userId && userId !== 0) {
+      return null;
+    }
+    var key = PROFILE_CACHE_PREFIX + String(userId).trim();
+    var snapshot = getSnapshotFromCache(key);
+    if (snapshot) {
+      return snapshot;
+    }
+
+    var propertyKey = PROFILE_PROPERTY_PREFIX + String(userId).trim();
+    snapshot = getSnapshotFromProperties(propertyKey);
+    if (snapshot) {
+      storeSnapshot(snapshot);
+    }
+    return snapshot;
+  }
+
+  function getAuthorizationSnapshotForSession(sessionToken) {
+    if (!sessionToken && sessionToken !== 0) {
+      return null;
+    }
+    var key = SESSION_CACHE_PREFIX + String(sessionToken).trim();
+    var snapshot = getSnapshotFromCache(key);
+    if (snapshot) {
+      return snapshot;
+    }
+
+    var propertyKey = SESSION_PROPERTY_PREFIX + String(sessionToken).trim();
+    snapshot = getSnapshotFromProperties(propertyKey);
+    if (snapshot) {
+      storeSnapshot(snapshot);
+    }
+    return snapshot;
+  }
+
+  function clearAuthorizationSnapshot(criteria) {
+    var userId = criteria && criteria.userId ? String(criteria.userId).trim() : '';
+    var sessionToken = criteria && criteria.sessionToken ? String(criteria.sessionToken).trim() : '';
+
+    var cache = getScriptCache();
+    if (userId) {
+      safeCacheRemove(cache, PROFILE_CACHE_PREFIX + userId);
+    }
+    if (sessionToken) {
+      safeCacheRemove(cache, SESSION_CACHE_PREFIX + sessionToken);
+    }
+
+    var props = getScriptProperties();
+    if (props) {
+      try {
+        if (userId) props.deleteProperty(PROFILE_PROPERTY_PREFIX + userId);
+        if (sessionToken) props.deleteProperty(SESSION_PROPERTY_PREFIX + sessionToken);
+      } catch (err) {
+        console.warn('AuthorizationRegistry: failed to clear stored snapshot', err);
+      }
+    }
+  }
+
+  function registerAuthorizationSnapshot(userPayload, options) {
+    var snapshot = buildAuthorizationSnapshot(userPayload, options || {});
+    if (!snapshot) {
+      return null;
+    }
+    return storeSnapshot(snapshot);
+  }
+
+  function buildContextSummary(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') {
+      return null;
+    }
+
+    var summary = {
+      userId: snapshot.userId || null,
+      currentUserId: snapshot.currentUserId || snapshot.userId || null,
+      userName: snapshot.userName || null,
+      fullName: snapshot.fullName || null,
+      email: snapshot.email || null,
+      sessionToken: snapshot.sessionToken || (snapshot.session && snapshot.session.token) || null,
+      activeCampaignId: snapshot.currentCampaignId || (snapshot.campaign && snapshot.campaign.activeCampaignId) || null,
+      roleKey: snapshot.highestRole && snapshot.highestRole.key ? snapshot.highestRole.key : null,
+      roleLabel: snapshot.highestRole && snapshot.highestRole.label ? snapshot.highestRole.label : null,
+      flags: snapshot.flags || {},
+      roleCapabilities: snapshot.roleCapabilities || {},
+      permissionLevels: Array.isArray(snapshot.permissionLevels) ? snapshot.permissionLevels.slice() : [],
+      claims: Array.isArray(snapshot.claims) ? snapshot.claims.slice() : [],
+      directReports: Array.isArray(snapshot.directReports) ? snapshot.directReports.slice() : [],
+      timestamp: snapshot.timestamp || null
+    };
+
+    if (snapshot.campaign && typeof snapshot.campaign === 'object') {
+      summary.campaign = {
+        activeCampaignId: snapshot.campaign.activeCampaignId || null,
+        currentCampaignId: snapshot.campaign.currentCampaignId || summary.activeCampaignId || null,
+        defaultCampaignId: snapshot.campaign.defaultCampaignId || null,
+        allowedCampaignIds: Array.isArray(snapshot.campaign.allowedCampaignIds)
+          ? snapshot.campaign.allowedCampaignIds.slice()
+          : [],
+        managedCampaignIds: Array.isArray(snapshot.campaign.managedCampaignIds)
+          ? snapshot.campaign.managedCampaignIds.slice()
+          : [],
+        adminCampaignIds: Array.isArray(snapshot.campaign.adminCampaignIds)
+          ? snapshot.campaign.adminCampaignIds.slice()
+          : [],
+        activePermission: snapshot.campaign.activePermission || null
+      };
+    } else {
+      summary.campaign = {
+        activeCampaignId: null,
+        currentCampaignId: null,
+        defaultCampaignId: null,
+        allowedCampaignIds: [],
+        managedCampaignIds: [],
+        adminCampaignIds: [],
+        activePermission: null
+      };
+    }
+
+    if (snapshot.session && typeof snapshot.session === 'object') {
+      summary.session = {
+        token: snapshot.session.token || summary.sessionToken || null,
+        expiresAt: snapshot.session.expiresAt || null,
+        lastActivityAt: snapshot.session.lastActivityAt || null,
+        idleTimeoutMinutes: typeof snapshot.session.idleTimeoutMinutes === 'number'
+          ? snapshot.session.idleTimeoutMinutes
+          : null
+      };
+    } else {
+      summary.session = {
+        token: summary.sessionToken || null,
+        expiresAt: null,
+        lastActivityAt: null,
+        idleTimeoutMinutes: null
+      };
+    }
+
+    if (snapshot.tenant) {
+      try {
+        summary.tenant = JSON.parse(JSON.stringify(snapshot.tenant));
+      } catch (tenantErr) {
+        summary.tenant = snapshot.tenant;
+      }
+    } else {
+      summary.tenant = null;
+    }
+
+    if (snapshot.rawScope) {
+      try {
+        summary.rawScope = JSON.parse(JSON.stringify(snapshot.rawScope));
+      } catch (scopeErr) {
+        summary.rawScope = snapshot.rawScope;
+      }
+    } else {
+      summary.rawScope = null;
+    }
+
+    return summary;
+  }
+
+  function getAuthorizationContextSummaryForSession(sessionToken) {
+    var snapshot = getAuthorizationSnapshotForSession(sessionToken);
+    return buildContextSummary(snapshot);
+  }
+
+  function getAuthorizationContextSummaryForUser(userId) {
+    var snapshot = getAuthorizationSnapshotForUser(userId);
+    return buildContextSummary(snapshot);
+  }
+
+  function getActiveCampaignIdForSession(sessionToken) {
+    var summary = getAuthorizationContextSummaryForSession(sessionToken);
+    return summary && summary.activeCampaignId ? summary.activeCampaignId : null;
+  }
+
+  function getActiveCampaignIdForUser(userId) {
+    var summary = getAuthorizationContextSummaryForUser(userId);
+    return summary && summary.activeCampaignId ? summary.activeCampaignId : null;
+  }
+
+  function getCurrentUserIdForSession(sessionToken) {
+    var summary = getAuthorizationContextSummaryForSession(sessionToken);
+    return summary && summary.currentUserId ? summary.currentUserId : null;
+  }
+
+  function userHasCapability(subject, capability) {
+    if (!capability && capability !== 0) {
+      return false;
+    }
+    var snapshot = (subject && typeof subject === 'object' && subject.userId)
+      ? subject
+      : getAuthorizationSnapshotForUser(subject);
+    if (!snapshot) {
+      return false;
+    }
+
+    var key = String(capability).trim();
+    if (!key) {
+      return false;
+    }
+
+    if (snapshot.roleCapabilities && typeof snapshot.roleCapabilities === 'object' && key in snapshot.roleCapabilities) {
+      return !!snapshot.roleCapabilities[key];
+    }
+
+    if (snapshot.flags && typeof snapshot.flags === 'object' && key in snapshot.flags) {
+      return !!snapshot.flags[key];
+    }
+
+    return false;
+  }
+
+  function userManagesUser(managerSubject, targetUserId) {
+    if (!targetUserId && targetUserId !== 0) {
+      return false;
+    }
+
+    var snapshot = (managerSubject && typeof managerSubject === 'object' && managerSubject.userId)
+      ? managerSubject
+      : getAuthorizationSnapshotForUser(managerSubject);
+
+    if (!snapshot) {
+      return false;
+    }
+
+    if (snapshot.flags && snapshot.flags.isSystemAdmin) {
+      return true;
+    }
+
+    var target = String(targetUserId).trim().toLowerCase();
+    if (!target) {
+      return false;
+    }
+
+    var directReports = Array.isArray(snapshot.directReports) ? snapshot.directReports : [];
+    for (var i = 0; i < directReports.length; i++) {
+      if (String(directReports[i]).trim().toLowerCase() === target) {
+        return true;
+      }
+    }
+
+    var managedUsers = Array.isArray(snapshot.managedUsers) ? snapshot.managedUsers : [];
+    for (var j = 0; j < managedUsers.length; j++) {
+      var managed = managedUsers[j];
+      var managedId = managed && (managed.id || managed.userId);
+      if (managedId && String(managedId).trim().toLowerCase() === target) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function ensureRoleHierarchyRules(defaultRules) {
+    var props = getScriptProperties();
+    if (!props) {
+      return DEFAULT_ROLE_RULES.slice();
+    }
+
+    try {
+      var stored = props.getProperty(ROLE_RULES_PROPERTY_KEY);
+      if (!stored) {
+        var rulesToPersist = sanitizeRules(defaultRules && defaultRules.length ? defaultRules : DEFAULT_ROLE_RULES);
+        props.setProperty(ROLE_RULES_PROPERTY_KEY, JSON.stringify(rulesToPersist));
+        var cache = getScriptCache();
+        if (cache) {
+          cache.remove(ROLE_INDEX_CACHE_KEY);
+        }
+        return rulesToPersist.slice();
+      }
+    } catch (err) {
+      console.warn('AuthorizationRegistry: unable to ensure role hierarchy rules', err);
+      try {
+        props.setProperty(ROLE_RULES_PROPERTY_KEY, JSON.stringify(DEFAULT_ROLE_RULES));
+      } catch (persistError) {
+        console.warn('AuthorizationRegistry: failed to reset role rules to defaults', persistError);
+      }
+    }
+
+    return getStoredRoleRules();
+  }
+
+  function setRoleHierarchyRules(rules) {
+    var sanitized = sanitizeRules(rules);
+    if (!sanitized.length) {
+      sanitized = DEFAULT_ROLE_RULES.slice();
+    }
+
+    persistRoleRules(sanitized);
+
+    var cache = getScriptCache();
+    if (cache) {
+      try {
+        cache.remove(ROLE_INDEX_CACHE_KEY);
+      } catch (err) {
+        console.warn('AuthorizationRegistry: unable to clear role index cache', err);
+      }
+    }
+
+    return sanitized.slice();
+  }
+
+  function getRoleHierarchyRules(defaults) {
+    if (defaults && defaults.length) {
+      ensureRoleHierarchyRules(defaults);
+    }
+    var stored = getStoredRoleRules();
+    return stored.slice();
+  }
+
+  function getDefaultRoleHierarchyRules() {
+    return DEFAULT_ROLE_RULES.slice();
+  }
+
+  return {
+    getRoleHierarchyRules: getRoleHierarchyRules,
+    getDefaultRoleHierarchyRules: getDefaultRoleHierarchyRules,
+    setRoleHierarchyRules: setRoleHierarchyRules,
+    ensureRoleHierarchyRules: ensureRoleHierarchyRules,
+    registerAuthorizationSnapshot: registerAuthorizationSnapshot,
+    getAuthorizationSnapshotForUser: getAuthorizationSnapshotForUser,
+    getAuthorizationSnapshotForSession: getAuthorizationSnapshotForSession,
+    getAuthorizationContextSummaryForSession: getAuthorizationContextSummaryForSession,
+    getAuthorizationContextSummaryForUser: getAuthorizationContextSummaryForUser,
+    getActiveCampaignIdForSession: getActiveCampaignIdForSession,
+    getActiveCampaignIdForUser: getActiveCampaignIdForUser,
+    getCurrentUserIdForSession: getCurrentUserIdForSession,
+    clearAuthorizationSnapshot: clearAuthorizationSnapshot,
+    compareRoleLevels: compareRoleLevels,
+    roleIsAtLeast: roleIsAtLeast,
+    userHasCapability: userHasCapability,
+    userManagesUser: userManagesUser
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = AuthorizationRegistry;
+}

--- a/MainUtilities.js
+++ b/MainUtilities.js
@@ -183,6 +183,202 @@ if (typeof ERROR_LOGS_HEADERS === 'undefined') var ERROR_LOGS_HEADERS = ["Timest
 if (typeof NOTIFICATIONS_HEADERS === 'undefined') var NOTIFICATIONS_HEADERS = ["ID", "UserId", "Type", "Severity", "Title", "Message", "Data", "Read", "ActionTaken", "CreatedAt", "ReadAt", "ExpiresAt"];
 
 // ────────────────────────────────────────────────────────────────────────────
+// Authorization hierarchy helpers (shared across the system)
+// ────────────────────────────────────────────────────────────────────────────
+
+function ensureAuthorizationHierarchyDefaults_() {
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.ensureRoleHierarchyRules === 'function') {
+      AuthorizationRegistry.ensureRoleHierarchyRules();
+    }
+  } catch (err) {
+    console.warn('MainUtilities.ensureAuthorizationHierarchyDefaults_: unable to ensure role hierarchy', err);
+  }
+}
+
+function getAuthorizationSnapshotForUser(userId) {
+  if (!userId && userId !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getAuthorizationSnapshotForUser === 'function') {
+      return AuthorizationRegistry.getAuthorizationSnapshotForUser(userId);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getAuthorizationSnapshotForUser: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getAuthorizationSnapshotForSession(sessionToken) {
+  if (!sessionToken && sessionToken !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getAuthorizationSnapshotForSession === 'function') {
+      return AuthorizationRegistry.getAuthorizationSnapshotForSession(sessionToken);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getAuthorizationSnapshotForSession: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getSessionAuthorizationContext(sessionToken) {
+  if (!sessionToken && sessionToken !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getAuthorizationContextSummaryForSession === 'function') {
+      return AuthorizationRegistry.getAuthorizationContextSummaryForSession(sessionToken);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getSessionAuthorizationContext: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getUserAuthorizationContext(userId) {
+  if (!userId && userId !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getAuthorizationContextSummaryForUser === 'function') {
+      return AuthorizationRegistry.getAuthorizationContextSummaryForUser(userId);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getUserAuthorizationContext: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getSessionActiveCampaignId(sessionToken) {
+  if (!sessionToken && sessionToken !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getActiveCampaignIdForSession === 'function') {
+      return AuthorizationRegistry.getActiveCampaignIdForSession(sessionToken);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getSessionActiveCampaignId: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getUserActiveCampaignId(userId) {
+  if (!userId && userId !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getActiveCampaignIdForUser === 'function') {
+      return AuthorizationRegistry.getActiveCampaignIdForUser(userId);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getUserActiveCampaignId: lookup failed', err);
+  }
+
+  return null;
+}
+
+function getSessionCurrentUserId(sessionToken) {
+  if (!sessionToken && sessionToken !== 0) {
+    return null;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.getCurrentUserIdForSession === 'function') {
+      return AuthorizationRegistry.getCurrentUserIdForSession(sessionToken);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.getSessionCurrentUserId: lookup failed', err);
+  }
+
+  return null;
+}
+
+function userHasCapabilityFlag(userOrId, capabilityKey) {
+  if (!capabilityKey && capabilityKey !== 0) {
+    return false;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.userHasCapability === 'function') {
+      return AuthorizationRegistry.userHasCapability(userOrId, capabilityKey);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.userHasCapabilityFlag: lookup failed', err);
+  }
+
+  return false;
+}
+
+function userCanManageUser(managerUserOrId, targetUserId) {
+  if (!targetUserId && targetUserId !== 0) {
+    return false;
+  }
+
+  ensureAuthorizationHierarchyDefaults_();
+
+  try {
+    if (typeof AuthorizationRegistry !== 'undefined'
+      && AuthorizationRegistry
+      && typeof AuthorizationRegistry.userManagesUser === 'function') {
+      return AuthorizationRegistry.userManagesUser(managerUserOrId, targetUserId);
+    }
+  } catch (err) {
+    console.warn('MainUtilities.userCanManageUser: lookup failed', err);
+  }
+
+  return false;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // HR / Benefits – Users sheet upgrade + calculators
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -2033,3 +2229,6 @@ console.log('   - clientGetNavigationForUser()');
 console.log('   - clientGetCampaignNavigation()');
 console.log('   - clientRunEnhancedDiscovery() / clientSetupEnhancedCategories() / clientRunEnhancedSetup()');
 console.log('   - clientDebugMultiCampaignSetup()');
+console.log('   - getSessionAuthorizationContext() / getUserAuthorizationContext()');
+console.log('   - getSessionActiveCampaignId() / getUserActiveCampaignId()');
+console.log('   - getSessionCurrentUserId()');


### PR DESCRIPTION
## Summary
- enrich the authorization registry snapshot with session metadata, current user/campaign identifiers, and shareable context summaries
- expose convenience helpers in MainUtilities so other modules can resolve active campaign or user context from the registry
- broadcast the current user and campaign identifiers through generated claims so downstream checks can recognize the logged-in session

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1ac65c32c83268413f9b9a5ee2e10