### PR TITLE
Fix numeric literal for Apps Script compatibility

### DIFF
--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -2083,7 +2083,7 @@ function generateUniqueAttendanceId(existingIds, batchIds) {
   }
 
   let attempts = 0;
-  while (attempts < 5_000) {
+  while (attempts < 5000) {
     attempts += 1;
     const candidate = Utilities.getUuid();
     if (!existingIds.has(candidate) && !batchIds.has(candidate)) {


### PR DESCRIPTION
## Summary
- replace the numeric literal in `generateUniqueAttendanceId` to avoid using underscore separators that Apps Script cannot parse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3afb2645483269c1372d409816a04