### PR TITLE
Move turnover metrics to employment report

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -4255,6 +4255,34 @@
     }
   }
 
+  function formatTurnoverRate(value) {
+    if (value === null || value === undefined) return '';
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return '';
+      if (trimmed.endsWith('%')) return trimmed;
+
+      const numeric = Number(trimmed.replace(/[^0-9.\-]/g, ''));
+      if (!Number.isNaN(numeric)) {
+        value = numeric;
+      } else {
+        return trimmed;
+      }
+    }
+
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return String(value);
+
+    const normalized = numericValue > 1 ? numericValue : numericValue * 100;
+    const precision = Number.isInteger(normalized)
+      ? 0
+      : normalized >= 10
+        ? 1
+        : 2;
+    return `${normalized.toFixed(precision)}%`;
+  }
+
   function formatHireVisual(dateStr) {
     if (!dateStr) return '';
     try {
@@ -4358,6 +4386,25 @@
       return { status, count, percentage };
     }).sort((a, b) => b.count - a.count);
 
+    const turnover = data.turnoverMetrics || {};
+    const lookbackDays = Number(turnover.lookbackDays) || 90;
+    const lookbackSummaryLabel = lookbackDays === 30 ? 'Last 30 days' : `Last ${lookbackDays} days`;
+    const windowRangeDisplay = (turnover.windowStart && turnover.windowEnd)
+      ? `${formatHireVisual(turnover.windowStart)} – ${formatHireVisual(turnover.windowEnd)}`
+      : '';
+    const totalHiresRecorded = Number.isFinite(turnover.totalHires) ? turnover.totalHires : 0;
+    const totalTerminationsRecorded = Number.isFinite(turnover.totalTerminations) ? turnover.totalTerminations : 0;
+    const activeHeadcount = Number.isFinite(turnover.activeHeadcount)
+      ? turnover.activeHeadcount
+      : Math.max(0, totalUsers - totalTerminationsRecorded);
+    const hiresWindow = Number.isFinite(turnover.hiresWithinWindow) ? turnover.hiresWithinWindow : 0;
+    const terminationsWindow = Number.isFinite(turnover.terminationsWithinWindow) ? turnover.terminationsWithinWindow : 0;
+    const hiringRateDisplay = formatTurnoverRate(turnover.hiringRate);
+    const turnoverRateDisplay = formatTurnoverRate(turnover.turnoverRate);
+    const activeStatusCount = statusCounts['Active'] || 0;
+    const unspecifiedCount = statusCounts['Unspecified'] || 0;
+    const inactiveStatusCount = (statusCounts['Inactive'] || 0) + (statusCounts['Terminated'] || 0);
+
     content.innerHTML = `
     <div class="row">
       <div class="col-md-8">
@@ -4386,28 +4433,50 @@
       </div>
       <div class="col-md-4">
         <h6 class="fw-bold"><i class="fas fa-info-circle me-2"></i>Summary</h6>
-        <div class="card">
+        <div class="card mb-3">
           <div class="card-body">
+            <div class="text-uppercase small text-muted mb-2">Headcount Overview</div>
             <div class="d-flex justify-content-between align-items-center mb-2">
               <span>Total Users:</span><strong>${totalUsers}</strong>
             </div>
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <span>Active Employees:</span><strong class="text-success">${statusCounts['Active'] || 0}</strong>
+              <span>Active Headcount:</span><strong class="text-success">${activeHeadcount}</strong>
             </div>
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <span>Inactive/Terminated:</span><strong class="text-danger">${(statusCounts['Inactive'] || 0) + (statusCounts['Terminated'] || 0)}</strong>
+              <span>Status = Active:</span><strong>${activeStatusCount}</strong>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Inactive / Terminated Status:</span><strong class="text-danger">${inactiveStatusCount}</strong>
             </div>
             <div class="d-flex justify-content-between align-items-center">
-              <span>Unspecified:</span><strong class="text-muted">${statusCounts['Unspecified'] || 0}</strong>
+              <span>Unspecified Status:</span><strong class="text-muted">${unspecifiedCount}</strong>
             </div>
           </div>
         </div>
-        <div class="mt-3">
-          <h6 class="fw-bold"><i class="fas fa-calendar-alt me-2"></i>Recent Activity</h6>
-          <div class="small text-muted">
-            <ul class="mb-0">
-              ${(data.recentChanges || []).slice(0,5).map(r => `<li>${escapeHtml(r)}</li>`).join('') || '<li>No recent changes</li>'}
-            </ul>
+        <div class="card">
+          <div class="card-body">
+            <div class="text-uppercase small text-muted mb-2">Turnover Insights</div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Hires Recorded:</span><strong>${totalHiresRecorded}</strong>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Terminations Recorded:</span><strong>${totalTerminationsRecorded}</strong>
+            </div>
+            <hr class="my-3">
+            <div class="small text-muted mb-2">${escapeHtml(lookbackSummaryLabel)} snapshot</div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Hires:</span><strong>${hiresWindow}</strong>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Terminations:</span><strong>${terminationsWindow}</strong>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span>Hiring Rate:</span><strong>${hiringRateDisplay || '—'}</strong>
+            </div>
+            <div class="d-flex justify-content-between align-items-center">
+              <span>Turnover Rate:</span><strong>${turnoverRateDisplay || '—'}</strong>
+            </div>
+            ${windowRangeDisplay ? `<div class="small text-muted mt-3">Window: ${escapeHtml(windowRangeDisplay)}</div>` : ''}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the turnover rate badge from user cards so employment insights live in the report modal
- add turnover and hiring sections to the employment status report UI, including 90-day rate calculations and window details
- extend the employment status report service to calculate headcount, hire/termination totals, and turnover metrics returned to the frontend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f201a96c688326b8ec0cc97f8d49b4