### PR TITLE
Open AI Analyzer as modal in call reports

### DIFF
--- a/CallReports.html
+++ b/CallReports.html
@@ -1177,48 +1177,57 @@
     </div>
 </div>
 
-<div id="aiInsightPanel" class="ai-analytics-panel d-none" aria-hidden="true">
-    <div class="ai-panel-header d-flex flex-wrap justify-content-between align-items-start gap-3">
-        <div>
-            <h2 class="mb-1"><i class="fas fa-robot me-2"></i>AI Call Performance Analyzer</h2>
-            <p class="mb-0">Autonomous insights synthesised from your imported call reports and live metrics.</p>
-        </div>
-        <div class="ai-confidence-chip" id="aiConfidenceChip">Confidence: Collecting data…</div>
-    </div>
-    <div class="row g-3 mt-2" id="aiSummaryStats">
-        <!-- Dynamically populated -->
-    </div>
-    <div class="row g-3 mt-1">
-        <div class="col-lg-6">
-            <div class="ai-insight-card">
-                <h6 class="ai-section-title"><i class="fas fa-lightbulb me-2 text-warning"></i>Key Insights</h6>
-                <ul class="ai-insight-list" id="aiInsightList">
-                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Insights will appear once data loads.</li>
-                </ul>
+<div class="modal fade" id="aiAnalyzerModal" tabindex="-1" aria-labelledby="aiAnalyzerModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="aiAnalyzerModalLabel"><i class="fas fa-robot me-2"></i>AI Call Performance Analyzer</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-        </div>
-        <div class="col-lg-6">
-            <div class="ai-insight-card">
-                <h6 class="ai-section-title"><i class="fas fa-magic me-2 text-primary"></i>AI Recommendations</h6>
-                <ul class="ai-insight-list" id="aiRecommendationList">
-                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Recommendations will appear once data loads.</li>
-                </ul>
-            </div>
-        </div>
-    </div>
-    <div class="row g-3 mt-1">
-        <div class="col-lg-6">
-            <div class="ai-insight-card">
-                <h6 class="ai-section-title"><i class="fas fa-clock me-2 text-info"></i>Peak Call Windows</h6>
-                <ul class="peak-window-list" id="peakWindowList">
-                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Loading peak windows…</li>
-                </ul>
-            </div>
-        </div>
-        <div class="col-lg-6">
-            <div class="ai-insight-card">
-                <h6 class="ai-section-title"><i class="fas fa-utensils me-2 text-success"></i>Break & Lunch Planner</h6>
-                <div id="schedulePlannerContainer" class="schedule-planner-container text-muted">Recommendations will appear once data loads.</div>
+            <div class="modal-body">
+                <div id="aiInsightPanel" class="ai-analytics-panel" aria-live="polite">
+                    <div class="ai-panel-header d-flex flex-wrap justify-content-between align-items-start gap-3">
+                        <p class="mb-0">Autonomous insights synthesised from your imported call reports and live metrics.</p>
+                        <div class="ai-confidence-chip" id="aiConfidenceChip">Confidence: Collecting data…</div>
+                    </div>
+                    <div class="row g-3 mt-2" id="aiSummaryStats">
+                        <!-- Dynamically populated -->
+                    </div>
+                    <div class="row g-3 mt-1">
+                        <div class="col-lg-6">
+                            <div class="ai-insight-card">
+                                <h6 class="ai-section-title"><i class="fas fa-lightbulb me-2 text-warning"></i>Key Insights</h6>
+                                <ul class="ai-insight-list" id="aiInsightList">
+                                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Insights will appear once data loads.</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="col-lg-6">
+                            <div class="ai-insight-card">
+                                <h6 class="ai-section-title"><i class="fas fa-magic me-2 text-primary"></i>AI Recommendations</h6>
+                                <ul class="ai-insight-list" id="aiRecommendationList">
+                                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Recommendations will appear once data loads.</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row g-3 mt-1">
+                        <div class="col-lg-6">
+                            <div class="ai-insight-card">
+                                <h6 class="ai-section-title"><i class="fas fa-clock me-2 text-info"></i>Peak Call Windows</h6>
+                                <ul class="peak-window-list" id="peakWindowList">
+                                    <li class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Loading peak windows…</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="col-lg-6">
+                            <div class="ai-insight-card">
+                                <h6 class="ai-section-title"><i class="fas fa-utensils me-2 text-success"></i>Break & Lunch Planner</h6>
+                                <div id="schedulePlannerContainer" class="schedule-planner-container text-muted">Recommendations will appear once data loads.</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -1547,25 +1556,43 @@
       });
 
     const aiAnalyzerBtn = document.getElementById("aiAnalyzerBtn");
