### PR TITLE
Rebuild landing suite with shared template styling

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -1,920 +1,216 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <base target="_top">
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>LuminaHQ – Intelligent Workforce Command Center</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-navy-alt: #103060;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #ffffff;
-      --lumina-muted: #f1f5fb;
-      --lumina-muted-dark: #d6e2f5;
-      --lumina-text: #101828;
-      --lumina-text-muted: #475467;
-      --shadow-primary: 0 12px 24px rgba(4, 120, 211, 0.18);
-      --shadow-card: 0 8px 18px rgba(15, 23, 42, 0.08);
-      --radius-lg: 24px;
-      --radius-md: 16px;
-      --radius-sm: 12px;
-      --transition: all 0.28s ease;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      margin: 0;
-      color: var(--lumina-text);
-      background: var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    body.landing-page {
-      background: var(--lumina-surface);
-    }
-
-    body.landing-page::before {
-      display: none;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-    }
-
-    .landing-main {
-      width: 100%;
-      max-width: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    .hero {
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.25rem clamp(3rem, 5vw, 5rem);
-      width: 100%;
-      margin: 0;
-      position: relative;
-      background: var(--lumina-navy-alt);
-      color: rgba(226, 232, 240, 0.92);
-    }
-
-    .hero-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .hero-surface {
-      background: transparent;
-      border-radius: var(--radius-lg);
-      border: none;
-      box-shadow: none;
-      padding: clamp(2.5rem, 5vw, 3.2rem);
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      backdrop-filter: blur(14px);
-      background: rgba(255, 255, 255, 0.85);
-      border-bottom: 1px solid rgba(226, 232, 240, 0.7);
-      margin: 0;
-      padding: 0;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.25rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-    }
-
-    .brand-logo {
-      height: 46px;
-      width: auto;
-      display: block;
-    }
-
-    .brand h1 {
-      font-size: 1.35rem;
-      font-weight: 700;
-      color: var(--lumina-navy);
-      margin: 0;
-      letter-spacing: 0.01em;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 500;
-      text-transform: uppercase;
-      color: var(--lumina-text-muted);
-      letter-spacing: 0.14em;
-    }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .nav-actions a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.3rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .nav-actions .btn-outline {
-      color: var(--lumina-blue-dark);
-      background: transparent;
-      border: 1px solid rgba(4, 120, 211, 0.36);
-    }
-
-    .nav-actions .btn-outline:hover {
-      background: rgba(4, 120, 211, 0.1);
-      transform: translateY(-1px);
-    }
-
-    .nav-actions .btn-primary {
-      color: white;
-      background: var(--lumina-blue);
-      box-shadow: none;
-    }
-
-    .nav-actions .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 10px 20px rgba(4, 120, 211, 0.24);
-    }
-
-    .hero-content {
-      position: relative;
-      display: grid;
-      gap: clamp(2.5rem, 5vw, 3.5rem);
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      z-index: 1;
-    }
-
-    .hero-copy {
-      display: flex;
-      flex-direction: column;
-      gap: 1.75rem;
-    }
-
-    .hero-tag {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.55rem 1rem;
-      background: rgba(56, 189, 248, 0.16);
-      color: var(--lumina-surface);
-      border-radius: 999px;
-      font-weight: 600;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .hero-title {
-      font-size: clamp(2.4rem, 3.4vw + 1rem, 3.7rem);
-      line-height: 1.1;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .hero-subtitle {
-      margin: 0;
-      max-width: 520px;
-      font-size: 1.05rem;
-      color: rgba(226, 232, 240, 0.72);
-    }
-
-    .hero-points {
-      margin: 0;
-      padding-left: 1.1rem;
-      display: grid;
-      gap: 0.85rem;
-      color: rgba(226, 232, 240, 0.85);
-      font-size: 0.95rem;
-      line-height: 1.5;
-      list-style: none;
-    }
-
-    .hero-points li {
-      position: relative;
-      padding-left: 2rem;
-    }
-
-    .hero-points li i {
-      position: absolute;
-      left: 0;
-      top: 0.1rem;
-      color: var(--lumina-cyan);
-    }
-
-    .hero-ctas {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-
-    .hero-ctas a {
-      text-decoration: none;
-      font-weight: 600;
-      padding: 0.8rem 1.6rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      transition: var(--transition);
-    }
-
-    .hero-ctas .primary {
-      background: var(--lumina-blue);
-      color: white;
-      box-shadow: none;
-    }
-
-    .hero-ctas .primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 12px 24px rgba(4, 120, 211, 0.22);
-    }
-
-    .hero-ctas .ghost {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .hero-ctas .ghost:hover {
-      background: rgba(255, 255, 255, 0.18);
-      color: var(--lumina-surface);
-      border-color: rgba(226, 232, 240, 0.32);
-    }
-
-    .hero-showcase {
-      background: rgba(11, 27, 63, 0.55);
-      border-radius: var(--radius-md);
-      padding: clamp(1.5rem, 3vw, 2rem);
-      box-shadow: none;
-      border: 1px solid rgba(226, 232, 240, 0.15);
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .showcase-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .showcase-header h2 {
-      font-size: 1.1rem;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .status-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.45rem 0.85rem;
-      border-radius: 999px;
-      background: rgba(56, 189, 248, 0.24);
-      color: var(--lumina-surface);
-      font-size: 0.8rem;
-      font-weight: 600;
-    }
-
-    .metrics-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 1.25rem;
-    }
-
-    .metric-card {
-      background: rgba(15, 23, 42, 0.45);
-      color: var(--lumina-surface);
-      padding: 1.4rem;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(226, 232, 240, 0.12);
-      position: relative;
-    }
-
-    .metric-card strong {
-      display: block;
-      font-size: 2rem;
-      font-weight: 700;
-    }
-
-    .metric-card span {
-      font-size: 0.85rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgba(226, 232, 240, 0.7);
-    }
-
-    .metric-card i {
-      font-size: 1.4rem;
-      opacity: 0.85;
-    }
-
-    .metric-card .icon-circle {
-      width: 48px;
-      height: 48px;
-      border-radius: 50%;
-      background: rgba(255, 255, 255, 0.14);
-      display: grid;
-      place-items: center;
-      margin-bottom: 1rem;
-    }
-
-    .section {
-      width: 100%;
-      margin: 0;
-      padding: clamp(3rem, 5vw + 1rem, 4.5rem) 1.25rem;
-    }
-
-    .section-light {
-      background: var(--lumina-surface);
-    }
-
-    .section-dark {
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-    }
-
-    .section-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    .section-dark .section-shell {
-      max-width: 1100px;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 0.75rem;
-      max-width: 720px;
-    }
-
-    .section-header h2 {
-      margin: 0;
-      font-size: clamp(2rem, 2vw + 1rem, 2.6rem);
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      font-size: 1.02rem;
-    }
-
-    .section-dark .section-header h2 {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .section-header p {
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    .feature-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.6rem;
-    }
-
-    .feature-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      padding: 1.8rem;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      display: grid;
-      gap: 1rem;
-      transition: var(--transition);
-    }
-
-    .feature-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.1);
-    }
-
-    .feature-icon {
-      width: 54px;
-      height: 54px;
-      border-radius: 16px;
-      background: #e6f2ff;
-      display: grid;
-      place-items: center;
-      color: var(--lumina-blue-dark);
-      font-size: 1.35rem;
-    }
-
-    .feature-card h3 {
-      margin: 0;
-      font-size: 1.2rem;
-      color: var(--lumina-navy);
-    }
-
-    .feature-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .section-cta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .section-cta a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.35rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .section-cta a.primary {
-      background: var(--lumina-blue);
-      color: #fff;
-      box-shadow: 0 12px 20px rgba(4, 120, 211, 0.18);
-      border: 1px solid transparent;
-    }
-
-    .section-cta a.ghost {
-      background: transparent;
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.28);
-    }
-
-    .section-cta a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .section-dark .section-cta a {
-      box-shadow: none;
-    }
-
-    .section-dark .section-cta a.primary {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(255, 255, 255, 0.28);
-    }
-
-    .section-dark .section-cta a.ghost {
-      color: rgba(226, 232, 240, 0.9);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .section-dark .section-cta a:hover {
-      background: rgba(255, 255, 255, 0.14);
-      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
-    }
-
-    .about-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 2rem;
-    }
-
-    .about-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 2rem;
-      display: grid;
-      gap: 0.75rem;
-      box-shadow: none;
-    }
-
-    .section-dark .feature-card {
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(226, 232, 240, 0.18);
-    }
-
-    .section-dark .feature-card h3,
-    .section-dark .feature-card p {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card p {
-      color: rgba(226, 232, 240, 0.78);
-    }
-
-    .section-dark .feature-icon {
-      background: rgba(56, 189, 248, 0.18);
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card:hover {
-      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
-    }
-
-    .about-card small {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--lumina-blue-dark);
-      font-weight: 600;
-    }
-
-    .about-card h3 {
-      margin: 0;
-      color: var(--lumina-navy);
-    }
-
-    .about-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.6rem;
-    }
-
-    .module-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 1.8rem;
-      display: grid;
-      gap: 1.2rem;
-      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.06);
-      transition: var(--transition);
-    }
-
-    .module-card header {
-      display: flex;
-      align-items: center;
-      gap: 0.9rem;
-    }
-
-    .module-card h3 {
-      margin: 0;
-      font-size: 1.15rem;
-      color: var(--lumina-navy);
-    }
-
-    .module-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .module-card ul {
-      margin: 0;
-      padding-left: 1.2rem;
-      display: grid;
-      gap: 0.55rem;
-      list-style: none;
-    }
-
-    .module-card ul li {
-      position: relative;
-      padding-left: 1.5rem;
-      color: var(--lumina-text-muted);
-      font-weight: 500;
-    }
-
-    .module-card ul li i {
-      position: absolute;
-      left: 0;
-      top: 0.1rem;
-      color: var(--lumina-blue);
-    }
-
-    .module-icon {
-      width: 48px;
-      height: 48px;
-      border-radius: 16px;
-      background: #e6f2ff;
-      color: var(--lumina-blue-dark);
-      display: grid;
-      place-items: center;
-      font-size: 1.35rem;
-    }
-
-    .module-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 16px 28px rgba(4, 120, 211, 0.12);
-    }
-
-    footer {
-      padding: 2.5rem 1.25rem 2rem;
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-      margin-top: auto;
-      width: 100%;
-      margin-left: 0;
-      margin-right: 0;
-    }
-
-    .footer-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .footer-shell a {
-      color: rgba(226, 232, 240, 0.85);
-      text-decoration: none;
-      font-weight: 500;
-    }
-
-    .footer-shell a:hover {
-      color: white;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
-      }
-
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-
-      .hero {
-        padding-top: 3rem;
-      }
-
-      .hero-ctas {
-        width: 100%;
-      }
-
-      .hero-ctas a {
-        flex: 1;
-        justify-content: center;
-      }
-    }
-  </style>
-  <?
-    var loginUrl = buildLoginPageUrl({});
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-</head>
-
-<body class="landing-page">
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="#top" aria-label="LuminaHQ home">
-          <img class="brand-logo" src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
-          </div>
-        </a>
-        <div class="nav-actions">
-          <a class="btn-outline" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="btn-primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login</a>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: (typeof currentPage !== 'undefined' && currentPage) ? currentPage : 'landing-home',
+  pageTitle: 'LuminaHQ – Intelligent Workforce Command Center',
+  pageDescription: 'Preview LuminaHQ quality, coaching, and workforce automation in a unified landing experience.'
+}) ?>
+
+<?
+  var landingBase = (typeof scriptUrl !== 'undefined' && scriptUrl)
+    ? scriptUrl
+    : ((typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '');
+
+  var landingHomeUrl = landingBase ? landingBase + '?page=landing' : 'Landing.html';
+  var landingAboutUrl = landingBase ? landingBase + '?page=landing-about' : 'LandingAbout.html';
+  var landingCapabilitiesUrl = landingBase ? landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+  var landingCapabilitiesDetailUrl = landingBase ? landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+  var landingStoryUrl = landingBase ? landingBase + '?page=landing-story' : 'LandingStory.html';
+  var loginUrl = (typeof buildLoginPageUrl === 'function') ? buildLoginPageUrl({}) : (landingBase || '#');
+?>
+
+<?!= includeOnce('LandingTemplateStyles') ?>
+
+<div class="landing-shell landing-theme-slate" style="--landing-hero-image: url('https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1600&q=80');">
+  <header class="landing-hero">
+    <div class="container">
+      <div class="landing-hero-content">
+        <span class="landing-badge">
+          <i class="fa-solid fa-chart-line"></i>
+          LuminaHQ Command Center
+        </span>
+        <h1>Orchestrate high-performing support operations</h1>
+        <p>
+          Illuminate the full coaching, quality, and workforce lifecycle with one connected workspace.
+          LuminaHQ brings AI-assisted evaluations, proactive scheduling, and agent enablement together so
+          operations leaders can scale consistency with confidence.
+        </p>
+        <div class="landing-cta">
+          <a class="btn btn-primary" href="<?= loginUrl ?>">Sign in to LuminaHQ</a>
+          <a class="btn btn-outline-light" href="<?= landingCapabilitiesUrl ?>">Explore capabilities</a>
+        </div>
+        <div class="landing-hero-meta">
+          <span><i class="fa-solid fa-layer-group"></i> Quality · Coaching · Workforce</span>
+          <span><i class="fa-solid fa-wand-magic-sparkles"></i> AI-guided automations</span>
+          <span><i class="fa-solid fa-globe"></i> Built for hybrid global teams</span>
         </div>
       </div>
-    </header>
+      <div class="landing-hero-media">
+        <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1600&q=80" alt="LuminaHQ operations analytics overview" loading="lazy">
+      </div>
+    </div>
+  </header>
 
-    <main class="landing-main">
-      <section class="hero" id="top">
-        <div class="hero-inner">
-          <div class="hero-surface">
-            <div class="hero-content">
-              <div class="hero-copy">
-                <span class="hero-tag"><i class="fa-solid fa-sparkles"></i> AI-Orchestrated Workforce Platform</span>
-                <h2 class="hero-title">Synchronize scheduling, quality, and automation in one command center.</h2>
-                <p class="hero-subtitle">LuminaHQ layers an operations graph across every queue, site, and partner so leaders can translate live performance data into confident decisions in seconds.</p>
-                <ul class="hero-points" role="list">
-                  <li><i class="fa-solid fa-compass"></i> Forecast-aware dashboards that warn of staffing or SLA drift before it hits customers.</li>
-                  <li><i class="fa-solid fa-waveform"></i> AI-assisted coaching loops that convert QA findings into prioritized actions for every leader.</li>
-                  <li><i class="fa-solid fa-plug"></i> Native Google Workspace deployment with SSO, audit trails, and tenant isolation from day one.</li>
-                </ul>
-                <div class="hero-ctas">
-                  <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
-                  <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-                </div>
-              </div>
-              <aside class="hero-showcase" aria-label="Platform highlights">
-                <div class="showcase-header">
-                  <h2>Live intelligence snapshot</h2>
-                  <span class="status-pill"><i class="fa-solid fa-signal"></i> Live data fabric</span>
-                </div>
-                <div class="metrics-grid">
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
-                    <strong>3.4K</strong>
-                    <span>Agents orchestrated</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
-                    <strong>12%</strong>
-                    <span>Lift in SLA adherence</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
-                    <strong>9m</strong>
-                    <span>Average onboarding</span>
-                  </div>
-                </div>
-                <p class="hero-subtitle" style="margin:0;">Designed for managers, analysts, and specialists who need a precise pulse on every customer moment.</p>
-              </aside>
+  <main class="landing-main">
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Unify the workforce playbook</h2>
+          <p>
+            LuminaHQ centralizes the quality, coaching, and workforce tools that operations teams rely on every day.
+            Align insight to action with curated dashboards, configurable workflows, and acknowledgment tracking in one hub.
+          </p>
+        </div>
+        <div class="landing-grid">
+          <article class="landing-card">
+            <h3>Quality intelligence</h3>
+            <p>
+              See trends instantly with dashboards that tie evaluation results to actionable QA backlogs and collaborative reviews.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-circle-check"></i> Live QA boards with filters for campaigns, analysts, and coaching moments.</li>
+              <li><i class="fa-solid fa-share-nodes"></i> Shared calibrations keep analysts aligned on scoring criteria.</li>
+              <li><i class="fa-solid fa-file-arrow-down"></i> Export-ready packets summarize findings for leadership briefings.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Coaching activations</h3>
+            <p>
+              Launch guided coaching sessions that capture commitments, acknowledgments, and follow-up tasks within minutes.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-handshake-angle"></i> Personalized forms document conversations and next steps.</li>
+              <li><i class="fa-solid fa-bell"></i> Automated nudges keep owners ahead of due dates.</li>
+              <li><i class="fa-solid fa-clipboard-check"></i> Signature-ready acknowledgments close the loop with agents.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Workforce precision</h3>
+            <p>
+              Balance staffing, attendance, and shift coverage with centralized calendars and scenario planning utilities.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-calendar-check"></i> Smart schedule management highlights gaps before they impact SLAs.</li>
+              <li><i class="fa-solid fa-diagram-project"></i> Cross-team dashboards blend adherence with coaching touchpoints.</li>
+              <li><i class="fa-solid fa-user-shield"></i> Access-aware controls ensure the right leaders see the right data.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Operations snapshots</h2>
+          <p>
+            Preview the experiences that await once teams step inside LuminaHQ. Every module is crafted from real contact center workflows
+            and shaped to keep agents, analysts, and leaders aligned.
+          </p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Agent experience</h3>
+            <p>
+              Surface personalized scorecards, coaching actions, and acknowledgment status the moment an agent logs in.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-user-gear"></i> Consolidated view of feedback, QA results, and performance metrics.</li>
+              <li><i class="fa-solid fa-paper-plane"></i> Quick links jump directly into forms, chats, or acknowledgments.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Executive oversight</h3>
+            <p>
+              Leadership dashboards synthesize campaign health, trending escalations, and operational readiness at a glance.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-chart-pie"></i> Drill into campaign-level KPIs or filter by priority programs.</li>
+              <li><i class="fa-solid fa-shield"></i> Built-in controls protect sensitive client views while enabling collaboration.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Knowledge continuity</h3>
+            <p>
+              Guide teams through change with embedded documentation, policy references, and training roadmaps.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-book-open"></i> LuminaHQ user guides live alongside operations dashboards.</li>
+              <li><i class="fa-solid fa-lightbulb"></i> Highlight best practices and workflow explainers for new hires.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Collaboration fabric</h3>
+            <p>
+              Shared workspaces and comment threads empower analysts, supervisors, and enablement teams to solve together.
+            </p>
+            <ul>
+              <li><i class="fa-solid fa-comments"></i> Threaded discussions keep evaluation context connected to outcomes.</li>
+              <li><i class="fa-solid fa-link"></i> Deep links hop into escalations, tasks, or playbooks without breaking flow.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Continue exploring LuminaHQ</h2>
+          <p>Follow the guided paths below for the story, detailed capability breakdowns, and the teams behind the platform.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>About LuminaHQ</h3>
+            <p>Meet the operations principles, leadership commitments, and cultural anchors powering the platform.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingAboutUrl ?>"><i class="fa-solid fa-circle-info"></i> Visit About page</a>
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="section section-dark" id="features">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Operate with clarity and confidence</h2>
-            <p>LuminaHQ turns scattered spreadsheets and disconnected tools into a unified control tower. Every feature is tuned for contact center pace—revealing what changed, why it matters, and the action to take next.</p>
-          </div>
-          <div class="feature-grid">
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-headset"></i></div>
-              <h3>Unified agent visibility</h3>
-              <p>See adherence, skills, coaching, and productivity in a single glance to resolve staffing gaps before they impact experience.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-gauge-high"></i></div>
-              <h3>Performance intelligence</h3>
-              <p>Layer KPIs, QA signals, and customer sentiment into interactive scorecards that spotlight wins and risks by site, line of business, or client.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-shield-halved"></i></div>
-              <h3>Secure, tenant-ready</h3>
-              <p>Granular roles, audit logging, and tenant isolation give enterprise partners confidence without slowing delivery.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-rocket"></i></div>
-              <h3>Ready in minutes</h3>
-              <p>Deploy on Google Workspace in under an hour—keeping teams in familiar tools while unlocking enterprise automation.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore full capabilities</a>
-            <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
-          </div>
-        </div>
-      </section>
-
-      <section class="section section-light" id="modules">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Mission-critical modules</h2>
-            <p>Each LuminaHQ module is purpose-built yet deeply connected. Together they orchestrate agent experience, customer outcomes, and compliance from a single mission control.</p>
-          </div>
-          <div class="module-grid">
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-calendar-check"></i></span>
-                <h3>Adaptive Scheduling</h3>
-              </header>
-              <p>Balance staffing in real time with forecasting overlays, automated shift swaps, and instant communication to every affected agent.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-bolt"></i> Rolling interval forecasts blended with live adherence.</li>
-                <li><i class="fa-solid fa-comments"></i> Native shift notifications and approvals.</li>
-                <li><i class="fa-solid fa-chart-area"></i> Attendance anomaly alerts with root-cause context.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-user-shield"></i></span>
-                <h3>QA & Compliance</h3>
-              </header>
-              <p>Run calibrated evaluations, automate dispute workflows, and codify remediation steps to keep every campaign audit-ready.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-list-check"></i> Dynamic scorecards with weighted criteria.</li>
-                <li><i class="fa-solid fa-repeat"></i> Closed-loop disputes that sync with coaching plans.</li>
-                <li><i class="fa-solid fa-lock"></i> Granular permissions and audit-ready exports.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-chart-simple"></i></span>
-                <h3>Performance Intelligence</h3>
-              </header>
-              <p>Blend telephony, CRM, WFM, and customer sentiment data into interactive scoreboards that broadcast wins and spotlight gaps.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-arrows-rotate"></i> Real-time KPI sync with predictive targets.</li>
-                <li><i class="fa-solid fa-wand-magic-sparkles"></i> Auto-generated insights for supervisors and executives.</li>
-                <li><i class="fa-solid fa-people-arrows"></i> Role-based dashboards with drill-through.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-robot"></i></span>
-                <h3>Automation Studio</h3>
-              </header>
-              <p>Trigger workflows across Sheets, Gmail, and external APIs with reusable recipes that shrink manual effort and accelerate resolution.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-diagram-next"></i> Drag-and-drop flow builder with approvals.</li>
-                <li><i class="fa-solid fa-cloud-arrow-up"></i> Secure integrations and webhook triggers.</li>
-                <li><i class="fa-solid fa-stopwatch-20"></i> SLA-aware automations with guardrails.</li>
-              </ul>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Dive into detailed capabilities</a>
-            <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Experience LuminaHQ live</a>
-          </div>
-        </div>
-      </section>
-
-      <section class="section section-light" id="about">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>The story behind LuminaHQ</h2>
-            <p>LuminaHQ was born inside Lumina's Innovation Lab in Kingston, Jamaica. We pair decades of contact center experience with modern data engineering to remove the friction between people, processes, and platforms.</p>
-          </div>
-          <div class="about-grid">
-            <article class="about-card">
-              <small>Purpose</small>
-              <h3>Elevate every customer moment</h3>
-              <p>Provide managers, analysts, and enablement leaders with a cohesive view of scheduling, coaching, QA, and collaboration so they can invest their time in people—not manual busywork.</p>
-            </article>
-            <article class="about-card">
-              <small>Built For</small>
-              <h3>Global call center teams</h3>
-              <p>From BPO networks to in-house support centers, LuminaHQ adapts to campaigns of every scale with tenant-aware governance baked in.</p>
-            </article>
-            <article class="about-card">
-              <small>Crafted In</small>
-              <h3>Kingston, Jamaica</h3>
-              <p>Engineered by Lumina's product studio with a focus on modern, flat UI, AI-ready data pipelines, and a seamless Google Apps Script backbone.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> Discover our story</a>
-            <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <p>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</p>
-        <div>
-          <a href="PrivacyPolicy.html">Privacy</a> &middot;
-          <a href="TermsOfService.html">Terms</a> &middot;
-          <a href="<?!= loginUrl ?>">Login</a>
+          </article>
+          <article class="landing-card">
+            <h3>Explore capabilities</h3>
+            <p>Review the full catalog of workforce, quality, and enablement solutions available on launch day.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesUrl ?>"><i class="fa-solid fa-sitemap"></i> View capabilities</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Dive into the details</h3>
+            <p>See how each capability layer works together with example workflows, data flows, and analyst toolkits.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-magnifying-glass-chart"></i> Dive deeper</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Discover our story</h3>
+            <p>Learn how LuminaHQ grew from task tracking to an AI-ready command center that scales with every client.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingStoryUrl ?>"><i class="fa-solid fa-book"></i> Read the story</a>
+            </div>
+          </article>
         </div>
       </div>
-    </footer>
-  </div>
-</body>
+    </section>
+  </main>
 
-</html>
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="brand-lockup">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+        LuminaHQ by VLBPO
+      </div>
+      <nav>
+        <a href="<?= landingAboutUrl ?>">About</a>
+        <a href="<?= landingCapabilitiesUrl ?>">Capabilities</a>
+        <a href="<?= landingCapabilitiesDetailUrl ?>">Deep dive</a>
+        <a href="<?= landingStoryUrl ?>">Our story</a>
+      </nav>
+      <div class="landing-metrics">
+        <span><i class="fa-solid fa-people-group"></i> Teams in sync</span>
+        <span><i class="fa-solid fa-shield"></i> Trust by design</span>
+        <span><i class="fa-solid fa-bolt"></i> AI-ready workflows</span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -1,523 +1,195 @@
-<!DOCTYPE html>
-<html lang="en">
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: 'landing-about',
+  pageTitle: 'About LuminaHQ',
+  pageDescription: 'Meet the LuminaHQ team, culture, and operational principles behind the platform.'
+}) ?>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About LuminaHQ</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f5f8ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --lumina-gradient: linear-gradient(135deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.9));
-      --shadow-card: 0 30px 60px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --transition: all 0.28s ease;
-    }
+<?
+  var landingBase = (typeof scriptUrl !== 'undefined' && scriptUrl)
+    ? scriptUrl
+    : ((typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '');
 
-    * {
-      box-sizing: border-box;
-    }
+  var landingHomeUrl = landingBase ? landingBase + '?page=landing' : 'Landing.html';
+  var landingAboutUrl = landingBase ? landingBase + '?page=landing-about' : 'LandingAbout.html';
+  var landingCapabilitiesUrl = landingBase ? landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+  var landingCapabilitiesDetailUrl = landingBase ? landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+  var landingStoryUrl = landingBase ? landingBase + '?page=landing-story' : 'LandingStory.html';
+  var loginUrl = (typeof buildLoginPageUrl === 'function') ? buildLoginPageUrl({}) : (landingBase || '#');
+?>
 
-    body {
-      margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: radial-gradient(circle at 20% 20%, rgba(4, 120, 211, 0.08), transparent 55%),
-        radial-gradient(circle at 80% 0, rgba(56, 189, 248, 0.1), transparent 45%),
-        var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
+<?!= includeOnce('LandingTemplateStyles') ?>
 
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.82);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.5rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-      color: inherit;
-    }
-
-    .brand img {
-      width: 46px;
-      height: 46px;
-    }
-
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .nav-actions a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
-      border-radius: 999px;
-      transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.9);
-    }
-
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 14px 22px rgba(4, 120, 211, 0.15);
-    }
-
-    main {
-      flex: 1;
-    }
-
-    .hero {
-      position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
-    }
-
-    .hero::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: 0 0 48px 48px;
-      background: var(--lumina-gradient);
-      z-index: 0;
-    }
-
-    .hero-inner {
-      position: relative;
-      z-index: 1;
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.5rem;
-    }
-
-    .hero-meta {
-      display: grid;
-      gap: 1rem;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-
-    .meta-card {
-      background: rgba(255, 255, 255, 0.14);
-      padding: 1.25rem 1.4rem;
-      border-radius: var(--radius-md);
-      display: flex;
-      flex-direction: column;
-      gap: 0.4rem;
-      border: 1px solid rgba(255, 255, 255, 0.22);
-    }
-
-    .meta-card span {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      font-weight: 600;
-      font-size: 0.72rem;
-      color: rgba(248, 250, 252, 0.72);
-    }
-
-    .meta-card strong {
-      font-size: 1.4rem;
-      font-weight: 700;
-    }
-
-    .content-section {
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: clamp(3rem, 5vw, 4.5rem) 1.5rem;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin-bottom: 1rem;
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      font-size: 1.05rem;
-      line-height: 1.8;
-      color: var(--lumina-muted);
-    }
-
-    .value-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .value-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .value-card i {
-      font-size: 1.5rem;
-      color: var(--lumina-blue);
-    }
-
-    .value-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .value-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .story-timeline {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.5rem;
-      position: relative;
-    }
-
-    .story-card {
-      background: rgba(255, 255, 255, 0.92);
-      border-radius: var(--radius-md);
-      padding: 1.75rem 1.9rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
-    }
-
-    .story-card strong {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .story-card h4 {
-      font-size: 1.35rem;
-      margin: 0.75rem 0;
-    }
-
-    .story-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .culture-banner {
-      background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(4, 120, 211, 0.18));
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 2rem;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      border: 1px solid rgba(4, 120, 211, 0.25);
-    }
-
-    .culture-banner h4 {
-      margin: 0;
-      font-size: 1.6rem;
-    }
-
-    .culture-banner ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.9rem;
-    }
-
-    .culture-banner li {
-      display: flex;
-      align-items: flex-start;
-      gap: 0.75rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .culture-banner li i {
-      color: var(--lumina-blue);
-      margin-top: 0.2rem;
-    }
-
-    footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
-    }
-
-    .footer-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
-      text-decoration: none;
-    }
-
-    .footer-shell a:hover {
-      color: #fff;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
-      }
-
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-    }
-  </style>
-</head>
-
-<body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
-          </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+<div class="landing-shell landing-theme-emerald" style="--landing-hero-image: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80');">
+  <header class="landing-hero">
+    <div class="container">
+      <div class="landing-hero-content">
+        <span class="landing-badge"><i class="fa-solid fa-seedling"></i>Built for people-first operations</span>
+        <h1>The team energizing LuminaHQ</h1>
+        <p>
+          LuminaHQ is created by operators, analysts, and leaders who understand the pace of modern customer experience teams.
+          We craft tooling that supports clarity, accountability, and growth across every campaign and site.
+        </p>
+        <div class="landing-cta">
+          <a class="btn btn-primary" href="<?= landingStoryUrl ?>">Discover our story</a>
+          <a class="btn btn-outline-light" href="<?= loginUrl ?>">Contact LuminaHQ</a>
+        </div>
+        <div class="landing-hero-meta">
+          <span><i class="fa-solid fa-hands-holding"></i> Culture of partnership</span>
+          <span><i class="fa-solid fa-earth-americas"></i> Global-first delivery</span>
+          <span><i class="fa-solid fa-shield-heart"></i> Security and trust embedded</span>
         </div>
       </div>
