### PR TITLE
Align landing suite with shared hero visuals and add detailed story pages

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -287,14 +287,45 @@
       border-color: rgba(226, 232, 240, 0.32);
     }
 
-    .hero-showcase {
-      background: rgba(11, 27, 63, 0.55);
-      border-radius: var(--radius-md);
-      padding: clamp(1.5rem, 3vw, 2rem);
-      box-shadow: none;
-      border: 1px solid rgba(226, 232, 240, 0.15);
+    .hero-visual {
       display: grid;
-      gap: 1.5rem;
+      gap: 1.2rem;
+      position: relative;
+    }
+
+    .hero-visual-frame {
+      position: relative;
+      border-radius: var(--radius-md);
+      padding: clamp(1.2rem, 2.5vw, 2rem);
+      background: linear-gradient(150deg, rgba(11, 27, 63, 0.6), rgba(4, 120, 211, 0.35));
+      border: 1px solid rgba(226, 232, 240, 0.16);
+      overflow: hidden;
+      min-height: 320px;
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    .hero-visual-frame img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: calc(var(--radius-md) - 8px);
+      box-shadow: 0 34px 70px rgba(8, 47, 73, 0.35);
+    }
+
+    .hero-showcase {
+      position: absolute;
+      left: clamp(1.4rem, 7vw, 3.2rem);
+      bottom: clamp(1.4rem, 6vw, 3.2rem);
+      width: min(340px, 72%);
+      background: rgba(11, 27, 63, 0.92);
+      border-radius: var(--radius-md);
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(226, 232, 240, 0.22);
+      box-shadow: 0 24px 45px rgba(8, 47, 73, 0.35);
+      display: grid;
+      gap: 1.25rem;
     }
 
     .showcase-header {
@@ -305,9 +336,11 @@
     }
 
     .showcase-header h2 {
-      font-size: 1.1rem;
+      font-size: 1rem;
       margin: 0;
       color: var(--lumina-surface);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .status-pill {
@@ -318,51 +351,94 @@
       border-radius: 999px;
       background: rgba(56, 189, 248, 0.24);
       color: var(--lumina-surface);
-      font-size: 0.8rem;
+      font-size: 0.72rem;
       font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .metrics-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 1.25rem;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 1rem;
     }
 
     .metric-card {
-      background: rgba(15, 23, 42, 0.45);
+      background: rgba(15, 23, 42, 0.68);
       color: var(--lumina-surface);
-      padding: 1.4rem;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(226, 232, 240, 0.12);
-      position: relative;
+      padding: 1rem;
+      border-radius: var(--radius-sm);
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      display: grid;
+      gap: 0.5rem;
     }
 
     .metric-card strong {
       display: block;
-      font-size: 2rem;
+      font-size: 1.6rem;
       font-weight: 700;
     }
 
     .metric-card span {
-      font-size: 0.85rem;
+      font-size: 0.75rem;
       letter-spacing: 0.06em;
       text-transform: uppercase;
       color: rgba(226, 232, 240, 0.7);
     }
 
     .metric-card i {
-      font-size: 1.4rem;
+      font-size: 1.2rem;
       opacity: 0.85;
     }
 
     .metric-card .icon-circle {
-      width: 48px;
-      height: 48px;
+      width: 40px;
+      height: 40px;
       border-radius: 50%;
       background: rgba(255, 255, 255, 0.14);
       display: grid;
       place-items: center;
-      margin-bottom: 1rem;
+    }
+
+    .hero-mini-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+
+    .hero-mini-card {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(226, 232, 240, 0.24);
+      border-radius: var(--radius-sm);
+      padding: 1.1rem;
+      text-align: left;
+      display: grid;
+      gap: 0.5rem;
+      color: var(--lumina-surface);
+    }
+
+    .hero-mini-card i {
+      font-size: 1.35rem;
+      color: var(--lumina-cyan);
+    }
+
+    .hero-mini-card strong {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(226, 232, 240, 0.85);
+    }
+
+    .hero-mini-card span {
+      font-size: 0.85rem;
+      color: rgba(226, 232, 240, 0.75);
+    }
+
+    .hero-note {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.75);
+      font-size: 0.82rem;
+      line-height: 1.5;
     }
 
     .section {
@@ -698,6 +774,16 @@
         flex: 1;
         justify-content: center;
       }
+
+      .hero-visual-frame {
+        min-height: 260px;
+        padding: 1rem;
+      }
+
+      .hero-showcase {
+        position: static;
+        width: 100%;
+      }
     }
   </style>
   <?
@@ -706,6 +792,8 @@
     var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
     var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
     var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+    var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+    var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
   ?>
 </head>
 
@@ -722,6 +810,8 @@
         </a>
         <div class="nav-actions">
           <a class="btn-outline" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a class="btn-outline" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Capabilities</a>
+          <a class="btn-outline" href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Story</a>
           <a class="btn-primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login</a>
         </div>
       </div>
@@ -743,33 +833,55 @@
                 </ul>
                 <div class="hero-ctas">
                   <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
-                  <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+                  <a class="ghost" href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-diagram-project"></i> Dive into capabilities</a>
                 </div>
               </div>
-              <aside class="hero-showcase" aria-label="Platform highlights">
-                <div class="showcase-header">
-                  <h2>Live intelligence snapshot</h2>
-                  <span class="status-pill"><i class="fa-solid fa-signal"></i> Live data fabric</span>
+              <div class="hero-visual" aria-hidden="true">
+                <div class="hero-visual-frame">
+                  <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80" alt="LuminaHQ analytics preview with charts and graphs" loading="lazy">
+                  <div class="hero-showcase" aria-hidden="true">
+                    <div class="showcase-header">
+                      <h2>Live intelligence snapshot</h2>
+                      <span class="status-pill"><i class="fa-solid fa-signal"></i> Live data fabric</span>
+                    </div>
+                    <div class="metrics-grid">
+                      <div class="metric-card">
+                        <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
+                        <strong>3.4K</strong>
+                        <span>Agents orchestrated</span>
+                      </div>
+                      <div class="metric-card">
+                        <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
+                        <strong>12%</strong>
+                        <span>Lift in SLA adherence</span>
+                      </div>
+                      <div class="metric-card">
+                        <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
+                        <strong>9m</strong>
+                        <span>Average onboarding</span>
+                      </div>
+                    </div>
+                    <p class="hero-note">Signals stream in from scheduling, QA, and collaboration channels to guide frontline action without delay.</p>
+                  </div>
                 </div>
-                <div class="metrics-grid">
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
-                    <strong>3.4K</strong>
-                    <span>Agents orchestrated</span>
+                <div class="hero-mini-grid">
+                  <div class="hero-mini-card">
+                    <i class="fa-solid fa-calendar-check"></i>
+                    <strong>Scheduling</strong>
+                    <span>Forecast-aware shift orchestration for every queue.</span>
                   </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
