### PR TITLE
Enhance agent schedule APIs and swap workflow

### DIFF
--- a/AgentSchedule.html
+++ b/AgentSchedule.html
@@ -798,6 +798,7 @@
   <script>
     // Global variables
         let currentAgent = null;
+        let currentAgentSnapshot = null;
         let agentSchedules = [];
         let agentSwapRequests = [];
 
@@ -808,7 +809,7 @@
             try {
                 initializeAgentPage();
                 setupEventListeners();
-                loadAgentData();
+                loadAgentSnapshot();
                 console.log('✅ Agent Schedule Page initialized successfully');
             } catch (error) {
                 console.error('❌ Failed to initialize Agent Schedule Page:', error);
@@ -865,7 +866,7 @@
             
             switch(tabId) {
                 case 'overview':
-                    loadOverviewData();
+                    loadAgentSnapshot();
                     break;
                 case 'my-schedule':
                     loadMySchedule();
@@ -882,83 +883,87 @@
             }
         }
 
-        function loadAgentData() {
-            console.log('Loading agent data...');
-            
-            // Extract agent ID from token (in real implementation)
-            const agentId = 'agent123'; // This would come from the token
-            
+        function loadAgentSnapshot(options = {}) {
+            console.log('Loading agent snapshot...');
+
+            const agentId = currentAgent && currentAgent.id ? currentAgent.id : null;
+            const payloadOptions = Object.assign({ limitUpcoming: 7, limitHistory: 5 }, options);
+            if (agentId) {
+                payloadOptions.agentId = agentId;
+            }
+            if (currentAgent && currentAgent.campaignId) {
+                payloadOptions.campaignId = currentAgent.campaignId;
+            }
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
-                    .withSuccessHandler(handleAgentDataLoaded)
+                    .withSuccessHandler(handleAgentSnapshot)
                     .withFailureHandler(handleError)
-                    .getAgentData(agentId);
+                    .clientGetAgentScheduleSnapshot(agentId, null, null, null, payloadOptions);
             } else {
-                // Use placeholder data for demo
-                handleAgentDataLoaded({
-                    id: 'agent123',
-                    name: 'John Doe',
-                    email: 'john.doe@company.com'
+                // Placeholder data when running outside Apps Script
+                handleAgentSnapshot({
+                    success: true,
+                    agentId: 'agent123',
+                    campaignId: 'campaign-1',
+                    summary: {
+                        agentId: 'agent123',
+                        agentName: 'John Doe',
+                        agentEmail: 'john.doe@company.com',
+                        totalShifts: 12,
+                        totalScheduledHours: 96,
+                        weekendShifts: 2,
+                        nightShifts: 1,
+                        pendingSwaps: 1,
+                        upcomingHolidays: 2,
+                        preferenceScore: 88,
+                        complianceScore: 92
+                    },
+                    upcomingShifts: [],
+                    recentShifts: [],
+                    alerts: []
                 });
             }
         }
 
-        function handleAgentDataLoaded(agent) {
-            console.log('Agent data loaded:', agent);
-            
-            currentAgent = agent;
-            
-            // Update UI with agent info
-            document.getElementById('agentName').textContent = agent.name;
-            document.getElementById('agentEmail').textContent = agent.email;
-            document.getElementById('agentId').textContent = agent.id;
-            
-            // Set current period
+        function handleAgentSnapshot(snapshot) {
+            if (!snapshot || snapshot.success === false) {
+                console.warn('Agent snapshot unavailable:', snapshot && snapshot.error);
+                showNotices([{ type: 'warning', title: 'Schedule', message: snapshot && snapshot.error ? snapshot.error : 'Unable to load your schedule snapshot.' }]);
+                return;
+            }
+
+            currentAgentSnapshot = snapshot;
+
+            const summary = snapshot.summary || {};
+            currentAgent = Object.assign({}, currentAgent || {}, {
+                id: summary.agentId || snapshot.agentId || currentAgent?.id || 'agent',
+                name: summary.agentName || currentAgent?.name || 'Agent',
+                email: summary.agentEmail || currentAgent?.email || 'agent@example.com',
+                campaignId: snapshot.campaignId || currentAgent?.campaignId || null
+            });
+
+            document.getElementById('agentName').textContent = currentAgent.name;
+            document.getElementById('agentEmail').textContent = currentAgent.email;
+            document.getElementById('agentId').textContent = currentAgent.id;
+
             const today = new Date();
             const endDate = new Date();
             endDate.setDate(today.getDate() + 14);
-            
-            document.getElementById('currentPeriod').textContent = 
-                `${today.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
-            
-            // Load initial data
-            loadOverviewData();
-        }
+            document.getElementById('currentPeriod').textContent = `${today.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
 
-        function loadOverviewData() {
-            console.log('Loading overview data...');
-            
-            if (typeof google !== 'undefined' && google.script && google.script.run) {
-                google.script.run
-                    .withSuccessHandler(handleOverviewDataLoaded)
-                    .withFailureHandler(handleError)
-                    .getAgentOverview(currentAgent.id);
-            } else {
-                // Use placeholder data for demo
-                handleOverviewDataLoaded({
-                    totalShifts: 12,
-                    totalHours: 96,
-                    pendingSwaps: 1,
-                    upcomingHolidays: 2,
-                    upcomingShifts: []
-                });
-            }
-        }
+            document.getElementById('totalShifts').textContent = summary.totalShifts || 0;
+            document.getElementById('totalHours').textContent = summary.totalScheduledHours || 0;
+            document.getElementById('pendingSwaps').textContent = summary.pendingSwaps || 0;
+            document.getElementById('upcomingHolidays').textContent = summary.upcomingHolidays || 0;
 
-        function handleOverviewDataLoaded(data) {
-            console.log('Overview data loaded:', data);
-            
-            // Update stats
-            document.getElementById('totalShifts').textContent = data.totalShifts || 0;
-            document.getElementById('totalHours').textContent = data.totalHours || 0;
-            document.getElementById('pendingSwaps').textContent = data.pendingSwaps || 0;
-            document.getElementById('upcomingHolidays').textContent = data.upcomingHolidays || 0;
-            
-            // Show notices if any
-            showNotices(data.notices || []);
-            
-            // Load upcoming shifts preview
-            loadUpcomingShiftsPreview(data.upcomingShifts || []);
+            showNotices((snapshot.alerts || []).map(alert => ({
+                type: alert && alert.toLowerCase && alert.toLowerCase().includes('compliance') ? 'danger' : 'info',
+                title: 'Schedule Alert',
+                message: alert
+            })));
+
+            loadUpcomingShiftsPreview(snapshot.upcomingShifts || []);
         }
 
         function showNotices(notices) {
@@ -1002,26 +1007,30 @@
                 const shiftDate = new Date(shift.date);
                 const isToday = shiftDate.toDateString() === new Date().toDateString();
                 const isTomorrow = shiftDate.toDateString() === new Date(Date.now() + 86400000).toDateString();
-                
+
                 let dateLabel = shiftDate.toLocaleDateString();
                 if (isToday) dateLabel = 'Today';
                 else if (isTomorrow) dateLabel = 'Tomorrow';
-                
+
+                const shiftLabel = shift.skill || shift.location || shift.notes || 'Scheduled shift';
+                const statusLabel = shift.status || 'Scheduled';
+                const shiftId = shift.id || '';
+
                 shiftsHtml += `
                     <div class="schedule-item ${isToday ? 'today' : 'upcoming'}">
                         <div class="schedule-header-row">
                             <div>
                                 <div class="schedule-date">${dateLabel}</div>
                                 <div class="schedule-time">${shift.startTime} - ${shift.endTime}</div>
-                                <div class="text-muted">${shift.shiftSlot}</div>
+                                <div class="text-muted">${shiftLabel}</div>
                             </div>
-                            <span class="schedule-status ${shift.status}">${shift.status}</span>
+                            <span class="schedule-status ${statusLabel}">${statusLabel}</span>
                         </div>
                         <div class="schedule-actions">
-                            <button class="btn btn-sm btn-secondary" onclick="viewShiftDetails('${shift.id}')">
+                            <button class="btn btn-sm btn-secondary" ${shiftId ? `onclick="viewShiftDetails('${shiftId}')"` : 'disabled'}>
                                 <i class="fas fa-eye"></i> Details
                             </button>
-                            <button class="btn btn-sm btn-warning" onclick="requestShiftSwap('${shift.id}')">
+                            <button class="btn btn-sm btn-warning" ${shiftId ? `onclick="requestShiftSwap('${shiftId}')"` : 'disabled'}>
                                 <i class="fas fa-exchange-alt"></i> Request Swap
                             </button>
                         </div>
@@ -1032,37 +1041,75 @@
             container.innerHTML = shiftsHtml;
         }
 
-        function loadMySchedule() {
+        function loadMySchedule(options = {}) {
             console.log('Loading my schedule...');
-            
+
+            if (!currentAgent || !currentAgent.id) {
+                showAlert('Agent information is not available yet. Please refresh.', 'warning');
+                return;
+            }
+
             const container = document.getElementById('myScheduleContainer');
             container.innerHTML = '<div class="loading-spinner"><div class="spinner"></div><span style="margin-left: 1rem;">Loading your schedule...</span></div>';
-            
+
+            const payloadOptions = Object.assign({ windowDays: 45 }, options, {
+                agentId: currentAgent.id
+            });
+            if (currentAgent.campaignId) {
+                payloadOptions.campaignId = currentAgent.campaignId;
+            }
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleMyScheduleLoaded)
                     .withFailureHandler(handleError)
-                    .getAgentSchedule(currentAgent.id);
+                    .clientGetAgentSchedule(currentAgent.id, payloadOptions);
             } else {
                 setTimeout(() => {
-                    handleMyScheduleLoaded([]);
-                }, 1000);
+                    const fallbackSchedules = (currentAgentSnapshot && Array.isArray(currentAgentSnapshot.upcomingShifts))
+                        ? currentAgentSnapshot.upcomingShifts.map(shift => ({
+                            id: shift.id,
+                            date: shift.date,
+                            startTime: shift.startTime,
+                            endTime: shift.endTime,
+                            shiftSlot: shift.skill || shift.shiftSlot || 'Scheduled',
+                            status: 'upcoming',
+                            startDateTime: shift.date ? `${shift.date}T${(shift.startTime || '08:00')}:00` : '',
+                            endDateTime: shift.date ? `${shift.date}T${(shift.endTime || '17:00')}:00` : ''
+                        }))
+                        : [];
+                    handleMyScheduleLoaded({ success: true, schedules: fallbackSchedules });
+                }, 500);
             }
         }
 
-        function handleMyScheduleLoaded(schedules) {
+        function handleMyScheduleLoaded(response) {
+            const isError = response && response.success === false;
+            if (isError) {
+                console.warn('My schedule unavailable:', response && response.error);
+                showAlert(response && response.error ? response.error : 'Unable to load schedule.', 'warning');
+                agentSchedules = [];
+                displaySchedules([]);
+                populateMyShifts([]);
+                return;
+            }
+
+            const schedules = Array.isArray(response)
+                ? response
+                : Array.isArray(response?.schedules) ? response.schedules : [];
+
             console.log('My schedule loaded:', schedules);
-            
+
             agentSchedules = schedules;
             displaySchedules(schedules);
-            
+
             // Populate shift selector for swap requests
             populateMyShifts(schedules);
         }
 
         function displaySchedules(schedules) {
             const container = document.getElementById('myScheduleContainer');
-            
+
             if (schedules.length === 0) {
                 container.innerHTML = `
                     <div class="empty-state">
@@ -1073,33 +1120,56 @@
                 `;
                 return;
             }
-            
+
             let schedulesHtml = '';
             schedules.forEach(schedule => {
-                const scheduleDate = new Date(schedule.date);
-                const isToday = scheduleDate.toDateString() === new Date().toDateString();
-                const isPast = scheduleDate < new Date();
-                
+                let scheduleDate = null;
+                if (schedule.startDateTime) {
+                    const parsed = new Date(schedule.startDateTime);
+                    if (!isNaN(parsed)) scheduleDate = parsed;
+                }
+                if (!scheduleDate && schedule.dateIso) {
+                    const parsed = new Date(schedule.dateIso);
+                    if (!isNaN(parsed)) scheduleDate = parsed;
+                }
+                if (!scheduleDate && schedule.date) {
+                    const parsed = new Date(schedule.date);
+                    if (!isNaN(parsed)) scheduleDate = parsed;
+                }
+
+                scheduleDate = scheduleDate || new Date();
+
+                const today = new Date();
+                today.setHours(0, 0, 0, 0);
+                const scheduleDay = new Date(scheduleDate.getTime());
+                scheduleDay.setHours(0, 0, 0, 0);
+
+                const isToday = scheduleDay.getTime() === today.getTime();
+                const isPast = scheduleDay.getTime() < today.getTime();
+
                 let scheduleClass = 'schedule-item';
                 if (isToday) scheduleClass += ' today';
                 else if (isPast) scheduleClass += ' past';
                 else scheduleClass += ' upcoming';
-                
+
+                const statusLabel = (schedule.status || 'upcoming').toLowerCase();
+                const shiftSlotLabel = schedule.shiftSlot || schedule.skill || 'Scheduled Shift';
+
                 schedulesHtml += `
                     <div class="${scheduleClass}">
                         <div class="schedule-header-row">
                             <div>
                                 <div class="schedule-date">${scheduleDate.toLocaleDateString()}</div>
-                                <div class="schedule-time">${schedule.startTime} - ${schedule.endTime}</div>
-                                <div class="text-muted">${schedule.shiftSlot}</div>
+                                <div class="schedule-time">${schedule.startTime || '00:00'} - ${schedule.endTime || ''}</div>
+                                <div class="text-muted">${shiftSlotLabel}</div>
                             </div>
-                            <span class="schedule-status ${schedule.status}">${schedule.status}</span>
+                            <span class="schedule-status ${statusLabel}">${statusLabel.toUpperCase()}</span>
                         </div>
                         <div class="schedule-actions">
                             <button class="btn btn-sm btn-secondary" onclick="viewShiftDetails('${schedule.id}')">
                                 <i class="fas fa-eye"></i> Details
                             </button>
-                            ${schedule.status === 'active' && !isPast ? `
+                            ${(statusLabel === 'active' || statusLabel === 'upcoming') && !isPast ? `
                                 <button class="btn btn-sm btn-warning" onclick="requestShiftSwap('${schedule.id}')">
                                     <i class="fas fa-exchange-alt"></i> Request Swap
                                 </button>
@@ -1115,36 +1185,47 @@
         function populateMyShifts(schedules) {
             const select = document.getElementById('myShiftSelect');
             select.innerHTML = '<option value="">Select your shift to swap</option>';
-            
+
             // Only show upcoming shifts that are active
-            const upcomingShifts = schedules.filter(s => 
-                new Date(s.date) > new Date() && s.status === 'active'
+            const upcomingShifts = schedules.filter(s =>
+                (() => {
+                    const startDate = s.startDateTime ? new Date(s.startDateTime) : (s.dateIso ? new Date(s.dateIso) : new Date(s.date));
+                    const validDate = startDate && !isNaN(startDate);
+                    const isFuture = validDate ? startDate > new Date() : false;
+                    const statusLabel = (s.status || '').toLowerCase();
+                    return isFuture && (statusLabel === 'active' || statusLabel === 'upcoming');
+                })()
             );
-            
+
             upcomingShifts.forEach(shift => {
                 const option = document.createElement('option');
                 option.value = shift.id;
-                option.textContent = `${new Date(shift.date).toLocaleDateString()} - ${shift.startTime}-${shift.endTime} (${shift.shiftSlot})`;
+                const startDate = shift.startDateTime ? new Date(shift.startDateTime) : (shift.dateIso ? new Date(shift.dateIso) : new Date(shift.date));
+                const startLabel = startDate && !isNaN(startDate) ? startDate.toLocaleDateString() : shift.date || 'Upcoming';
+                option.textContent = `${startLabel} - ${shift.startTime || ''}${shift.endTime ? `-${shift.endTime}` : ''} (${shift.shiftSlot || shift.skill || 'Shift'})`;
                 select.appendChild(option);
             });
         }
 
         function filterSchedules(filter) {
             console.log('Filtering schedules by:', filter);
-            
+
             let filteredSchedules = [...agentSchedules];
             const now = new Date();
-            
+
             switch(filter) {
                 case 'upcoming':
-                    filteredSchedules = agentSchedules.filter(s => new Date(s.date) > now);
+                    filteredSchedules = agentSchedules.filter(s => {
+                        const startDate = s.startDateTime ? new Date(s.startDateTime) : (s.dateIso ? new Date(s.dateIso) : new Date(s.date));
+                        return startDate && !isNaN(startDate) && startDate > now;
+                    });
                     break;
                 case 'this-week':
                     const endOfWeek = new Date(now);
                     endOfWeek.setDate(now.getDate() + (7 - now.getDay()));
                     filteredSchedules = agentSchedules.filter(s => {
-                        const date = new Date(s.date);
-                        return date >= now && date <= endOfWeek;
+                        const date = s.startDateTime ? new Date(s.startDateTime) : (s.dateIso ? new Date(s.dateIso) : new Date(s.date));
+                        return date && !isNaN(date) && date >= now && date <= endOfWeek;
                     });
                     break;
                 case 'next-week':
@@ -1153,40 +1234,64 @@
                     const endOfNextWeek = new Date(startOfNextWeek);
                     endOfNextWeek.setDate(startOfNextWeek.getDate() + 6);
                     filteredSchedules = agentSchedules.filter(s => {
-                        const date = new Date(s.date);
-                        return date >= startOfNextWeek && date <= endOfNextWeek;
+                        const date = s.startDateTime ? new Date(s.startDateTime) : (s.dateIso ? new Date(s.dateIso) : new Date(s.date));
+                        return date && !isNaN(date) && date >= startOfNextWeek && date <= endOfNextWeek;
                     });
                     break;
             }
-            
+
             displaySchedules(filteredSchedules);
         }
 
         function loadSwapRequests() {
             console.log('Loading swap requests...');
-            
+
             const container = document.getElementById('mySwapRequests');
             container.innerHTML = '<div class="loading-spinner"><div class="spinner"></div><span style="margin-left: 1rem;">Loading swap requests...</span></div>';
-            
+
+            if (!currentAgent || !currentAgent.id) {
+                showAlert('Agent information is missing. Please refresh.', 'warning');
+                container.innerHTML = '';
+                return;
+            }
+
+            const payloadOptions = {
+                agentId: currentAgent.id,
+                windowDays: 90
+            };
+            if (currentAgent.campaignId) {
+                payloadOptions.campaignId = currentAgent.campaignId;
+            }
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleSwapRequestsLoaded)
                     .withFailureHandler(handleError)
-                    .getAgentSwapRequests(currentAgent.id);
+                    .clientGetAgentSwapRequests(currentAgent.id, payloadOptions);
             } else {
                 setTimeout(() => {
-                    handleSwapRequestsLoaded([]);
-                }, 1000);
+                    handleSwapRequestsLoaded({ success: true, requests: [] });
+                }, 500);
             }
         }
 
-        function handleSwapRequestsLoaded(requests) {
+        function handleSwapRequestsLoaded(response) {
+            const isError = response && response.success === false;
+            const requests = Array.isArray(response)
+                ? response
+                : Array.isArray(response?.requests) ? response.requests : [];
+
+            if (isError) {
+                console.warn('Swap requests unavailable:', response && response.error);
+                showAlert(response && response.error ? response.error : 'Unable to load swap requests.', 'warning');
+            }
+
             console.log('Swap requests loaded:', requests);
-            
+
             agentSwapRequests = requests;
-            
+
             const container = document.getElementById('mySwapRequests');
-            
+
             if (requests.length === 0) {
                 container.innerHTML = `
                     <div class="empty-state">
@@ -1195,14 +1300,17 @@
                         <p>You haven't made any shift swap requests yet.</p>
                     </div>
                 `;
+                loadAvailableAgents();
                 return;
             }
-            
+
             let requestsHtml = '';
             requests.forEach(request => {
-                const statusClass = request.status === 'pending' ? 'warning' : 
-                                   request.status === 'approved' ? 'success' : 'danger';
-                
+                const status = (request.status || '').toLowerCase();
+                const statusClass = status === 'pending' ? 'warning' :
+                                   status === 'approved' ? 'success' :
+                                   status === 'cancelled' ? 'secondary' : 'danger';
+
                 requestsHtml += `
                     <div class="card mb-3">
                         <div class="card-body">
@@ -1210,19 +1318,19 @@
                                 <div>
                                     <h6>Swap Request with ${request.swapWithName}</h6>
                                     <p class="mb-1">
-                                        <strong>Your shift:</strong> ${new Date(request.myShiftDate).toLocaleDateString()} ${request.myShiftTime}
+                                        <strong>Your shift:</strong> ${request.myShiftDate ? new Date(request.myShiftDate).toLocaleDateString() : 'TBD'} ${request.myShiftTime || ''}
                                     </p>
                                     ${request.theirShiftDate ? `
                                         <p class="mb-1">
-                                            <strong>Their shift:</strong> ${new Date(request.theirShiftDate).toLocaleDateString()} ${request.theirShiftTime}
+                                            <strong>Their shift:</strong> ${new Date(request.theirShiftDate).toLocaleDateString()} ${request.theirShiftTime || ''}
                                         </p>
                                     ` : ''}
                                     <p class="mb-1"><strong>Reason:</strong> ${request.reason}</p>
-                                    <small class="text-muted">Requested: ${new Date(request.requestedAt).toLocaleDateString()}</small>
+                                    <small class="text-muted">Requested: ${request.requestedAt ? new Date(request.requestedAt).toLocaleDateString() : 'Pending'}</small>
                                 </div>
-                                <span class="badge bg-${statusClass}">${request.status.toUpperCase()}</span>
+                                <span class="badge bg-${statusClass}">${status.toUpperCase()}</span>
                             </div>
-                            ${request.status === 'pending' ? `
+                            ${status === 'pending' ? `
                                 <div class="mt-2">
                                     <button class="btn btn-sm btn-danger" onclick="cancelSwapRequest('${request.id}')">
                                         <i class="fas fa-times"></i> Cancel Request
@@ -1233,26 +1341,43 @@
                     </div>
                 `;
             });
-            
+
             container.innerHTML = requestsHtml;
-            
+
             // Load available agents for new swap requests
             loadAvailableAgents();
         }
 
         function loadAvailableAgents() {
+            if (!currentAgent || !currentAgent.id) {
+                return;
+            }
+
+            const options = {
+                agentId: currentAgent.id
+            };
+            if (currentAgent.campaignId) {
+                options.campaignId = currentAgent.campaignId;
+            }
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleAvailableAgentsLoaded)
                     .withFailureHandler(handleError)
-                    .getAvailableAgents();
+                    .clientGetAvailableSwapAgents(currentAgent.id, options);
+            } else {
+                handleAvailableAgentsLoaded({ success: true, agents: [] });
             }
         }
 
-        function handleAvailableAgentsLoaded(agents) {
+        function handleAvailableAgentsLoaded(response) {
+            const agents = Array.isArray(response)
+                ? response
+                : Array.isArray(response?.agents) ? response.agents : [];
+
             const select = document.getElementById('swapWithAgent');
             select.innerHTML = '<option value="">Select agent to swap with</option>';
-            
+
             // Filter out current agent
             const availableAgents = agents.filter(a => a.id !== currentAgent.id);
             
@@ -1269,23 +1394,40 @@
                 document.getElementById('theirShiftSelect').innerHTML = '<option value="">Select their shift (or leave blank)</option>';
                 return;
             }
-            
+
+            const options = { agentId, limit: 10 };
+            if (currentAgent && currentAgent.campaignId) {
+                options.campaignId = currentAgent.campaignId;
+            }
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleAgentShiftsLoaded)
                     .withFailureHandler(handleError)
-                    .getAgentUpcomingShifts(agentId);
+                    .clientGetAgentUpcomingShifts(agentId, options);
+            } else {
+                handleAgentShiftsLoaded({ success: true, shifts: [] });
             }
         }
 
-        function handleAgentShiftsLoaded(shifts) {
+        function handleAgentShiftsLoaded(response) {
             const select = document.getElementById('theirShiftSelect');
             select.innerHTML = '<option value="">Select their shift (or leave blank)</option>';
-            
+
+            const shifts = Array.isArray(response)
+                ? response
+                : Array.isArray(response?.shifts) ? response.shifts : [];
+
+            if (!shifts || shifts.length === 0) {
+                return;
+            }
+
             shifts.forEach(shift => {
                 const option = document.createElement('option');
                 option.value = shift.id;
-                option.textContent = `${new Date(shift.date).toLocaleDateString()} - ${shift.startTime}-${shift.endTime} (${shift.shiftSlot})`;
+                const startDate = shift.startDateTime ? new Date(shift.startDateTime) : (shift.dateIso ? new Date(shift.dateIso) : new Date(shift.date));
+                const startLabel = startDate && !isNaN(startDate) ? startDate.toLocaleDateString() : shift.date || 'Upcoming';
+                option.textContent = `${startLabel} - ${shift.startTime || ''}${shift.endTime ? `-${shift.endTime}` : ''} (${shift.shiftSlot || shift.skill || 'Shift'})`;
                 select.appendChild(option);
             });
         }
@@ -1441,38 +1583,51 @@
         }
 
         function submitSwapRequest() {
-            const swapRequest = {
-                myShift: document.getElementById('myShiftSelect').value,
-                swapWithAgent: document.getElementById('swapWithAgent').value,
-                theirShift: document.getElementById('theirShiftSelect').value,
-                reason: document.getElementById('swapReason').value
-            };
-            
-            if (!swapRequest.myShift || !swapRequest.swapWithAgent || !swapRequest.reason) {
-                showAlert('Please fill in all required fields', 'warning');
+            if (!currentAgent || !currentAgent.id) {
+                showAlert('Agent data not available. Please refresh.', 'warning');
                 return;
             }
-            
+
+            const swapRequest = {
+                myShiftId: document.getElementById('myShiftSelect').value,
+                swapWith: document.getElementById('swapWithAgent').value,
+                theirShiftId: document.getElementById('theirShiftSelect').value,
+                reason: document.getElementById('swapReason').value.trim()
+            };
+
+            if (!swapRequest.myShiftId || !swapRequest.swapWith || !swapRequest.reason) {
+                showAlert('Please select your shift, a teammate, and provide a reason.', 'warning');
+                return;
+            }
+
+            const hasShift = agentSchedules.some(shift => shift.id === swapRequest.myShiftId);
+            if (!hasShift) {
+                showAlert('The selected shift could not be found. Please refresh and try again.', 'warning');
+                return;
+            }
+
             console.log('Submitting swap request:', swapRequest);
-            
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleSwapRequestSubmitted)
                     .withFailureHandler(handleError)
-                    .submitShiftSwapRequest(currentAgent.id, swapRequest);
+                    .clientSubmitShiftSwapRequest(currentAgent.id, Object.assign({}, swapRequest, {
+                        campaignId: currentAgent.campaignId || null
+                    }));
             } else {
                 setTimeout(() => {
-                    handleSwapRequestSubmitted({ success: true });
-                }, 1000);
+                    handleSwapRequestSubmitted({ success: true, request: Object.assign({}, swapRequest, { id: Date.now() }) });
+                }, 500);
             }
         }
 
         function handleSwapRequestSubmitted(result) {
-            if (result.success) {
+            if (result && result.success) {
                 showAlert('Swap request submitted successfully! You will be notified when it is processed.', 'success');
                 bootstrap.Modal.getInstance(document.getElementById('swapRequestModal')).hide();
                 document.getElementById('swapRequestForm').reset();
-                
+
                 // Refresh swap requests
                 loadSwapRequests();
             } else {
@@ -1484,14 +1639,14 @@
             if (!confirm('Are you sure you want to cancel this swap request?')) {
                 return;
             }
-            
+
             console.log('Cancelling swap request:', requestId);
-            
+
             if (typeof google !== 'undefined' && google.script && google.script.run) {
                 google.script.run
                     .withSuccessHandler(handleSwapRequestCancelled)
                     .withFailureHandler(handleError)
-                    .cancelShiftSwapRequest(requestId);
+                    .clientCancelShiftSwapRequest(requestId, currentAgent?.id || null);
             } else {
                 setTimeout(() => {
                     handleSwapRequestCancelled({ success: true });
@@ -1500,7 +1655,7 @@
         }
 
         function handleSwapRequestCancelled(result) {
-            if (result.success) {
+            if (result && result.success) {
                 showAlert('Swap request cancelled successfully', 'success');
                 loadSwapRequests();
             } else {

--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -568,30 +568,57 @@
 
         <!-- AI Dashboard Tab -->
         <div class="tab-pane fade show active" id="dashboard" role="tabpanel">
-            <!-- Metrics Row -->
+            <!-- Schedule Health Metrics -->
+            <div class="row g-4 mb-4">
+                <div class="col-xl-3 col-sm-6">
+                    <div class="metric-card">
+                        <div class="metric-number text-primary" id="scheduleHealthScore">0</div>
+                        <div class="metric-label">Schedule Health</div>
+                    </div>
+                </div>
+                <div class="col-xl-3 col-sm-6">
+                    <div class="metric-card">
+                        <div class="metric-number text-success" id="scheduleServiceLevel">0%</div>
+                        <div class="metric-label">Service Level</div>
+                    </div>
+                </div>
+                <div class="col-xl-3 col-sm-6">
+                    <div class="metric-card">
+                        <div class="metric-number text-warning" id="scheduleFairnessIndex">0</div>
+                        <div class="metric-label">Fairness Index</div>
+                    </div>
+                </div>
+                <div class="col-xl-3 col-sm-6">
+                    <div class="metric-card">
+                        <div class="metric-number text-info" id="scheduleComplianceScore">0</div>
+                        <div class="metric-label">Compliance Score</div>
+                    </div>
+                </div>
+            </div>
+
             <div class="row g-4 mb-4">
                 <div class="col-lg-3 col-sm-6">
                     <div class="metric-card">
                         <div class="metric-number text-primary" id="totalUsers">0</div>
-                        <div class="metric-label">Total Users</div>
+                        <div class="metric-label">Managed Agents</div>
                     </div>
                 </div>
                 <div class="col-lg-3 col-sm-6">
                     <div class="metric-card">
-                        <div class="metric-number text-success" id="attendanceRate">0%</div>
-                        <div class="metric-label">Attendance Rate</div>
+                        <div class="metric-number text-info" id="scheduleRosterHours">0h</div>
+                        <div class="metric-label">Scheduled Hours</div>
                     </div>
                 </div>
                 <div class="col-lg-3 col-sm-6">
                     <div class="metric-card">
-                        <div class="metric-number text-primary" id="totalSchedules">0</div>
-                        <div class="metric-label">Active Schedules</div>
+                        <div class="metric-number text-primary" id="scheduleRequiredFte">0</div>
+                        <div class="metric-label">Required FTE</div>
                     </div>
                 </div>
                 <div class="col-lg-3 col-sm-6">
                     <div class="metric-card">
-                        <div class="metric-number text-info" id="totalSlots">0</div>
-                        <div class="metric-label">Shift Slots</div>
+                        <div class="metric-number text-primary" id="scheduleStaffedFte">0</div>
+                        <div class="metric-label">Staffed FTE</div>
                     </div>
                 </div>
             </div>
@@ -603,7 +630,7 @@
                         <div class="modern-card-header">
                             <h5 class="modern-card-title">
                                 <i class="fas fa-chart-line text-primary"></i>
-                                Attendance Trends
+                                Coverage vs Requirement
                             </h5>
                             <button class="btn btn-outline-modern btn-sm" onclick="refreshDashboard()">
                                 <i class="fas fa-sync"></i>
@@ -612,7 +639,7 @@
                         </div>
                         <div class="modern-card-body p-0">
                             <div class="chart-container">
-                                <canvas id="attendanceChart"></canvas>
+                                <canvas id="scheduleCoverageChart"></canvas>
                             </div>
                         </div>
                     </div>
@@ -621,15 +648,15 @@
                     <div class="modern-card h-100">
                         <div class="modern-card-header">
                             <h5 class="modern-card-title">
-                                <i class="fas fa-robot text-info"></i>
-                                AI Insights
+                                <i class="fas fa-lightbulb text-info"></i>
+                                Optimizer Insights
                             </h5>
                         </div>
                         <div class="modern-card-body">
-                            <div id="aiInsights">
+                            <div id="scheduleInsights">
                                 <div class="text-center text-muted">
                                     <div class="loading-spinner mx-auto mb-3"></div>
-                                    <p>Analyzing patterns...</p>
+                                    <p>Analyzing schedule health...</p>
                                 </div>
                             </div>
                         </div>
@@ -643,14 +670,14 @@
                     <div class="modern-card">
                         <div class="modern-card-header">
                             <h5 class="modern-card-title">
-                                <i class="fas fa-trophy text-warning"></i>
-                                Top Performers
+                                <i class="fas fa-balance-scale text-warning"></i>
+                                Fairness Watchlist
                             </h5>
                         </div>
                         <div class="modern-card-body">
-                            <div id="topPerformers">
+                            <div id="fairnessWatchlist">
                                 <div class="text-center text-muted">
-                                    <p>Loading performance data...</p>
+                                    <p>Evaluating rotation balance...</p>
                                 </div>
                             </div>
                         </div>
@@ -660,15 +687,15 @@
                     <div class="modern-card">
                         <div class="modern-card-header">
                             <h5 class="modern-card-title">
-                                <i class="fas fa-exclamation-triangle text-warning"></i>
-                                Alerts
+                                <i class="fas fa-shield-alt text-danger"></i>
+                                Compliance Alerts
                             </h5>
                         </div>
                         <div class="modern-card-body">
-                            <div id="attendanceAlerts">
+                            <div id="complianceAlerts">
                                 <div class="text-center text-success">
                                     <i class="fas fa-check-circle fa-2x mb-2"></i>
-                                    <p>No issues detected</p>
+                                    <p>No compliance issues detected</p>
                                 </div>
                             </div>
                         </div>
@@ -1653,7 +1680,7 @@
                 this.currentUser = window.user || window.currentUser || window.CURRENT_USER || {};
                 this.availableUsers = [];
                 this.availableCampaigns = [];
-                this.attendanceChart = null;
+                this.coverageChart = null;
                 this.pendingImportSchedules = [];
                 this.pendingImportSummary = null;
                 this.lastImportResult = null;
@@ -2150,7 +2177,10 @@
                     const slots = await this.callServerFunction('clientGetAllShiftSlots');
 
                     this.displayShiftSlots(Array.isArray(slots) ? slots : []);
-                    document.getElementById('totalSlots').textContent = Array.isArray(slots) ? slots.length : 0;
+                    const totalSlotsElement = document.getElementById('totalSlots');
+                    if (totalSlotsElement) {
+                        totalSlotsElement.textContent = Array.isArray(slots) ? slots.length : 0;
+                    }
 
                     console.log(`✅ Loaded ${Array.isArray(slots) ? slots.length : 0} shift slots`);
                 } catch (error) {
@@ -2206,79 +2236,138 @@
             async refreshDashboard() {
                 try {
                     console.log('📊 Refreshing dashboard...');
+                    await this.ensureScheduleContext();
+
                     const endDate = new Date();
                     const startDate = new Date();
-                    startDate.setDate(endDate.getDate() - 30); // Last 30 days
+                    startDate.setDate(endDate.getDate() - 30);
 
-                    const dashboard = await this.callServerFunction('clientGetAttendanceDashboard',
-                        startDate.toISOString().split('T')[0],
-                        endDate.toISOString().split('T')[0]
-                    );
+                    const managerId = this.getCurrentUserId();
+                    const campaignId = this.resolvedCampaignId || this.getCurrentCampaignId();
+                    const options = {
+                        startDate: startDate.toISOString().split('T')[0],
+                        endDate: endDate.toISOString().split('T')[0],
+                        intervalMinutes: 30,
+                        openingHour: 8,
+                        closingHour: 21
+                    };
+
+                    const dashboard = await this.callServerFunction('clientGetScheduleDashboard', managerId, campaignId || null, options);
 
                     if (dashboard && dashboard.success) {
-                        this.updateDashboardMetrics(dashboard.dashboard);
-                        this.updateAttendanceChart(dashboard.dashboard.trends);
-                        this.displayAIInsights(dashboard.dashboard.insights);
-                        this.displayTopPerformers(dashboard.dashboard.userStats);
-                        this.displayAttendanceAlerts(dashboard.dashboard.insights);
+                        this.updateScheduleMetrics(dashboard);
+                        this.renderCoverageChart(dashboard.coverage);
+                        this.renderScheduleInsights(dashboard);
+                        this.renderFairnessWatchlist(dashboard.fairness);
+                        this.renderComplianceAlerts(dashboard.compliance);
+                    } else {
+                        throw new Error(dashboard && dashboard.error ? dashboard.error : 'Unknown dashboard error');
                     }
 
                 } catch (error) {
                     console.error('❌ Error refreshing dashboard:', error);
-                    this.displayAIInsights([{
-                        type: 'warning',
-                        category: 'System',
-                        message: 'Unable to load dashboard data. Please check system configuration.',
-                        priority: 'high'
-                    }]);
+                    this.renderScheduleInsights({
+                        recommendations: [`Unable to load schedule dashboard: ${error.message || error}`]
+                    });
+                    this.renderCoverageChart(null);
+                    this.renderFairnessWatchlist(null);
+                    this.renderComplianceAlerts(null);
                 }
             }
 
-            updateDashboardMetrics(dashboard) {
-                if (dashboard.metrics) {
-                    document.getElementById('attendanceRate').textContent = dashboard.metrics.attendanceRate + '%';
-                }
+            updateScheduleMetrics(dashboard) {
+                const summary = dashboard && dashboard.summary ? dashboard.summary : {};
+                const totals = dashboard && dashboard.totals ? dashboard.totals : {};
+                const fairness = dashboard && dashboard.fairness ? dashboard.fairness : {};
+                const compliance = dashboard && dashboard.compliance ? dashboard.compliance : {};
+
+                const setText = (id, value) => {
+                    const element = document.getElementById(id);
+                    if (element) {
+                        element.textContent = value;
+                    }
+                };
+
+                setText('scheduleHealthScore', `${Math.round(dashboard.healthScore || 0)}`);
+                setText('scheduleServiceLevel', `${Math.round(summary.serviceLevel || 0)}%`);
+                setText('scheduleFairnessIndex', `${Math.round(summary.fairnessIndex || fairness.fairnessIndex || 0)}`);
+                setText('scheduleComplianceScore', `${Math.round(summary.complianceScore || compliance.complianceScore || 0)}`);
+                setText('scheduleRosterHours', `${Number(totals.rosterHours || 0).toFixed(1)}h`);
+                setText('scheduleRequiredFte', Number(totals.requiredFTE || 0).toFixed(1));
+                setText('scheduleStaffedFte', Number(totals.staffedFTE || 0).toFixed(1));
+                setText('totalUsers', String(dashboard.roster?.agentCount || this.availableUsers.length || 0));
             }
 
-            updateAttendanceChart(trends) {
-                const ctx = document.getElementById('attendanceChart')?.getContext('2d');
-                if (!ctx || !trends) return;
+            renderCoverageChart(coverage) {
+                const canvas = document.getElementById('scheduleCoverageChart');
+                if (!canvas) return;
 
-                if (this.attendanceChart) {
-                    this.attendanceChart.destroy();
+                const ctx = canvas.getContext('2d');
+                const container = canvas.parentElement;
+                if (this.coverageChart) {
+                    this.coverageChart.destroy();
+                    this.coverageChart = null;
                 }
 
-                const dailyTrends = trends.daily || [];
+                const placeholder = container.querySelector('.coverage-no-data');
+                if (placeholder) {
+                    placeholder.remove();
+                }
 
-                this.attendanceChart = new Chart(ctx, {
-                    type: 'line',
+                if (!coverage || !Array.isArray(coverage.intervalSummaries) || coverage.intervalSummaries.length === 0) {
+                    canvas.style.display = 'none';
+                    const message = document.createElement('div');
+                    message.className = 'coverage-no-data p-4 text-center text-muted';
+                    message.innerHTML = '<i class="fas fa-info-circle mb-2"></i><p class="mb-0">No coverage data available for the selected range.</p>';
+                    container.appendChild(message);
+                    return;
+                }
+
+                canvas.style.display = 'block';
+
+                const sortedIntervals = coverage.intervalSummaries.slice().sort((a, b) => a.intervalKey.localeCompare(b.intervalKey));
+                const sample = sortedIntervals.slice(0, 24);
+                const labels = sample.map(item => item.intervalKey.slice(5));
+                const required = sample.map(item => Number(item.requiredFTE || 0));
+                const staffed = sample.map(item => Number(item.staffedFTE || 0));
+
+                this.coverageChart = new Chart(ctx, {
+                    type: 'bar',
                     data: {
-                        labels: dailyTrends.map(d => d.date),
-                        datasets: [{
-                            label: 'Attendance Rate (%)',
-                            data: dailyTrends.map(d => d.attendanceRate),
-                            borderColor: 'rgb(0, 82, 204)',
-                            backgroundColor: 'rgba(0, 82, 204, 0.1)',
-                            tension: 0.4,
-                            fill: true
-                        }]
+                        labels,
+                        datasets: [
+                            {
+                                label: 'Required FTE',
+                                data: required,
+                                backgroundColor: 'rgba(0, 82, 204, 0.35)'
+                            },
+                            {
+                                label: 'Staffed FTE',
+                                data: staffed,
+                                backgroundColor: 'rgba(0, 150, 57, 0.6)'
+                            }
+                        ]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
                         plugins: {
                             legend: {
-                                display: false
+                                display: true
                             }
                         },
                         scales: {
                             y: {
                                 beginAtZero: true,
-                                max: 100,
                                 ticks: {
-                                    callback: function(value) {
-                                        return value + '%';
-                                    }
+                                    callback: value => `${value}`
+                                }
+                            },
+                            x: {
+                                ticks: {
+                                    maxRotation: 0,
+                                    autoSkip: true,
+                                    maxTicksLimit: 12
                                 }
                             }
                         }
@@ -2286,79 +2375,125 @@
                 });
             }
 
-            displayAIInsights(insights) {
-                const container = document.getElementById('aiInsights');
+            renderScheduleInsights(dashboard) {
+                const container = document.getElementById('scheduleInsights');
                 if (!container) return;
 
-                if (!insights || insights.length === 0) {
+                const recommendations = dashboard && Array.isArray(dashboard.recommendations) ? dashboard.recommendations : [];
+                const coverage = dashboard && dashboard.coverage ? dashboard.coverage : null;
+                const fairness = dashboard && dashboard.fairness ? dashboard.fairness : null;
+                const compliance = dashboard && dashboard.compliance ? dashboard.compliance : null;
+
+                const insights = recommendations.slice(0, 5).map(message => ({ type: 'insight', message }));
+
+                if (coverage && Array.isArray(coverage.backlogRiskIntervals) && coverage.backlogRiskIntervals.length) {
+                    const interval = coverage.backlogRiskIntervals[0];
+                    insights.unshift({
+                        type: 'coverage',
+                        message: `Most under-staffed window: ${interval.intervalKey} (${interval.deficit.toFixed(2)} FTE deficit)`
+                    });
+                }
+
+                if (fairness && fairness.rotationHealth < 75) {
+                    insights.push({
+                        type: 'fairness',
+                        message: `Fairness rotation health at ${Math.round(fairness.rotationHealth)}. Consider rebalancing weekends.`
+                    });
+                }
+
+                if (compliance && compliance.totalViolations > 0) {
+                    insights.push({
+                        type: 'compliance',
+                        message: `${compliance.totalViolations} potential compliance issues detected. Review the alerts panel.`
+                    });
+                }
+
+                if (insights.length === 0) {
                     container.innerHTML = `
-                            <div class="text-center text-muted py-4">
-                                <i class="fas fa-brain fa-2x mb-3 opacity-50"></i>
-                                <p>No insights available yet.</p>
-                                <p class="small">Start tracking attendance to see AI-powered insights.</p>
-                            </div>
-                        `;
+                        <div class="text-center text-muted py-4">
+                            <i class="fas fa-lightbulb fa-2x mb-3 opacity-50"></i>
+                            <p>Schedule health looks great! No actions required right now.</p>
+                        </div>
+                    `;
                     return;
                 }
 
-                container.innerHTML = insights.slice(0, 5).map(insight => `
-                        <div class="insight-card insight-${insight.type}">
-                            <div class="d-flex align-items-start gap-2">
-                                <i class="fas fa-${this.getInsightIcon(insight.type)}"></i>
-                                <div class="flex-grow-1">
-                                    <h6 class="mb-1">${insight.category}</h6>
-                                    <p class="mb-0 small">${insight.message}</p>
-                                </div>
-                            </div>
+                container.innerHTML = insights.slice(0, 6).map(insight => `
+                    <div class="insight-card insight-${insight.type}">
+                        <div class="d-flex align-items-start gap-2">
+                            <i class="fas fa-${this.getInsightIcon(insight.type)}"></i>
+                            <div class="flex-grow-1 small">${insight.message}</div>
                         </div>
-                    `).join('');
+                    </div>
+                `).join('');
             }
 
-            displayTopPerformers(userStats) {
-                const container = document.getElementById('topPerformers');
+            renderFairnessWatchlist(fairness) {
+                const container = document.getElementById('fairnessWatchlist');
                 if (!container) return;
 
-                if (!userStats || userStats.length === 0) {
-                    container.innerHTML = '<p class="text-muted py-4">No performance data available yet.</p>';
+                if (!fairness || !Array.isArray(fairness.agentSummaries) || fairness.agentSummaries.length === 0) {
+                    container.innerHTML = '<p class="text-muted py-4">No fairness data available yet.</p>';
                     return;
                 }
 
-                const topPerformers = userStats.slice(0, 5);
+                const watchlist = fairness.agentSummaries
+                    .slice()
+                    .sort((a, b) => (a.fairnessScore || 0) - (b.fairnessScore || 0))
+                    .slice(0, 5);
 
-                container.innerHTML = topPerformers.map((user, index) => `
-                        <div class="d-flex justify-content-between align-items-center mb-2 p-2 border-bottom">
-                            <div>
-                                <span class="badge bg-primary me-2">${index + 1}</span>
-                                <strong>${user.userName}</strong>
-                            </div>
-                            <div class="text-end">
-                                <span class="badge bg-success">${user.attendanceRate}%</span>
-                            </div>
+                container.innerHTML = watchlist.map(agent => `
+                    <div class="d-flex justify-content-between align-items-center mb-2 p-2 border-bottom">
+                        <div>
+                            <strong>${agent.userName || agent.userId}</strong>
+                            <div class="small text-muted">Weekend: ${agent.weekendShifts || 0} • Night: ${agent.nightShifts || 0}</div>
                         </div>
-                    `).join('');
+                        <div class="text-end">
+                            <span class="badge bg-warning text-dark">${Math.round(agent.fairnessScore || 0)}</span>
+                        </div>
+                    </div>
+                `).join('');
             }
 
-            displayAttendanceAlerts(insights) {
-                const container = document.getElementById('attendanceAlerts');
+            renderComplianceAlerts(compliance) {
+                const container = document.getElementById('complianceAlerts');
                 if (!container) return;
 
-                const alerts = insights.filter(i => i.priority === 'high' || i.priority === 'critical');
-
-                if (alerts.length === 0) {
+                if (!compliance || !Array.isArray(compliance.violationDetails) || compliance.violationDetails.length === 0) {
                     container.innerHTML = `
-                            <div class="text-center text-success py-4">
-                                <i class="fas fa-check-circle fa-2x mb-2"></i>
-                                <p>No attendance issues detected.</p>
-                            </div>
-                        `;
+                        <div class="text-center text-success py-4">
+                            <i class="fas fa-check-circle fa-2x mb-2"></i>
+                            <p>No compliance issues detected</p>
+                        </div>
+                    `;
                     return;
                 }
 
-                container.innerHTML = alerts.map(alert => `
-                        <div class="alert alert-${alert.priority === 'critical' ? 'danger' : 'warning'}-modern mb-2">
-                            <strong>${alert.category}:</strong> ${alert.message}
+                const alerts = compliance.violationDetails.slice(0, 5);
+                container.innerHTML = alerts.map(alert => {
+                    const severity = alert.type === 'SHIFT_DURATION' || alert.type === 'REST_PERIOD' ? 'danger' : 'warning';
+                    const message = (() => {
+                        if (alert.message) return alert.message;
+                        switch (alert.type) {
+                            case 'SHIFT_DURATION':
+                                return `Scheduled ${Number(alert.scheduledHours || 0).toFixed(2)}h (limit ${alert.maxHoursPerDay || 12}h)`;
+                            case 'REST_PERIOD':
+                                return `Rest ${Number(alert.restHours || 0).toFixed(2)}h (required ${alert.requiredRestHours || 10}h)`;
+                            case 'CONSECUTIVE_DAYS':
+                                return `${alert.consecutiveDays || '?'} consecutive days (max ${alert.maxConsecutiveDays || 6})`;
+                            case 'MISSING_BREAK':
+                                return `Missing required break on ${alert.date || 'scheduled day'}`;
+                            default:
+                                return 'Review schedule details for compliance adjustments.';
+                        }
+                    })();
+
+                    return `
+                        <div class="alert alert-${severity}-modern mb-2">
+                            <strong>${alert.type.replace('_', ' ')}:</strong> ${alert.userName || alert.userId || 'Agent'} - ${message}
                         </div>
-                    `).join('');
+                    `;
+                }).join('');
             }
 
             async generateSchedules() {
@@ -4894,6 +5029,10 @@
 
             getInsightIcon(type) {
                 switch (type) {
+                    case 'coverage': return 'chart-area';
+                    case 'fairness': return 'balance-scale';
+                    case 'compliance': return 'shield-alt';
+                    case 'insight': return 'lightbulb';
                     case 'positive': return 'thumbs-up';
                     case 'warning': return 'exclamation-triangle';
                     case 'critical': return 'exclamation-circle';

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -226,6 +226,203 @@ function filterUsersByCampaign(users, campaignId) {
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Resolve the active schedule context for the requesting user or manager.
+ * Provides manager/campaign identifiers, identity metadata, and managed roster.
+ */
+function clientGetScheduleContext(managerIdCandidate, campaignIdCandidate) {
+  const providedManagerId = normalizeUserIdValue(managerIdCandidate);
+  const providedCampaignId = normalizeCampaignIdValue(campaignIdCandidate);
+  const timestamp = new Date().toISOString();
+
+  const context = {
+    success: false,
+    providedManagerId,
+    providedCampaignId,
+    managerId: '',
+    campaignId: '',
+    user: null,
+    managedUserIds: [],
+    managedUserCount: 0,
+    managedCampaigns: [],
+    identity: null,
+    authenticated: false,
+    timestamp
+  };
+
+  try {
+    const allUsers = readSheet(USERS_SHEET) || [];
+    const usersById = new Map();
+    const usersByUsername = new Map();
+
+    allUsers.forEach(user => {
+      if (!user || typeof user !== 'object') {
+        return;
+      }
+
+      const normalizedId = normalizeUserIdValue(user.ID);
+      if (normalizedId) {
+        usersById.set(normalizedId, user);
+      }
+
+      const normalizedUsername = normalizeUserIdValue(user.UserName || user.Username);
+      if (normalizedUsername) {
+        const usernameKey = normalizedUsername.toLowerCase();
+        if (!usersByUsername.has(usernameKey)) {
+          usersByUsername.set(usernameKey, user);
+        }
+      }
+    });
+
+    const currentUser = (typeof getCurrentUser === 'function') ? getCurrentUser() : null;
+    const currentUserId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+
+    const managerIdSources = [];
+    let resolvedManagerId = providedManagerId;
+
+    if (resolvedManagerId) {
+      managerIdSources.push('parameter');
+    }
+
+    if (!resolvedManagerId && currentUserId) {
+      resolvedManagerId = currentUserId;
+      managerIdSources.push('current-user');
+    }
+
+    let resolvedManagerUser = resolvedManagerId ? usersById.get(resolvedManagerId) : null;
+
+    if (!resolvedManagerUser && resolvedManagerId) {
+      const key = resolvedManagerId.toLowerCase ? resolvedManagerId.toLowerCase() : String(resolvedManagerId || '').toLowerCase();
+      const usernameMatch = usersByUsername.get(key);
+      if (usernameMatch) {
+        resolvedManagerUser = usernameMatch;
+        resolvedManagerId = normalizeUserIdValue(usernameMatch.ID) || resolvedManagerId;
+        managerIdSources.push('username-match');
+      }
+    }
+
+    if (!resolvedManagerUser && currentUserId) {
+      resolvedManagerUser = usersById.get(currentUserId) || currentUser || null;
+    }
+
+    const campaignIdSources = [];
+    let resolvedCampaignId = providedCampaignId;
+
+    if (resolvedCampaignId) {
+      campaignIdSources.push('parameter');
+    }
+
+    const appendCampaignCandidate = (value, source) => {
+      if (resolvedCampaignId) {
+        return;
+      }
+      const normalized = normalizeCampaignIdValue(value);
+      if (normalized) {
+        resolvedCampaignId = normalized;
+        campaignIdSources.push(source);
+      }
+    };
+
+    appendCampaignCandidate(resolvedManagerUser && (resolvedManagerUser.CampaignID || resolvedManagerUser.campaignID || resolvedManagerUser.Campaign || resolvedManagerUser.campaign), 'manager-profile');
+    appendCampaignCandidate(currentUser && (currentUser.CampaignID || currentUser.campaignID || currentUser.Campaign || currentUser.campaign), 'current-user');
+
+    const managedSet = resolvedManagerId ? buildManagedUserSet(resolvedManagerId) : new Set();
+    const managedUserIds = Array.from(managedSet).map(normalizeUserIdValue).filter(Boolean);
+
+    let managedCampaigns = [];
+    try {
+      if (resolvedManagerId && typeof getUserManagedCampaigns === 'function') {
+        const campaigns = getUserManagedCampaigns(resolvedManagerId) || [];
+        managedCampaigns = campaigns
+          .filter(Boolean)
+          .map(campaign => ({
+            id: normalizeCampaignIdValue(campaign.ID || campaign.Id || campaign.id),
+            name: campaign.Name || campaign.name || '',
+            isPrimary: scheduleFlagToBool(campaign.IsPrimary || campaign.isPrimary)
+          }));
+
+        if (!resolvedCampaignId) {
+          const primary = managedCampaigns.find(campaign => campaign.isPrimary);
+          if (primary && primary.id) {
+            resolvedCampaignId = primary.id;
+            campaignIdSources.push('managed-campaign');
+          }
+        }
+      }
+    } catch (campaignError) {
+      console.warn('clientGetScheduleContext: unable to resolve managed campaigns', campaignError);
+    }
+
+    const roles = collectUserRoleCandidates(resolvedManagerUser || currentUser || {});
+    const normalizedRoles = roles
+      .map(role => String(role || '').trim())
+      .filter(Boolean);
+
+    const identity = {
+      authenticated: !!currentUserId,
+      resolvedAt: timestamp,
+      managerId: resolvedManagerId || '',
+      campaignId: resolvedCampaignId || '',
+      providedManagerId,
+      providedCampaignId,
+      managerIdSources,
+      campaignIdSources,
+      managedUserCount: managedUserIds.length,
+      roles: normalizedRoles,
+      isAdmin: scheduleFlagToBool((resolvedManagerUser && resolvedManagerUser.IsAdmin) || (currentUser && currentUser.IsAdmin)),
+      userId: currentUserId || resolvedManagerId || '',
+      userName: (currentUser && (currentUser.UserName || currentUser.Username)) || '',
+      fullName: (currentUser && (currentUser.FullName || currentUser.Name)) || '',
+      email: (currentUser && (currentUser.Email || currentUser.email)) || ''
+    };
+
+    const clientUser = Object.assign({}, resolvedManagerUser || currentUser || {}, {
+      ID: normalizeUserIdValue((resolvedManagerUser && resolvedManagerUser.ID) || (currentUser && currentUser.ID) || resolvedManagerId),
+      CampaignID: resolvedCampaignId || (resolvedManagerUser && resolvedManagerUser.CampaignID) || '',
+      Roles: normalizedRoles,
+      IsAdmin: identity.isAdmin,
+      managedUserCount: managedUserIds.length
+    });
+
+    if (!clientUser.UserName && clientUser.Username) {
+      clientUser.UserName = clientUser.Username;
+    }
+    if (!clientUser.FullName && clientUser.Name) {
+      clientUser.FullName = clientUser.Name;
+    }
+
+    context.permissions = {
+      canManageSchedules: identity.isAdmin || managedUserIds.length > 0,
+      canApproveSchedules: identity.isAdmin || managedUserIds.length > 0,
+      canImport: identity.isAdmin,
+      canEditShiftSlots: identity.isAdmin || normalizedRoles.some(role => role.toLowerCase() === 'workforce' || role.toLowerCase() === 'scheduler')
+    };
+
+    context.success = true;
+    context.authenticated = identity.authenticated;
+    context.managerId = resolvedManagerId || '';
+    context.campaignId = resolvedCampaignId || '';
+    context.user = clientUser;
+    identity.permissions = context.permissions;
+
+    context.identity = identity;
+    context.managedUserIds = managedUserIds;
+    context.managedUserCount = managedUserIds.length;
+    context.managedCampaigns = managedCampaigns;
+
+    return context;
+  } catch (error) {
+    console.error('❌ Error resolving schedule context:', error);
+    context.error = error && error.message ? error.message : String(error || 'Unknown error');
+    try {
+      safeWriteError && safeWriteError('clientGetScheduleContext', error);
+    } catch (_) {
+      // ignore logging failures
+    }
+    return context;
+  }
+}
+
+/**
  * Get users for schedule management with manager filtering
  * Uses MainUtilities user functions with campaign support
  */
@@ -2426,6 +2623,47 @@ function clientRunSystemDiagnostics() {
       });
     }
 
+    // Test schedule analytics + health scoring
+    try {
+      if (typeof evaluateSchedulePerformance === 'function') {
+        const analyticsSample = loadScheduleDataBundle(null, { limitSamples: 20 });
+        const sampleEvaluation = evaluateSchedulePerformance(
+          analyticsSample.scheduleRows.slice(0, 25),
+          analyticsSample.demandRows.slice(0, 25),
+          analyticsSample.agentProfiles.slice(0, 50),
+          { intervalMinutes: 30 }
+        );
+
+        diagnostics.scheduleAnalytics = {
+          working: true,
+          sampleHealthScore: sampleEvaluation.healthScore,
+          sampleServiceLevel: sampleEvaluation.summary ? sampleEvaluation.summary.serviceLevel : null
+        };
+      } else {
+        diagnostics.scheduleAnalytics = {
+          working: false,
+          error: 'Schedule analytics utilities not available'
+        };
+
+        diagnostics.issues.push({
+          severity: 'MEDIUM',
+          component: 'Schedule Analytics',
+          message: 'Schedule analytics utilities are not loaded from ScheduleUtilities'
+        });
+      }
+    } catch (error) {
+      diagnostics.scheduleAnalytics = {
+        working: false,
+        error: error.message
+      };
+
+      diagnostics.issues.push({
+        severity: 'MEDIUM',
+        component: 'Schedule Analytics',
+        message: 'Schedule analytics evaluation failed: ' + error.message
+      });
+    }
+
     // Generate recommendations
     if (diagnostics.issues.length === 0) {
       diagnostics.recommendations.push('System is working well. All components are functional with proper utility integration.');
@@ -2981,6 +3219,1299 @@ function extractSpreadsheetId(input) {
   }
 
   return '';
+}
+
+function scheduleToNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return isFinite(numeric) ? numeric : fallback;
+}
+
+function safeNormalizeScheduleDate(value) {
+  try {
+    if (typeof normalizeScheduleDate === 'function') {
+      return normalizeScheduleDate(value);
+    }
+  } catch (error) {
+    console.warn('safeNormalizeScheduleDate: normalizeScheduleDate failed', error);
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (typeof value === 'number') {
+    if (value > 100000000000) {
+      return new Date(value);
+    }
+    return new Date(value * 24 * 60 * 60 * 1000);
+  }
+
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (!text) {
+      return null;
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+      return new Date(`${text}T00:00:00`);
+    }
+    const parsed = new Date(text);
+    if (!isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function safeNormalizeScheduleTimeToMinutes(value) {
+  try {
+    if (typeof normalizeScheduleTimeToMinutes === 'function') {
+      const normalized = normalizeScheduleTimeToMinutes(value);
+      if (typeof normalized === 'number' && isFinite(normalized)) {
+        return normalized;
+      }
+    }
+  } catch (error) {
+    console.warn('safeNormalizeScheduleTimeToMinutes: normalizeScheduleTimeToMinutes failed', error);
+  }
+
+  if (value instanceof Date) {
+    return value.getHours() * 60 + value.getMinutes();
+  }
+
+  if (typeof value === 'number') {
+    if (value > 100000000000) {
+      const date = new Date(value);
+      return date.getHours() * 60 + date.getMinutes();
+    }
+
+    if (value >= 0 && value <= 1) {
+      return Math.round(value * 24 * 60);
+    }
+
+    if (value > 1 && value < 24) {
+      return Math.round(value * 60);
+    }
+
+    return Math.round(value);
+  }
+
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (!text) {
+      return null;
+    }
+
+    const ampmMatch = text.match(/^(\d{1,2})(?::(\d{1,2}))?(?::(\d{1,2}))?\s*(AM|PM)$/i);
+    if (ampmMatch) {
+      let hours = parseInt(ampmMatch[1], 10);
+      const minutes = parseInt(ampmMatch[2] || '0', 10);
+      const period = ampmMatch[4].toUpperCase();
+      if (period === 'PM' && hours < 12) {
+        hours += 12;
+      }
+      if (period === 'AM' && hours === 12) {
+        hours = 0;
+      }
+      return hours * 60 + minutes;
+    }
+
+    const isoMatch = text.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}):(\d{2})/);
+    if (isoMatch) {
+      return parseInt(isoMatch[2], 10) * 60 + parseInt(isoMatch[3], 10);
+    }
+
+    const hhmmMatch = text.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+    if (hhmmMatch) {
+      return parseInt(hhmmMatch[1], 10) * 60 + parseInt(hhmmMatch[2], 10);
+    }
+  }
+
+  return null;
+}
+
+function safeNormalizeSchedulePercentage(value, fallback = 0) {
+  try {
+    if (typeof normalizeSchedulePercentage === 'function') {
+      return normalizeSchedulePercentage(value, fallback);
+    }
+  } catch (error) {
+    console.warn('safeNormalizeSchedulePercentage: normalizeSchedulePercentage failed', error);
+  }
+
+  const numeric = Number(value);
+  if (!isFinite(numeric)) {
+    return fallback;
+  }
+  if (Math.abs(numeric) > 1) {
+    return numeric / 100;
+  }
+  return numeric;
+}
+
+function minutesToTimeString(minutes) {
+  if (!isFinite(minutes)) {
+    return '';
+  }
+
+  const normalized = ((minutes % (24 * 60)) + (24 * 60)) % (24 * 60);
+  const hours = Math.floor(normalized / 60);
+  const mins = Math.round(normalized % 60);
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+}
+
+function formatDateForOutput(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return '';
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function mapScheduleRowToAgentShift(row) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const date = safeNormalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+  const startMinutes = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+  const endMinutes = safeNormalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+
+  const startDateTime = date ? combineDateAndMinutes(date, startMinutes !== null && startMinutes !== undefined ? startMinutes : 0) : null;
+  const endDateTime = date ? combineDateAndMinutes(date, endMinutes !== null && endMinutes !== undefined ? endMinutes : (startMinutes || 0)) : null;
+
+  const fallbackId = (typeof Utilities !== 'undefined' && Utilities.getUuid)
+    ? Utilities.getUuid()
+    : `schedule_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+
+  return {
+    id: row.ID || row.Id || row.ScheduleID || row.ScheduleId || row.scheduleId || fallbackId,
+    date: date ? formatDateForOutput(date) : '',
+    dateIso: date ? date.toISOString() : '',
+    dayOfWeek: date ? date.toLocaleDateString('en-US', { weekday: 'short' }) : '',
+    startTime: startMinutes !== null && startMinutes !== undefined ? minutesToTimeString(startMinutes) : '',
+    endTime: endMinutes !== null && endMinutes !== undefined ? minutesToTimeString(endMinutes) : '',
+    startTimestamp: startDateTime ? startDateTime.getTime() : null,
+    endTimestamp: endDateTime ? endDateTime.getTime() : null,
+    startDateTime: startDateTime ? startDateTime.toISOString() : '',
+    endDateTime: endDateTime ? endDateTime.toISOString() : '',
+    shiftSlot: row.SlotName || row.SlotID || row.Slot || '',
+    status: String(row.Status || row.State || 'pending').toLowerCase(),
+    location: row.Location || '',
+    department: row.Department || '',
+    skill: row.Skill || row.Queue || '',
+    notes: row.Notes || '',
+    raw: row
+  };
+}
+
+function buildScheduleRowLookup(rows) {
+  const map = new Map();
+  (rows || []).forEach(row => {
+    const idCandidates = [row.ID, row.Id, row.ScheduleID, row.ScheduleId, row.scheduleId];
+    for (let i = 0; i < idCandidates.length; i++) {
+      const id = idCandidates[i];
+      if (!id) continue;
+      const key = String(id).trim();
+      if (key) {
+        map.set(key, row);
+        break;
+      }
+    }
+  });
+  return map;
+}
+
+function buildAgentProfileLookup(profiles) {
+  const map = new Map();
+  (profiles || []).forEach(profile => {
+    const id = normalizeUserIdValue(profile && (profile.ID || profile.Id || profile.UserID || profile.UserId));
+    if (id) {
+      map.set(id, profile);
+    }
+  });
+  return map;
+}
+
+function resolveAgentScheduleWindow(agentId, context, options = {}) {
+  const windowDays = Number(options.windowDays) > 0 ? Number(options.windowDays) : 30;
+  const startDate = safeNormalizeScheduleDate(options.startDate) || new Date();
+  startDate.setHours(0, 0, 0, 0);
+
+  const endDate = safeNormalizeScheduleDate(options.endDate) || new Date(startDate.getTime() + windowDays * 24 * 60 * 60 * 1000);
+  endDate.setHours(23, 59, 59, 999);
+
+  const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId, {
+    managedUserIds: [agentId],
+    startDate,
+    endDate
+  });
+
+  const agentSchedules = bundle.scheduleRows.filter(row => normalizeUserIdValue(row.UserID || row.UserId || row.AgentID || row.AgentId) === agentId);
+
+  return {
+    agentSchedules,
+    bundle,
+    startDate,
+    endDate
+  };
+}
+
+function formatShiftSwapRequestForAgent(row, agentId, lookups = {}) {
+  if (!row) {
+    return null;
+  }
+
+  const scheduleLookup = lookups.scheduleLookup || new Map();
+  const profileLookup = lookups.profileLookup || new Map();
+
+  const requestorId = normalizeUserIdValue(row.RequestorUserID || row.RequestorUserId);
+  const targetId = normalizeUserIdValue(row.TargetUserID || row.TargetUserId);
+
+  if (agentId && requestorId !== agentId && targetId !== agentId) {
+    return null;
+  }
+
+  const isRequestor = requestorId === agentId;
+  const counterpartId = isRequestor ? targetId : requestorId;
+
+  const requestorScheduleRow = scheduleLookup.get(String(row.RequestorScheduleID || row.RequestorScheduleId || '').trim());
+  const targetScheduleRow = scheduleLookup.get(String(row.TargetScheduleID || row.TargetScheduleId || '').trim());
+
+  const myScheduleRow = isRequestor ? requestorScheduleRow : targetScheduleRow;
+  const theirScheduleRow = isRequestor ? targetScheduleRow : requestorScheduleRow;
+
+  const myShift = mapScheduleRowToAgentShift(myScheduleRow);
+  const theirShift = mapScheduleRowToAgentShift(theirScheduleRow);
+
+  const swapDate = safeNormalizeScheduleDate(row.SwapDate || (myShift && myShift.date ? myShift.date : null));
+  const counterpartProfile = profileLookup.get(counterpartId);
+  const counterpartName = (counterpartProfile && (counterpartProfile.FullName || counterpartProfile.UserName || counterpartProfile.Email))
+    || (isRequestor ? row.TargetUserName : row.RequestorUserName)
+    || 'Teammate';
+
+  const createdAtRaw = row.CreatedAt || row.RequestedAt || swapDate || null;
+  const createdAtDate = createdAtRaw instanceof Date ? createdAtRaw : (createdAtRaw ? new Date(createdAtRaw) : null);
+
+  const statusValue = String(row.Status || row.status || (typeof SHIFT_SWAP_STATUS !== 'undefined' ? SHIFT_SWAP_STATUS.PENDING : 'PENDING')).toUpperCase();
+
+  return {
+    id: row.ID || row.Id || row.id || '',
+    status: statusValue.toLowerCase(),
+    statusRaw: statusValue,
+    myShiftId: myShift ? myShift.id : (isRequestor ? (row.RequestorScheduleID || row.RequestorScheduleId || '') : (row.TargetScheduleID || row.TargetScheduleId || '')),
+    theirShiftId: theirShift ? theirShift.id : (!isRequestor ? (row.RequestorScheduleID || row.RequestorScheduleId || '') : (row.TargetScheduleID || row.TargetScheduleId || '')),
+    myShiftDate: myShift && myShift.date ? myShift.date : (swapDate ? formatDateForOutput(swapDate) : ''),
+    myShiftTime: myShift && myShift.startTime ? `${myShift.startTime}${myShift.endTime ? ` - ${myShift.endTime}` : ''}` : '',
+    theirShiftDate: theirShift && theirShift.date ? theirShift.date : '',
+    theirShiftTime: theirShift && theirShift.startTime ? `${theirShift.startTime}${theirShift.endTime ? ` - ${theirShift.endTime}` : ''}` : '',
+    swapWith: counterpartId || '',
+    swapWithName: counterpartName,
+    reason: row.Reason || row.reason || '',
+    requestedAt: createdAtDate ? createdAtDate.toISOString() : '',
+    raw: row
+  };
+}
+
+function combineDateAndMinutes(date, minutes) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return null;
+  }
+  const clone = new Date(date.getTime());
+  clone.setHours(0, 0, 0, 0);
+  const normalizedMinutes = Number(minutes);
+  if (isFinite(normalizedMinutes)) {
+    clone.setMinutes(normalizedMinutes);
+  }
+  return clone;
+}
+
+function loadScheduleDataBundle(campaignId, options = {}) {
+  const normalizedCampaignId = normalizeCampaignIdValue(campaignId);
+  const managedUserIds = Array.isArray(options.managedUserIds)
+    ? options.managedUserIds.map(normalizeUserIdValue).filter(Boolean)
+    : [];
+  const managedUserSet = new Set(managedUserIds);
+
+  const startDate = options.startDate ? safeNormalizeScheduleDate(options.startDate) : (options.dateRange && options.dateRange.start ? safeNormalizeScheduleDate(options.dateRange.start) : null);
+  const endDate = options.endDate ? safeNormalizeScheduleDate(options.endDate) : (options.dateRange && options.dateRange.end ? safeNormalizeScheduleDate(options.dateRange.end) : null);
+  const inclusiveEnd = endDate ? new Date(endDate.getTime()) : null;
+  if (inclusiveEnd) {
+    inclusiveEnd.setHours(23, 59, 59, 999);
+  }
+
+  const limitSamples = scheduleToNumber(options.limitSamples, 0);
+
+  const loadSheet = (sheetName) => {
+    if (typeof readScheduleSheet !== 'function') {
+      return [];
+    }
+    try {
+      let rows = readScheduleSheet(sheetName) || [];
+      if (limitSamples && rows.length > limitSamples) {
+        rows = rows.slice(0, limitSamples);
+      }
+      return rows;
+    } catch (error) {
+      console.warn('loadScheduleDataBundle: unable to read sheet', sheetName, error);
+      return [];
+    }
+  };
+
+  const scheduleRows = loadSheet(SCHEDULE_GENERATION_SHEET);
+  const demandRows = loadSheet(DEMAND_SHEET);
+  const ftePlanRows = loadSheet(FTE_PLAN_SHEET);
+
+  let agentProfiles = [];
+  try {
+    agentProfiles = readSheet(USERS_SHEET) || [];
+    if (limitSamples && agentProfiles.length > limitSamples * 2) {
+      agentProfiles = agentProfiles.slice(0, limitSamples * 2);
+    }
+  } catch (error) {
+    console.warn('loadScheduleDataBundle: unable to read users sheet', error);
+  }
+
+  const matchesCampaign = (record) => {
+    if (!normalizedCampaignId) {
+      return true;
+    }
+    const candidates = [
+      record && record.Campaign,
+      record && record.CampaignID,
+      record && record.CampaignId,
+      record && record.campaign,
+      record && record.campaignId,
+      record && record.campaignID,
+      record && record.AssignedCampaign
+    ];
+    return candidates.some(value => normalizeCampaignIdValue(value) === normalizedCampaignId);
+  };
+
+  const matchesDateRange = (record) => {
+    if (!startDate && !endDate) {
+      return true;
+    }
+
+    const dateCandidates = [
+      record && record.Date,
+      record && record.ScheduleDate,
+      record && record.PeriodStart,
+      record && record.StartDate,
+      record && record.Day,
+      record && record.IntervalStart,
+      record && record.intervalStart
+    ];
+
+    let recordDate = null;
+    for (let i = 0; i < dateCandidates.length; i++) {
+      const candidate = safeNormalizeScheduleDate(dateCandidates[i]);
+      if (candidate) {
+        recordDate = candidate;
+        break;
+      }
+    }
+
+    if (!recordDate) {
+      return true;
+    }
+
+    const timeValue = recordDate.getTime();
+    if (startDate && timeValue < startDate.getTime()) {
+      return false;
+    }
+    if (inclusiveEnd && timeValue > inclusiveEnd.getTime()) {
+      return false;
+    }
+    return true;
+  };
+
+  const matchesUserFilter = (record) => {
+    if (!managedUserSet.size) {
+      return true;
+    }
+    const userId = normalizeUserIdValue(record && (record.UserID || record.UserId || record.AgentID || record.AgentId));
+    return managedUserSet.has(userId);
+  };
+
+  const filterRows = (rows, options = {}) => rows.filter(row => matchesCampaign(row) && matchesDateRange(row) && (options.skipUserFilter || matchesUserFilter(row)));
+
+  const filteredSchedules = filterRows(scheduleRows);
+  const filteredDemand = filterRows(demandRows, { skipUserFilter: true });
+  const filteredFtePlans = filterRows(ftePlanRows, { skipUserFilter: true });
+  const filteredProfiles = agentProfiles.filter(profile => matchesCampaign(profile));
+
+  return {
+    campaignId: normalizedCampaignId,
+    scheduleRows: filteredSchedules,
+    demandRows: filteredDemand,
+    ftePlanRows: filteredFtePlans,
+    agentProfiles: filteredProfiles,
+    startDate,
+    endDate
+  };
+}
+
+function buildScheduleRecommendations(evaluation, bundle) {
+  const recommendations = [];
+  if (!evaluation || !evaluation.summary) {
+    return recommendations;
+  }
+
+  const coverage = evaluation.coverage || {};
+  const fairness = evaluation.fairness || {};
+  const compliance = evaluation.compliance || {};
+
+  if (coverage.serviceLevel < 80) {
+    const topInterval = (coverage.backlogRiskIntervals || [])[0];
+    if (topInterval) {
+      recommendations.push(`Add staffing to ${topInterval.intervalKey} for skill ${topInterval.skill || 'general'} (deficit ${topInterval.deficit} FTE).`);
+    } else {
+      recommendations.push('Increase staffing in critical intervals to protect service level.');
+    }
+  }
+
+  if (coverage.peakCoverage < 85) {
+    recommendations.push('Rebalance opening and closing coverage to meet first/last hour SLAs.');
+  }
+
+  if (fairness.rotationHealth < 75) {
+    recommendations.push('Review weekend and night rotation to improve fairness.');
+  }
+
+  if (compliance.complianceScore < 85) {
+    recommendations.push('Resolve compliance issues (breaks, rest periods, overtime) before publishing schedules.');
+  }
+
+  if (!bundle || !bundle.scheduleRows || bundle.scheduleRows.length === 0) {
+    recommendations.push('No schedules found for the selected filters. Import or generate schedules to proceed.');
+  }
+
+  return recommendations;
+}
+
+function persistScheduleHealthSnapshot(context, evaluation, bundle, options = {}) {
+  if (!context || !evaluation || !evaluation.summary) {
+    return;
+  }
+
+  if (typeof ensureScheduleSheetWithHeaders !== 'function') {
+    return;
+  }
+
+  try {
+    const sheet = ensureScheduleSheetWithHeaders(SCHEDULE_HEALTH_SHEET, SCHEDULE_HEALTH_HEADERS);
+    const id = (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.getUuid === 'function')
+      ? Utilities.getUuid()
+      : `health_${Date.now()}`;
+
+    const totalMinutes = (bundle.scheduleRows || []).reduce((sum, row) => {
+      const start = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+      const end = safeNormalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+      if (start === null || end === null) {
+        return sum;
+      }
+      let diff = end - start;
+      if (diff < 0) {
+        diff += 24 * 60;
+      }
+      return sum + diff;
+    }, 0);
+
+    const agentSet = new Set((bundle.scheduleRows || []).map(row => normalizeUserIdValue(row.UserID || row.UserId || row.AgentID || row.AgentId)).filter(Boolean));
+    const totalHours = totalMinutes / 60;
+    const standardHours = scheduleToNumber(options.standardHoursPerAgent || 8, 8);
+    const overtimeHours = Math.max(0, totalHours - (agentSet.size * standardHours));
+
+    const summary = evaluation.summary;
+    const fairness = evaluation.fairness || {};
+    const compliance = evaluation.compliance || {};
+    const coverage = evaluation.coverage || {};
+
+    const costPerStaffedHour = options.costPerStaffedHour || '';
+    const rowValues = [
+      id,
+      context.campaignId || context.providedCampaignId || '',
+      evaluation.generatedAt,
+      summary.serviceLevel || 0,
+      summary.asa || 0,
+      summary.abandonRate || 0,
+      summary.occupancy || 0,
+      summary.occupancy || 0,
+      Number(overtimeHours.toFixed(2)),
+      costPerStaffedHour,
+      fairness.fairnessIndex || 0,
+      fairness.preferenceSatisfaction || 0,
+      compliance.complianceScore || 0,
+      summary.scheduleEfficiency || coverage.coverageScore || 0,
+      `SL ${summary.serviceLevel || 0}%, Fairness ${fairness.fairnessIndex || 0}, Compliance ${compliance.complianceScore || 0}`
+    ];
+
+    sheet.appendRow(rowValues);
+  } catch (error) {
+    console.warn('persistScheduleHealthSnapshot failed:', error);
+  }
+}
+
+function clientGetScheduleDashboard(managerIdCandidate, campaignIdCandidate, options = {}) {
+  try {
+    console.log('📊 Building schedule dashboard for manager/campaign:', managerIdCandidate, campaignIdCandidate);
+
+    if (typeof evaluateSchedulePerformance !== 'function') {
+      throw new Error('Schedule analytics utilities are not available. Ensure ScheduleUtilities is loaded.');
+    }
+
+    const context = clientGetScheduleContext(managerIdCandidate || null, campaignIdCandidate || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context',
+        context
+      };
+    }
+
+    const dateRange = options.dateRange || {};
+    const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId || null, {
+      managedUserIds: (context.managedUserIds || []).concat(context.managerId ? [context.managerId] : []),
+      startDate: options.startDate || dateRange.start,
+      endDate: options.endDate || dateRange.end
+    });
+
+    const metricsOptions = Object.assign({}, options.metrics || {}, {
+      intervalMinutes: options.intervalMinutes || (options.metrics && options.metrics.intervalMinutes) || 30,
+      targetServiceLevel: options.targetServiceLevel || (options.metrics && options.metrics.targetServiceLevel) || 0.8,
+      baselineASA: options.baselineASA || (options.metrics && options.metrics.baselineASA) || 45,
+      openingHour: options.openingHour || (options.metrics && options.metrics.openingHour),
+      closingHour: options.closingHour || (options.metrics && options.metrics.closingHour)
+    });
+
+    const evaluation = evaluateSchedulePerformance(bundle.scheduleRows, bundle.demandRows, bundle.agentProfiles, metricsOptions);
+
+    const agentSet = new Set(bundle.scheduleRows.map(row => normalizeUserIdValue(row.UserID || row.UserId || row.AgentID || row.AgentId)).filter(Boolean));
+    const totalMinutes = bundle.scheduleRows.reduce((sum, row) => {
+      const start = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+      const end = safeNormalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+      if (start === null || end === null) {
+        return sum;
+      }
+      let diff = end - start;
+      if (diff < 0) {
+        diff += 24 * 60;
+      }
+      return sum + diff;
+    }, 0);
+
+    const totalHours = Number((totalMinutes / 60).toFixed(2));
+    const rosterSummary = {
+      agentCount: agentSet.size,
+      totalHours,
+      averageHoursPerAgent: agentSet.size ? Number((totalHours / agentSet.size).toFixed(2)) : 0
+    };
+
+    const fteTotals = bundle.ftePlanRows.reduce((acc, row) => {
+      acc.planned += scheduleToNumber(row.PlannedFTE || row.Planned || row.FTEPlanned, 0);
+      acc.actual += scheduleToNumber(row.ActualFTE || row.Actual || row.FTEActual, 0);
+      return acc;
+    }, { planned: 0, actual: 0 });
+
+    const recommendations = buildScheduleRecommendations(evaluation, bundle);
+
+    const response = {
+      success: true,
+      context: {
+        managerId: context.managerId,
+        campaignId: context.campaignId,
+        providedManagerId: context.providedManagerId,
+        providedCampaignId: context.providedCampaignId,
+        permissions: context.permissions,
+        managedUserCount: context.managedUserCount
+      },
+      generatedAt: evaluation.generatedAt,
+      healthScore: evaluation.healthScore,
+      summary: evaluation.summary,
+      coverage: evaluation.coverage,
+      fairness: evaluation.fairness,
+      compliance: evaluation.compliance,
+      totals: {
+        requiredFTE: evaluation.coverage.totalRequiredFTE,
+        staffedFTE: evaluation.coverage.totalStaffedFTE,
+        plannedFTE: Number(fteTotals.planned.toFixed(2)),
+        actualFTE: Number(fteTotals.actual.toFixed(2)),
+        varianceFTE: Number((fteTotals.actual - fteTotals.planned).toFixed(2)),
+        rosterHours: totalHours,
+        agentCount: rosterSummary.agentCount
+      },
+      roster: rosterSummary,
+      backlogIntervals: evaluation.coverage.backlogRiskIntervals,
+      recommendations,
+      demandSamples: bundle.demandRows.slice(0, 50)
+    };
+
+    if (!options.skipPersistence) {
+      persistScheduleHealthSnapshot(context, evaluation, bundle, options);
+    }
+
+    return response;
+  } catch (error) {
+    console.error('Error generating schedule dashboard:', error);
+    safeWriteError && safeWriteError('clientGetScheduleDashboard', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function applyScenarioAdjustments(bundle, scenario = {}) {
+  const volumeMultiplier = scenario.volumeMultiplier || (scenario.volumeDelta ? 1 + scenario.volumeDelta : 1);
+  const ahtMultiplier = scenario.ahtMultiplier || (scenario.ahtDelta ? 1 + scenario.ahtDelta : 1);
+  const shrinkageDelta = scenario.shrinkageDelta || 0;
+  const absenceRate = scenario.absenceRate || 0;
+  const additionalOvertimeMinutes = scheduleToNumber(scenario.additionalOvertimeMinutes || scenario.overtimeMinutes, 0);
+
+  const adjustedDemand = (bundle.demandRows || []).map(row => {
+    const clone = Object.assign({}, row);
+    if (clone.ForecastContacts !== undefined) {
+      clone.ForecastContacts = scheduleToNumber(clone.ForecastContacts, 0) * volumeMultiplier;
+    }
+    if (clone.ForecastAHT !== undefined) {
+      clone.ForecastAHT = scheduleToNumber(clone.ForecastAHT, 0) * ahtMultiplier;
+    }
+    const shrinkage = safeNormalizeSchedulePercentage(clone.Shrinkage, 0.3) + shrinkageDelta;
+    clone.Shrinkage = Math.max(0, shrinkage);
+    return clone;
+  });
+
+  const adjustedSchedules = (bundle.scheduleRows || []).map(row => {
+    const clone = Object.assign({}, row);
+    const start = safeNormalizeScheduleTimeToMinutes(clone.StartTime || clone.PeriodStart || clone.ScheduleStart || clone.ShiftStart);
+    const end = safeNormalizeScheduleTimeToMinutes(clone.EndTime || clone.PeriodEnd || clone.ScheduleEnd || clone.ShiftEnd);
+    if (additionalOvertimeMinutes && end !== null) {
+      const newEnd = end + additionalOvertimeMinutes;
+      clone.EndTime = minutesToTimeString(newEnd);
+      clone.PeriodEnd = clone.EndTime;
+    }
+
+    if (absenceRate > 0) {
+      clone.FTE = scheduleToNumber(clone.FTE || 1, 1) * Math.max(0, 1 - absenceRate);
+    }
+
+    return clone;
+  });
+
+  return { scheduleRows: adjustedSchedules, demandRows: adjustedDemand };
+}
+
+function clientSimulateScheduleScenario(scenario = {}) {
+  try {
+    console.log('🧪 Simulating schedule scenario:', scenario && scenario.name ? scenario.name : '(ad-hoc scenario)');
+
+    if (typeof evaluateSchedulePerformance !== 'function') {
+      throw new Error('Schedule analytics utilities are not available. Ensure ScheduleUtilities is loaded.');
+    }
+
+    const context = clientGetScheduleContext(scenario.managerId || scenario.manager || null, scenario.campaignId || scenario.campaign || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context',
+        context
+      };
+    }
+
+    const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId, {
+      managedUserIds: scenario.managedUserIds || context.managedUserIds,
+      startDate: scenario.startDate,
+      endDate: scenario.endDate
+    });
+
+    const metricsOptions = Object.assign({ intervalMinutes: scenario.intervalMinutes || 30 }, scenario.metrics || {});
+
+    const baseline = evaluateSchedulePerformance(bundle.scheduleRows, bundle.demandRows, bundle.agentProfiles, metricsOptions);
+    const adjusted = applyScenarioAdjustments(bundle, scenario);
+    const projection = evaluateSchedulePerformance(adjusted.scheduleRows, adjusted.demandRows, bundle.agentProfiles, metricsOptions);
+
+    return {
+      success: true,
+      context: {
+        managerId: context.managerId,
+        campaignId: context.campaignId
+      },
+      scenario,
+      baseline,
+      projection,
+      delta: {
+        serviceLevel: projection.summary.serviceLevel - baseline.summary.serviceLevel,
+        healthScore: projection.healthScore - baseline.healthScore,
+        compliance: projection.summary.complianceScore - baseline.summary.complianceScore,
+        fairness: projection.summary.fairnessIndex - baseline.summary.fairnessIndex
+      },
+      recommendations: buildScheduleRecommendations(projection, bundle)
+    };
+  } catch (error) {
+    console.error('Error simulating schedule scenario:', error);
+    safeWriteError && safeWriteError('clientSimulateScheduleScenario', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientGetAgentScheduleSnapshot(agentIdCandidate, startDateCandidate, endDateCandidate, campaignIdCandidate = null, options = {}) {
+  try {
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate) || normalizeUserIdValue(options.agentId);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    if (!agentId) {
+      return {
+        success: false,
+        error: 'Agent could not be resolved from parameters or current user context.'
+      };
+    }
+
+    const context = clientGetScheduleContext(agentId, campaignIdCandidate || options.campaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve agent context',
+        context
+      };
+    }
+
+    const startDate = safeNormalizeScheduleDate(startDateCandidate || options.startDate) || new Date();
+    const endDate = safeNormalizeScheduleDate(endDateCandidate || options.endDate) || new Date(startDate.getTime() + 14 * 24 * 60 * 60 * 1000);
+
+    const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId, {
+      managedUserIds: [agentId],
+      startDate,
+      endDate
+    });
+
+    const agentSchedules = bundle.scheduleRows.filter(row => normalizeUserIdValue(row.UserID || row.UserId || row.AgentID || row.AgentId) === agentId);
+    const agentProfile = bundle.agentProfiles.find(profile => normalizeUserIdValue(profile.ID || profile.UserID || profile.UserId) === agentId) || (context.user && normalizeUserIdValue(context.user.ID) === agentId ? context.user : null);
+
+    const now = new Date();
+    const upcomingShifts = agentSchedules
+      .map(row => {
+        const date = safeNormalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+        const startMinutes = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+        const startDateTime = date ? combineDateAndMinutes(date, startMinutes || 0) : null;
+        return { row, date, startMinutes, startDateTime };
+      })
+      .filter(item => item.startDateTime && item.startDateTime >= now)
+      .sort((a, b) => a.startDateTime - b.startDateTime);
+
+    const historyShifts = agentSchedules
+      .map(row => {
+        const date = safeNormalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+        const startMinutes = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+        const startDateTime = date ? combineDateAndMinutes(date, startMinutes || 0) : null;
+        return { row, date, startMinutes, startDateTime };
+      })
+      .filter(item => item.startDateTime && item.startDateTime < now)
+      .sort((a, b) => b.startDateTime - a.startDateTime);
+
+    const totalMinutes = agentSchedules.reduce((sum, row) => {
+      const start = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+      const end = safeNormalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+      if (start === null || end === null) {
+        return sum;
+      }
+      let diff = end - start;
+      if (diff < 0) {
+        diff += 24 * 60;
+      }
+      return sum + diff;
+    }, 0);
+
+    const weekendShifts = agentSchedules.filter(row => {
+      const date = safeNormalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+      return date && WEEKEND.includes(date.getDay());
+    }).length;
+
+    const nightShifts = agentSchedules.filter(row => {
+      const start = safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+      const end = safeNormalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+      return (start !== null && start >= (options.nightThresholdStart || 20 * 60)) || (end !== null && end <= (options.nightThresholdEnd || 6 * 60));
+    }).length;
+
+    const averageStartMinutes = agentSchedules.length
+      ? agentSchedules.reduce((sum, row) => sum + (safeNormalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart) || 0), 0) / agentSchedules.length
+      : null;
+
+    let preferenceScore = null;
+    let complianceScore = null;
+    let fairnessSummary = null;
+    if (typeof calculateFairnessMetrics === 'function') {
+      const fairness = calculateFairnessMetrics(agentSchedules, agentProfile ? [agentProfile] : [], options.metrics || {});
+      fairnessSummary = fairness && fairness.agentSummaries && fairness.agentSummaries.length ? fairness.agentSummaries[0] : null;
+      if (fairnessSummary && typeof fairnessSummary.preferenceScore === 'number') {
+        preferenceScore = fairnessSummary.preferenceScore;
+      }
+    }
+
+    if (typeof calculateComplianceMetrics === 'function') {
+      const compliance = calculateComplianceMetrics(agentSchedules, agentProfile ? [agentProfile] : [], {
+        allowedBreakOverlap: options.allowedBreakOverlap || 3,
+        maxHoursPerDay: options.maxHoursPerDay || 12,
+        minRestHours: options.minRestHours || 10
+      });
+      complianceScore = compliance && typeof compliance.complianceScore === 'number' ? compliance.complianceScore : null;
+    }
+
+    const nextShift = upcomingShifts.length ? upcomingShifts[0] : null;
+    const alerts = [];
+
+    let pendingSwaps = 0;
+    if (typeof listShiftSwapRequests === 'function') {
+      try {
+        const swapRows = listShiftSwapRequests({ userId: agentId });
+        pendingSwaps = (swapRows || []).filter(row => {
+          const status = String(row.Status || row.status || (typeof SHIFT_SWAP_STATUS !== 'undefined' ? SHIFT_SWAP_STATUS.PENDING : 'PENDING')).toUpperCase();
+          return status === (typeof SHIFT_SWAP_STATUS !== 'undefined' ? SHIFT_SWAP_STATUS.PENDING : 'PENDING');
+        }).length;
+      } catch (swapError) {
+        console.warn('clientGetAgentScheduleSnapshot: unable to load swap requests', swapError);
+      }
+    }
+
+    if (nightShifts >= 3) {
+      alerts.push('Multiple night shifts scheduled this period. Ensure adequate rest between shifts.');
+    }
+    if (weekendShifts >= 3) {
+      alerts.push('Heavy weekend coverage detected. Consider requesting swaps if needed.');
+    }
+    if (complianceScore !== null && complianceScore < 85) {
+      alerts.push('Compliance score below target. Review breaks, lunches, and rest periods.');
+    }
+    if (pendingSwaps > 0) {
+      alerts.push(`You have ${pendingSwaps} pending swap request${pendingSwaps === 1 ? '' : 's'}.`);
+    }
+
+    const formatShiftOutput = (item) => ({
+      id: item.row.ID || item.row.Id || item.row.id || '',
+      date: item.date ? formatDateForOutput(item.date) : '',
+      dayOfWeek: item.date ? item.date.toLocaleDateString('en-US', { weekday: 'short' }) : '',
+      startTime: item.startMinutes !== null && item.startMinutes !== undefined ? minutesToTimeString(item.startMinutes) : '',
+      endTime: (() => {
+        const end = safeNormalizeScheduleTimeToMinutes(item.row.EndTime || item.row.PeriodEnd || item.row.ScheduleEnd || item.row.ShiftEnd);
+        return end !== null && end !== undefined ? minutesToTimeString(end) : '';
+      })(),
+      location: item.row.Location || '',
+      skill: item.row.Skill || item.row.Queue || '',
+      status: item.row.Status || item.row.State || '',
+      notes: item.row.Notes || ''
+    });
+
+    const summary = {
+      agentId,
+      agentName: (agentProfile && (agentProfile.FullName || agentProfile.UserName || agentProfile.Name)) || (context.user && (context.user.FullName || context.user.UserName)) || '',
+      agentEmail: (agentProfile && (agentProfile.Email || agentProfile.email)) || (context.user && (context.user.Email || context.user.email)) || '',
+      totalShifts: agentSchedules.length,
+      totalScheduledHours: Number((totalMinutes / 60).toFixed(2)),
+      weekendShifts,
+      nightShifts,
+      averageStartTime: averageStartMinutes !== null ? minutesToTimeString(averageStartMinutes) : '',
+      preferenceScore,
+      complianceScore,
+      pendingSwaps,
+      upcomingHolidays: 0,
+      nextShift: nextShift ? formatShiftOutput(nextShift) : null
+    };
+
+    return {
+      success: true,
+      agentId,
+      campaignId: context.campaignId || context.providedCampaignId || '',
+      summary,
+      upcomingShifts: upcomingShifts.slice(0, options.limitUpcoming || 5).map(formatShiftOutput),
+      recentShifts: historyShifts.slice(0, options.limitHistory || 5).map(formatShiftOutput),
+      alerts,
+      context: {
+        permissions: context.permissions,
+        managedUserCount: context.managedUserCount
+      }
+    };
+  } catch (error) {
+    console.error('Error generating agent schedule snapshot:', error);
+    safeWriteError && safeWriteError('clientGetAgentScheduleSnapshot', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientGetAgentSchedule(agentIdCandidate, options = {}) {
+  try {
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate) || normalizeUserIdValue(options.agentId);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    if (!agentId) {
+      return {
+        success: false,
+        error: 'Agent could not be resolved from parameters or current user context.'
+      };
+    }
+
+    const context = clientGetScheduleContext(agentId, options.campaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context.'
+      };
+    }
+
+    const windowOptions = Object.assign({}, options);
+    const { agentSchedules, startDate, endDate } = resolveAgentScheduleWindow(agentId, context, windowOptions);
+
+    const schedules = agentSchedules
+      .map(mapScheduleRowToAgentShift)
+      .filter(Boolean)
+      .sort((a, b) => {
+        const aKey = typeof a.startTimestamp === 'number' ? a.startTimestamp : Number.MAX_SAFE_INTEGER;
+        const bKey = typeof b.startTimestamp === 'number' ? b.startTimestamp : Number.MAX_SAFE_INTEGER;
+        return aKey - bKey;
+      });
+
+    return {
+      success: true,
+      agentId,
+      campaignId: context.campaignId || context.providedCampaignId || '',
+      schedules,
+      summary: {
+        total: schedules.length,
+        startDate: formatDateForOutput(startDate),
+        endDate: formatDateForOutput(endDate)
+      }
+    };
+  } catch (error) {
+    console.error('Error fetching agent schedule:', error);
+    safeWriteError && safeWriteError('clientGetAgentSchedule', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientGetAgentUpcomingShifts(agentIdCandidate, options = {}) {
+  try {
+    const scheduleResponse = clientGetAgentSchedule(agentIdCandidate, Object.assign({}, options, {
+      windowDays: options.windowDays || 60
+    }));
+
+    if (!scheduleResponse || scheduleResponse.success === false) {
+      return scheduleResponse;
+    }
+
+    const now = Date.now();
+    const limit = Number(options.limit) > 0 ? Number(options.limit) : 10;
+
+    const upcoming = (scheduleResponse.schedules || [])
+      .filter(shift => typeof shift.startTimestamp === 'number' ? shift.startTimestamp >= now : true)
+      .sort((a, b) => {
+        const aKey = typeof a.startTimestamp === 'number' ? a.startTimestamp : Number.MAX_SAFE_INTEGER;
+        const bKey = typeof b.startTimestamp === 'number' ? b.startTimestamp : Number.MAX_SAFE_INTEGER;
+        return aKey - bKey;
+      })
+      .slice(0, limit);
+
+    return {
+      success: true,
+      agentId: scheduleResponse.agentId,
+      campaignId: scheduleResponse.campaignId,
+      shifts: upcoming
+    };
+  } catch (error) {
+    console.error('Error fetching upcoming shifts:', error);
+    safeWriteError && safeWriteError('clientGetAgentUpcomingShifts', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientGetAgentSwapRequests(agentIdCandidate, options = {}) {
+  try {
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate) || normalizeUserIdValue(options.agentId);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    if (!agentId) {
+      return {
+        success: false,
+        error: 'Agent could not be resolved.'
+      };
+    }
+
+    const context = clientGetScheduleContext(agentId, options.campaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context.'
+      };
+    }
+
+    const windowDays = Number(options.windowDays) > 0 ? Number(options.windowDays) : 60;
+    const startDate = safeNormalizeScheduleDate(options.startDate) || new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = safeNormalizeScheduleDate(options.endDate) || new Date(startDate.getTime() + windowDays * 24 * 60 * 60 * 1000);
+    endDate.setHours(23, 59, 59, 999);
+
+    const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId, {
+      startDate,
+      endDate
+    });
+
+    const scheduleLookup = buildScheduleRowLookup(bundle.scheduleRows || []);
+    const profileLookup = buildAgentProfileLookup(bundle.agentProfiles || []);
+
+    const rawRequests = typeof listShiftSwapRequests === 'function'
+      ? listShiftSwapRequests({ userId: agentId })
+      : [];
+
+    const formatted = (rawRequests || [])
+      .map(row => formatShiftSwapRequestForAgent(row, agentId, { scheduleLookup, profileLookup }))
+      .filter(Boolean)
+      .sort((a, b) => {
+        const aDate = a.requestedAt ? new Date(a.requestedAt).getTime() : 0;
+        const bDate = b.requestedAt ? new Date(b.requestedAt).getTime() : 0;
+        return bDate - aDate;
+      });
+
+    return {
+      success: true,
+      agentId,
+      campaignId: context.campaignId || context.providedCampaignId || '',
+      requests: formatted
+    };
+  } catch (error) {
+    console.error('Error loading agent swap requests:', error);
+    safeWriteError && safeWriteError('clientGetAgentSwapRequests', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientGetAvailableSwapAgents(agentIdCandidate, options = {}) {
+  try {
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate) || normalizeUserIdValue(options.agentId);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    if (!agentId) {
+      return {
+        success: false,
+        error: 'Agent could not be resolved.'
+      };
+    }
+
+    const context = clientGetScheduleContext(agentId, options.campaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context.'
+      };
+    }
+
+    const scheduleUsers = clientGetScheduleUsers(agentId, context.campaignId || context.providedCampaignId || null);
+
+    const agents = (scheduleUsers || [])
+      .map(user => {
+        const id = normalizeUserIdValue(user && (user.ID || user.Id || user.UserID || user.UserId));
+        if (!id || id === agentId) {
+          return null;
+        }
+        return {
+          id,
+          name: user.FullName || user.UserName || user.Email || `Agent ${id}`,
+          email: user.Email || '',
+          team: user.Team || user.Department || ''
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return {
+      success: true,
+      agents
+    };
+  } catch (error) {
+    console.error('Error loading available swap agents:', error);
+    safeWriteError && safeWriteError('clientGetAvailableSwapAgents', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientSubmitShiftSwapRequest(agentIdCandidate, request = {}) {
+  try {
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate) || normalizeUserIdValue(request.agentId);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    if (!agentId) {
+      return {
+        success: false,
+        error: 'Agent context is required to submit a swap request.'
+      };
+    }
+
+    const targetId = normalizeUserIdValue(request.swapWith || request.targetUserId);
+    if (!targetId) {
+      return {
+        success: false,
+        error: 'Please select an agent to swap with.'
+      };
+    }
+
+    const myShiftId = String(request.myShiftId || request.requestorScheduleId || '').trim();
+    if (!myShiftId) {
+      return {
+        success: false,
+        error: 'Select the shift you would like to swap.'
+      };
+    }
+
+    const context = clientGetScheduleContext(agentId, request.campaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context.'
+      };
+    }
+
+    const windowDays = Number(request.windowDays) > 0 ? Number(request.windowDays) : 60;
+    const startDate = safeNormalizeScheduleDate(request.startDate) || new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = safeNormalizeScheduleDate(request.endDate) || new Date(startDate.getTime() + windowDays * 24 * 60 * 60 * 1000);
+    endDate.setHours(23, 59, 59, 999);
+
+    const bundle = loadScheduleDataBundle(context.campaignId || context.providedCampaignId, {
+      startDate,
+      endDate
+    });
+
+    const scheduleLookup = buildScheduleRowLookup(bundle.scheduleRows || []);
+    const profileLookup = buildAgentProfileLookup(bundle.agentProfiles || []);
+
+    const myScheduleRow = scheduleLookup.get(myShiftId);
+    if (!myScheduleRow) {
+      return {
+        success: false,
+        error: 'Unable to locate the selected shift. Please refresh and try again.'
+      };
+    }
+
+    const theirShiftId = String(request.theirShiftId || request.targetScheduleId || '').trim();
+    const theirScheduleRow = theirShiftId ? scheduleLookup.get(theirShiftId) : null;
+
+    const requestorProfile = profileLookup.get(agentId) || context.user || {};
+    const targetProfile = profileLookup.get(targetId) || null;
+
+    const swapDate = safeNormalizeScheduleDate(request.swapDate)
+      || safeNormalizeScheduleDate(myScheduleRow.Date || myScheduleRow.ScheduleDate || myScheduleRow.PeriodStart || myScheduleRow.StartDate || myScheduleRow.Day)
+      || new Date();
+
+    const reason = String(request.reason || '').trim();
+
+    const entry = createShiftSwapRequestEntry({
+      requestorUserId: agentId,
+      requestorUserName: requestorProfile.FullName || requestorProfile.UserName || requestorProfile.Email || 'Agent',
+      targetUserId: targetId,
+      targetUserName: targetProfile ? (targetProfile.FullName || targetProfile.UserName || targetProfile.Email) : (request.targetUserName || ''),
+      requestorScheduleId: myShiftId,
+      targetScheduleId: theirShiftId || '',
+      swapDate,
+      reason,
+      status: (typeof SHIFT_SWAP_STATUS !== 'undefined' ? SHIFT_SWAP_STATUS.PENDING : 'PENDING')
+    });
+
+    const formatted = formatShiftSwapRequestForAgent(entry, agentId, { scheduleLookup, profileLookup });
+
+    return {
+      success: true,
+      requestId: entry.ID || entry.Id || entry.id || '',
+      request: formatted
+    };
+  } catch (error) {
+    console.error('Error submitting shift swap request:', error);
+    safeWriteError && safeWriteError('clientSubmitShiftSwapRequest', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+}
+
+function clientCancelShiftSwapRequest(requestId, agentIdCandidate = null) {
+  try {
+    const normalizedRequestId = String(requestId || '').trim();
+    if (!normalizedRequestId) {
+      return {
+        success: false,
+        error: 'Swap request ID is required.'
+      };
+    }
+
+    const resolvedAgentId = normalizeUserIdValue(agentIdCandidate);
+    const currentUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+    const fallbackAgentId = normalizeUserIdValue(currentUser && (currentUser.ID || currentUser.UserID));
+    const agentId = resolvedAgentId || fallbackAgentId;
+
+    const requests = typeof listShiftSwapRequests === 'function' ? listShiftSwapRequests() : [];
+    const targetRequest = (requests || []).find(row => String(row.ID || row.Id || row.id || '').trim() === normalizedRequestId);
+
+    if (!targetRequest) {
+      return {
+        success: false,
+        error: 'Swap request not found.'
+      };
+    }
+
+    const requestorId = normalizeUserIdValue(targetRequest.RequestorUserID || targetRequest.RequestorUserId);
+    const targetId = normalizeUserIdValue(targetRequest.TargetUserID || targetRequest.TargetUserId);
+
+    if (agentId && agentId !== requestorId && agentId !== targetId) {
+      return {
+        success: false,
+        error: 'You are not authorized to update this swap request.'
+      };
+    }
+
+    updateShiftSwapRequestEntry(normalizedRequestId, {
+      Status: (typeof SHIFT_SWAP_STATUS !== 'undefined' ? SHIFT_SWAP_STATUS.CANCELLED : 'CANCELLED'),
+      DecisionNotes: 'Cancelled by agent',
+      UpdatedAt: new Date()
+    });
+
+    return {
+      success: true
+    };
+  } catch (error) {
+    console.error('Error cancelling swap request:', error);
+    safeWriteError && safeWriteError('clientCancelShiftSwapRequest', error);
+    return {
+      success: false,
+      error: error.message
+    };
+  }
 }
 
 console.log('✅ Enhanced Schedule Management Backend v4.1 loaded successfully');

--- a/ScheduleUtilities.js
+++ b/ScheduleUtilities.js
@@ -169,6 +169,10 @@ const SCHEDULE_NOTIFICATIONS_SHEET = "ScheduleNotifications";
 const SCHEDULE_ADHERENCE_SHEET = "ScheduleAdherence";
 const SCHEDULE_CONFLICTS_SHEET = "ScheduleConflicts";
 const RECURRING_SCHEDULES_SHEET = "RecurringSchedules";
+const DEMAND_SHEET = "Demand";
+const FTE_PLAN_SHEET = "FTEPlan";
+const SCHEDULE_FORECAST_METADATA_SHEET = "ScheduleForecastMetadata";
+const SCHEDULE_HEALTH_SHEET = "ScheduleHealth";
 
 // Attendance and holiday sheets
 const ATTENDANCE_STATUS_SHEET = "AttendanceStatus";
@@ -225,6 +229,30 @@ const SCHEDULE_CONFLICTS_HEADERS = [
 const RECURRING_SCHEDULES_HEADERS = [
   'ID', 'UserID', 'UserName', 'SlotID', 'SlotName', 'RecurrencePattern',
   'StartDate', 'EndDate', 'IsActive', 'CreatedBy', 'CreatedAt', 'UpdatedAt'
+];
+
+const DEMAND_HEADERS = [
+  'ID', 'Campaign', 'Skill', 'IntervalStart', 'IntervalEnd',
+  'ForecastContacts', 'ForecastAHT', 'TargetSL', 'TargetASA',
+  'Shrinkage', 'RequiredFTE', 'Notes', 'CreatedAt', 'UpdatedAt'
+];
+
+const FTE_PLAN_HEADERS = [
+  'ID', 'Campaign', 'Skill', 'IntervalStart', 'IntervalEnd',
+  'PlannedFTE', 'ActualFTE', 'Variance', 'CoverageStatus',
+  'CreatedAt', 'UpdatedAt', 'CreatedBy', 'Notes'
+];
+
+const SCHEDULE_FORECAST_METADATA_HEADERS = [
+  'ID', 'Campaign', 'GeneratedAt', 'ForecastWindowStart', 'ForecastWindowEnd',
+  'ModelType', 'Parameters', 'Notes', 'Author'
+];
+
+const SCHEDULE_HEALTH_HEADERS = [
+  'ID', 'Campaign', 'GeneratedAt', 'ServiceLevel', 'ASA', 'AbandonRate',
+  'Occupancy', 'Utilization', 'OvertimeHours', 'CostPerHour',
+  'FairnessIndex', 'PreferenceSatisfaction', 'ComplianceScore',
+  'ScheduleEfficiency', 'Summary'
 ];
 
 const ATTENDANCE_STATUS_HEADERS = [
@@ -304,6 +332,13 @@ const CONFLICT_TYPES = {
   INVALID_ASSIGNMENT: 'INVALID_ASSIGNMENT'
 };
 
+const SHIFT_SWAP_STATUS = {
+  PENDING: 'PENDING',
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
+  CANCELLED: 'CANCELLED'
+};
+
 const RECURRENCE_PATTERNS = {
   DAILY: 'daily',
   WEEKLY: 'weekly',
@@ -347,6 +382,10 @@ function getHeadersForSheet(sheetName) {
   map[SCHEDULE_ADHERENCE_SHEET] = SCHEDULE_ADHERENCE_HEADERS;
   map[SCHEDULE_CONFLICTS_SHEET] = SCHEDULE_CONFLICTS_HEADERS;
   map[RECURRING_SCHEDULES_SHEET] = RECURRING_SCHEDULES_HEADERS;
+  map[DEMAND_SHEET] = DEMAND_HEADERS;
+  map[FTE_PLAN_SHEET] = FTE_PLAN_HEADERS;
+  map[SCHEDULE_FORECAST_METADATA_SHEET] = SCHEDULE_FORECAST_METADATA_HEADERS;
+  map[SCHEDULE_HEALTH_SHEET] = SCHEDULE_HEALTH_HEADERS;
   map[ATTENDANCE_STATUS_SHEET] = ATTENDANCE_STATUS_HEADERS;
   map[USER_HOLIDAY_PAY_STATUS_SHEET] = USER_HOLIDAY_PAY_STATUS_HEADERS;
   map[HOLIDAYS_SHEET] = HOLIDAYS_HEADERS;
@@ -519,7 +558,14 @@ function setupScheduleManagementSheets() {
       { name: RECURRING_SCHEDULES_SHEET, headers: RECURRING_SCHEDULES_HEADERS }
     ];
 
-    coreSheets.forEach(sheetConfig => {
+    const analyticsSheets = [
+      { name: DEMAND_SHEET, headers: DEMAND_HEADERS },
+      { name: FTE_PLAN_SHEET, headers: FTE_PLAN_HEADERS },
+      { name: SCHEDULE_FORECAST_METADATA_SHEET, headers: SCHEDULE_FORECAST_METADATA_HEADERS },
+      { name: SCHEDULE_HEALTH_SHEET, headers: SCHEDULE_HEALTH_HEADERS }
+    ];
+
+    const setupSheetDefinition = (sheetConfig) => {
       try {
         const ss = getScheduleSpreadsheet();
         const existedBefore = ss.getSheetByName(sheetConfig.name) !== null;
@@ -535,7 +581,10 @@ function setupScheduleManagementSheets() {
         console.error(`Failed to setup sheet ${sheetConfig.name}:`, error);
         throw error;
       }
-    });
+    };
+
+    coreSheets.forEach(setupSheetDefinition);
+    analyticsSheets.forEach(setupSheetDefinition);
 
     // Attendance and holiday sheets
     console.log('Creating attendance and holiday sheets...');
@@ -546,23 +595,7 @@ function setupScheduleManagementSheets() {
       { name: HOLIDAYS_SHEET, headers: HOLIDAYS_HEADERS }
     ];
 
-    attendanceSheets.forEach(sheetConfig => {
-      try {
-        const ss = getScheduleSpreadsheet();
-        const existedBefore = ss.getSheetByName(sheetConfig.name) !== null;
-
-        ensureScheduleSheetWithHeaders(sheetConfig.name, sheetConfig.headers);
-
-        if (existedBefore) {
-          sheetsUpdated.push(sheetConfig.name);
-        } else {
-          sheetsCreated.push(sheetConfig.name);
-        }
-      } catch (error) {
-        console.error(`Failed to setup sheet ${sheetConfig.name}:`, error);
-        throw error;
-      }
-    });
+    attendanceSheets.forEach(setupSheetDefinition);
 
     // Create default shift slots if none exist
     console.log('Checking for default shift slots...');
@@ -625,6 +658,10 @@ function fixExistingScheduleSheetsFormatting() {
       SCHEDULE_ADHERENCE_SHEET,
       SCHEDULE_CONFLICTS_SHEET,
       RECURRING_SCHEDULES_SHEET,
+      DEMAND_SHEET,
+      FTE_PLAN_SHEET,
+      SCHEDULE_FORECAST_METADATA_SHEET,
+      SCHEDULE_HEALTH_SHEET,
       ATTENDANCE_STATUS_SHEET,
       USER_HOLIDAY_PAY_STATUS_SHEET,
       HOLIDAYS_SHEET
@@ -938,6 +975,10 @@ function invalidateScheduleCaches() {
     SHIFT_SLOTS_SHEET,
     SHIFT_SWAPS_SHEET,
     SCHEDULE_TEMPLATES_SHEET,
+    DEMAND_SHEET,
+    FTE_PLAN_SHEET,
+    SCHEDULE_FORECAST_METADATA_SHEET,
+    SCHEDULE_HEALTH_SHEET,
     ATTENDANCE_STATUS_SHEET,
     USER_HOLIDAY_PAY_STATUS_SHEET,
     HOLIDAYS_SHEET
@@ -951,6 +992,133 @@ function invalidateScheduleCaches() {
       console.warn(`Failed to invalidate cache for ${sheetName}:`, error);
     }
   });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// SHIFT SWAP DATA HELPERS
+// ────────────────────────────────────────────────────────────────────────────
+
+function ensureShiftSwapsSheet() {
+  return ensureScheduleSheetWithHeaders(SHIFT_SWAPS_SHEET, SHIFT_SWAPS_HEADERS);
+}
+
+function listShiftSwapRequests(options = {}) {
+  const rows = readScheduleSheet(SHIFT_SWAPS_SHEET) || [];
+  if (!rows.length) {
+    return [];
+  }
+
+  const statusFilter = Array.isArray(options.status)
+    ? options.status.map(value => String(value || '').toUpperCase()).filter(Boolean)
+    : (options.status ? [String(options.status).toUpperCase()] : null);
+
+  const userFilter = Array.isArray(options.userIds)
+    ? options.userIds.map(value => String(value || '').trim()).filter(Boolean)
+    : (options.userId ? [String(options.userId).trim()] : null);
+
+  return rows.filter(row => {
+    if (statusFilter && statusFilter.length) {
+      const status = String(row.Status || row.status || SHIFT_SWAP_STATUS.PENDING).toUpperCase();
+      if (!statusFilter.includes(status)) {
+        return false;
+      }
+    }
+
+    if (userFilter && userFilter.length) {
+      const requestorId = String(row.RequestorUserID || row.RequestorUserId || row.requestorUserId || '').trim();
+      const targetId = String(row.TargetUserID || row.TargetUserId || row.targetUserId || '').trim();
+      if (!userFilter.includes(requestorId) && !userFilter.includes(targetId)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+function createShiftSwapRequestEntry(request = {}) {
+  const sheet = ensureShiftSwapsSheet();
+  const id = request.ID || request.Id || request.id || (typeof Utilities !== 'undefined' && Utilities.getUuid ? Utilities.getUuid() : `swap_${Date.now()}`);
+  const now = new Date();
+
+  const normalized = {
+    ID: id,
+    RequestorUserID: request.requestorUserId || request.RequestorUserID || '',
+    RequestorUserName: request.requestorUserName || request.RequestorUserName || '',
+    TargetUserID: request.targetUserId || request.TargetUserID || '',
+    TargetUserName: request.targetUserName || request.TargetUserName || '',
+    RequestorScheduleID: request.requestorScheduleId || request.RequestorScheduleID || '',
+    TargetScheduleID: request.targetScheduleId || request.TargetScheduleID || '',
+    SwapDate: request.swapDate || request.SwapDate || '',
+    Reason: request.reason || request.Reason || '',
+    Status: (request.status || SHIFT_SWAP_STATUS.PENDING),
+    ApprovedBy: request.approvedBy || request.ApprovedBy || '',
+    RejectedBy: request.rejectedBy || request.RejectedBy || '',
+    DecisionNotes: request.decisionNotes || request.DecisionNotes || '',
+    CreatedAt: request.createdAt || request.CreatedAt || now,
+    UpdatedAt: request.updatedAt || request.UpdatedAt || now
+  };
+
+  const rowValues = SHIFT_SWAPS_HEADERS.map(header => Object.prototype.hasOwnProperty.call(normalized, header) ? normalized[header] : '');
+  sheet.appendRow(rowValues);
+
+  removeFromCache && removeFromCache(`schedule_${SHIFT_SWAPS_SHEET}`);
+  return normalized;
+}
+
+function updateShiftSwapRequestEntry(requestId, updates = {}) {
+  if (!requestId) {
+    return null;
+  }
+
+  const sheet = ensureShiftSwapsSheet();
+  const idValue = String(requestId).trim();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    return null;
+  }
+
+  const headers = SHIFT_SWAPS_HEADERS.slice();
+  const idColumn = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
+  let targetRowNumber = null;
+  for (let index = 0; index < idColumn.length; index++) {
+    if (String(idColumn[index][0] || '').trim() === idValue) {
+      targetRowNumber = index + 2;
+      break;
+    }
+  }
+
+  if (!targetRowNumber) {
+    return null;
+  }
+
+  const currentValues = sheet.getRange(targetRowNumber, 1, 1, headers.length).getValues()[0];
+  const currentRecord = {};
+  headers.forEach((header, columnIndex) => {
+    currentRecord[header] = currentValues[columnIndex];
+  });
+
+  const now = new Date();
+  const merged = Object.assign({}, currentRecord, updates, { ID: currentRecord.ID || idValue });
+
+  if (merged.status && !merged.Status) {
+    merged.Status = merged.status;
+  }
+
+  const normalizedStatus = merged.Status || SHIFT_SWAP_STATUS.PENDING;
+  merged.Status = String(normalizedStatus).toUpperCase();
+  merged.UpdatedAt = merged.UpdatedAt || merged.updatedAt || now;
+
+  const rowValues = headers.map(header => Object.prototype.hasOwnProperty.call(merged, header) ? merged[header] : currentRecord[header]);
+  sheet.getRange(targetRowNumber, 1, 1, headers.length).setValues([rowValues]);
+
+  removeFromCache && removeFromCache(`schedule_${SHIFT_SWAPS_SHEET}`);
+
+  const resultRecord = {};
+  headers.forEach((header, columnIndex) => {
+    resultRecord[header] = rowValues[columnIndex];
+  });
+  return resultRecord;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1508,6 +1676,914 @@ function createSuccessResponse(message, data = null) {
     message: message,
     data: data,
     timestamp: new Date().toISOString()
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// SCHEDULE ANALYTICS AND HEALTH METRICS
+// ────────────────────────────────────────────────────────────────────────────
+
+function normalizeScheduleUserId(value) {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const normalized = normalizeScheduleUserId(value[i]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    const candidates = [value.ID, value.Id, value.id, value.UserID, value.UserId, value.userId, value.value];
+    for (let i = 0; i < candidates.length; i++) {
+      const normalized = normalizeScheduleUserId(candidates[i]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return '';
+  }
+
+  const text = String(value).trim();
+  return text;
+}
+
+function normalizeScheduleDate(value) {
+  if (!value && value !== 0) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (typeof value === 'number') {
+    if (value > 100000000000) {
+      return new Date(value);
+    }
+
+    const baseDate = new Date(Date.UTC(1899, 11, 30));
+    baseDate.setUTCDate(baseDate.getUTCDate() + Math.floor(value));
+    return new Date(Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate()));
+  }
+
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (!text) {
+      return null;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+      return new Date(`${text}T00:00:00`);
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}/.test(text)) {
+      const parsed = new Date(text.replace(' ', 'T'));
+      if (!isNaN(parsed.getTime())) {
+        return parsed;
+      }
+    }
+
+    const parsedDate = new Date(text);
+    if (!isNaN(parsedDate.getTime())) {
+      return parsedDate;
+    }
+  }
+
+  return null;
+}
+
+function normalizeScheduleTimeToMinutes(value) {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.getHours() * 60 + value.getMinutes();
+  }
+
+  if (typeof value === 'number') {
+    if (value > 100000000000) {
+      const date = new Date(value);
+      return date.getHours() * 60 + date.getMinutes();
+    }
+
+    if (value >= 0 && value <= 1) {
+      return Math.round(value * 24 * 60);
+    }
+
+    if (value > 1 && value < 24) {
+      return Math.round(value * 60);
+    }
+
+    return Math.round(value);
+  }
+
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+
+  const ampmMatch = text.match(/^(\d{1,2})(?::(\d{1,2}))?(?::(\d{1,2}))?\s*(AM|PM)$/i);
+  if (ampmMatch) {
+    let hours = parseInt(ampmMatch[1], 10);
+    const minutes = parseInt(ampmMatch[2] || '0', 10);
+    const period = ampmMatch[4].toUpperCase();
+    if (period === 'PM' && hours < 12) {
+      hours += 12;
+    }
+    if (period === 'AM' && hours === 12) {
+      hours = 0;
+    }
+    return hours * 60 + minutes;
+  }
+
+  const isoMatch = text.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (isoMatch) {
+    const hours = parseInt(isoMatch[2], 10);
+    const minutes = parseInt(isoMatch[3], 10);
+    return hours * 60 + minutes;
+  }
+
+  const hhmmMatch = text.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (hhmmMatch) {
+    const hours = parseInt(hhmmMatch[1], 10);
+    const minutes = parseInt(hhmmMatch[2], 10);
+    return hours * 60 + minutes;
+  }
+
+  const numeric = parseFloat(text);
+  if (!isNaN(numeric)) {
+    return normalizeScheduleTimeToMinutes(numeric);
+  }
+
+  return null;
+}
+
+function normalizeSchedulePercentage(value, fallback = 0) {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return fallback;
+  }
+
+  const numeric = Number(value);
+  if (!isFinite(numeric)) {
+    return fallback;
+  }
+
+  if (Math.abs(numeric) > 1) {
+    return numeric / 100;
+  }
+
+  return numeric;
+}
+
+function buildIntervalKeyFromDate(date, minutesFromMidnight, intervalMinutes = 30) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return null;
+  }
+
+  const normalized = new Date(date.getTime());
+  normalized.setHours(0, 0, 0, 0);
+
+  const roundedMinutes = Math.max(0, Math.round(minutesFromMidnight / intervalMinutes) * intervalMinutes);
+  const hours = Math.floor(roundedMinutes / 60);
+  const minutes = roundedMinutes % 60;
+
+  normalized.setHours(hours, minutes, 0, 0);
+
+  const year = normalized.getFullYear();
+  const month = String(normalized.getMonth() + 1).padStart(2, '0');
+  const day = String(normalized.getDate()).padStart(2, '0');
+  const hour = String(hours).padStart(2, '0');
+  const minute = String(minutes).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
+function expandScheduleIntervals(scheduleRow, intervalMinutes = 30, options = {}) {
+  const dateValue = scheduleRow.Date || scheduleRow.ScheduleDate || scheduleRow.PeriodStart || scheduleRow.StartDate || scheduleRow.Day;
+  const date = normalizeScheduleDate(dateValue);
+  if (!date) {
+    return [];
+  }
+
+  const startMinutes = normalizeScheduleTimeToMinutes(scheduleRow.StartTime || scheduleRow.PeriodStart || scheduleRow.ScheduleStart || scheduleRow.ShiftStart);
+  const endMinutes = normalizeScheduleTimeToMinutes(scheduleRow.EndTime || scheduleRow.PeriodEnd || scheduleRow.ScheduleEnd || scheduleRow.ShiftEnd);
+
+  if (startMinutes === null || endMinutes === null) {
+    return [];
+  }
+
+  const breakRanges = [];
+
+  const addBreakRange = (startValue, endValue) => {
+    const breakStart = normalizeScheduleTimeToMinutes(startValue);
+    const breakEnd = normalizeScheduleTimeToMinutes(endValue);
+    if (breakStart === null || breakEnd === null) {
+      return;
+    }
+    const start = Math.min(breakStart, breakEnd);
+    const end = Math.max(breakStart, breakEnd);
+    if (end > start) {
+      breakRanges.push([start, end]);
+    }
+  };
+
+  addBreakRange(scheduleRow.BreakStart || scheduleRow.Break1Start, scheduleRow.BreakEnd || scheduleRow.Break1End);
+  addBreakRange(scheduleRow.Break2Start, scheduleRow.Break2End);
+  addBreakRange(scheduleRow.LunchStart, scheduleRow.LunchEnd);
+  addBreakRange(scheduleRow.MealStart, scheduleRow.MealEnd);
+
+  const coverage = [];
+  const bufferMinutes = Number(options.breakBufferMinutes || 0);
+
+  for (let minute = startMinutes; minute < endMinutes; minute += intervalMinutes) {
+    const intervalCenter = minute + intervalMinutes / 2;
+    const onBreak = breakRanges.some(range => intervalCenter >= range[0] - bufferMinutes && intervalCenter < range[1] + bufferMinutes);
+    if (!onBreak) {
+      const key = buildIntervalKeyFromDate(date, minute, intervalMinutes);
+      if (key) {
+        coverage.push(key);
+      }
+    }
+  }
+
+  return coverage;
+}
+
+function aggregateIntervalsFromDemandRow(demandRow, intervalMinutes = 30) {
+  const intervals = [];
+  const intervalStartValue = demandRow.IntervalStart || demandRow.intervalStart || demandRow.Interval || demandRow.Start;
+  const intervalEndValue = demandRow.IntervalEnd || demandRow.intervalEnd || demandRow.End;
+
+  const startDate = normalizeScheduleDate(intervalStartValue || demandRow.Date || demandRow.Day);
+  const endDate = normalizeScheduleDate(intervalEndValue);
+
+  if (!startDate) {
+    return intervals;
+  }
+
+  const startMinutes = normalizeScheduleTimeToMinutes(intervalStartValue);
+  const endMinutes = normalizeScheduleTimeToMinutes(intervalEndValue);
+
+  if (startMinutes === null) {
+    const derivedMinutes = normalizeScheduleTimeToMinutes(demandRow.StartTime || demandRow.IntervalTime || demandRow.Time);
+    if (derivedMinutes !== null) {
+      intervals.push(buildIntervalKeyFromDate(startDate, derivedMinutes, intervalMinutes));
+      return intervals;
+    }
+    intervals.push(buildIntervalKeyFromDate(startDate, 0, intervalMinutes));
+    return intervals;
+  }
+
+  const finalMinutes = endMinutes !== null ? endMinutes : startMinutes + intervalMinutes;
+  for (let minute = startMinutes; minute < finalMinutes; minute += intervalMinutes) {
+    const key = buildIntervalKeyFromDate(startDate, minute, intervalMinutes);
+    if (key) {
+      intervals.push(key);
+    }
+  }
+
+  return intervals;
+}
+
+function toNumeric(value, fallback = 0) {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return fallback;
+  }
+
+  const numberValue = Number(value);
+  return isFinite(numberValue) ? numberValue : fallback;
+}
+
+function average(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return 0;
+  }
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
+
+function standardDeviation(values, meanValue) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return 0;
+  }
+  const mean = typeof meanValue === 'number' ? meanValue : average(values);
+  const variance = values.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+function calculateCoverageMetrics(scheduleRows, demandRows, options = {}) {
+  const intervalMinutes = Number(options.intervalMinutes || 30);
+  const peakWeight = Number(options.peakWindowWeight || 1.25);
+  const openingHour = Number(options.openingHour || 8);
+  const closingHour = Number(options.closingHour || 21);
+  const baselineASA = Number(options.baselineASA || 45);
+  const targetServiceLevel = Number(options.targetServiceLevel || 0.8);
+
+  const demandByInterval = new Map();
+  const coverageByInterval = new Map();
+  const intervalDemandMetadata = new Map();
+
+  if (Array.isArray(demandRows)) {
+    demandRows.forEach(row => {
+      const intervals = aggregateIntervalsFromDemandRow(row, intervalMinutes);
+      const requiredFTE = toNumeric(row.RequiredFTE || row.requiredFTE, null);
+      const contacts = toNumeric(row.ForecastContacts || row.Contacts || row.Volume, 0);
+      const aht = toNumeric(row.ForecastAHT || row.AHT || row.HandleTime, 0);
+      const shrinkage = normalizeSchedulePercentage(row.Shrinkage, options.defaultShrinkage || 0.3);
+
+      const computedFTE = requiredFTE !== null && requiredFTE !== undefined && requiredFTE !== ''
+        ? Number(requiredFTE)
+        : ((contacts * aht) / (intervalMinutes * 60 || 1)) / Math.max(1 - shrinkage, 0.5);
+
+      intervals.forEach((key, index) => {
+        if (!key) {
+          return;
+        }
+
+        const existing = demandByInterval.get(key) || { requiredFTE: 0, contacts: 0 };
+        existing.requiredFTE += computedFTE || 0;
+        existing.contacts += contacts;
+        existing.weight = (existing.weight || 0) + (computedFTE || 1);
+        demandByInterval.set(key, existing);
+        intervalDemandMetadata.set(key, {
+          campaign: row.Campaign || row.campaign || row.CampaignID || row.CampaignId || '',
+          skill: row.Skill || row.skill || row.Queue || '',
+          targetSL: toNumeric(row.TargetSL || row.TargetServiceLevel, targetServiceLevel * 100),
+          targetASA: toNumeric(row.TargetASA || row.ASA || baselineASA),
+          shrinkage: shrinkage
+        });
+      });
+    });
+  }
+
+  const scheduleRowsArray = Array.isArray(scheduleRows) ? scheduleRows : [];
+  scheduleRowsArray.forEach(row => {
+    const intervals = expandScheduleIntervals(row, intervalMinutes, options);
+    if (!intervals.length) {
+      return;
+    }
+
+    const userId = normalizeScheduleUserId(row.UserID || row.UserId || row.AgentID || row.AgentId);
+    const fteWeight = toNumeric(row.FTE || row.Fte || row.FTEEquivalent || row.WorkdayTarget, 1);
+    const skill = row.Skill || row.Queue || row.Channel || '';
+    const campaign = row.Campaign || row.CampaignID || row.CampaignId || '';
+
+    intervals.forEach(intervalKey => {
+      if (!intervalKey) {
+        return;
+      }
+
+      if (!coverageByInterval.has(intervalKey)) {
+        coverageByInterval.set(intervalKey, {
+          staffedFTE: 0,
+          agentSet: new Set(),
+          skillSet: new Set(),
+          campaignSet: new Set()
+        });
+      }
+
+      const coverage = coverageByInterval.get(intervalKey);
+      coverage.staffedFTE += fteWeight || 1;
+      if (userId) {
+        coverage.agentSet.add(userId);
+      }
+      if (skill) {
+        coverage.skillSet.add(String(skill));
+      }
+      if (campaign) {
+        coverage.campaignSet.add(String(campaign));
+      }
+    });
+  });
+
+  const intervalSummaries = [];
+  let totalRequired = 0;
+  let totalStaffed = 0;
+  let weightedCoverage = 0;
+  let weightedRequirement = 0;
+  let peakCoverageWeighted = 0;
+  let peakWeightTotal = 0;
+  let underIntervals = 0;
+  let overIntervals = 0;
+
+  const backlogRiskIntervals = [];
+
+  demandByInterval.forEach((demand, key) => {
+    const required = Number(demand.requiredFTE || 0);
+    const coverage = coverageByInterval.get(key) || { staffedFTE: 0, agentSet: new Set(), skillSet: new Set(), campaignSet: new Set() };
+    const staffed = Number(coverage.staffedFTE || 0);
+
+    totalRequired += required;
+    totalStaffed += staffed;
+
+    const coverageRatio = required > 0 ? staffed / required : (staffed > 0 ? 1 : 1);
+    const normalizedCoverage = Math.min(Math.max(coverageRatio, 0), 2);
+
+    const intervalDate = normalizeScheduleDate(key);
+    const intervalHour = intervalDate instanceof Date ? intervalDate.getHours() : Number(String(key).substring(11, 13));
+    const isOpening = intervalHour <= openingHour;
+    const isClosing = intervalHour >= (closingHour - 1);
+
+    const weight = demand.weight || (required > 0 ? required : 1);
+    const adjustedWeight = weight * (isOpening || isClosing ? peakWeight : 1);
+
+    weightedCoverage += Math.min(normalizedCoverage, 1) * adjustedWeight;
+    weightedRequirement += adjustedWeight;
+
+    if (isOpening || isClosing) {
+      peakCoverageWeighted += Math.min(normalizedCoverage, 1) * adjustedWeight;
+      peakWeightTotal += adjustedWeight;
+    }
+
+    if (coverageRatio < 0.95) {
+      underIntervals += 1;
+      backlogRiskIntervals.push({
+        intervalKey: key,
+        requiredFTE: Number(required.toFixed(2)),
+        staffedFTE: Number(staffed.toFixed(2)),
+        coverageRatio: Number(coverageRatio.toFixed(3)),
+        deficit: Number((required - staffed).toFixed(2)),
+        skill: (intervalDemandMetadata.get(key) || {}).skill || ''
+      });
+    } else if (coverageRatio > 1.15) {
+      overIntervals += 1;
+    }
+
+    intervalSummaries.push({
+      intervalKey: key,
+      requiredFTE: Number(required.toFixed(2)),
+      staffedFTE: Number(staffed.toFixed(2)),
+      coverageRatio: Number(coverageRatio.toFixed(3)),
+      variance: Number((staffed - required).toFixed(2)),
+      agents: Array.from(coverage.agentSet || []),
+      skillsCovered: Array.from(coverage.skillSet || []),
+      campaigns: Array.from(coverage.campaignSet || []),
+      isOpeningWindow: isOpening,
+      isClosingWindow: isClosing,
+      metadata: intervalDemandMetadata.get(key) || {}
+    });
+  });
+
+  coverageByInterval.forEach((coverage, key) => {
+    if (demandByInterval.has(key)) {
+      return;
+    }
+    intervalSummaries.push({
+      intervalKey: key,
+      requiredFTE: 0,
+      staffedFTE: Number((coverage.staffedFTE || 0).toFixed(2)),
+      coverageRatio: coverage.staffedFTE > 0 ? 2 : 0,
+      variance: Number((coverage.staffedFTE || 0).toFixed(2)),
+      agents: Array.from(coverage.agentSet || []),
+      skillsCovered: Array.from(coverage.skillSet || []),
+      campaigns: Array.from(coverage.campaignSet || []),
+      metadata: intervalDemandMetadata.get(key) || {}
+    });
+  });
+
+  intervalSummaries.sort((a, b) => a.intervalKey.localeCompare(b.intervalKey));
+  backlogRiskIntervals.sort((a, b) => b.deficit - a.deficit);
+
+  const averageCoverageRatio = totalRequired > 0 ? totalStaffed / totalRequired : 1;
+  const serviceLevel = Math.round(Math.min(1, weightedRequirement ? weightedCoverage / weightedRequirement : 1) * 100);
+  const asa = Math.round(Math.max(5, baselineASA / Math.max(averageCoverageRatio, 0.4)));
+  const abandonRate = Number(Math.max(0, Math.min(40, (1 - Math.min(averageCoverageRatio, 1)) * 25)).toFixed(2));
+  const occupancy = Number(Math.max(50, Math.min(98, averageCoverageRatio * 90)).toFixed(2));
+  const peakCoverage = peakWeightTotal > 0 ? Number((peakCoverageWeighted / peakWeightTotal * 100).toFixed(2)) : serviceLevel;
+
+  return {
+    intervalMinutes,
+    intervalSummaries,
+    totalRequiredFTE: Number(totalRequired.toFixed(2)),
+    totalStaffedFTE: Number(totalStaffed.toFixed(2)),
+    coverageScore: Number(Math.min(100, Math.max(0, (weightedRequirement ? (weightedCoverage / weightedRequirement) : 1) * 100)).toFixed(2)),
+    averageCoverageRatio: Number(averageCoverageRatio.toFixed(3)),
+    serviceLevel,
+    asa,
+    abandonRate,
+    occupancy,
+    peakCoverage,
+    underStaffedIntervals: underIntervals,
+    overStaffedIntervals: overIntervals,
+    backlogRiskIntervals: backlogRiskIntervals.slice(0, 10)
+  };
+}
+
+function evaluatePreferenceAlignment(stats, profile, options = {}) {
+  if (!profile) {
+    return 100;
+  }
+
+  const preferenceText = String(profile.PreferenceNotes || profile.Preferences || profile.preferences || '').toLowerCase();
+  if (!preferenceText) {
+    return 100;
+  }
+
+  let score = 100;
+  const totalShifts = Math.max(stats.totalShifts || 0, 1);
+
+  if (/no weekend|avoid weekend|weekend off/.test(preferenceText)) {
+    score -= Math.min(40, (stats.weekendShifts / totalShifts) * 120);
+  }
+
+  if (/no night|avoid night|prefer day|day shift/.test(preferenceText)) {
+    score -= Math.min(35, (stats.nightShifts / totalShifts) * 120);
+  }
+
+  if (/prefer morning|prefer opening|early shift/.test(preferenceText)) {
+    const ratio = stats.openingShifts / totalShifts;
+    score -= Math.max(0, 30 - ratio * 100);
+  }
+
+  if (/prefer evening|prefer closing|late shift/.test(preferenceText)) {
+    const ratio = stats.closingShifts / totalShifts;
+    score -= Math.max(0, 30 - ratio * 100);
+  }
+
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function calculateFairnessMetrics(scheduleRows, agentProfiles = [], options = {}) {
+  const statsByUser = new Map();
+  const profileByUser = new Map();
+
+  (agentProfiles || []).forEach(profile => {
+    const userId = normalizeScheduleUserId(profile.ID || profile.UserID || profile.UserId || profile.Email || profile.Username);
+    if (userId) {
+      profileByUser.set(userId, profile);
+    }
+  });
+
+  const ensureStats = (userId) => {
+    if (!statsByUser.has(userId)) {
+      statsByUser.set(userId, {
+        userId,
+        userName: '',
+        totalShifts: 0,
+        totalMinutes: 0,
+        weekendShifts: 0,
+        nightShifts: 0,
+        openingShifts: 0,
+        closingShifts: 0,
+        consecutiveDayBlocks: 0,
+        skills: new Set(),
+        locations: new Set(),
+        preferenceScore: 100,
+        fairnessScore: 100
+      });
+    }
+    return statsByUser.get(userId);
+  };
+
+  const nightStart = Number(options.nightThresholdStart || 20 * 60);
+  const nightEnd = Number(options.nightThresholdEnd || 6 * 60);
+  const openingThreshold = Number(options.openingThreshold || 8 * 60);
+  const closingThreshold = Number(options.closingThreshold || 21 * 60);
+
+  const scheduleRowsArray = Array.isArray(scheduleRows) ? scheduleRows : [];
+  scheduleRowsArray.forEach(row => {
+    const userId = normalizeScheduleUserId(row.UserID || row.UserId || row.AgentID || row.AgentId);
+    if (!userId) {
+      return;
+    }
+
+    const stats = ensureStats(userId);
+    const date = normalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+    if (!date) {
+      return;
+    }
+
+    const startMinutes = normalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+    const endMinutes = normalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+
+    if (row.UserName || row.FullName || row.Name) {
+      stats.userName = stats.userName || row.UserName || row.FullName || row.Name;
+    }
+
+    stats.totalShifts += 1;
+    if (startMinutes !== null && endMinutes !== null) {
+      let duration = endMinutes - startMinutes;
+      if (duration < 0) {
+        duration += 24 * 60;
+      }
+      stats.totalMinutes += Math.max(0, duration);
+    }
+
+    const dayOfWeek = date.getDay();
+    if (WEEKEND.includes(dayOfWeek)) {
+      stats.weekendShifts += 1;
+    }
+
+    if ((startMinutes !== null && startMinutes >= nightStart) || (endMinutes !== null && endMinutes <= nightEnd)) {
+      stats.nightShifts += 1;
+    }
+
+    if (startMinutes !== null && startMinutes <= openingThreshold) {
+      stats.openingShifts += 1;
+    }
+
+    if (endMinutes !== null && endMinutes >= closingThreshold) {
+      stats.closingShifts += 1;
+    }
+
+    if (row.Skill) {
+      stats.skills.add(String(row.Skill));
+    }
+    if (row.Location) {
+      stats.locations.add(String(row.Location));
+    }
+  });
+
+  const userStats = Array.from(statsByUser.values());
+  const weekendCounts = userStats.map(stats => stats.weekendShifts);
+  const nightCounts = userStats.map(stats => stats.nightShifts);
+  const closingCounts = userStats.map(stats => stats.closingShifts);
+
+  const weekendMean = average(weekendCounts);
+  const nightMean = average(nightCounts);
+  const closingMean = average(closingCounts);
+
+  const weekendStd = standardDeviation(weekendCounts, weekendMean);
+  const nightStd = standardDeviation(nightCounts, nightMean);
+  const closingStd = standardDeviation(closingCounts, closingMean);
+
+  const normalizeVariance = (stdDev, mean) => {
+    if (!isFinite(stdDev) || mean <= 0) {
+      return 0;
+    }
+    return Math.min(1.5, stdDev / Math.max(mean, 0.5));
+  };
+
+  const fairnessVariance = (normalizeVariance(weekendStd, weekendMean) + normalizeVariance(nightStd, nightMean) + normalizeVariance(closingStd, closingMean)) / 3;
+  const fairnessIndex = Math.max(0, Math.min(100, Math.round(100 - fairnessVariance * 50)));
+
+  let preferenceTotal = 0;
+
+  userStats.forEach(stats => {
+    const profile = profileByUser.get(stats.userId);
+    stats.preferenceScore = evaluatePreferenceAlignment(stats, profile, options);
+    preferenceTotal += stats.preferenceScore;
+
+    const fairnessPenalty = (
+      Math.abs(stats.weekendShifts - weekendMean) / Math.max(weekendMean || 1, 1) +
+      Math.abs(stats.nightShifts - nightMean) / Math.max(nightMean || 1, 1) +
+      Math.abs(stats.closingShifts - closingMean) / Math.max(closingMean || 1, 1)
+    ) / 3;
+
+    stats.fairnessScore = Math.max(0, Math.min(100, Math.round(100 - fairnessPenalty * 40)));
+    stats.skills = Array.from(stats.skills);
+    stats.locations = Array.from(stats.locations);
+  });
+
+  const preferenceSatisfaction = userStats.length ? Math.round(preferenceTotal / userStats.length) : 100;
+  const rotationHealth = Math.max(0, Math.min(100, Math.round(100 - normalizeVariance(weekendStd, weekendMean) * 60)));
+
+  return {
+    fairnessIndex,
+    preferenceSatisfaction,
+    rotationHealth,
+    weekendBalance: {
+      average: Number(weekendMean.toFixed(2)),
+      stdDev: Number(weekendStd.toFixed(2)),
+      counts: weekendCounts
+    },
+    nightBalance: {
+      average: Number(nightMean.toFixed(2)),
+      stdDev: Number(nightStd.toFixed(2)),
+      counts: nightCounts
+    },
+    closingBalance: {
+      average: Number(closingMean.toFixed(2)),
+      stdDev: Number(closingStd.toFixed(2)),
+      counts: closingCounts
+    },
+    agentSummaries: userStats
+  };
+}
+
+function calculateComplianceMetrics(scheduleRows, agentProfiles = [], options = {}) {
+  const maxHoursPerDay = Number(options.maxHoursPerDay || 12);
+  const minRestHours = Number(options.minRestHours || 10);
+  const allowedBreakOverlap = Number(options.allowedBreakOverlap || 3);
+  const maxConsecutiveDays = Number(options.maxConsecutiveDays || 6);
+
+  const violationDetails = [];
+  const shiftsByUser = new Map();
+  const breakOverlapCounter = new Map();
+
+  const addViolation = (type, details) => {
+    violationDetails.push(Object.assign({ type, timestamp: new Date().toISOString() }, details || {}));
+  };
+
+  const scheduleRowsArray = Array.isArray(scheduleRows) ? scheduleRows : [];
+  scheduleRowsArray.forEach(row => {
+    const userId = normalizeScheduleUserId(row.UserID || row.UserId || row.AgentID || row.AgentId);
+    if (!userId) {
+      return;
+    }
+
+    const date = normalizeScheduleDate(row.Date || row.ScheduleDate || row.PeriodStart || row.StartDate || row.Day);
+    if (!date) {
+      return;
+    }
+
+    const startMinutes = normalizeScheduleTimeToMinutes(row.StartTime || row.PeriodStart || row.ScheduleStart || row.ShiftStart);
+    const endMinutes = normalizeScheduleTimeToMinutes(row.EndTime || row.PeriodEnd || row.ScheduleEnd || row.ShiftEnd);
+    if (startMinutes === null || endMinutes === null) {
+      return;
+    }
+
+    const shiftStart = new Date(date.getTime());
+    shiftStart.setHours(0, 0, 0, 0);
+    shiftStart.setMinutes(shiftStart.getMinutes() + startMinutes);
+
+    const shiftEnd = new Date(date.getTime());
+    shiftEnd.setHours(0, 0, 0, 0);
+    shiftEnd.setMinutes(shiftEnd.getMinutes() + endMinutes);
+    if (shiftEnd <= shiftStart) {
+      shiftEnd.setDate(shiftEnd.getDate() + 1);
+    }
+
+    const durationHours = (shiftEnd.getTime() - shiftStart.getTime()) / (1000 * 60 * 60);
+    if (durationHours > maxHoursPerDay) {
+      addViolation('SHIFT_DURATION', {
+        userId,
+        userName: row.UserName || row.FullName || row.Name,
+        scheduledHours: Number(durationHours.toFixed(2)),
+        maxHoursPerDay
+      });
+    }
+
+    const breaks = [];
+    const addBreak = (startValue, endValue, type) => {
+      const breakStartMinutes = normalizeScheduleTimeToMinutes(startValue);
+      const breakEndMinutes = normalizeScheduleTimeToMinutes(endValue);
+      if (breakStartMinutes === null || breakEndMinutes === null) {
+        return;
+      }
+      breaks.push({
+        startMinutes: breakStartMinutes,
+        endMinutes: breakEndMinutes,
+        type: type || 'BREAK'
+      });
+      const key = `${date.toISOString().slice(0, 10)}|${breakStartMinutes}`;
+      breakOverlapCounter.set(key, (breakOverlapCounter.get(key) || 0) + 1);
+    };
+
+    addBreak(row.BreakStart || row.Break1Start, row.BreakEnd || row.Break1End, 'BREAK');
+    addBreak(row.Break2Start, row.Break2End, 'BREAK');
+    addBreak(row.LunchStart, row.LunchEnd, 'LUNCH');
+
+    if (breaks.length === 0) {
+      addViolation('MISSING_BREAK', {
+        userId,
+        userName: row.UserName || row.FullName || row.Name,
+        date: date.toISOString().slice(0, 10)
+      });
+    }
+
+    if (!shiftsByUser.has(userId)) {
+      shiftsByUser.set(userId, []);
+    }
+
+    shiftsByUser.get(userId).push({
+      start: shiftStart,
+      end: shiftEnd,
+      date,
+      breaks,
+      userName: row.UserName || row.FullName || row.Name
+    });
+  });
+
+  let restViolations = 0;
+  let consecutiveViolations = 0;
+
+  shiftsByUser.forEach((shifts, userId) => {
+    shifts.sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    for (let i = 1; i < shifts.length; i++) {
+      const restHours = (shifts[i].start.getTime() - shifts[i - 1].end.getTime()) / (1000 * 60 * 60);
+      if (restHours < minRestHours) {
+        restViolations += 1;
+        addViolation('REST_PERIOD', {
+          userId,
+          userName: shifts[i].userName,
+          restHours: Number(restHours.toFixed(2)),
+          requiredRestHours: minRestHours,
+          previousShiftEnd: shifts[i - 1].end.toISOString(),
+          nextShiftStart: shifts[i].start.toISOString()
+        });
+      }
+    }
+
+    let currentStreak = 1;
+    for (let i = 1; i < shifts.length; i++) {
+      const previousDay = shifts[i - 1].date;
+      const currentDay = shifts[i].date;
+      const dayDifference = Math.floor((currentDay - previousDay) / (24 * 60 * 60 * 1000));
+      if (dayDifference === 1) {
+        currentStreak += 1;
+      } else if (dayDifference > 1) {
+        currentStreak = 1;
+      }
+
+      if (currentStreak > maxConsecutiveDays) {
+        consecutiveViolations += 1;
+        addViolation('CONSECUTIVE_DAYS', {
+          userId,
+          userName: shifts[i].userName,
+          consecutiveDays: currentStreak,
+          maxConsecutiveDays
+        });
+        currentStreak = 1;
+      }
+    }
+  });
+
+  let maxBreakOverlap = 0;
+  breakOverlapCounter.forEach(count => {
+    if (count > maxBreakOverlap) {
+      maxBreakOverlap = count;
+    }
+  });
+
+  const breakOverlapViolations = Math.max(0, maxBreakOverlap - allowedBreakOverlap);
+
+  const totalViolations = violationDetails.length;
+  const penalty = totalViolations * 3 + restViolations * 2 + breakOverlapViolations * 5 + consecutiveViolations * 2;
+  const complianceScore = Math.max(0, Math.min(100, Math.round(100 - penalty)));
+
+  const recommendations = [];
+  if (restViolations > 0) {
+    recommendations.push(`Increase rest periods to at least ${minRestHours} hours between consecutive shifts.`);
+  }
+  if (breakOverlapViolations > 0) {
+    recommendations.push(`Stagger breaks to ensure no more than ${allowedBreakOverlap} agents are off simultaneously.`);
+  }
+  if (violationDetails.some(v => v.type === 'MISSING_BREAK')) {
+    recommendations.push('Insert the required paid breaks and unpaid lunch for every shift.');
+  }
+  if (violationDetails.some(v => v.type === 'SHIFT_DURATION')) {
+    recommendations.push(`Review long shifts exceeding ${maxHoursPerDay} hours and split or reassign as needed.`);
+  }
+
+  return {
+    complianceScore,
+    totalViolations,
+    restViolations,
+    consecutiveViolations,
+    breakOverlap: {
+      maxSimultaneous: maxBreakOverlap,
+      allowed: allowedBreakOverlap
+    },
+    violationDetails,
+    recommendations
+  };
+}
+
+function evaluateSchedulePerformance(scheduleRows, demandRows, agentProfiles = [], options = {}) {
+  const coverage = calculateCoverageMetrics(scheduleRows, demandRows, options);
+  const fairness = calculateFairnessMetrics(scheduleRows, agentProfiles, options);
+  const compliance = calculateComplianceMetrics(scheduleRows, agentProfiles, options);
+
+  const weights = Object.assign({ coverage: 0.45, fairness: 0.25, compliance: 0.2, preference: 0.1 }, options.healthWeights || {});
+
+  const coverageComponent = (coverage.coverageScore || 0) / 100;
+  const fairnessComponent = (fairness.fairnessIndex || 0) / 100;
+  const complianceComponent = (compliance.complianceScore || 0) / 100;
+  const preferenceComponent = (fairness.preferenceSatisfaction || 0) / 100;
+
+  const healthScore = Math.round(
+    (coverageComponent * weights.coverage) +
+    (fairnessComponent * weights.fairness) +
+    (complianceComponent * weights.compliance) +
+    (preferenceComponent * weights.preference)
+  * 100
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    healthScore,
+    coverage,
+    fairness,
+    compliance,
+    summary: {
+      serviceLevel: coverage.serviceLevel,
+      asa: coverage.asa,
+      abandonRate: coverage.abandonRate,
+      occupancy: coverage.occupancy,
+      fairnessIndex: fairness.fairnessIndex,
+      preferenceSatisfaction: fairness.preferenceSatisfaction,
+      complianceScore: compliance.complianceScore,
+      scheduleEfficiency: coverage.coverageScore
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- add shift swap helpers and status constants to ScheduleUtilities for creating and updating swap requests
- extend ScheduleService with agent schedule retrieval, swap request management, and available-agent endpoints while enriching snapshots with pending swap counts
- update the agent schedule UI to call the new APIs, improve schedule rendering, and handle swap requests end-to-end

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f2d67b3144832688b228d375ad7c06