-    </header>
+      <div class="landing-hero-media">
+        <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80" alt="LuminaHQ team collaborating around analytics" loading="lazy">
+      </div>
+    </div>
+  </header>
 
-    <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>The humans and history behind our workforce command center.</h2>
-            <p>We build LuminaHQ in Kingston, Jamaica with an obsession for frontline momentum. Designers, engineers, analysts, and former operations leaders sit side-by-side to remove the friction contact center teams feel every day.</p>
-            <div class="hero-meta">
-              <div class="meta-card">
-                <span>Origin</span>
-                <strong>Innovation Lab</strong>
-                <p>Born from Lumina's partnerships with BPO networks across the Caribbean and North America.</p>
-              </div>
-              <div class="meta-card">
-                <span>Craft</span>
-                <strong>Design × Data</strong>
-                <p>Product strategy meets applied data science to translate raw signals into guided action.</p>
-              </div>
-              <div class="meta-card">
-                <span>Promise</span>
-                <strong>Operational clarity</strong>
-                <p>Every workflow unifies scheduling, QA, coaching, and collaboration inside one control tower.</p>
-              </div>
+  <main class="landing-main">
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Grounded in operational empathy</h2>
+          <p>
+            Our playbook was shaped by years of guiding workforce, quality, and enablement programs. LuminaHQ distills those lessons into
+            tangible rituals that teams can adopt from day one.
+          </p>
+        </div>
+        <div class="landing-grid">
+          <article class="landing-card">
+            <h3>Mission</h3>
+            <p>Equip frontline teams with clarity so every interaction reflects the brand promise.</p>
+            <ul>
+              <li><i class="fa-solid fa-bullseye"></i> Provide a single pane of glass for quality, coaching, and staffing insights.</li>
+              <li><i class="fa-solid fa-lightbulb"></i> Translate data into clear actions that accelerate decision-making.</li>
+              <li><i class="fa-solid fa-heart"></i> Build tools that celebrate agent growth as much as they track metrics.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Vision</h3>
+            <p>Make world-class contact center operations accessible to every partner, regardless of scale.</p>
+            <ul>
+              <li><i class="fa-solid fa-earth-asia"></i> Support hybrid, remote, and on-site teams with equal excellence.</li>
+              <li><i class="fa-solid fa-link"></i> Seamless integrations with Lumina apps keep workflows flowing.</li>
+              <li><i class="fa-solid fa-star"></i> Continuous improvements rooted in agent and client feedback loops.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Values</h3>
+            <p>We lead with curiosity, transparency, and inclusivity inside LuminaHQ and across every campaign.</p>
+            <ul>
+              <li><i class="fa-solid fa-people-roof"></i> Collaboration over silos when solving client challenges.</li>
+              <li><i class="fa-solid fa-shield-check"></i> Governance and privacy safeguards that exceed compliance requirements.</li>
+              <li><i class="fa-solid fa-graduation-cap"></i> Structured enablement so teams keep learning together.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Leadership commitments</h2>
+          <p>Our leadership circle keeps customers and agents at the heart of every release cycle.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Operational readiness</h3>
+            <p>Before updates ship, we ensure change management plans and adoption kits are in place.</p>
+            <ul>
+              <li><i class="fa-solid fa-clipboard-list"></i> Go-live checklists tailored for workforce and quality leads.</li>
+              <li><i class="fa-solid fa-chalkboard-user"></i> Enablement toolkits for trainers and site leaders.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Security & trust</h3>
+            <p>Data privacy is architected into every module, from user authentication to export controls.</p>
+            <ul>
+              <li><i class="fa-solid fa-lock"></i> Role-aware experiences keep sensitive dashboards safe.</li>
+              <li><i class="fa-solid fa-file-shield"></i> Compliance-ready audit trails support policy reviews.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Innovation cadence</h3>
+            <p>We iterate alongside program owners to bring AI-assisted workflows where they create the most value.</p>
+            <ul>
+              <li><i class="fa-solid fa-rocket"></i> Quarterly roadmap checkpoints with partner feedback.</li>
+              <li><i class="fa-solid fa-wand-magic-sparkles"></i> Pilots with analyst squads to validate automation paths.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>People-first focus</h3>
+            <p>Every release respects the humans behind the metrics—agents, analysts, and supervisors.</p>
+            <ul>
+              <li><i class="fa-solid fa-user-group"></i> Built-in recognition moments celebrate coaching wins.</li>
+              <li><i class="fa-solid fa-scale-balanced"></i> Tools designed to reduce admin effort, not increase it.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Where to next</h2>
+          <p>Dive deeper into the platform or explore the story behind LuminaHQ.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Platform tour</h3>
+            <p>Jump into the capabilities overview to see how we translate operations strategy into execution.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesUrl ?>"><i class="fa-solid fa-compass"></i> Explore capabilities</a>
             </div>