-                    <strong>12%</strong>
-                    <span>Lift in SLA adherence</span>
+                  <div class="hero-mini-card">
+                    <i class="fa-solid fa-chalkboard-user"></i>
+                    <strong>Coaching</strong>
+                    <span>Guided workflows that transform QA insights into action.</span>
                   </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
-                    <strong>9m</strong>
-                    <span>Average onboarding</span>
+                  <div class="hero-mini-card">
+                    <i class="fa-solid fa-chart-column"></i>
+                    <strong>Analytics</strong>
+                    <span>Role-based dashboards aligned to every partner.</span>
                   </div>
                 </div>
-                <p class="hero-subtitle" style="margin:0;">Designed for managers, analysts, and specialists who need a precise pulse on every customer moment.</p>
-              </aside>
+              </div>
             </div>
           </div>
         </div>
@@ -867,7 +979,7 @@
             </article>
           </div>
           <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Dive into detailed capabilities</a>
+            <a class="primary" href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-diagram-project"></i> Dive into detailed capabilities</a>
             <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Experience LuminaHQ live</a>
           </div>
         </div>
@@ -897,7 +1009,7 @@
             </article>
           </div>
           <div class="section-cta">
-            <a class="primary" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> Discover our story</a>
+            <a class="primary" href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Discover our story</a>
             <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
           </div>
         </div>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -15,6 +15,8 @@
     var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
     var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
     var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+    var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+    var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
   ?>
   <style>
     :root {
@@ -391,6 +393,8 @@
         </a>
         <div class="nav-actions">
           <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Dive into details</a>
+          <a href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Discover story</a>
           <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
         </div>
       </div>
@@ -512,6 +516,8 @@
         <strong>Ready to explore the workspace?</strong>
         <div>
           <a href="<?!= landingCapabilitiesUrl ?>">Discover LuminaHQ capabilities</a> &middot;
+          <a href="<?!= landingCapabilitiesDetailUrl ?>">Dive into detailed capabilities</a> &middot;
+          <a href="<?!= landingStoryUrl ?>">Explore our story</a> &middot;
           <a href="<?!= landingHomeUrl ?>#about">Back to landing overview</a>
         </div>
         <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -16,6 +16,8 @@
     var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
     var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
     var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+    var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+    var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
   ?>
   <style>
     :root {
@@ -188,6 +190,142 @@
       margin-bottom: 1.6rem;
     }
 
+    .hero-visual {
+      display: grid;
+      gap: 1.2rem;
+      position: relative;
+    }
+
+    .hero-visual-frame {
+      position: relative;
+      border-radius: var(--radius-md);
+      padding: clamp(1.1rem, 2.5vw, 1.8rem);
+      background: linear-gradient(155deg, rgba(11, 27, 63, 0.65), rgba(4, 120, 211, 0.35));
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      overflow: hidden;
+      min-height: 320px;
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    .hero-visual-frame img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: calc(var(--radius-md) - 8px);
+      box-shadow: 0 32px 60px rgba(8, 47, 73, 0.32);
+    }
+
+    .hero-showcase {
+      position: absolute;
+      left: clamp(1.2rem, 6vw, 3rem);
+      bottom: clamp(1.2rem, 5vw, 3rem);
+      width: min(320px, 70%);
+      background: rgba(11, 27, 63, 0.9);
+      border-radius: var(--radius-md);
+      padding: 1.25rem 1.45rem;
+      border: 1px solid rgba(226, 232, 240, 0.22);
+      box-shadow: 0 24px 45px rgba(8, 47, 73, 0.32);
+      display: grid;
+      gap: 1.1rem;
+    }
+
+    .showcase-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.8rem;
+    }
+
+    .showcase-header h3 {
+      font-size: 0.9rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin: 0;
+      color: #fff;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.4rem 0.8rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.24);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.85rem;
+    }
+
+    .metric-card {
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      border-radius: var(--radius-sm);
+      padding: 0.9rem;
+      display: grid;
+      gap: 0.45rem;
+      color: #fff;
+    }
+
+    .metric-card strong {
+      font-size: 1.45rem;
+    }
+
+    .metric-card span {
+      font-size: 0.74rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.75);
+    }
+
+    .hero-note {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.7);
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
+
+    .hero-mini-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+
+    .hero-mini-card {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(226, 232, 240, 0.24);
+      border-radius: var(--radius-sm);
+      padding: 1rem;
+      display: grid;
+      gap: 0.45rem;
+      color: rgba(241, 247, 255, 0.92);
+    }
+
+    .hero-mini-card i {
+      font-size: 1.3rem;
+      color: var(--lumina-cyan);
+    }
+
+    .hero-mini-card strong {
+      font-size: 0.92rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .hero-mini-card span {
+      font-size: 0.82rem;
+      color: rgba(226, 232, 240, 0.78);
+    }
+
     .hero-cta {
       display: inline-flex;
       align-items: center;
@@ -206,6 +344,16 @@
     .hero-cta:hover {
       transform: translateY(-2px);
       background: rgba(255, 255, 255, 0.24);
+    }
+
+    .hero-cta.secondary {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(255, 255, 255, 0.22);
+      color: rgba(241, 247, 255, 0.9);
+    }
+
+    .hero-cta.secondary:hover {
+      background: rgba(255, 255, 255, 0.16);
     }
 
     main {
@@ -417,6 +565,18 @@
       box-shadow: 0 16px 30px rgba(255, 255, 255, 0.25);
     }
 
+    .cta-panel a.secondary {
+      background: transparent;
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.45);
+      box-shadow: none;
+    }
+
+    .cta-panel a.secondary:hover {
+      background: rgba(255, 255, 255, 0.16);
+      box-shadow: none;
+    }
+
     footer {
       padding: 2.5rem 1.5rem 3rem;
       background: #0b1b3f;
@@ -450,6 +610,16 @@
         flex-direction: column;
         align-items: flex-start;
       }
+
+      .hero-visual-frame {
+        min-height: 260px;
+        padding: 1rem;
+      }
+
+      .hero-showcase {
+        position: static;
+        width: 100%;
+      }
     }
   </style>
 </head>
@@ -467,6 +637,8 @@
         </a>
         <div class="nav-actions">
           <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Dive deeper</a>
+          <a href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Story</a>
           <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
         </div>
       </div>
@@ -478,41 +650,51 @@
           <div class="hero-copy">
             <h2>Every capability connects frontline execution to leadership insight.</h2>
             <p>Explore the mission-ready modules that power LuminaHQ. Each capability extends a unified operations graph so every decision reflects what is happening on the floor right now.</p>
-            <a class="hero-cta" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to experience LuminaHQ</a>
+            <div style="display:flex;flex-wrap:wrap;gap:0.75rem;">
+              <a class="hero-cta" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to experience LuminaHQ</a>
+              <a class="hero-cta secondary" href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Dive into detailed modules</a>
+            </div>
           </div>