+    const aiAnalyzerModalEl = document.getElementById("aiAnalyzerModal");
     const aiInsightPanel = document.getElementById("aiInsightPanel");
-    if (aiAnalyzerBtn && aiInsightPanel) {
-      aiInsightPanel.setAttribute("aria-hidden", "true");
-      aiAnalyzerBtn.addEventListener("click", () => {
-        const isHidden = aiInsightPanel.classList.toggle("d-none");
-        const expanded = !isHidden;
-        aiAnalyzerBtn.setAttribute("aria-expanded", expanded.toString());
-        aiInsightPanel.setAttribute("aria-hidden", (!expanded).toString());
-        aiInsightPanel.classList.toggle("active", expanded);
-
-        const label = aiAnalyzerBtn.querySelector('.btn-label');
-        if (label) {
-          label.textContent = expanded ? 'Hide AI Analyzer' : 'AI Analyzer';
-        }
-
-        if (expanded) {
-          aiInsightPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      });
+    if (aiAnalyzerBtn && aiAnalyzerModalEl) {
+      const bootstrapModal = window.bootstrap?.Modal;
+      if (bootstrapModal) {
+        const aiAnalyzerModal = new bootstrapModal(aiAnalyzerModalEl);
+        aiAnalyzerBtn.addEventListener("click", () => {
+          aiAnalyzerBtn.setAttribute("aria-expanded", "true");
+          aiAnalyzerModal.show();
+        });
+        aiAnalyzerModalEl.addEventListener("shown.bs.modal", () => {
+          aiInsightPanel?.classList.add("active");
+        });
+        aiAnalyzerModalEl.addEventListener("hidden.bs.modal", () => {
+          aiAnalyzerBtn.setAttribute("aria-expanded", "false");
+          aiInsightPanel?.classList.remove("active");
+        });
+      } else {
+        aiAnalyzerBtn.addEventListener("click", () => {
+          const isOpen = aiAnalyzerModalEl.classList.toggle("show");
+          aiAnalyzerBtn.setAttribute("aria-expanded", isOpen.toString());
+          aiAnalyzerModalEl.setAttribute("aria-hidden", (!isOpen).toString());
+          if (aiInsightPanel) {
+            aiInsightPanel.classList.toggle("active", isOpen);
+          }
+        });
+        aiAnalyzerModalEl
+          .querySelectorAll('[data-bs-dismiss="modal"]')
+          .forEach((btn) => {
+            btn.addEventListener("click", () => {
+              aiAnalyzerModalEl.classList.remove("show");
+              aiAnalyzerModalEl.setAttribute("aria-hidden", "true");
+              aiAnalyzerBtn.setAttribute("aria-expanded", "false");
+              aiInsightPanel?.classList.remove("active");
+            });
+          });
+      }
     }
 
     // Add enhanced keyboard navigation


### PR DESCRIPTION
## Summary
- wrap the AI Analyzer content in a Bootstrap modal so it no longer expands inline on the dashboard
- update the AI Analyzer button logic to launch the modal and manage accessibility state and fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3eeb34fdc83269e1b74a346ed51da