-          </div>
-          <div class="hero-visual" aria-hidden="true">
-            <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1710450011/vlbpo/lumina/about-grid_qws7ir.png" alt="LuminaHQ culture collage" style="width:100%;border-radius:24px;box-shadow:0 32px 60px rgba(8, 47, 73, 0.2);object-fit:cover;">
-          </div>
-        </div>
-      </section>
-
-      <section class="content-section">
-        <div class="section-header">
-          <h3>Why we exist</h3>
-          <p>Contact center leaders are asked to coach, forecast, report, and innovate at the same time. LuminaHQ eliminates the swivel-chair effort by giving every role a shared workspace that adapts to each campaign, geography, and client requirement.</p>
-        </div>
-        <div class="value-grid">
-          <article class="value-card">
-            <i class="fa-solid fa-compass"></i>
-            <h4>Customer-first design</h4>
-            <p>Every workflow is tested with active operations teams so the UI stays intuitive even as programs scale or pivot.</p>
           </article>
-          <article class="value-card">
-            <i class="fa-solid fa-people-group"></i>
-            <h4>Human-centered automation</h4>
-            <p>Automation is only valuable when it empowers analysts and supervisors. Our scripts reduce manual steps while keeping humans in control.</p>
+          <article class="landing-card">
+            <h3>Deep dive reference</h3>
+            <p>Use the detailed breakdown to map LuminaHQ workflows to your existing processes.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-chart-tree-map"></i> Review the deep dive</a>
+            </div>
           </article>