-          <div class="hero-visual" aria-hidden="true" style="display:grid;gap:1rem;">
-            <div style="background:rgba(255,255,255,0.12);border-radius:22px;padding:1.4rem 1.6rem;border:1px solid rgba(255,255,255,0.28);display:grid;gap:0.75rem;">
-              <div style="display:flex;align-items:center;justify-content:space-between;">
-                <strong style="font-size:0.95rem;letter-spacing:0.12em;text-transform:uppercase;">Live insights</strong>
-                <span style="display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;"><i class="fa-solid fa-signal"></i> Synced</span>
-              </div>
-              <div style="display:grid;gap:0.6rem;">
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Schedule adherence</span>
-                  <strong>97.4%</strong>
+          <div class="hero-visual" aria-hidden="true">
+            <div class="hero-visual-frame">
+              <img src="https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=1200&q=80" alt="Operational dashboards showing LuminaHQ capabilities" loading="lazy">
+              <div class="hero-showcase" aria-hidden="true">
+                <div class="showcase-header">
+                  <h3>Capability pulse</h3>
+                  <span class="status-pill"><i class="fa-solid fa-wave-square"></i> Synced</span>
                 </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>QA coaching cycles</span>
-                  <strong>128</strong>
+                <div class="metrics-grid">
+                  <div class="metric-card">
+                    <strong>97.4%</strong>
+                    <span>Schedule adherence</span>
+                  </div>
+                  <div class="metric-card">
+                    <strong>128</strong>
+                    <span>Coaching cycles</span>
+                  </div>
+                  <div class="metric-card">
+                    <strong>Green</strong>
+                    <span>Campaign health</span>
+                  </div>
                 </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Campaign health</span>
-                  <strong>Green</strong>
-                </div>
+                <p class="hero-note">Operational telemetry merges workforce, QA, and collaboration signals to inform every module.</p>
               </div>
             </div>
-            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.75rem;">
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-calendar-check" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Scheduling</p>
+            <div class="hero-mini-grid">
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-calendar-check"></i>
+                <strong>Scheduling</strong>
+                <span>Predictive staffing and instant shift orchestration.</span>
               </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chalkboard-user" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Coaching</p>
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-chalkboard-user"></i>
+                <strong>Coaching</strong>
+                <span>Guided workflows that fuel accountability and wins.</span>
               </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chart-line" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Analytics</p>
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-chart-line"></i>
+                <strong>Analytics</strong>
+                <span>Live intelligence that elevates decisions at every level.</span>
               </div>
             </div>
           </div>
@@ -649,6 +831,7 @@
             <h3>See LuminaHQ in action</h3>
             <p>Log in to your workspace or request a guided walkthrough to explore how LuminaHQ adapts to the rhythm of your operations.</p>
             <a href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to LuminaHQ</a>
+            <a class="secondary" href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Explore module deep dive</a>
           </div>
         </div>
       </section>
@@ -659,6 +842,8 @@
         <strong>Looking for our story?</strong>
         <div>
           <a href="<?!= landingAboutUrl ?>">Visit the LuminaHQ about page</a> &middot;
+          <a href="<?!= landingCapabilitiesDetailUrl ?>">Dive into detailed modules</a> &middot;
+          <a href="<?!= landingStoryUrl ?>">Discover our story</a> &middot;
           <a href="<?!= landingHomeUrl ?>#features">Return to landing highlights</a>
         </div>
         <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</small>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -1,0 +1,914 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dive into LuminaHQ Capabilities</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+  <?
