### PR TITLE
Fix login layout whitespace on large screens

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -934,11 +934,11 @@
 
 <body class="bg-light">
 
-  <div class="container-fluid h-100 page-wrapper">
+  <div class="container-fluid h-100 page-wrapper px-0">
     <div class="row h-100 g-0 align-items-stretch">
 
       <!-- LEFT: Hero / Feature Panel -->
-      <div class="col-lg-5 d-none d-lg-flex align-items-center justify-content-center feature-panel">
+      <div class="col-lg-5 col-xl-6 d-none d-lg-flex align-items-center justify-content-center feature-panel">
         <div class="feature-content text-center text-lg-start">
           <span class="feature-badge">
             <i class="fas fa-sparkles"></i> Lumina HQ Platform
@@ -958,7 +958,7 @@
       </div>
 
       <!-- RIGHT: Login Form -->
-      <div class="col-lg-7 col-xl-6 ms-auto d-flex align-items-center justify-content-center bg-light form-column">
+      <div class="col-lg-7 col-xl-6 d-flex align-items-center justify-content-center bg-light form-column">
         <div class="login-container">
           <div class="login-body">
 


### PR DESCRIPTION
## Summary
- remove the container padding so the login layout stretches edge to edge
- balance the login columns on xl screens and drop the auto margin to prevent the extra gutter

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f201ffd6448326b85a91a5206e6a83