-          <article class="value-card">
-            <i class="fa-solid fa-shield-heart"></i>
-            <h4>Secure collaboration</h4>
-            <p>Multi-tenant controls, audit trails, and granular permissions safeguard customer data while keeping teams aligned.</p>
+          <article class="landing-card">
+            <h3>Origin story</h3>
+            <p>See how our operations heritage guided the product path in the Discover Our Story page.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingStoryUrl ?>"><i class="fa-solid fa-book"></i> Read the story</a>
+            </div>
           </article>
-          <article class="value-card">
-            <i class="fa-solid fa-globe"></i>
-            <h4>Global reach, local roots</h4>
-            <p>We support distributed teams across the Americas while grounding our craft and culture in the Caribbean.</p>
+          <article class="landing-card">
+            <h3>Return home</h3>
+            <p>Visit the main landing page for the full LuminaHQ snapshot and quick navigation.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+            </div>
           </article>
         </div>
-      </section>
-
-      <section class="content-section">
-        <div class="section-header">
-          <h3>How LuminaHQ evolved</h3>
-          <p>A cross-functional team of engineers, data analysts, and operations specialists continues to expand LuminaHQ based on live call center feedback.</p>
-        </div>
-        <div class="story-timeline">
-          <article class="story-card">
-            <strong><i class="fa-solid fa-flag"></i> 2019</strong>
-            <h4>Scheduling foundations</h4>
-            <p>Rolled out Google Workspace scripts to automate agent shift updates and broadcast daily coaching plans.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-rocket"></i> 2021</strong>
-            <h4>Unified coaching</h4>
-            <p>Expanded into coaching dashboards, QA data pipelines, and collaboration workflows for hybrid teams.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-shield"></i> 2023</strong>
-            <h4>Enterprise-ready security</h4>
-            <p>Shipped tenant-aware access controls, SSO alignment, and audit logging for compliance-focused partners.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-chart-line"></i> Today</strong>
-            <h4>Predictive intelligence</h4>
-            <p>Integrating forecasting, AI summarization, and proactive alerts so teams anticipate change instead of reacting to it.</p>
-          </article>
-        </div>
-      </section>
-
-      <section class="content-section" style="padding-bottom:4.5rem;">
-        <div class="culture-banner">
-          <div>
-            <h4>Inside the LuminaHQ culture</h4>
-            <p style="color:var(--lumina-muted);line-height:1.7;margin-top:0.75rem;">We operate with curiosity, empathy, and a bias toward shipping. Product rituals keep customer teams connected to the builders shaping their tools.</p>
-          </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-lightbulb"></i> Weekly design reviews align engineering, QA, and enablement on upcoming experiments.</li>
-              <li><i class="fa-solid fa-person-chalkboard"></i> Immersive onboarding embeds our product team inside partner operations for live feedback.</li>
-              <li><i class="fa-solid fa-hands"></i> Community initiatives reinvest in Jamaican tech talent through mentorship, internships, and open-source learning.</li>
-            </ul>
-          </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-headset"></i> Dedicated customer pods pair product managers with operations leads for faster roadmap alignment.</li>
-              <li><i class="fa-solid fa-leaf"></i> We balance rapid delivery with sustainable workloads to maintain a resilient, creative team.</li>
-            </ul>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <strong>Ready to explore the workspace?</strong>
-        <div>
-          <a href="<?!= landingCapabilitiesUrl ?>">Discover LuminaHQ capabilities</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#about">Back to landing overview</a>
-        </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
       </div>
-    </footer>
-  </div>
-</body>
+    </section>
+  </main>
 