+    var loginUrl = buildLoginPageUrl({});
+    var __landingBase = scriptUrl || baseUrl || '';
+    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+    var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+    var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+  ?>
+  <style>
+    :root {
+      --lumina-navy: #0b1b3f;
+      --lumina-blue: #0478d3;
+      --lumina-blue-dark: #035799;
+      --lumina-cyan: #38bdf8;
+      --lumina-surface: #f5f8ff;
+      --lumina-card: #ffffff;
+      --lumina-muted: #475467;
+      --lumina-border: rgba(15, 23, 42, 0.08);
+      --shadow-card: 0 30px 60px rgba(11, 27, 63, 0.14);
+      --radius-lg: 28px;
+      --radius-md: 18px;
+      --radius-sm: 14px;
+      --transition: all 0.28s ease;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--lumina-navy);
+      background: radial-gradient(circle at 0% 0%, rgba(4, 120, 211, 0.08), transparent 45%),
+        radial-gradient(circle at 100% 0%, rgba(56, 189, 248, 0.1), transparent 40%),
+        var(--lumina-surface);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page-shell {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(16px);
+      background: rgba(255, 255, 255, 0.9);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    }
+
+    .nav-container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.8rem;
+      text-decoration: none;
+    }
+
+    .brand img {
+      height: 46px;
+      width: auto;
+    }
+
+    .brand span {
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--lumina-muted);
+      font-weight: 600;
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--lumina-navy);
+    }
+
+    .nav-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .nav-actions a {
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: var(--transition);
+      border: 1px solid rgba(4, 120, 211, 0.26);
+      color: var(--lumina-blue-dark);
+      background: rgba(4, 120, 211, 0.08);
+    }
+
+    .nav-actions a.primary {
+      background: var(--lumina-blue);
+      border-color: var(--lumina-blue);
+      color: #fff;
+      box-shadow: 0 18px 36px rgba(4, 120, 211, 0.16);
+    }
+
+    .nav-actions a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 36px rgba(4, 120, 211, 0.16);
+    }
+
+    .hero {
+      padding: clamp(4.5rem, 5vw + 2rem, 6.5rem) 1.5rem clamp(4rem, 5vw, 5.5rem);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(130deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.88));
+      border-radius: 0 0 48px 48px;
+      z-index: 0;
+    }
+
+    .hero::after {
+      content: '';
+      position: absolute;
+      top: -25%;
+      right: -15%;
+      width: 420px;
+      height: 420px;
+      background: radial-gradient(circle, rgba(56, 189, 248, 0.32), transparent 60%);
+      z-index: 0;
+    }
+
+    .hero-inner {
+      position: relative;
+      z-index: 1;
+      max-width: 1180px;
+      margin: 0 auto;
+      display: grid;
+      gap: 3rem;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      align-items: center;
+      color: rgba(241, 247, 255, 0.95);
+    }
+
+    .hero-copy {
+      display: grid;
+      gap: 1.6rem;
+    }
+
+    .hero-copy h2 {
+      margin: 0;
+      font-size: clamp(2.6rem, 4vw, 3.4rem);
+      line-height: 1.1;
+      color: #fff;
+    }
+
+    .hero-copy p {
+      margin: 0;
+      font-size: 1.05rem;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.82);
+      max-width: 560px;
+    }
+
+    .hero-points {
+      margin: 0;
+      padding-left: 1rem;
+      display: grid;
+      gap: 0.75rem;
+      list-style: none;
+      color: rgba(226, 232, 240, 0.85);
+    }
+
+    .hero-points li {
+      position: relative;
+      padding-left: 1.6rem;
+      font-size: 0.95rem;
+    }
+
+    .hero-points li i {
+      position: absolute;
+      left: 0;
+      top: 0.1rem;
+      color: var(--lumina-cyan);
+    }
+
+    .hero-ctas {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .hero-ctas a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: var(--transition);
+    }
+
+    .hero-ctas a.primary {
+      background: #fff;
+      color: var(--lumina-blue-dark);
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+    }
+
+    .hero-ctas a.ghost {
+      border: 1px solid rgba(226, 232, 240, 0.4);
+      color: rgba(226, 232, 240, 0.92);
+      background: transparent;
+    }
+
+    .hero-ctas a.ghost:hover {
+      background: rgba(255, 255, 255, 0.16);
+    }
+
+    .hero-visual {
+      display: grid;
+      gap: 1.2rem;
+      position: relative;
+    }
+
+    .hero-visual-frame {
+      position: relative;
+      border-radius: var(--radius-md);
+      padding: clamp(1.2rem, 2.5vw, 2rem);
+      background: linear-gradient(150deg, rgba(11, 27, 63, 0.6), rgba(4, 120, 211, 0.35));
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      overflow: hidden;
+      min-height: 320px;
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    .hero-visual-frame img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: calc(var(--radius-md) - 8px);
+      box-shadow: 0 34px 70px rgba(8, 47, 73, 0.35);
+    }
+
+    .hero-showcase {
+      position: absolute;
+      left: clamp(1.4rem, 7vw, 3.2rem);
+      bottom: clamp(1.4rem, 6vw, 3.2rem);
+      width: min(340px, 72%);
+      background: rgba(11, 27, 63, 0.9);
+      border-radius: var(--radius-md);
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(226, 232, 240, 0.22);
+      box-shadow: 0 24px 45px rgba(8, 47, 73, 0.32);
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .showcase-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .showcase-header h3 {
+      margin: 0;
+      font-size: 0.92rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.45rem 0.85rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.24);
+      color: #fff;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.9rem;
+    }
+
+    .metric-card {
+      background: rgba(15, 23, 42, 0.68);
+      color: #fff;
+      padding: 1rem;
+      border-radius: var(--radius-sm);
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .metric-card strong {
+      font-size: 1.5rem;
+    }
+
+    .metric-card span {
+      font-size: 0.76rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.75);
+    }
+
+    .hero-note {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.75);
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+
+    .hero-mini-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+
+    .hero-mini-card {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(226, 232, 240, 0.24);
+      border-radius: var(--radius-sm);
+      padding: 1rem;
+      display: grid;
+      gap: 0.45rem;
+      color: rgba(241, 247, 255, 0.92);
+    }
+
+    .hero-mini-card i {
+      font-size: 1.3rem;
+      color: var(--lumina-cyan);
+    }
+
+    .hero-mini-card strong {
+      font-size: 0.92rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .hero-mini-card span {
+      font-size: 0.82rem;
+      color: rgba(226, 232, 240, 0.78);
+    }
+
+    main {
+      flex: 1;
+    }
+
+    .section {
+      padding: clamp(3.5rem, 5vw, 4.8rem) 1.5rem;
+    }
+
+    .section-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.8rem;
+    }
+
+    .section-header {
+      display: grid;
+      gap: 0.8rem;
+      max-width: 720px;
+    }
+
+    .section-header h3 {
+      margin: 0;
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+      color: var(--lumina-navy);
+    }
+
+    .section-header p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--lumina-muted);
+      line-height: 1.7;
+    }
+
+    .detail-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.75rem;
+    }
+
+    .detail-card {
+      background: var(--lumina-card);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--lumina-border);
+      padding: 2.1rem 2.3rem;
+      display: grid;
+      gap: 1rem;
+      box-shadow: var(--shadow-card);
+    }
+
+    .detail-card header {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+    }
+
+    .detail-card header span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: rgba(4, 120, 211, 0.12);
+      color: var(--lumina-blue);
+      font-size: 1.4rem;
+    }
+
+    .detail-card h4 {
+      margin: 0;
+      font-size: 1.32rem;
+    }
+
+    .detail-card p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.65;
+    }
+
+    .detail-card ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: grid;
+      gap: 0.55rem;
+      color: var(--lumina-muted);
+    }
+
+    .detail-card ul li {
+      position: relative;
+      padding-left: 1.4rem;
+    }
+
+    .detail-card ul li i {
+      position: absolute;
+      left: 0;
+      top: 0.15rem;
+      color: var(--lumina-blue);
+    }
+
+    .section-muted {
+      background: rgba(4, 120, 211, 0.06);
+    }
+
+    .workflow-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.6rem;
+    }
+
+    .workflow-card {
+      background: #fff;
+      border-radius: var(--radius-md);
+      padding: 2rem 2.2rem;
+      border: 1px solid rgba(4, 120, 211, 0.16);
+      box-shadow: 0 30px 60px rgba(11, 27, 63, 0.12);
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .workflow-card h4 {
+      margin: 0;
+      font-size: 1.28rem;
+    }
+
+    .workflow-card p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.65;
+    }
+
+    .workflow-points {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.55rem;
+      color: var(--lumina-muted);
+    }
+
+    .workflow-points li {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.6rem;
+    }
+
+    .workflow-points li i {
+      color: var(--lumina-blue);
+      margin-top: 0.15rem;
+    }
+
+    .timeline {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.4rem;
+    }
+
+    .timeline-card {
+      background: var(--lumina-card);
+      border-radius: var(--radius-sm);
+      padding: 1.6rem 1.8rem;
+      border: 1px solid var(--lumina-border);
+      display: grid;
+      gap: 0.6rem;
+      box-shadow: 0 24px 45px rgba(11, 27, 63, 0.1);
+    }
+
+    .timeline-card strong {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--lumina-blue);
+    }
+
+    .timeline-card h4 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .timeline-card p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .cta-banner {
+      background: linear-gradient(130deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.92));
+      border-radius: var(--radius-lg);
+      color: #fff;
+      padding: 3rem 2.5rem;
+      display: grid;
+      gap: 1.5rem;
+      justify-items: start;
+      box-shadow: 0 40px 80px rgba(11, 27, 63, 0.2);
+    }
+
+    .cta-banner h3 {
+      margin: 0;
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+    }
+
+    .cta-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.8rem;
+    }
+
+    .cta-actions a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: var(--transition);
+    }
+
+    .cta-actions a.primary {
+      background: #fff;
+      color: var(--lumina-blue-dark);
+    }
+
+    .cta-actions a.secondary {
+      border: 1px solid rgba(226, 232, 240, 0.4);
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    .cta-actions a.secondary:hover {
+      background: rgba(255, 255, 255, 0.12);
+    }
+
+    footer {
+      padding: 2.5rem 1.5rem 3rem;
+      background: #0b1b3f;
+      color: rgba(226, 232, 240, 0.85);
+      margin-top: auto;
+    }
+
+    .footer-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .footer-shell a {
+      color: rgba(148, 163, 184, 0.85);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .footer-shell a:hover {
+      color: #fff;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        position: static;
+      }
+
+      .nav-container {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .hero-visual-frame {
+        min-height: 260px;
+        padding: 1rem;
+      }
+
+      .hero-showcase {
+        position: static;
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-shell">
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="<?!= landingHomeUrl ?>">
+          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+          <div>
+            <span>LuminaHQ</span>
+            <h1>Command Center</h1>
+          </div>
+        </a>
+        <div class="nav-actions">
+          <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Capabilities overview</a>
+          <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Story</a>
+          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-inner">
+          <div class="hero-copy">
+            <h2>Blueprints for every LuminaHQ module.</h2>
+            <p>Go layer-by-layer through the workflows that keep LuminaHQ synchronized. These capability playbooks combine the scheduling, QA, coaching, and automation data fabric you saw in the overview into detailed, ready-to-run operations recipes.</p>
+            <ul class="hero-points" role="list">
+              <li><i class="fa-solid fa-sitemap"></i> Understand how data flows between modules before, during, and after each customer interaction.</li>
+              <li><i class="fa-solid fa-person-rays"></i> See the human touchpoints that anchor automation so supervisors stay in command.</li>
+              <li><i class="fa-solid fa-shield-check"></i> Validate the governance guardrails that make every capability enterprise ready.</li>
+            </ul>
+            <div class="hero-ctas">
+              <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to configure modules</a>
+              <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Return to overview</a>
+            </div>
+          </div>
+          <div class="hero-visual" aria-hidden="true">
+            <div class="hero-visual-frame">
+              <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80" alt="Detailed LuminaHQ analytics boards" loading="lazy">
+              <div class="hero-showcase" aria-hidden="true">
+                <div class="showcase-header">
+                  <h3>Module telemetry</h3>
+                  <span class="status-pill"><i class="fa-solid fa-wave-square"></i> Synced</span>
+                </div>
+                <div class="metrics-grid">
+                  <div class="metric-card">
+                    <strong>42</strong>
+                    <span>Automation recipes</span>
+                  </div>
+                  <div class="metric-card">
+                    <strong>18</strong>
+                    <span>QA templates</span>
+                  </div>
+                  <div class="metric-card">
+                    <strong>9</strong>
+                    <span>Scheduling models</span>
+                  </div>
+                </div>
+                <p class="hero-note">Live orchestration data is captured for every module so you can trace impact from trigger to action.</p>
+              </div>
+            </div>
+            <div class="hero-mini-grid">
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-calendar-check"></i>
+                <strong>Scheduling</strong>
+                <span>Interval forecasts blended with adherence overlays and swap controls.</span>
+              </div>
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-chalkboard-user"></i>
+                <strong>Coaching</strong>
+                <span>Playbooks aligned to QA signals and agent readiness surveys.</span>
+              </div>
+              <div class="hero-mini-card">
+                <i class="fa-solid fa-chart-line"></i>
+                <strong>Analytics</strong>
+                <span>Executive scorecards distilled from campaign, QA, and WFM data.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="modules">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Detailed module playbooks</h3>
+            <p>These summaries expand on the modules you explored previously. They draw from the same scheduling, QA, coaching, and automation capabilities already described across the LuminaHQ landing pages—now packaged with configuration guidance.</p>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card">
+              <header>
+                <span><i class="fa-solid fa-calendar-check"></i></span>
+                <h4>Adaptive scheduling</h4>
+              </header>
+              <p>Balance staffing in real time with forecasting overlays, automated shift swaps, and instant communications to every affected agent.</p>
+              <ul role="list">
+                <li><i class="fa-solid fa-waveform"></i> Rolling interval forecasts fused with attendance trends for proactive staffing.</li>
+                <li><i class="fa-solid fa-arrows-rotate"></i> Exception workflows that loop in workforce, HR, and operations leads.</li>
+                <li><i class="fa-solid fa-bell"></i> Native notifications and approvals aligned to Google Chat and Gmail.</li>
+              </ul>
+            </article>
+            <article class="detail-card">
+              <header>
+                <span><i class="fa-solid fa-clipboard-check"></i></span>
+                <h4>QA intelligence</h4>
+              </header>
+              <p>Aggregate evaluator feedback, calibrate teams, and surface QA performance trends with a modern reporting layer.</p>
+              <ul role="list">
+                <li><i class="fa-solid fa-list-check"></i> Weighted scorecards with variance alerts across lines of business.</li>
+                <li><i class="fa-solid fa-people-arrows"></i> Calibration dashboards that preserve historical context and disputes.</li>
+                <li><i class="fa-solid fa-wand-magic-sparkles"></i> AI-ready exports for deeper analytics or generative summaries.</li>
+              </ul>
+            </article>
+            <article class="detail-card">
+              <header>
+                <span><i class="fa-solid fa-user-graduate"></i></span>
+                <h4>Coaching orchestration</h4>
+              </header>
+              <p>Give supervisors guided workflows to assign action plans, capture feedback, and celebrate wins in one place.</p>
+              <ul role="list">
+                <li><i class="fa-solid fa-chart-simple"></i> Performance heatmaps highlight the biggest coaching opportunities.</li>
+                <li><i class="fa-solid fa-person-chalkboard"></i> Templates with digital sign-offs and attachments to keep everyone aligned.</li>
+                <li><i class="fa-solid fa-clock-rotate-left"></i> Automated nudges ensure follow-ups and reinforcements stay on schedule.</li>
+              </ul>
+            </article>
+            <article class="detail-card">
+              <header>
+                <span><i class="fa-solid fa-robot"></i></span>
+                <h4>Automation studio</h4>
+              </header>
+              <p>Trigger workflows across Sheets, Gmail, and external APIs with reusable recipes that shrink manual effort and accelerate resolution.</p>
+              <ul role="list">
+                <li><i class="fa-solid fa-diagram-next"></i> Drag-and-drop flow builder with guardrails and approvals.</li>
+                <li><i class="fa-solid fa-cloud-arrow-up"></i> Secure integrations and webhook triggers to keep systems synced.</li>
+                <li><i class="fa-solid fa-stopwatch-20"></i> SLA-aware automations that escalate before targets are missed.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section-muted" id="workflows">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Workflow blueprints in action</h3>
+            <p>Reuse the scenarios described on the capabilities page—operations control, team performance, and executive visibility—and layer on step-by-step orchestration details.</p>
+          </div>
+          <div class="workflow-grid">
+            <article class="workflow-card">
+              <h4>Operations control tower</h4>
+              <p>Surface the next best action for every role on the floor.</p>
+              <ul class="workflow-points" role="list">
+                <li><i class="fa-solid fa-route"></i> Prescriptive playbooks for coaching, staffing, and client communication.</li>
+                <li><i class="fa-solid fa-gauge-high"></i> Real-time dashboards that align supervisors and workforce analysts.</li>
+                <li><i class="fa-solid fa-gears"></i> Automations triggered by thresholds, statuses, or campaign events.</li>
+              </ul>
+            </article>
+            <article class="workflow-card">
+              <h4>Team performance lab</h4>
+              <p>Blend QA, coaching, and productivity signals for every specialist.</p>
+              <ul class="workflow-points" role="list">
+                <li><i class="fa-solid fa-chart-line"></i> Role-based scorecards with drill-through to call recordings and notes.</li>
+                <li><i class="fa-solid fa-hand-holding-heart"></i> Recognition loops that capture wins and share them across pods.</li>
+                <li><i class="fa-solid fa-clipboard-user"></i> Action plans that sync back to QA disputes and attendance follow-ups.</li>
+              </ul>
+            </article>
+            <article class="workflow-card">
+              <h4>Executive visibility</h4>
+              <p>Translate frontline operations into boardroom clarity.</p>
+              <ul class="workflow-points" role="list">
+                <li><i class="fa-solid fa-chart-pie"></i> Roll-up scorecards across programs with drill-downs to agent level.</li>
+                <li><i class="fa-solid fa-file-lines"></i> Auto-generated executive briefs summarizing wins and risks.</li>
+                <li><i class="fa-solid fa-globe"></i> Global dashboards that segment by client, region, or outsourcing partner.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="journey">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Implementation journey</h3>
+            <p>The same evolution captured on our About page guides your rollout. Start with scheduling foundations, layer in coaching and QA, then expand into enterprise automation.</p>
+          </div>
+          <div class="timeline">
+            <article class="timeline-card">
+              <strong><i class="fa-solid fa-flag"></i> 2019</strong>
+              <h4>Scheduling foundations</h4>
+              <p>Rolled out Google Workspace scripts to automate agent shift updates and broadcast daily coaching plans.</p>
+            </article>
+            <article class="timeline-card">
+              <strong><i class="fa-solid fa-rocket"></i> 2021</strong>
+              <h4>Unified coaching</h4>
+              <p>Expanded into coaching dashboards, QA data pipelines, and collaboration workflows for hybrid teams.</p>
+            </article>
+            <article class="timeline-card">
+              <strong><i class="fa-solid fa-shield"></i> 2023</strong>
+              <h4>Enterprise-ready security</h4>
+              <p>Shipped tenant-aware access controls, SSO alignment, and audit logging for compliance-focused partners.</p>
+            </article>
+            <article class="timeline-card">
+              <strong><i class="fa-solid fa-chart-line"></i> Today</strong>
+              <h4>Predictive intelligence</h4>
+              <p>Integrating forecasting, AI summarization, and proactive alerts so teams anticipate change instead of reacting to it.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" style="padding-bottom:4.5rem;">
+        <div class="section-shell">
+          <div class="cta-banner">
+            <h3>Ready to orchestrate every capability?</h3>
+            <p>Log in to activate modules, or revisit the overview and LuminaHQ story to keep stakeholders aligned.</p>
+            <div class="cta-actions">
+              <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to configure</a>
+              <a class="secondary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Return to overview</a>
+              <a class="secondary" href="<?!= landingStoryUrl ?>"><i class="fa-solid fa-book-open"></i> Discover the story</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <strong>Continue exploring LuminaHQ.</strong>
+        <div>
+          <a href="<?!= landingCapabilitiesUrl ?>">Capabilities overview</a> &middot;
+          <a href="<?!= landingStoryUrl ?>">Our story</a> &middot;
+          <a href="<?!= landingAboutUrl ?>">About the team</a> &middot;
+          <a href="<?!= landingHomeUrl ?>#modules">Back to landing modules</a>
+        </div>
+        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
+      </div>
+    </footer>
+  </div>
+</body>
+
+</html>

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -1,0 +1,719 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Discover the LuminaHQ Story</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+  <?
+    var loginUrl = buildLoginPageUrl({});
+    var __landingBase = scriptUrl || baseUrl || '';
+    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+    var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+    var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+  ?>
+  <style>
+    :root {
+      --lumina-navy: #0b1b3f;
+      --lumina-blue: #0478d3;
+      --lumina-blue-dark: #035799;
+      --lumina-cyan: #38bdf8;
+      --lumina-surface: #ffffff;
+      --lumina-muted: #475467;
+      --shadow-card: 0 32px 64px rgba(11, 27, 63, 0.16);
+      --radius-lg: 28px;
+      --radius-md: 18px;
+      --radius-sm: 14px;
+      --transition: all 0.28s ease;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--lumina-navy);
+      background: linear-gradient(180deg, rgba(4, 120, 211, 0.08) 0%, rgba(255, 255, 255, 1) 45%);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .page-shell {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(16px);
+      background: rgba(255, 255, 255, 0.9);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    }
+
+    .nav-container {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 1rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      text-decoration: none;
+    }
+
+    .brand img {
+      height: 46px;
+      width: auto;
+    }
+
+    .brand span {
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--lumina-muted);
+      font-weight: 600;
+    }
+
+    .brand h1 {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--lumina-navy);
+    }
+
+    .nav-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .nav-actions a {
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: var(--transition);
+      border: 1px solid rgba(4, 120, 211, 0.26);
+      color: var(--lumina-blue-dark);
+      background: rgba(4, 120, 211, 0.08);
+    }
+
+    .nav-actions a.primary {
+      background: var(--lumina-blue);
+      border-color: var(--lumina-blue);
+      color: #fff;
+      box-shadow: 0 18px 36px rgba(4, 120, 211, 0.16);
+    }
+
+    .nav-actions a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 36px rgba(4, 120, 211, 0.16);
+    }
+
+    .hero {
+      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem clamp(4rem, 5vw, 5.5rem);
+    }
+
+    .hero-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 2.8rem;
+      align-items: center;
+    }
+
+    .hero-copy {
+      display: grid;
+      gap: 1.6rem;
+    }
+
+    .hero-copy h2 {
+      margin: 0;
+      font-size: clamp(2.6rem, 4vw, 3.4rem);
+      line-height: 1.1;
+      color: var(--lumina-navy);
+    }
+
+    .hero-copy p {
+      margin: 0;
+      font-size: 1.05rem;
+      line-height: 1.7;
+      color: var(--lumina-muted);
+      max-width: 560px;
+    }
+
+    .hero-points {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: grid;
+      gap: 0.75rem;
+      color: var(--lumina-muted);
+      list-style: none;
+    }
+
+    .hero-points li {
+      position: relative;
+      padding-left: 1.6rem;
+      font-size: 0.95rem;
+    }
+
+    .hero-points li i {
+      position: absolute;
+      left: 0;
+      top: 0.1rem;
+      color: var(--lumina-blue);
+    }
+
+    .hero-ctas {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .hero-ctas a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: var(--transition);
+    }
+
+    .hero-ctas a.primary {
+      background: var(--lumina-blue);
+      color: #fff;
+      box-shadow: 0 20px 40px rgba(4, 120, 211, 0.2);
+    }
+
+    .hero-ctas a.ghost {
+      border: 1px solid rgba(4, 120, 211, 0.18);
+      color: var(--lumina-blue-dark);
+      background: rgba(4, 120, 211, 0.06);
+    }
+
+    .hero-visual {
+      display: grid;
+      gap: 1.2rem;
+      position: relative;
+    }
+
+    .hero-visual-frame {
+      position: relative;
+      border-radius: var(--radius-md);
+      padding: clamp(1.2rem, 2.5vw, 2rem);
+      background: linear-gradient(150deg, rgba(11, 27, 63, 0.6), rgba(4, 120, 211, 0.32));
+      border: 1px solid rgba(11, 27, 63, 0.12);
+      overflow: hidden;
+      min-height: 320px;
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    .hero-visual-frame img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: calc(var(--radius-md) - 8px);
+      box-shadow: 0 34px 70px rgba(8, 47, 73, 0.32);
+    }
+
+    .hero-showcase {
+      position: absolute;
+      left: clamp(1.4rem, 7vw, 3.2rem);
+      bottom: clamp(1.4rem, 6vw, 3.2rem);
+      width: min(320px, 72%);
+      background: rgba(11, 27, 63, 0.9);
+      border-radius: var(--radius-md);
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(226, 232, 240, 0.22);
+      box-shadow: 0 24px 45px rgba(8, 47, 73, 0.32);
+      display: grid;
+      gap: 1.2rem;
+      color: rgba(241, 247, 255, 0.95);
+    }
+
+    .showcase-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .showcase-header h3 {
+      margin: 0;
+      font-size: 0.92rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.45rem 0.85rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.24);
+      color: #fff;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .hero-note {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.75);
+      font-size: 0.82rem;
+      line-height: 1.5;
+    }
+
+    .metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.9rem;
+    }
+
+    .metric-card {
+      background: rgba(15, 23, 42, 0.68);
+      color: #fff;
+      padding: 1rem;
+      border-radius: var(--radius-sm);
+      border: 1px solid rgba(226, 232, 240, 0.18);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .metric-card strong {
+      font-size: 1.45rem;
+    }
+
+    .metric-card span {
+      font-size: 0.76rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.75);
+    }
+
+    main {
+      flex: 1;
+    }
+
+    .section {
+      padding: clamp(3.5rem, 5vw, 4.8rem) 1.5rem;
+    }
+
+    .section-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.6rem;
+    }
+
+    .section-header {
+      display: grid;
+      gap: 0.8rem;
+      max-width: 720px;
+    }
+
+    .section-header h3 {
+      margin: 0;
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+    }
+
+    .section-header p {
+      margin: 0;
+      color: var(--lumina-muted);
+      font-size: 1.05rem;
+      line-height: 1.7;
+    }
+
+    .story-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.75rem;
+    }
+
+    .story-card {
+      background: #fff;
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      padding: 2.1rem 2.3rem;
+      display: grid;
+      gap: 0.9rem;
+      box-shadow: var(--shadow-card);
+    }
+
+    .story-card h4 {
+      margin: 0;
+      font-size: 1.3rem;
+    }
+
+    .story-card p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.65;
+    }
+
+    .values-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.4rem;
+    }
+
+    .value-tile {
+      background: rgba(4, 120, 211, 0.08);
+      border-radius: var(--radius-sm);
+      border: 1px solid rgba(4, 120, 211, 0.16);
+      padding: 1.8rem 2rem;
+      display: grid;
+      gap: 0.6rem;
+      color: var(--lumina-navy);
+    }
+
+    .value-tile strong {
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--lumina-blue);
+    }
+
+    .value-tile p {
+      margin: 0;
+      color: var(--lumina-muted);
+      line-height: 1.6;
+    }
+
+    .culture-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .culture-card {
+      background: #fff;
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      padding: 2rem 2.2rem;
+      display: grid;
+      gap: 0.75rem;
+      box-shadow: 0 28px 48px rgba(11, 27, 63, 0.1);
+    }
+
+    .culture-card ul {
+      margin: 0;
+      padding-left: 1rem;
+      display: grid;
+      gap: 0.6rem;
+      color: var(--lumina-muted);
+    }
+
+    .culture-card li {
+      position: relative;
+      padding-left: 1.4rem;
+      list-style: none;
+    }
+
+    .culture-card li i {
+      position: absolute;
+      left: 0;
+      top: 0.15rem;
+      color: var(--lumina-blue);
+    }
+
+    .cta-panel {
+      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.9));
+      color: #fff;
+      border-radius: var(--radius-lg);
+      padding: 3rem 2.5rem;
+      display: grid;
+      gap: 1.5rem;
+      box-shadow: 0 40px 80px rgba(11, 27, 63, 0.2);
+      justify-items: start;
+    }
+
+    .cta-panel h3 {
+      margin: 0;
+      font-size: clamp(2rem, 3.5vw, 2.6rem);
+    }
+
+    .cta-panel p {
+      margin: 0;
+      max-width: 540px;
+      font-size: 1.05rem;
+      line-height: 1.7;
+      color: rgba(226, 232, 240, 0.85);
+    }
+
+    .cta-panel a {
+      text-decoration: none;
+      font-weight: 600;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      transition: var(--transition);
+    }
+
+    .cta-panel a.primary {
+      background: #fff;
+      color: var(--lumina-blue-dark);
+    }
+
+    .cta-panel a.secondary {
+      border: 1px solid rgba(226, 232, 240, 0.4);
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    .cta-panel a.secondary:hover {
+      background: rgba(255, 255, 255, 0.16);
+    }
+
+    footer {
+      padding: 2.5rem 1.5rem 3rem;
+      background: #0b1b3f;
+      color: rgba(226, 232, 240, 0.85);
+      margin-top: auto;
+    }
+
+    .footer-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .footer-shell a {
+      color: rgba(148, 163, 184, 0.85);
+      text-decoration: none;
+      font-weight: 500;
+    }
+
+    .footer-shell a:hover {
+      color: #fff;
+    }
+
+    @media (max-width: 720px) {
+      header {
+        position: static;
+      }
+
+      .nav-container {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .hero-visual-frame {
+        min-height: 260px;
+        padding: 1rem;
+      }
+
+      .hero-showcase {
+        position: static;
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="page-shell">
+    <header>
+      <div class="nav-container">
+        <a class="brand" href="<?!= landingHomeUrl ?>">
+          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+          <div>
+            <span>LuminaHQ</span>
+            <h1>Command Center</h1>
+          </div>
+        </a>
+        <div class="nav-actions">
+          <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Capabilities</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Deep dive</a>
+          <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
+          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-shell">
+          <div class="hero-copy">
+            <h2>The story behind our command center.</h2>
+            <p>LuminaHQ was born inside Lumina's Innovation Lab in Kingston, Jamaica. We pair decades of contact center experience with modern data engineering to remove the friction between people, processes, and platforms.</p>
+            <ul class="hero-points" role="list">
+              <li><i class="fa-solid fa-location-dot"></i> Rooted in the Caribbean with partners across the Americas.</li>
+              <li><i class="fa-solid fa-people-group"></i> Product designers, engineers, analysts, and operators working side-by-side.</li>
+              <li><i class="fa-solid fa-compass"></i> Guided by customer teams who need clarity, not another dashboard.</li>
+            </ul>
+            <div class="hero-ctas">
+              <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to LuminaHQ</a>
+              <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+            </div>
+          </div>
+          <div class="hero-visual" aria-hidden="true">
+            <div class="hero-visual-frame">
+              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80" alt="LuminaHQ team collaborating" loading="lazy">
+              <div class="hero-showcase" aria-hidden="true">
+                <div class="showcase-header">
+                  <h3>Innovation lab</h3>
+                  <span class="status-pill"><i class="fa-solid fa-heart"></i> Human-first</span>
+                </div>
+                <div class="metrics-grid">
+                  <div class="metric-card">
+                    <strong>3 continents</strong>
+                    <span>Customer teams</span>
+                  </div>
+                  <div class="metric-card">
+                    <strong>12 disciplines</strong>
+                    <span>Working together</span>
+                  </div>
+                </div>
+                <p class="hero-note">Operations leaders co-create every workflow so automation elevates people instead of replacing them.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="origin">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Our origin and promise</h3>
+            <p>The story mirrors what you saw on the landing overview: a relentless focus on operational clarity for contact centers moving at real-world speed.</p>
+          </div>
+          <div class="story-grid">
+            <article class="story-card">
+              <h4>Origin</h4>
+              <p>Born from Lumina's partnerships with BPO networks across the Caribbean and North America. Early scripts automated shift updates and broadcast daily coaching plans.</p>
+            </article>
+            <article class="story-card">
+              <h4>Craft</h4>
+              <p>Product strategy meets applied data science to translate raw signals into guided action. We blend forecasting, QA feedback, and collaboration flows into one fabric.</p>
+            </article>
+            <article class="story-card">
+              <h4>Promise</h4>
+              <p>Operational clarity for every role. Whether you're an agent, supervisor, or executive, LuminaHQ keeps the path from insight to action obvious.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="values">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>What guides our product decisions</h3>
+            <p>These values echo the bullets you encountered on the about page, captured here so the full story stays in one place.</p>
+          </div>
+          <div class="values-grid">
+            <div class="value-tile">
+              <strong>Customer-first design</strong>
+              <p>Every workflow is tested with active operations teams so the UI stays intuitive even as programs scale or pivot.</p>
+            </div>
+            <div class="value-tile">
+              <strong>Human-centered automation</strong>
+              <p>Automation is only valuable when it empowers analysts and supervisors. Scripts reduce manual steps while keeping humans in control.</p>
+            </div>
+            <div class="value-tile">
+              <strong>Secure collaboration</strong>
+              <p>Multi-tenant controls, audit trails, and granular permissions safeguard customer data while keeping teams aligned.</p>
+            </div>
+            <div class="value-tile">
+              <strong>Global reach, local roots</strong>
+              <p>We support distributed teams across the Americas while grounding our craft and culture in the Caribbean.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="culture">
+        <div class="section-shell">
+          <div class="section-header">
+            <h3>Inside the LuminaHQ culture</h3>
+            <p>The rituals we highlight here expand on the culture banner you saw earlier—making it easy to retell our story with the same details.</p>
+          </div>
+          <div class="culture-grid">
+            <div class="culture-card">
+              <h4>How we build</h4>
+              <ul role="list">
+                <li><i class="fa-solid fa-lightbulb"></i> Weekly design reviews align engineering, QA, and enablement on upcoming experiments.</li>
+                <li><i class="fa-solid fa-person-chalkboard"></i> Immersive onboarding embeds our product team inside partner operations for live feedback.</li>
+                <li><i class="fa-solid fa-hands"></i> Community initiatives reinvest in Jamaican tech talent through mentorship and open-source learning.</li>
+              </ul>
+            </div>
+            <div class="culture-card">
+              <h4>How we partner</h4>
+              <ul role="list">
+                <li><i class="fa-solid fa-headset"></i> Dedicated customer pods pair product managers with operations leads for faster roadmap alignment.</li>
+                <li><i class="fa-solid fa-handshake"></i> Transparent service levels and feedback loops keep deployments grounded in real outcomes.</li>
+                <li><i class="fa-solid fa-leaf"></i> We balance rapid delivery with sustainable workloads to maintain a resilient, creative team.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" style="padding-bottom:4.5rem;">
+        <div class="section-shell">
+          <div class="cta-panel">
+            <h3>Share the LuminaHQ story</h3>
+            <p>Bring stakeholders back to the capabilities overview or the detailed module blueprint to move from inspiration to action.</p>
+            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+            <a class="secondary" href="<?!= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-layer-group"></i> Dive into detailed modules</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <strong>Continue your LuminaHQ tour.</strong>
+        <div>
+          <a href="<?!= landingCapabilitiesUrl ?>">Capabilities overview</a> &middot;
+          <a href="<?!= landingCapabilitiesDetailUrl ?>">Detailed modules</a> &middot;
+          <a href="<?!= landingAboutUrl ?>">About LuminaHQ</a> &middot;
+          <a href="<?!= landingHomeUrl ?>#about">Back to landing story</a>
+        </div>
+        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
+      </div>
+    </footer>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- refresh the main landing hero with a photographic showcase, consistent mini capability cards, and updated navigation links
- update the About and Explore Capabilities pages to surface the new detailed capabilities and story destinations while keeping imagery consistent
- add dedicated Dive Into Capabilities and Discover Our Story static pages that expand on existing content with new structured sections and calls to action

## Testing
- no automated tests were run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f3e72c3e4c83269551fb9623e4e4a0