-</html>
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="brand-lockup">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+        LuminaHQ by VLBPO
+      </div>
+      <nav>
+        <a href="<?= landingHomeUrl ?>">Landing</a>
+        <a href="<?= landingCapabilitiesUrl ?>">Capabilities</a>
+        <a href="<?= landingCapabilitiesDetailUrl ?>">Deep dive</a>
+        <a href="<?= landingStoryUrl ?>">Our story</a>
+      </nav>
+      <div class="landing-metrics">
+        <span><i class="fa-solid fa-heart-circle-check"></i> People-first support</span>
+        <span><i class="fa-solid fa-lightbulb"></i> Continuous improvement</span>
+        <span><i class="fa-solid fa-lock"></i> Security at every layer</span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -1,670 +1,192 @@
-<!DOCTYPE html>
-<html lang="en">
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: 'landing-capabilities',
+  pageTitle: 'LuminaHQ Capabilities Overview',
+  pageDescription: 'Review the LuminaHQ capability suite across quality, coaching, workforce, and analytics domains.'
+}) ?>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Explore LuminaHQ Capabilities</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var loginUrl = buildLoginPageUrl({});
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f6f9ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --shadow-card: 0 28px 50px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --radius-sm: 14px;
-      --transition: all 0.28s ease;
-    }
+<?
+  var landingBase = (typeof scriptUrl !== 'undefined' && scriptUrl)
+    ? scriptUrl
+    : ((typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '');
 
-    * {
-      box-sizing: border-box;
-    }
+  var landingHomeUrl = landingBase ? landingBase + '?page=landing' : 'Landing.html';
+  var landingAboutUrl = landingBase ? landingBase + '?page=landing-about' : 'LandingAbout.html';
+  var landingCapabilitiesUrl = landingBase ? landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+  var landingCapabilitiesDetailUrl = landingBase ? landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+  var landingStoryUrl = landingBase ? landingBase + '?page=landing-story' : 'LandingStory.html';
+  var loginUrl = (typeof buildLoginPageUrl === 'function') ? buildLoginPageUrl({}) : (landingBase || '#');
+?>
 
-    body {
-      margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
+<?!= includeOnce('LandingTemplateStyles') ?>
 
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.9);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-      color: inherit;
-    }
-
-    .brand img {
-      width: 46px;
-      height: 46px;
-    }
-
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
-      display: flex;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .nav-actions a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
-      border-radius: 999px;
-      transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.92);
-    }
-
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .hero {
-      position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
-      overflow: hidden;
-    }
-
-    .hero::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      z-index: 0;
-      border-radius: 0 0 48px 48px;
-    }
-
-    .hero::after {
-      content: '';
-      position: absolute;
-      top: -20%;
-      right: -20%;
-      width: 420px;
-      height: 420px;
-      background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 60%);
-      z-index: 0;
-    }
-
-    .hero-inner {
-      position: relative;
-      z-index: 1;
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.6rem;
-    }
-
-    .hero-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      background: rgba(255, 255, 255, 0.18);
-      border-radius: 999px;
-      padding: 0.65rem 1.3rem;
-      font-weight: 600;
-      color: #fff;
-      text-decoration: none;
-      transition: var(--transition);
-      border: 1px solid rgba(255, 255, 255, 0.32);
-      max-width: fit-content;
-    }
-
-    .hero-cta:hover {
-      transform: translateY(-2px);
-      background: rgba(255, 255, 255, 0.24);
-    }
-
-    main {
-      flex: 1;
-    }
-
-    .section {
-      padding: clamp(3.2rem, 5vw, 4.5rem) 1.5rem;
-    }
-
-    .section-shell {
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 1rem;
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin: 0;
-    }
-
-    .section-header p {
-      margin: 0;
-      font-size: 1.05rem;
-      color: var(--lumina-muted);
-      line-height: 1.8;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .module-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 0.7rem;
-      transition: var(--transition);
-    }
-
-    .module-card:hover {
-      transform: translateY(-6px);
-      box-shadow: 0 32px 70px rgba(11, 27, 63, 0.16);
-    }
-
-    .module-card span {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .module-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .module-card p {
-      margin: 0;
-      line-height: 1.65;
-      color: var(--lumina-muted);
-    }
-
-    .module-card ul {
-      margin: 0.75rem 0 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .capability-matrix {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1.5rem;
-    }
-
-    .matrix-card {
-      background: linear-gradient(145deg, rgba(4, 120, 211, 0.1), rgba(56, 189, 248, 0.08));
-      border-radius: var(--radius-md);
-      padding: 2.1rem 2.3rem;
-      border: 1px solid rgba(4, 120, 211, 0.18);
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .matrix-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .matrix-card p {
-      margin: 0;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .matrix-points {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.65rem;
-    }
-
-    .matrix-points li {
-      display: flex;
-      gap: 0.55rem;
-      align-items: flex-start;
-      color: var(--lumina-muted);
-    }
-
-    .matrix-points li i {
-      color: var(--lumina-blue);
-      margin-top: 0.15rem;
-    }
-
-    .integration-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.4rem;
-    }
-
-    .integration-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-sm);
-      padding: 1.6rem 1.8rem;
-      border: 1px solid var(--lumina-border);
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
-    }
-
-    .integration-card strong {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .integration-card ul {
-      margin: 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .cta-panel {
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      color: #fff;
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 1.5rem;
-      justify-items: start;
-      box-shadow: 0 38px 70px rgba(8, 30, 70, 0.22);
-      text-align: left;
-    }
-
-    .cta-panel h3 {
-      margin: 0;
-      font-size: clamp(2rem, 3.5vw, 2.5rem);
-    }
-
-    .cta-panel p {
-      margin: 0;
-      font-size: 1.05rem;
-      max-width: 520px;
-      line-height: 1.7;
-      color: rgba(226, 232, 240, 0.85);
-    }
-
-    .cta-panel a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      background: #fff;
-      color: var(--lumina-blue-dark);
-      text-decoration: none;
-      padding: 0.75rem 1.5rem;
-      border-radius: 999px;
-      font-weight: 600;
-      transition: var(--transition);
-    }
-
-    .cta-panel a:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 30px rgba(255, 255, 255, 0.25);
-    }
-
-    footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
-    }
-
-    .footer-shell {
-      max-width: 1120px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
-      text-decoration: none;
-    }
-
-    .footer-shell a:hover {
-      color: #fff;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
-      }
-
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-    }
-  </style>
-</head>
-
-<body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
-          </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+<div class="landing-shell landing-theme-violet" style="--landing-hero-image: url('https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1600&q=80');">
+  <header class="landing-hero">
+    <div class="container">
+      <div class="landing-hero-content">
+        <span class="landing-badge"><i class="fa-solid fa-sitemap"></i>Capabilities at a glance</span>
+        <h1>Explore the LuminaHQ operations suite</h1>
+        <p>
+          Every LuminaHQ capability is designed to align leaders, analysts, and agents. Navigate the highlights below to preview how the
+          platform powers quality excellence, workforce precision, and enablement momentum.
+        </p>
+        <div class="landing-cta">
+          <a class="btn btn-primary" href="<?= landingCapabilitiesDetailUrl ?>">Open the deep dive</a>
+          <a class="btn btn-outline-light" href="<?= loginUrl ?>">Request a walkthrough</a>
+        </div>
+        <div class="landing-hero-meta">
+          <span><i class="fa-solid fa-layer-group"></i> Modular building blocks</span>
+          <span><i class="fa-solid fa-plug"></i> Connected across Lumina apps</span>
+          <span><i class="fa-solid fa-chart-bar"></i> Analytics-ready by default</span>
         </div>
       </div>
-    </header>
-
-    <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>Every capability connects frontline execution to leadership insight.</h2>
-            <p>Explore the mission-ready modules that power LuminaHQ. Each capability extends a unified operations graph so every decision reflects what is happening on the floor right now.</p>
-            <a class="hero-cta" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to experience LuminaHQ</a>
-          </div>
-          <div class="hero-visual" aria-hidden="true" style="display:grid;gap:1rem;">
-            <div style="background:rgba(255,255,255,0.12);border-radius:22px;padding:1.4rem 1.6rem;border:1px solid rgba(255,255,255,0.28);display:grid;gap:0.75rem;">
-              <div style="display:flex;align-items:center;justify-content:space-between;">
-                <strong style="font-size:0.95rem;letter-spacing:0.12em;text-transform:uppercase;">Live insights</strong>
-                <span style="display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;"><i class="fa-solid fa-signal"></i> Synced</span>
-              </div>
-              <div style="display:grid;gap:0.6rem;">
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Schedule adherence</span>
-                  <strong>97.4%</strong>
-                </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>QA coaching cycles</span>
-                  <strong>128</strong>
-                </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Campaign health</span>
-                  <strong>Green</strong>
-                </div>
-              </div>
-            </div>
-            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.75rem;">
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-calendar-check" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Scheduling</p>
-              </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chalkboard-user" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Coaching</p>
-              </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chart-line" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Analytics</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="modules">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Core modules that power your operations</h3>
-            <p>Each module is purpose-built for high-volume contact centers. They connect seamlessly but can roll out independently to match the maturity of each campaign.</p>
-          </div>
-          <div class="module-grid">
-            <article class="module-card">
-              <span><i class="fa-solid fa-calendar-check"></i> Scheduling</span>
-              <h4>Shift orchestration</h4>
-              <p>Balance coverage with predictive forecasts, automate shift swaps, and trigger exception workflows directly through Google Workspace.</p>
-              <ul>
-                <li>Scenario planning with interval forecasts and adherence overlays.</li>
-                <li>Automated swap approvals, overtime guardrails, and manager alerts.</li>
-                <li>Work-from-home readiness checks tied to equipment and network audits.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-user-graduate"></i> Coaching</span>
-              <h4>Enablement playbooks</h4>
-              <p>Give supervisors guided workflows to assign action plans, capture feedback, and celebrate wins in one place.</p>
-              <ul>
-                <li>Custom coaching templates with digital sign-offs and attachments.</li>
-                <li>Performance heatmaps that highlight the biggest coaching opportunities.</li>
-                <li>Automated nudges that keep follow-ups and reinforcements on schedule.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-shield-heart"></i> Quality</span>
-              <h4>QA intelligence hub</h4>
-              <p>Aggregate evaluator feedback, calibrate teams, and surface QA performance trends with a modern reporting layer.</p>
-              <ul>
-                <li>Weighted scoring with variance alerts across lines of business.</li>
-                <li>Calibration dashboards that preserve historical context and disputes.</li>
-                <li>AI-ready exports that feed deeper analytics or generative summaries.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-handshake"></i> Collaboration</span>
-              <h4>Campaign collaboration</h4>
-              <p>Coordinate cross-functional projects, document requirements, and drive accountability across partner teams.</p>
-              <ul>
-                <li>Project boards with owner visibility and SLA checkpoints.</li>
-                <li>Knowledge hubs that capture client requirements and SOP updates.</li>
-                <li>Escalation routing with automated reminders until resolution.</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="intelligence">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Intelligence woven into every workflow</h3>
-            <p>LuminaHQ turns raw metrics into proactive guidance. Supervisors, analysts, and executives see the same live picture, filtered through their priorities.</p>
-          </div>
-          <div class="capability-matrix">
-            <article class="matrix-card">
-              <h4>Operational awareness</h4>
-              <p>See how staffing, quality, and coaching interact in real-time.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-signal"></i> Color-coded adherence by site, line of business, or skill group.</li>
-                <li><i class="fa-solid fa-chart-area"></i> Trend analysis that blends historical performance with live data.</li>
-                <li><i class="fa-solid fa-bell"></i> Notifications when service levels or QA thresholds drift.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Guided decisioning</h4>
-              <p>Surface the next best action for every role on the floor.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-route"></i> Prescriptive playbooks for coaching, staffing, and client communication.</li>
-                <li><i class="fa-solid fa-person-chalkboard"></i> Supervisor dashboards tuned for quick huddles.</li>
-                <li><i class="fa-solid fa-gears"></i> Automations triggered by thresholds, statuses, or campaign events.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Executive visibility</h4>
-              <p>Translate frontline operations into boardroom clarity.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-chart-line"></i> Roll-up scorecards across programs with drill-downs to agent level.</li>
-                <li><i class="fa-solid fa-file-lines"></i> Auto-generated executive briefs summarizing wins and risks.</li>
-                <li><i class="fa-solid fa-globe"></i> Global dashboards that segment by client, region, or outsourcing partner.</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="integrations">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Works seamlessly with your existing stack</h3>
-            <p>Built on Google Workspace and Apps Script, LuminaHQ plays nicely with your contact center ecosystem, ensuring data stays secure and in sync.</p>
-          </div>
-          <div class="integration-grid">
-            <article class="integration-card">
-              <strong><i class="fa-brands fa-google"></i> Google Workspace native</strong>
-              <ul>
-                <li>Single sign-on with your Google accounts</li>
-                <li>Drive, Sheets, and Docs automations included</li>
-                <li>Calendar sync for schedule updates</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-cloud-arrow-up"></i> Data pipeline ready</strong>
-              <ul>
-                <li>Export-ready datasets for BI platforms</li>
-                <li>Webhook endpoints for real-time mirroring</li>
-                <li>Tenant-aware API keys and logging</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-lock"></i> Security controls</strong>
-              <ul>
-                <li>Role-based permissions with audit history</li>
-                <li>Granular data residency and retention rules</li>
-                <li>Compliance alignment for SOC 2 readiness</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" style="padding-bottom:4.5rem;">
-        <div class="section-shell">
-          <div class="cta-panel">
-            <h3>See LuminaHQ in action</h3>
-            <p>Log in to your workspace or request a guided walkthrough to explore how LuminaHQ adapts to the rhythm of your operations.</p>
-            <a href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to LuminaHQ</a>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer>
-      <div class="footer-shell">
-        <strong>Looking for our story?</strong>
-        <div>
-          <a href="<?!= landingAboutUrl ?>">Visit the LuminaHQ about page</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#features">Return to landing highlights</a>
-        </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</small>
+      <div class="landing-hero-media">
+        <img src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1600&q=80" alt="Team reviewing LuminaHQ capability roadmap" loading="lazy">
       </div>
-    </footer>
-  </div>
-</body>
+    </div>
+  </header>
 
-</html>
+  <main class="landing-main">
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Capability pillars</h2>
+          <p>Start with the core pillars that frame LuminaHQ implementations.</p>
+        </div>
+        <div class="landing-grid">
+          <article class="landing-card">
+            <h3>Quality excellence</h3>
+            <p>Measure what matters with calibrations, collaborative reviews, and fast publishing.</p>
+            <ul>
+              <li><i class="fa-solid fa-clipboard-check"></i> Quality dashboards with drillable filters and campaign rollups.</li>
+              <li><i class="fa-solid fa-comments"></i> Comment threading and coaching triggers within QA evaluations.</li>
+              <li><i class="fa-solid fa-file-export"></i> Export templates ready for executive briefings.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Coaching lifecycle</h3>
+            <p>Plan, deliver, and confirm coaching conversations end-to-end.</p>
+            <ul>
+              <li><i class="fa-solid fa-hand-pointer"></i> Guided coaching forms tied to agent scorecards.</li>
+              <li><i class="fa-solid fa-bell"></i> Notifications and check-ins keep action items on track.</li>
+              <li><i class="fa-solid fa-pen-to-square"></i> Digital acknowledgments secure agent sign-off.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Workforce orchestration</h3>
+            <p>Give workforce teams the visibility to balance coverage and compliance.</p>
+            <ul>
+              <li><i class="fa-solid fa-calendar-days"></i> Schedule management with proactive conflict resolution.</li>
+              <li><i class="fa-solid fa-people-line"></i> Attendance trackers with import utilities and alerts.</li>
+              <li><i class="fa-solid fa-chart-simple"></i> Forecast inputs align to QA and coaching capacity.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Enablement accelerators</h2>
+          <p>Capabilities that keep your teams informed, compliant, and empowered.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Knowledge and policy</h3>
+            <p>Centralized knowledge hubs hold SOPs, change logs, and policy alerts.</p>
+            <ul>
+              <li><i class="fa-solid fa-book"></i> In-app documentation tied directly to operational modules.</li>
+              <li><i class="fa-solid fa-bullhorn"></i> Announcement banners and notifications keep teams current.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Collaboration fabric</h3>
+            <p>Threads, mentions, and task integrations deliver shared accountability.</p>
+            <ul>
+              <li><i class="fa-solid fa-link"></i> Deep links from QA records to escalations and chats.</li>
+              <li><i class="fa-solid fa-diagram-project"></i> Cross-functional dashboards show handoffs across teams.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Analytics readiness</h3>
+            <p>Data pipelines and exports keep leadership and AI co-pilots informed.</p>
+            <ul>
+              <li><i class="fa-solid fa-database"></i> Structured exports for BI tools and GPT-style assistants.</li>
+              <li><i class="fa-solid fa-gauge-high"></i> Snapshot metrics highlight performance at-a-glance.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Security & governance</h3>
+            <p>Guardrails support compliance for regulated industries and enterprise clients.</p>
+            <ul>
+              <li><i class="fa-solid fa-user-shield"></i> Role-based navigation and safe defaults for every module.</li>
+              <li><i class="fa-solid fa-file-shield"></i> Audit logs for evaluations, acknowledgments, and exports.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Bridge to deeper content</h2>
+          <p>Ready to keep going? Jump into the detailed breakdown or revisit the story behind the platform.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Detailed capability reference</h3>
+            <p>Step-by-step walkthroughs, workflow diagrams, and role-specific callouts.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-magnifying-glass-chart"></i> Dive into detail</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Platform narrative</h3>
+            <p>Understand the evolution of LuminaHQ and how customer partners shaped our roadmap.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingStoryUrl ?>"><i class="fa-solid fa-book"></i> Discover the story</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>About the makers</h3>
+            <p>Meet the leadership commitments and operating values behind every release.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingAboutUrl ?>"><i class="fa-solid fa-circle-info"></i> Visit About LuminaHQ</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Return to landing</h3>
+            <p>See the full operations snapshot and navigation map.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="brand-lockup">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+        LuminaHQ by VLBPO
+      </div>
+      <nav>
+        <a href="<?= landingHomeUrl ?>">Landing</a>
+        <a href="<?= landingAboutUrl ?>">About</a>
+        <a href="<?= landingCapabilitiesDetailUrl ?>">Deep dive</a>
+        <a href="<?= landingStoryUrl ?>">Our story</a>
+      </nav>
+      <div class="landing-metrics">
+        <span><i class="fa-solid fa-layer-group"></i> Modular toolkit</span>
+        <span><i class="fa-solid fa-lock"></i> Enterprise security</span>
+        <span><i class="fa-solid fa-chart-line"></i> Insight-driven outcomes</span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -1,0 +1,239 @@
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: 'landing-capabilities-detail',
+  pageTitle: 'LuminaHQ Capability Deep Dive',
+  pageDescription: 'Detailed walkthrough of LuminaHQ workflows with sequencing, data inputs, and role expectations.'
+}) ?>
+
+<?
+  var landingBase = (typeof scriptUrl !== 'undefined' && scriptUrl)
+    ? scriptUrl
+    : ((typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '');
+
+  var landingHomeUrl = landingBase ? landingBase + '?page=landing' : 'Landing.html';
+  var landingAboutUrl = landingBase ? landingBase + '?page=landing-about' : 'LandingAbout.html';
+  var landingCapabilitiesUrl = landingBase ? landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+  var landingCapabilitiesDetailUrl = landingBase ? landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+  var landingStoryUrl = landingBase ? landingBase + '?page=landing-story' : 'LandingStory.html';
+  var loginUrl = (typeof buildLoginPageUrl === 'function') ? buildLoginPageUrl({}) : (landingBase || '#');
+?>
+
+<?!= includeOnce('LandingTemplateStyles') ?>
+
+<div class="landing-shell landing-theme-amber" style="--landing-hero-image: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80');">
+  <header class="landing-hero">
+    <div class="container">
+      <div class="landing-hero-content">
+        <span class="landing-badge"><i class="fa-solid fa-magnifying-glass-chart"></i>Detailed workflow guide</span>
+        <h1>Dive into LuminaHQ capabilities</h1>
+        <p>
+          Map each capability to the operational moments it supports. From intake to insights, LuminaHQ keeps your team aligned with clear
+          roles, repeatable workflows, and ready-to-use analytics outputs.
+        </p>
+        <div class="landing-cta">
+          <a class="btn btn-primary" href="<?= landingCapabilitiesUrl ?>">Return to overview</a>
+          <a class="btn btn-outline-light" href="<?= loginUrl ?>">Plan an implementation</a>
+        </div>
+        <div class="landing-hero-meta">
+          <span><i class="fa-solid fa-route"></i> Sequenced playbooks</span>
+          <span><i class="fa-solid fa-users"></i> Role clarity baked in</span>
+          <span><i class="fa-solid fa-file-circle-check"></i> Audit-friendly outputs</span>
+        </div>
+      </div>
+      <div class="landing-hero-media">
+        <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80" alt="Detailed LuminaHQ capability boards" loading="lazy">
+      </div>
+    </div>
+  </header>
+
+  <main class="landing-main">
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>How the modules connect</h2>
+          <p>Follow the orchestration path from insight capture to agent enablement.</p>
+        </div>
+        <div class="landing-grid">
+          <article class="landing-card">
+            <h3>1. Observe & evaluate</h3>
+            <p>Quality analysts capture evaluations with rich context and standardized scoring.</p>
+            <ul>
+              <li><i class="fa-solid fa-clipboard-list"></i> Guided forms collect customer impact, root cause, and policy notes.</li>
+              <li><i class="fa-solid fa-comments"></i> Collaboration widgets invite calibrations before publishing.</li>
+              <li><i class="fa-solid fa-diagram-project"></i> Evaluations flow to dashboards that highlight trend outliers.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>2. Coach & acknowledge</h3>
+            <p>Supervisors turn QA insights into action while agents stay looped in at every step.</p>
+            <ul>
+              <li><i class="fa-solid fa-handshake"></i> Coaching forms map improvement plans and celebrate wins.</li>
+              <li><i class="fa-solid fa-pen"></i> Agents sign digital acknowledgments that confirm understanding.</li>
+              <li><i class="fa-solid fa-clock"></i> Automated reminders surface pending follow-ups before deadlines.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>3. Optimize & forecast</h3>
+            <p>Workforce leaders blend attendance, scheduling, and coaching commitments to stay ahead of demand.</p>
+            <ul>
+              <li><i class="fa-solid fa-calendar"></i> Shared calendars display staffing coverage alongside coaching events.</li>
+              <li><i class="fa-solid fa-database"></i> Data exports feed BI layers or AI copilots for advanced modeling.</li>
+              <li><i class="fa-solid fa-shield"></i> Governance controls ensure only authorized leaders can trigger changes.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Workflow deep dives</h2>
+          <p>Key processes showing how teams collaborate inside LuminaHQ.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Quality calibration loop</h3>
+            <p>Align criteria before evaluations impact scoring.</p>
+            <ul>
+              <li><i class="fa-solid fa-users-gear"></i> Analysts submit sample evaluations for leadership review.</li>
+              <li><i class="fa-solid fa-scale-balanced"></i> Calibration notes sync to scoring rubrics automatically.</li>
+              <li><i class="fa-solid fa-clipboard-check"></i> Finalized standards publish directly to QA forms.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Coaching follow-through</h3>
+            <p>Ensure accountability after every coaching conversation.</p>
+            <ul>
+              <li><i class="fa-solid fa-list-check"></i> Action items assigned to agents with due dates and owners.</li>
+              <li><i class="fa-solid fa-link"></i> Links to knowledge resources and policy updates embedded in context.</li>
+              <li><i class="fa-solid fa-chart-line"></i> Progress tracked across dashboards for leaders and QA partners.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Attendance harmonization</h3>
+            <p>Keep workforce, QA, and coaching schedules synchronized.</p>
+            <ul>
+              <li><i class="fa-solid fa-cloud-arrow-up"></i> Imports normalize data from biometric or WFM systems.</li>
+              <li><i class="fa-solid fa-bell"></i> Alerts notify leaders when adherence or compliance thresholds slip.</li>
+              <li><i class="fa-solid fa-people-group"></i> Joint reviews prioritize coverage for coaching-critical agents.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Executive insights</h3>
+            <p>Provide leadership with a cohesive view of operations health.</p>
+            <ul>
+              <li><i class="fa-solid fa-chart-pie"></i> Dashboards blend QA, CSAT, staffing, and escalation data.</li>
+              <li><i class="fa-solid fa-wand-magic-sparkles"></i> AI-ready summaries convert metrics into key talking points.</li>
+              <li><i class="fa-solid fa-file-signature"></i> Shareable packets export for governance and partner reviews.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Implementation blueprint</h2>
+          <p>Use these steps to align stakeholders and launch successfully.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Kickoff & discovery</h3>
+            <ul>
+              <li><i class="fa-solid fa-microphone-lines"></i> Workshops gather current QA, coaching, and WFM processes.</li>
+              <li><i class="fa-solid fa-map-location-dot"></i> Define campaign groupings, roles, and navigation access.</li>
+              <li><i class="fa-solid fa-folder-tree"></i> Consolidate templates, scripts, and policies for import.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Configuration sprint</h3>
+            <ul>
+              <li><i class="fa-solid fa-sliders"></i> Tailor evaluation rubrics, coaching forms, and notification cadences.</li>
+              <li><i class="fa-solid fa-diagram-next"></i> Map integrations and schedule data refresh windows.</li>
+              <li><i class="fa-solid fa-person-chalkboard"></i> Build enablement assets for analysts and supervisors.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Pilot & iterate</h3>
+            <ul>
+              <li><i class="fa-solid fa-people-arrows"></i> Select pilot teams across QA, coaching, and workforce functions.</li>
+              <li><i class="fa-solid fa-chart-column"></i> Collect baseline metrics to measure improvement.</li>
+              <li><i class="fa-solid fa-reply"></i> Incorporate feedback and finalize go-live runbooks.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Launch & expand</h3>
+            <ul>
+              <li><i class="fa-solid fa-rocket"></i> Deploy modules with coordinated communications.</li>
+              <li><i class="fa-solid fa-gauge"></i> Monitor adoption dashboards and respond to support signals.</li>
+              <li><i class="fa-solid fa-diagram-predecessor"></i> Extend automations and analytics layers as teams mature.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Continue the journey</h2>
+          <p>Keep exploring LuminaHQ or loop back to the overview pages.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Capability overview</h3>
+            <p>Summaries of each module with quick comparisons.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesUrl ?>"><i class="fa-solid fa-sitemap"></i> View overview</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>About LuminaHQ</h3>
+            <p>Learn about the people and principles backing the product.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingAboutUrl ?>"><i class="fa-solid fa-circle-info"></i> Meet the team</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Our story</h3>
+            <p>See how our operations heritage shaped this deep dive.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingStoryUrl ?>"><i class="fa-solid fa-book"></i> Read the story</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Main landing</h3>
+            <p>Jump back to the hero view with quick navigation shortcuts.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Go to landing</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="brand-lockup">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+        LuminaHQ by VLBPO
+      </div>
+      <nav>
+        <a href="<?= landingHomeUrl ?>">Landing</a>
+        <a href="<?= landingAboutUrl ?>">About</a>
+        <a href="<?= landingCapabilitiesUrl ?>">Capabilities</a>
+        <a href="<?= landingStoryUrl ?>">Our story</a>
+      </nav>
+      <div class="landing-metrics">
+        <span><i class="fa-solid fa-route"></i> Guided implementation</span>
+        <span><i class="fa-solid fa-users"></i> Cross-team alignment</span>
+        <span><i class="fa-solid fa-chart-line"></i> Outcome visibility</span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -1,0 +1,240 @@
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: 'landing-story',
+  pageTitle: 'LuminaHQ Story',
+  pageDescription: 'Follow the LuminaHQ journey from task tracker to AI-assisted workforce command center.'
+}) ?>
+
+<?
+  var landingBase = (typeof scriptUrl !== 'undefined' && scriptUrl)
+    ? scriptUrl
+    : ((typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : '');
+
+  var landingHomeUrl = landingBase ? landingBase + '?page=landing' : 'Landing.html';
+  var landingAboutUrl = landingBase ? landingBase + '?page=landing-about' : 'LandingAbout.html';
+  var landingCapabilitiesUrl = landingBase ? landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+  var landingCapabilitiesDetailUrl = landingBase ? landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+  var landingStoryUrl = landingBase ? landingBase + '?page=landing-story' : 'LandingStory.html';
+  var loginUrl = (typeof buildLoginPageUrl === 'function') ? buildLoginPageUrl({}) : (landingBase || '#');
+?>
+
+<?!= includeOnce('LandingTemplateStyles') ?>
+
+<div class="landing-shell landing-theme-slate" style="--landing-hero-image: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80');">
+  <header class="landing-hero">
+    <div class="container">
+      <div class="landing-hero-content">
+        <span class="landing-badge"><i class="fa-solid fa-book-open"></i>The LuminaHQ journey</span>
+        <h1>From spreadsheets to an operations nerve center</h1>
+        <p>
+          LuminaHQ started as a lightweight tracker. Today, it fuels end-to-end quality, coaching, and workforce programs for teams around the world.
+          Explore the milestones, lessons, and innovations that shaped the platform.
+        </p>
+        <div class="landing-cta">
+          <a class="btn btn-primary" href="<?= landingHomeUrl ?>">Visit the landing hub</a>
+          <a class="btn btn-outline-light" href="<?= loginUrl ?>">Connect with LuminaHQ</a>
+        </div>
+        <div class="landing-hero-meta">
+          <span><i class="fa-solid fa-timeline"></i> Built with operations leaders</span>
+          <span><i class="fa-solid fa-earth-americas"></i> Supporting global teams</span>
+          <span><i class="fa-solid fa-wand-magic-sparkles"></i> AI-ready foundation</span>
+        </div>
+      </div>
+      <div class="landing-hero-media">
+        <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80" alt="LuminaHQ growth story with teams collaborating" loading="lazy">
+      </div>
+    </div>
+  </header>
+
+  <main class="landing-main">
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Milestones that shaped LuminaHQ</h2>
+          <p>Every release responded to a real operational challenge.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Foundations</h3>
+            <p>We began by centralizing coaching notes and QA results for a single campaign.</p>
+            <ul>
+              <li><i class="fa-solid fa-square-check"></i> Shared spreadsheets transformed into guided digital forms.</li>
+              <li><i class="fa-solid fa-user-group"></i> Supervisors and QA partners collaborated without email ping-pong.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Scaling up</h3>
+            <p>Multiple campaigns required stronger governance and automation.</p>
+            <ul>
+              <li><i class="fa-solid fa-building"></i> Role-based navigation ensured the right teams saw the right data.</li>
+              <li><i class="fa-solid fa-bolt"></i> Attendance imports and schedule alerts streamlined workforce oversight.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Analytics evolution</h3>
+            <p>Partners wanted predictive insight, not just historical reporting.</p>
+            <ul>
+              <li><i class="fa-solid fa-chart-gantt"></i> Dashboards connected QA, CSAT, and staffing signals.</li>
+              <li><i class="fa-solid fa-robot"></i> AI copilots drafted summaries and surfaced trend commentary.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Global readiness</h3>
+            <p>Remote and hybrid teams needed flexible, secure access.</p>
+            <ul>
+              <li><i class="fa-solid fa-cloud"></i> Cloud-based delivery ensured uptime across regions.</li>
+              <li><i class="fa-solid fa-lock"></i> Compliance tooling supported privacy-first operations.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Voices from the journey</h2>
+          <p>Stories from the teams who helped steer LuminaHQ.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Operations leaders</h3>
+            <p>“LuminaHQ gave us visibility to align QA, coaching, and staffing for the first time.”</p>
+            <ul>
+              <li><i class="fa-solid fa-quote-left"></i> Leaders influence navigation updates and dashboard priorities.</li>
+              <li><i class="fa-solid fa-people-arrows"></i> Cross-functional councils keep releases grounded in frontline needs.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Quality analysts</h3>
+            <p>“Calibrations and feedback loops feel natural—we can focus on improving conversations.”</p>
+            <ul>
+              <li><i class="fa-solid fa-comment-dots"></i> Comment threads maintain context around every evaluation.</li>
+              <li><i class="fa-solid fa-wand-magic-sparkles"></i> Assisted summaries prepare talking points for coaching.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Supervisors & coaches</h3>
+            <p>“Coaching actions stay visible so nothing slips past due.”</p>
+            <ul>
+              <li><i class="fa-solid fa-list-check"></i> Task cues guide supervisors through follow-ups.</li>
+              <li><i class="fa-solid fa-handshake-angle"></i> Acknowledgment workflows reinforce accountability.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Agents</h3>
+            <p>“I see my progress, expectations, and resources in one workspace.”</p>
+            <ul>
+              <li><i class="fa-solid fa-gauge-high"></i> Personalized dashboards highlight achievements and next steps.</li>
+              <li><i class="fa-solid fa-lightbulb"></i> Integrated resources answer questions without leaving the page.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Looking ahead</h2>
+          <p>Where LuminaHQ is headed next.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>AI copilots</h3>
+            <p>Draft coaching insights, QA summaries, and staffing signals automatically.</p>
+            <ul>
+              <li><i class="fa-solid fa-robot"></i> Responsible AI guardrails keep humans in the loop.</li>
+              <li><i class="fa-solid fa-gears"></i> Configurable prompts tune outputs to each campaign.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Deeper integrations</h3>
+            <p>Connect LuminaHQ with CRM, telephony, and BI suites.</p>
+            <ul>
+              <li><i class="fa-solid fa-plug"></i> Flexible connectors speed up onboarding.</li>
+              <li><i class="fa-solid fa-database"></i> Unified data models power richer insights.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Experience design</h3>
+            <p>Elevate the agent and supervisor experience with contextual learning.</p>
+            <ul>
+              <li><i class="fa-solid fa-graduation-cap"></i> Micro-learnings surface during coaching and QA reviews.</li>
+              <li><i class="fa-solid fa-user"></i> Accessibility improvements ensure everyone can participate.</li>
+            </ul>
+          </article>
+          <article class="landing-card">
+            <h3>Community forums</h3>
+            <p>Share best practices and gather feedback across partner sites.</p>
+            <ul>
+              <li><i class="fa-solid fa-people-group"></i> Facilitated forums connect leaders, analysts, and agents.</li>
+              <li><i class="fa-solid fa-comments"></i> Knowledge exchanges highlight new use cases.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-section is-alt">
+      <div class="container">
+        <div class="section-header">
+          <h2>Explore more of LuminaHQ</h2>
+          <p>Continue your tour or step back to the overview.</p>
+        </div>
+        <div class="landing-grid is-two">
+          <article class="landing-card">
+            <h3>Landing hub</h3>
+            <p>Start from the hero experience for a quick orientation.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Go to landing</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>About LuminaHQ</h3>
+            <p>Meet the builders and principles behind the product.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingAboutUrl ?>"><i class="fa-solid fa-circle-info"></i> Visit About page</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Capabilities overview</h3>
+            <p>Review the pillars and modules that power LuminaHQ.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesUrl ?>"><i class="fa-solid fa-sitemap"></i> Explore capabilities</a>
+            </div>
+          </article>
+          <article class="landing-card">
+            <h3>Capability deep dive</h3>
+            <p>See the detailed workflows that connect the LuminaHQ ecosystem.</p>
+            <div class="landing-navigation">
+              <a href="<?= landingCapabilitiesDetailUrl ?>"><i class="fa-solid fa-magnifying-glass-chart"></i> Dive deeper</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="landing-footer">
+    <div class="container">
+      <div class="brand-lockup">
+        <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
+        LuminaHQ by VLBPO
+      </div>
+      <nav>
+        <a href="<?= landingHomeUrl ?>">Landing</a>
+        <a href="<?= landingAboutUrl ?>">About</a>
+        <a href="<?= landingCapabilitiesUrl ?>">Capabilities</a>
+        <a href="<?= landingCapabilitiesDetailUrl ?>">Deep dive</a>
+      </nav>
+      <div class="landing-metrics">
+        <span><i class="fa-solid fa-book-open"></i> Guided by experience</span>
+        <span><i class="fa-solid fa-compass"></i> Navigating what’s next</span>
+        <span><i class="fa-solid fa-bolt"></i> Momentum for every team</span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/LandingTemplateStyles.html
+++ b/LandingTemplateStyles.html
@@ -1,0 +1,437 @@
+<?
+  if (typeof window !== 'undefined' && window && window.document) {
+    (function ensureLandingBodyClass(doc) {
+      const applyClass = () => {
+        if (doc && doc.body) {
+          doc.body.classList.add('landing-template-page');
+        }
+      };
+
+      if (!doc) {
+        return;
+      }
+
+      if (doc.readyState === 'loading') {
+        doc.addEventListener('DOMContentLoaded', applyClass, { once: true });
+      } else {
+        applyClass();
+      }
+    })(window.document);
+  }
+?>
+<style>
+  body.landing-template-page {
+    background: #f4f6fb;
+    color: #0f172a;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body.landing-template-page::before {
+    display: none !important;
+  }
+
+  .landing-shell {
+    --landing-hero-bg: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(15, 118, 230, 0.85));
+    --landing-hero-overlay: rgba(8, 25, 60, 0.65);
+    --landing-accent: #0ea5e9;
+    --landing-surface: #ffffff;
+    --landing-muted: #475467;
+    --landing-border: rgba(15, 23, 42, 0.1);
+    --landing-card-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+    --landing-card-radius: 22px;
+    --landing-section-gap: clamp(3rem, 5vw, 5rem);
+    --landing-grid-gap: clamp(1.5rem, 4vw, 2.5rem);
+
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    color: #0f172a;
+  }
+
+  .landing-shell.landing-theme-slate {
+    --landing-hero-bg: linear-gradient(135deg, rgba(11, 27, 63, 0.92), rgba(30, 64, 175, 0.85));
+  }
+
+  .landing-shell.landing-theme-emerald {
+    --landing-hero-bg: linear-gradient(135deg, rgba(6, 95, 70, 0.9), rgba(16, 185, 129, 0.82));
+    --landing-accent: #10b981;
+  }
+
+  .landing-shell.landing-theme-violet {
+    --landing-hero-bg: linear-gradient(135deg, rgba(76, 29, 149, 0.9), rgba(79, 70, 229, 0.82));
+    --landing-accent: #6366f1;
+  }
+
+  .landing-shell.landing-theme-amber {
+    --landing-hero-bg: linear-gradient(135deg, rgba(120, 53, 15, 0.88), rgba(217, 119, 6, 0.78));
+    --landing-accent: #f59e0b;
+  }
+
+  .landing-hero {
+    position: relative;
+    padding: clamp(4.5rem, 6vw, 6.5rem) 0 clamp(3.5rem, 6vw, 5rem);
+    color: #eef2ff;
+    background: var(--landing-hero-bg);
+    overflow: hidden;
+  }
+
+  .landing-hero::before,
+  .landing-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .landing-hero::before {
+    background-image: var(--landing-hero-image, none);
+    background-size: cover;
+    background-position: center;
+    mix-blend-mode: lighten;
+    opacity: 0.15;
+    transform: scale(1.05);
+  }
+
+  .landing-hero::after {
+    background: var(--landing-hero-overlay);
+  }
+
+  .landing-hero .container {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+    gap: clamp(2rem, 5vw, 4rem);
+  }
+
+  .landing-hero-content h1 {
+    font-size: clamp(2.5rem, 4vw, 3.75rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.25rem;
+    color: #ffffff;
+  }
+
+  .landing-hero-content p {
+    font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+    line-height: 1.7;
+    color: rgba(226, 232, 240, 0.92);
+    margin-bottom: 2rem;
+    max-width: 34rem;
+  }
+
+  .landing-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.1);
+    color: #cbd5f5;
+    margin-bottom: 1.5rem;
+    backdrop-filter: blur(6px);
+  }
+
+  .landing-badge i {
+    color: var(--landing-accent);
+  }
+
+  .landing-hero-media {
+    position: relative;
+    border-radius: var(--landing-card-radius);
+    overflow: hidden;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.35);
+    background: rgba(15, 23, 42, 0.35);
+  }
+
+  .landing-hero-media img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .landing-hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    color: rgba(226, 232, 240, 0.85);
+    font-size: 0.95rem;
+  }
+
+  .landing-hero-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(226, 232, 240, 0.18);
+  }
+
+  .landing-cta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .landing-cta .btn-primary {
+    background: var(--landing-accent);
+    border: none;
+    padding: 0.75rem 1.75rem;
+    font-weight: 600;
+    font-size: 1rem;
+    border-radius: 999px;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    box-shadow: 0 16px 32px rgba(14, 165, 233, 0.35);
+  }
+
+  .landing-cta .btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(14, 165, 233, 0.4);
+  }
+
+  .landing-cta .btn-outline-light {
+    border-radius: 999px;
+    padding: 0.75rem 1.6rem;
+    border: 1px solid rgba(226, 232, 240, 0.4);
+    color: rgba(226, 232, 240, 0.95);
+    font-weight: 600;
+  }
+
+  .landing-main {
+    flex: 1;
+  }
+
+  .landing-section {
+    padding: var(--landing-section-gap) 0;
+  }
+
+  .landing-section .section-header {
+    text-align: center;
+    margin-bottom: clamp(2.5rem, 4vw, 3.75rem);
+  }
+
+  .landing-section .section-header h2 {
+    font-size: clamp(2rem, 3vw, 2.75rem);
+    margin-bottom: 1rem;
+    color: #0f172a;
+  }
+
+  .landing-section .section-header p {
+    max-width: 42rem;
+    margin: 0 auto;
+    color: var(--landing-muted);
+    font-size: 1.05rem;
+  }
+
+  .landing-section.is-alt {
+    background: rgba(15, 23, 42, 0.03);
+  }
+
+  .landing-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--landing-grid-gap);
+  }
+
+  .landing-grid.is-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .landing-grid.is-one {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .landing-card {
+    background: var(--landing-surface);
+    border-radius: var(--landing-card-radius);
+    box-shadow: var(--landing-card-shadow);
+    padding: clamp(1.75rem, 3vw, 2.25rem);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+  }
+
+  .landing-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.16);
+  }
+
+  .landing-card h3 {
+    font-size: 1.35rem;
+    margin: 0;
+    color: #0b162f;
+  }
+
+  .landing-card p {
+    margin: 0;
+    color: var(--landing-muted);
+    line-height: 1.65;
+  }
+
+  .landing-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.85rem;
+    color: var(--landing-muted);
+  }
+
+  .landing-card ul li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .landing-card ul li i {
+    color: var(--landing-accent);
+    margin-top: 0.15rem;
+  }
+
+  .landing-navigation {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+  }
+
+  .landing-navigation a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    background: rgba(14, 165, 233, 0.12);
+    color: #0369a1;
+    font-weight: 600;
+    border: 1px solid rgba(14, 165, 233, 0.2);
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+
+  .landing-navigation a i {
+    color: var(--landing-accent);
+  }
+
+  .landing-navigation a:hover {
+    background: rgba(14, 165, 233, 0.18);
+    transform: translateY(-1px);
+  }
+
+  .landing-footer {
+    background: #0b162f;
+    color: rgba(226, 232, 240, 0.82);
+    padding: clamp(2.5rem, 4vw, 3rem) 0;
+  }
+
+  .landing-footer .container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: center;
+    text-align: center;
+  }
+
+  .landing-footer .brand-lockup {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: #f8fafc;
+  }
+
+  .landing-footer .brand-lockup img {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.5rem;
+  }
+
+  .landing-footer nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+    justify-content: center;
+  }
+
+  .landing-footer nav a {
+    color: rgba(226, 232, 240, 0.82);
+    font-weight: 500;
+    text-decoration: none;
+  }
+
+  .landing-footer nav a:hover {
+    color: #38bdf8;
+  }
+
+  .landing-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    color: rgba(226, 232, 240, 0.8);
+  }
+
+  .landing-metrics span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(226, 232, 240, 0.22);
+  }
+
+  @media (max-width: 1100px) {
+    .landing-hero .container {
+      grid-template-columns: minmax(0, 1fr);
+      text-align: center;
+    }
+
+    .landing-hero-content p {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .landing-hero-media {
+      max-width: 580px;
+      margin: 0 auto;
+    }
+
+    .landing-hero-meta {
+      justify-content: center;
+    }
+  }
+
+  @media (max-width: 920px) {
+    .landing-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 680px) {
+    .landing-grid,
+    .landing-grid.is-two {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .landing-cta {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .landing-cta .btn-primary,
+    .landing-cta .btn-outline-light {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- introduce a shared landing template partial so hero layouts, grids, and footers reuse the same styling
- rebuild the landing, about, capabilities, deep dive, and story pages on top of the shared template with consistent navigation
- refresh copy and imagery across the suite to spotlight the Lumina hero asset and guide visitors between destinations

## Testing
- no automated tests were run (HTML-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f3e72c3e4c83269551fb9623e4e4a0