### PR TITLE
Rebuild landing pages with screenshot-inspired design

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -1,920 +1,246 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <base target="_top">
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>LuminaHQ – Intelligent Workforce Command Center</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-navy-alt: #103060;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #ffffff;
-      --lumina-muted: #f1f5fb;
-      --lumina-muted-dark: #d6e2f5;
-      --lumina-text: #101828;
-      --lumina-text-muted: #475467;
-      --shadow-primary: 0 12px 24px rgba(4, 120, 211, 0.18);
-      --shadow-card: 0 8px 18px rgba(15, 23, 42, 0.08);
-      --radius-lg: 24px;
-      --radius-md: 16px;
-      --radius-sm: 12px;
-      --transition: all 0.28s ease;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      margin: 0;
-      color: var(--lumina-text);
-      background: var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    body.landing-page {
-      background: var(--lumina-surface);
-    }
-
-    body.landing-page::before {
-      display: none;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-    }
-
-    .landing-main {
-      width: 100%;
-      max-width: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    .hero {
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.25rem clamp(3rem, 5vw, 5rem);
-      width: 100%;
-      margin: 0;
-      position: relative;
-      background: var(--lumina-navy-alt);
-      color: rgba(226, 232, 240, 0.92);
-    }
-
-    .hero-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .hero-surface {
-      background: transparent;
-      border-radius: var(--radius-lg);
-      border: none;
-      box-shadow: none;
-      padding: clamp(2.5rem, 5vw, 3.2rem);
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      backdrop-filter: blur(14px);
-      background: rgba(255, 255, 255, 0.85);
-      border-bottom: 1px solid rgba(226, 232, 240, 0.7);
-      margin: 0;
-      padding: 0;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.25rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-    }
-
-    .brand-logo {
-      height: 46px;
-      width: auto;
-      display: block;
-    }
-
-    .brand h1 {
-      font-size: 1.35rem;
-      font-weight: 700;
-      color: var(--lumina-navy);
-      margin: 0;
-      letter-spacing: 0.01em;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 500;
-      text-transform: uppercase;
-      color: var(--lumina-text-muted);
-      letter-spacing: 0.14em;
-    }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .nav-actions a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.3rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .nav-actions .btn-outline {
-      color: var(--lumina-blue-dark);
-      background: transparent;
-      border: 1px solid rgba(4, 120, 211, 0.36);
-    }
-
-    .nav-actions .btn-outline:hover {
-      background: rgba(4, 120, 211, 0.1);
-      transform: translateY(-1px);
-    }
-
-    .nav-actions .btn-primary {
-      color: white;
-      background: var(--lumina-blue);
-      box-shadow: none;
-    }
-
-    .nav-actions .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 10px 20px rgba(4, 120, 211, 0.24);
-    }
-
-    .hero-content {
-      position: relative;
-      display: grid;
-      gap: clamp(2.5rem, 5vw, 3.5rem);
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      z-index: 1;
-    }
-
-    .hero-copy {
-      display: flex;
-      flex-direction: column;
-      gap: 1.75rem;
-    }
-
-    .hero-tag {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.55rem 1rem;
-      background: rgba(56, 189, 248, 0.16);
-      color: var(--lumina-surface);
-      border-radius: 999px;
-      font-weight: 600;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .hero-title {
-      font-size: clamp(2.4rem, 3.4vw + 1rem, 3.7rem);
-      line-height: 1.1;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .hero-subtitle {
-      margin: 0;
-      max-width: 520px;
-      font-size: 1.05rem;
-      color: rgba(226, 232, 240, 0.72);
-    }
-
-    .hero-points {
-      margin: 0;
-      padding-left: 1.1rem;
-      display: grid;
-      gap: 0.85rem;
-      color: rgba(226, 232, 240, 0.85);
-      font-size: 0.95rem;
-      line-height: 1.5;
-      list-style: none;
-    }
-
-    .hero-points li {
-      position: relative;
-      padding-left: 2rem;
-    }
-
-    .hero-points li i {
-      position: absolute;
-      left: 0;
-      top: 0.1rem;
-      color: var(--lumina-cyan);
-    }
-
-    .hero-ctas {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-
-    .hero-ctas a {
-      text-decoration: none;
-      font-weight: 600;
-      padding: 0.8rem 1.6rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      transition: var(--transition);
-    }
-
-    .hero-ctas .primary {
-      background: var(--lumina-blue);
-      color: white;
-      box-shadow: none;
-    }
-
-    .hero-ctas .primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 12px 24px rgba(4, 120, 211, 0.22);
-    }
-
-    .hero-ctas .ghost {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .hero-ctas .ghost:hover {
-      background: rgba(255, 255, 255, 0.18);
-      color: var(--lumina-surface);
-      border-color: rgba(226, 232, 240, 0.32);
-    }
-
-    .hero-showcase {
-      background: rgba(11, 27, 63, 0.55);
-      border-radius: var(--radius-md);
-      padding: clamp(1.5rem, 3vw, 2rem);
-      box-shadow: none;
-      border: 1px solid rgba(226, 232, 240, 0.15);
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .showcase-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .showcase-header h2 {
-      font-size: 1.1rem;
-      margin: 0;
-      color: var(--lumina-surface);
-    }
-
-    .status-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.45rem 0.85rem;
-      border-radius: 999px;
-      background: rgba(56, 189, 248, 0.24);
-      color: var(--lumina-surface);
-      font-size: 0.8rem;
-      font-weight: 600;
-    }
-
-    .metrics-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 1.25rem;
-    }
-
-    .metric-card {
-      background: rgba(15, 23, 42, 0.45);
-      color: var(--lumina-surface);
-      padding: 1.4rem;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(226, 232, 240, 0.12);
-      position: relative;
-    }
-
-    .metric-card strong {
-      display: block;
-      font-size: 2rem;
-      font-weight: 700;
-    }
-
-    .metric-card span {
-      font-size: 0.85rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: rgba(226, 232, 240, 0.7);
-    }
-
-    .metric-card i {
-      font-size: 1.4rem;
-      opacity: 0.85;
-    }
-
-    .metric-card .icon-circle {
-      width: 48px;
-      height: 48px;
-      border-radius: 50%;
-      background: rgba(255, 255, 255, 0.14);
-      display: grid;
-      place-items: center;
-      margin-bottom: 1rem;
-    }
-
-    .section {
-      width: 100%;
-      margin: 0;
-      padding: clamp(3rem, 5vw + 1rem, 4.5rem) 1.25rem;
-    }
-
-    .section-light {
-      background: var(--lumina-surface);
-    }
-
-    .section-dark {
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-    }
-
-    .section-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-    }
-
-    .section-dark .section-shell {
-      max-width: 1100px;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 0.75rem;
-      max-width: 720px;
-    }
-
-    .section-header h2 {
-      margin: 0;
-      font-size: clamp(2rem, 2vw + 1rem, 2.6rem);
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      font-size: 1.02rem;
-    }
-
-    .section-dark .section-header h2 {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .section-header p {
-      color: rgba(226, 232, 240, 0.75);
-    }
-
-    .feature-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.6rem;
-    }
-
-    .feature-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      padding: 1.8rem;
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      display: grid;
-      gap: 1rem;
-      transition: var(--transition);
-    }
-
-    .feature-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.1);
-    }
-
-    .feature-icon {
-      width: 54px;
-      height: 54px;
-      border-radius: 16px;
-      background: #e6f2ff;
-      display: grid;
-      place-items: center;
-      color: var(--lumina-blue-dark);
-      font-size: 1.35rem;
-    }
-
-    .feature-card h3 {
-      margin: 0;
-      font-size: 1.2rem;
-      color: var(--lumina-navy);
-    }
-
-    .feature-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .section-cta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .section-cta a {
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.65rem 1.35rem;
-      border-radius: 999px;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      transition: var(--transition);
-    }
-
-    .section-cta a.primary {
-      background: var(--lumina-blue);
-      color: #fff;
-      box-shadow: 0 12px 20px rgba(4, 120, 211, 0.18);
-      border: 1px solid transparent;
-    }
-
-    .section-cta a.ghost {
-      background: transparent;
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.28);
-    }
-
-    .section-cta a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .section-dark .section-cta a {
-      box-shadow: none;
-    }
-
-    .section-dark .section-cta a.primary {
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--lumina-surface);
-      border: 1px solid rgba(255, 255, 255, 0.28);
-    }
-
-    .section-dark .section-cta a.ghost {
-      color: rgba(226, 232, 240, 0.9);
-      border: 1px solid rgba(226, 232, 240, 0.28);
-    }
-
-    .section-dark .section-cta a:hover {
-      background: rgba(255, 255, 255, 0.14);
-      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
-    }
-
-    .about-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 2rem;
-    }
-
-    .about-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 2rem;
-      display: grid;
-      gap: 0.75rem;
-      box-shadow: none;
-    }
-
-    .section-dark .feature-card {
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(226, 232, 240, 0.18);
-    }
-
-    .section-dark .feature-card h3,
-    .section-dark .feature-card p {
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card p {
-      color: rgba(226, 232, 240, 0.78);
-    }
-
-    .section-dark .feature-icon {
-      background: rgba(56, 189, 248, 0.18);
-      color: var(--lumina-surface);
-    }
-
-    .section-dark .feature-card:hover {
-      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
-    }
-
-    .about-card small {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--lumina-blue-dark);
-      font-weight: 600;
-    }
-
-    .about-card h3 {
-      margin: 0;
-      color: var(--lumina-navy);
-    }
-
-    .about-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.6rem;
-    }
-
-    .module-card {
-      background: var(--lumina-surface);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(15, 23, 42, 0.08);
-      padding: 1.8rem;
-      display: grid;
-      gap: 1.2rem;
-      box-shadow: 0 10px 18px rgba(4, 120, 211, 0.06);
-      transition: var(--transition);
-    }
-
-    .module-card header {
-      display: flex;
-      align-items: center;
-      gap: 0.9rem;
-    }
-
-    .module-card h3 {
-      margin: 0;
-      font-size: 1.15rem;
-      color: var(--lumina-navy);
-    }
-
-    .module-card p {
-      margin: 0;
-      color: var(--lumina-text-muted);
-      line-height: 1.6;
-    }
-
-    .module-card ul {
-      margin: 0;
-      padding-left: 1.2rem;
-      display: grid;
-      gap: 0.55rem;
-      list-style: none;
-    }
-
-    .module-card ul li {
-      position: relative;
-      padding-left: 1.5rem;
-      color: var(--lumina-text-muted);
-      font-weight: 500;
-    }
-
-    .module-card ul li i {
-      position: absolute;
-      left: 0;
-      top: 0.1rem;
-      color: var(--lumina-blue);
-    }
-
-    .module-icon {
-      width: 48px;
-      height: 48px;
-      border-radius: 16px;
-      background: #e6f2ff;
-      color: var(--lumina-blue-dark);
-      display: grid;
-      place-items: center;
-      font-size: 1.35rem;
-    }
-
-    .module-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 16px 28px rgba(4, 120, 211, 0.12);
-    }
-
-    footer {
-      padding: 2.5rem 1.25rem 2rem;
-      background: var(--lumina-navy);
-      color: rgba(226, 232, 240, 0.9);
-      margin-top: auto;
-      width: 100%;
-      margin-left: 0;
-      margin-right: 0;
-    }
-
-    .footer-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .footer-shell a {
-      color: rgba(226, 232, 240, 0.85);
-      text-decoration: none;
-      font-weight: 500;
-    }
-
-    .footer-shell a:hover {
-      color: white;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LuminaHQ – Grow your operations faster</title>
+    <link rel="stylesheet" href="LandingSharedStyles.css" />
+    <style>
+      .highlight-rows {
+        display: grid;
+        gap: 18px;
       }
 
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
+      .highlight-row {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }
 
-      .hero {
-        padding-top: 3rem;
+      .highlight-row .card {
+        min-height: 220px;
       }
 
-      .hero-ctas {
+      .phone-section {
         width: 100%;
-      }
-
-      .hero-ctas a {
-        flex: 1;
+        display: flex;
         justify-content: center;
+        padding: 48px 0 24px;
       }
-    }
-  </style>
-  <?
-    var loginUrl = buildLoginPageUrl({});
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-</head>
 
-<body class="landing-page">
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="#top" aria-label="LuminaHQ home">
-          <img class="brand-logo" src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
-          </div>
-        </a>
-        <div class="nav-actions">
-          <a class="btn-outline" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="btn-primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login</a>
-        </div>
-      </div>
-    </header>
+      .phone-grid {
+        width: var(--body-width);
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 32px;
+        align-items: center;
+      }
 
-    <main class="landing-main">
-      <section class="hero" id="top">
-        <div class="hero-inner">
-          <div class="hero-surface">
+      .phone-mockups {
+        display: flex;
+        justify-content: center;
+        gap: 24px;
+      }
+
+      .phone-mockups img {
+        width: clamp(160px, 38vw, 210px);
+        border-radius: 36px;
+        box-shadow: 0 18px 40px rgba(12, 32, 80, 0.24);
+      }
+
+      .phone-copy h3 {
+        color: var(--white);
+        margin: 0 0 16px;
+      }
+
+      .phone-copy p {
+        color: rgba(226, 235, 255, 0.82);
+        line-height: 1.7;
+      }
+
+      .phone-copy ul {
+        margin: 18px 0 0;
+        padding-left: 18px;
+        color: rgba(226, 235, 255, 0.82);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero-shell">
+        <div class="hero">
+          <div class="hero-grid">
             <div class="hero-content">
-              <div class="hero-copy">
-                <span class="hero-tag"><i class="fa-solid fa-sparkles"></i> AI-Orchestrated Workforce Platform</span>
-                <h2 class="hero-title">Synchronize scheduling, quality, and automation in one command center.</h2>
-                <p class="hero-subtitle">LuminaHQ layers an operations graph across every queue, site, and partner so leaders can translate live performance data into confident decisions in seconds.</p>
-                <ul class="hero-points" role="list">
-                  <li><i class="fa-solid fa-compass"></i> Forecast-aware dashboards that warn of staffing or SLA drift before it hits customers.</li>
-                  <li><i class="fa-solid fa-waveform"></i> AI-assisted coaching loops that convert QA findings into prioritized actions for every leader.</li>
-                  <li><i class="fa-solid fa-plug"></i> Native Google Workspace deployment with SSO, audit trails, and tenant isolation from day one.</li>
-                </ul>
-                <div class="hero-ctas">
-                  <a class="primary" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
-                  <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+              <span class="hero-badge">LuminaHQ Platform</span>
+              <h1>We help your operations grow faster</h1>
+              <p>
+                LuminaHQ centralizes quality, coaching, and workforce intelligence into one modern command
+                center. Align leaders and agents with AI-assisted workflows that accelerate insights into action.
+              </p>
+              <div class="hero-actions">
+                <a class="btn-primary" href="LandingCapabilities.html">Explore capabilities</a>
+                <a class="btn-ghost" href="LandingStory.html">Discover our story</a>
+              </div>
+              <div class="hero-metrics">
+                <div class="metric-card">
+                  <strong>20 days</strong>
+                  <span>to deploy and see measurable ROI</span>
+                </div>
+                <div class="metric-card">
+                  <strong>30%</strong>
+                  <span>coaching completion lift across teams</span>
+                </div>
+                <div class="metric-card">
+                  <strong>12+</strong>
+                  <span>modules covering QA, coaching, and staffing</span>
                 </div>
               </div>
-              <aside class="hero-showcase" aria-label="Platform highlights">
-                <div class="showcase-header">
-                  <h2>Live intelligence snapshot</h2>
-                  <span class="status-pill"><i class="fa-solid fa-signal"></i> Live data fabric</span>
-                </div>
-                <div class="metrics-grid">
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
-                    <strong>3.4K</strong>
-                    <span>Agents orchestrated</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-chart-line"></i></div>
-                    <strong>12%</strong>
-                    <span>Lift in SLA adherence</span>
-                  </div>
-                  <div class="metric-card">
-                    <div class="icon-circle"><i class="fa-solid fa-stopwatch"></i></div>
-                    <strong>9m</strong>
-                    <span>Average onboarding</span>
-                  </div>
-                </div>
-                <p class="hero-subtitle" style="margin:0;">Designed for managers, analysts, and specialists who need a precise pulse on every customer moment.</p>
-              </aside>
+            </div>
+            <div class="hero-visual">
+              <img
+                src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+                alt="LuminaHQ analytics overview"
+                loading="lazy"
+              />
+              <div class="hero-floating-card">
+                <h3>Overview snapshot</h3>
+                <p>
+                  Visualize sentiment, QA trends, and staffing forecasts in one glance so leaders can focus on
+                  coaching moments that matter.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="section section-dark" id="features">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Operate with clarity and confidence</h2>
-            <p>LuminaHQ turns scattered spreadsheets and disconnected tools into a unified control tower. Every feature is tuned for contact center pace—revealing what changed, why it matters, and the action to take next.</p>
+      <div class="partners">
+        <div class="partner-strip">
+          <span>Slack</span>
+          <span>Netflix</span>
+          <span>Google</span>
+          <span>Airbnb</span>
+          <span>Uber</span>
+        </div>
+      </div>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Measure impressions, reach, and performance with clarity</h2>
+            <p>
+              Bring together the insights your analysts, coaches, and workforce leaders rely on. LuminaHQ overlays
+              data visualization with contextual playbooks so every decision is grounded in operational reality.
+            </p>
           </div>
-          <div class="feature-grid">
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-headset"></i></div>
-              <h3>Unified agent visibility</h3>
-              <p>See adherence, skills, coaching, and productivity in a single glance to resolve staffing gaps before they impact experience.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-gauge-high"></i></div>
-              <h3>Performance intelligence</h3>
-              <p>Layer KPIs, QA signals, and customer sentiment into interactive scorecards that spotlight wins and risks by site, line of business, or client.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-shield-halved"></i></div>
-              <h3>Secure, tenant-ready</h3>
-              <p>Granular roles, audit logging, and tenant isolation give enterprise partners confidence without slowing delivery.</p>
-            </article>
-            <article class="feature-card">
-              <div class="feature-icon"><i class="fa-solid fa-rocket"></i></div>
-              <h3>Ready in minutes</h3>
-              <p>Deploy on Google Workspace in under an hour—keeping teams in familiar tools while unlocking enterprise automation.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore full capabilities</a>
-            <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to your workspace</a>
+          <div class="highlight-rows">
+            <div class="highlight-row">
+              <article class="card">
+                <h3>Quality intelligence</h3>
+                <p>
+                  Stream QA evaluations into dynamic dashboards that reveal trends, highlight skill gaps, and trigger
+                  targeted calibrations.
+                </p>
+              </article>
+              <article class="card">
+                <h3>Coaching activations</h3>
+                <p>
+                  Launch structured coaching plans with acknowledgments, next steps, and automated reminders embedded
+                  inside every conversation.
+                </p>
+              </article>
+              <article class="card">
+                <h3>Workforce precision</h3>
+                <p>
+                  Model schedules, track adherence, and manage attendance in a shared space designed for hybrid teams.
+                </p>
+              </article>
+            </div>
+            <div class="highlight-row">
+              <article class="card">
+                <h3>Analytics storytelling</h3>
+                <p>
+                  Present leaders with living stories that translate metrics into actions and celebrate operational wins.
+                </p>
+              </article>
+              <article class="card">
+                <h3>Automation ready</h3>
+                <p>
+                  Pair AI-driven suggestions with manual expertise to unlock efficiencies without losing the human touch.
+                </p>
+              </article>
+              <article class="card">
+                <h3>Secure collaboration</h3>
+                <p>
+                  Role-based spaces ensure partners, clients, and internal teams have the right context at the right time.
+                </p>
+              </article>
+            </div>
           </div>
         </div>
       </section>
 
-      <section class="section section-light" id="modules">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>Mission-critical modules</h2>
-            <p>Each LuminaHQ module is purpose-built yet deeply connected. Together they orchestrate agent experience, customer outcomes, and compliance from a single mission control.</p>
+      <section class="phone-section">
+        <div class="phone-grid">
+          <div class="phone-mockups">
+            <img
+              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=500&q=80"
+              alt="Lumina mobile insights"
+              loading="lazy"
+            />
+            <img
+              src="https://images.unsplash.com/photo-1516321497487-e288fb19713f?auto=format&fit=crop&w=500&q=80"
+              alt="Lumina coaching mobile"
+              loading="lazy"
+            />
           </div>
-          <div class="module-grid">
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-calendar-check"></i></span>
-                <h3>Adaptive Scheduling</h3>
-              </header>
-              <p>Balance staffing in real time with forecasting overlays, automated shift swaps, and instant communication to every affected agent.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-bolt"></i> Rolling interval forecasts blended with live adherence.</li>
-                <li><i class="fa-solid fa-comments"></i> Native shift notifications and approvals.</li>
-                <li><i class="fa-solid fa-chart-area"></i> Attendance anomaly alerts with root-cause context.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-user-shield"></i></span>
-                <h3>QA & Compliance</h3>
-              </header>
-              <p>Run calibrated evaluations, automate dispute workflows, and codify remediation steps to keep every campaign audit-ready.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-list-check"></i> Dynamic scorecards with weighted criteria.</li>
-                <li><i class="fa-solid fa-repeat"></i> Closed-loop disputes that sync with coaching plans.</li>
-                <li><i class="fa-solid fa-lock"></i> Granular permissions and audit-ready exports.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-chart-simple"></i></span>
-                <h3>Performance Intelligence</h3>
-              </header>
-              <p>Blend telephony, CRM, WFM, and customer sentiment data into interactive scoreboards that broadcast wins and spotlight gaps.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-arrows-rotate"></i> Real-time KPI sync with predictive targets.</li>
-                <li><i class="fa-solid fa-wand-magic-sparkles"></i> Auto-generated insights for supervisors and executives.</li>
-                <li><i class="fa-solid fa-people-arrows"></i> Role-based dashboards with drill-through.</li>
-              </ul>
-            </article>
-            <article class="module-card">
-              <header>
-                <span class="module-icon"><i class="fa-solid fa-robot"></i></span>
-                <h3>Automation Studio</h3>
-              </header>
-              <p>Trigger workflows across Sheets, Gmail, and external APIs with reusable recipes that shrink manual effort and accelerate resolution.</p>
-              <ul role="list">
-                <li><i class="fa-solid fa-diagram-next"></i> Drag-and-drop flow builder with approvals.</li>
-                <li><i class="fa-solid fa-cloud-arrow-up"></i> Secure integrations and webhook triggers.</li>
-                <li><i class="fa-solid fa-stopwatch-20"></i> SLA-aware automations with guardrails.</li>
-              </ul>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Dive into detailed capabilities</a>
-            <a class="ghost" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Experience LuminaHQ live</a>
+          <div class="phone-copy">
+            <h3>Designed for every screen size</h3>
+            <p>
+              Stay connected to your metrics wherever work happens. LuminaHQ delivers responsive dashboards, guided
+              tasks, and coaching workflows on desktop, tablet, and mobile.
+            </p>
+            <ul>
+              <li>Instantly review QA results and acknowledge coaching actions on the go.</li>
+              <li>Push alerts keep leaders on top of attendance trends and escalation activity.</li>
+              <li>Secure authentication keeps sensitive client data protected across devices.</li>
+            </ul>
           </div>
         </div>
       </section>
 
-      <section class="section section-light" id="about">
-        <div class="section-shell">
-          <div class="section-header">
-            <h2>The story behind LuminaHQ</h2>
-            <p>LuminaHQ was born inside Lumina's Innovation Lab in Kingston, Jamaica. We pair decades of contact center experience with modern data engineering to remove the friction between people, processes, and platforms.</p>
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Ready to dive deeper?</h2>
+            <p>
+              Explore how LuminaHQ aligns teams from onboarding through continuous optimization. Every page in our
+              landing suite expands on the modules, stories, and playbooks available to your operation.
+            </p>
           </div>
-          <div class="about-grid">
-            <article class="about-card">
-              <small>Purpose</small>
-              <h3>Elevate every customer moment</h3>
-              <p>Provide managers, analysts, and enablement leaders with a cohesive view of scheduling, coaching, QA, and collaboration so they can invest their time in people—not manual busywork.</p>
-            </article>
-            <article class="about-card">
-              <small>Built For</small>
-              <h3>Global call center teams</h3>
-              <p>From BPO networks to in-house support centers, LuminaHQ adapts to campaigns of every scale with tenant-aware governance baked in.</p>
-            </article>
-            <article class="about-card">
-              <small>Crafted In</small>
-              <h3>Kingston, Jamaica</h3>
-              <p>Engineered by Lumina's product studio with a focus on modern, flat UI, AI-ready data pipelines, and a seamless Google Apps Script backbone.</p>
-            </article>
-          </div>
-          <div class="section-cta">
-            <a class="primary" href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> Discover our story</a>
-            <a class="ghost" href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
+          <div class="navigation-cta">
+            <a class="btn-ghost" href="LandingAbout.html">About LuminaHQ</a>
+            <a class="btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
+            <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Dive into details</a>
+            <a class="btn-ghost" href="LandingStory.html">Discover our story</a>
           </div>
         </div>
       </section>
     </main>
 
-    <footer>
-      <div class="footer-shell">
-        <p>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</p>
-        <div>
-          <a href="PrivacyPolicy.html">Privacy</a> &middot;
-          <a href="TermsOfService.html">Terms</a> &middot;
-          <a href="<?!= loginUrl ?>">Login</a>
+    <footer class="footer-shell">
+      <div class="footer-card">
+        <h3>Experience LuminaHQ today</h3>
+        <p>
+          Connect with our team to see how LuminaHQ can amplify the impact of your quality, coaching, and workforce
+          leaders.
+        </p>
+        <div class="footer-links">
+          <a href="LandingAbout.html">Meet the platform</a>
+          <a href="LandingCapabilities.html">Capabilities overview</a>
+          <a href="LandingStory.html">Customer stories</a>
         </div>
       </div>
     </footer>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -1,523 +1,271 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About LuminaHQ</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f5f8ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --lumina-gradient: linear-gradient(135deg, rgba(11, 27, 63, 0.96), rgba(4, 120, 211, 0.9));
-      --shadow-card: 0 30px 60px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --transition: all 0.28s ease;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: radial-gradient(circle at 20% 20%, rgba(4, 120, 211, 0.08), transparent 55%),
-        radial-gradient(circle at 80% 0, rgba(56, 189, 248, 0.1), transparent 45%),
-        var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.82);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.5rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-      color: inherit;
-    }
-
-    .brand img {
-      width: 46px;
-      height: 46px;
-    }
-
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .nav-actions a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
-      border-radius: 999px;
-      transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.9);
-    }
-
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 14px 22px rgba(4, 120, 211, 0.15);
-    }
-
-    main {
-      flex: 1;
-    }
-
-    .hero {
-      position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
-    }
-
-    .hero::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: 0 0 48px 48px;
-      background: var(--lumina-gradient);
-      z-index: 0;
-    }
-
-    .hero-inner {
-      position: relative;
-      z-index: 1;
-      max-width: 1100px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.5rem;
-      align-items: center;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.5rem;
-    }
-
-    .hero-meta {
-      display: grid;
-      gap: 1rem;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-
-    .meta-card {
-      background: rgba(255, 255, 255, 0.14);
-      padding: 1.25rem 1.4rem;
-      border-radius: var(--radius-md);
-      display: flex;
-      flex-direction: column;
-      gap: 0.4rem;
-      border: 1px solid rgba(255, 255, 255, 0.22);
-    }
-
-    .meta-card span {
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      font-weight: 600;
-      font-size: 0.72rem;
-      color: rgba(248, 250, 252, 0.72);
-    }
-
-    .meta-card strong {
-      font-size: 1.4rem;
-      font-weight: 700;
-    }
-
-    .content-section {
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: clamp(3rem, 5vw, 4.5rem) 1.5rem;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin-bottom: 1rem;
-      color: var(--lumina-navy);
-    }
-
-    .section-header p {
-      font-size: 1.05rem;
-      line-height: 1.8;
-      color: var(--lumina-muted);
-    }
-
-    .value-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .value-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .value-card i {
-      font-size: 1.5rem;
-      color: var(--lumina-blue);
-    }
-
-    .value-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .value-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .story-timeline {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.5rem;
-      position: relative;
-    }
-
-    .story-card {
-      background: rgba(255, 255, 255, 0.92);
-      border-radius: var(--radius-md);
-      padding: 1.75rem 1.9rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
-    }
-
-    .story-card strong {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .story-card h4 {
-      font-size: 1.35rem;
-      margin: 0.75rem 0;
-    }
-
-    .story-card p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--lumina-muted);
-    }
-
-    .culture-banner {
-      background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(4, 120, 211, 0.18));
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 2rem;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      border: 1px solid rgba(4, 120, 211, 0.25);
-    }
-
-    .culture-banner h4 {
-      margin: 0;
-      font-size: 1.6rem;
-    }
-
-    .culture-banner ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.9rem;
-    }
-
-    .culture-banner li {
-      display: flex;
-      align-items: flex-start;
-      gap: 0.75rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .culture-banner li i {
-      color: var(--lumina-blue);
-      margin-top: 0.2rem;
-    }
-
-    footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
-    }
-
-    .footer-shell {
-      max-width: 1100px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
-      text-decoration: none;
-    }
-
-    .footer-shell a:hover {
-      color: #fff;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About LuminaHQ</title>
+    <link rel="stylesheet" href="LandingSharedStyles.css" />
+    <style>
+      .mission-grid {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
       }
 
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
+      .mission-card {
+        background: rgba(255, 255, 255, 0.96);
+        border-radius: 24px;
+        padding: 24px;
+        box-shadow: 0 18px 38px rgba(16, 34, 84, 0.18);
       }
-    }
-  </style>
-</head>
 
-<body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
-          </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingCapabilitiesUrl ?>"><i class="fa-solid fa-diagram-project"></i> Explore capabilities</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
-        </div>
-      </div>
-    </header>
+      .mission-card h3 {
+        margin: 0 0 12px;
+        color: var(--sky-900);
+      }
 
+      .timeline {
+        display: grid;
+        gap: 18px;
+      }
+
+      .timeline-step {
+        background: rgba(15, 31, 69, 0.65);
+        padding: 24px;
+        border-radius: 24px;
+        color: rgba(226, 235, 255, 0.9);
+        box-shadow: 0 18px 36px rgba(15, 31, 69, 0.2);
+      }
+
+      .timeline-step strong {
+        display: block;
+        font-size: 1.2rem;
+        margin-bottom: 8px;
+        color: var(--white);
+      }
+
+      .values-grid {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      .values-grid .card {
+        background: rgba(255, 255, 255, 0.92);
+      }
+
+      .team-photo {
+        width: 100%;
+        border-radius: 30px;
+        box-shadow: 0 20px 44px rgba(12, 32, 80, 0.22);
+      }
+
+      .hero-floating-card ul {
+        margin: 0;
+        padding-left: 18px;
+        color: var(--slate-500);
+      }
+    </style>
+  </head>
+  <body>
     <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>The humans and history behind our workforce command center.</h2>
-            <p>We build LuminaHQ in Kingston, Jamaica with an obsession for frontline momentum. Designers, engineers, analysts, and former operations leaders sit side-by-side to remove the friction contact center teams feel every day.</p>
-            <div class="hero-meta">
-              <div class="meta-card">
-                <span>Origin</span>
-                <strong>Innovation Lab</strong>
-                <p>Born from Lumina's partnerships with BPO networks across the Caribbean and North America.</p>
+      <section class="hero-shell">
+        <div class="hero">
+          <div class="hero-grid">
+            <div class="hero-content">
+              <span class="hero-badge">About LuminaHQ</span>
+              <h1>Building the modern nerve center for operations teams</h1>
+              <p>
+                LuminaHQ began with a simple belief: that quality, coaching, and workforce leaders deserve a single
+                workspace that reflects the pace of their teams. Our mission is to amplify every conversation,
+                evaluation, and schedule with intelligence.
+              </p>
+              <div class="hero-actions">
+                <a class="btn-primary" href="Landing.html">Return to landing</a>
+                <a class="btn-ghost" href="LandingStory.html">Read customer stories</a>
               </div>
-              <div class="meta-card">
-                <span>Craft</span>
-                <strong>Design × Data</strong>
-                <p>Product strategy meets applied data science to translate raw signals into guided action.</p>
+              <div class="hero-metrics">
+                <div class="metric-card">
+                  <strong>50+</strong>
+                  <span>specialists crafting LuminaHQ features</span>
+                </div>
+                <div class="metric-card">
+                  <strong>8 years</strong>
+                  <span>supporting global customer operations</span>
+                </div>
+                <div class="metric-card">
+                  <strong>24/5</strong>
+                  <span>product and enablement partnership coverage</span>
+                </div>
               </div>
-              <div class="meta-card">
-                <span>Promise</span>
-                <strong>Operational clarity</strong>
-                <p>Every workflow unifies scheduling, QA, coaching, and collaboration inside one control tower.</p>
+            </div>
+            <div class="hero-visual">
+              <img
+                src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+                alt="Team collaboration"
+                loading="lazy"
+              />
+              <div class="hero-floating-card">
+                <h3>What drives us</h3>
+                <ul>
+                  <li>Elevate the craft of quality and coaching professionals.</li>
+                  <li>Create clarity for leaders navigating complex operations.</li>
+                  <li>Design tools that honor the people behind every metric.</li>
+                </ul>
               </div>
             </div>
           </div>
-          <div class="hero-visual" aria-hidden="true">
-            <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1710450011/vlbpo/lumina/about-grid_qws7ir.png" alt="LuminaHQ culture collage" style="width:100%;border-radius:24px;box-shadow:0 32px 60px rgba(8, 47, 73, 0.2);object-fit:cover;">
+        </div>
+      </section>
+
+      <div class="partners">
+        <div class="partner-strip">
+          <span>Integrity</span>
+          <span>Innovation</span>
+          <span>Empathy</span>
+          <span>Momentum</span>
+          <span>Trust</span>
+        </div>
+      </div>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Our mission and promise</h2>
+            <p>
+              From the first calibration to enterprise-scale rollouts, LuminaHQ pairs attentive experts with a
+              product built for evolving customer experiences. We map workflows directly to your playbooks so your
+              teams can focus on the human moments.
+            </p>
+          </div>
+          <div class="mission-grid">
+            <article class="mission-card">
+              <h3>Human-centered design</h3>
+              <p>
+                Every feature is crafted with direct input from analysts, coaches, and workforce leaders who depend on
+                LuminaHQ each day.
+              </p>
+            </article>
+            <article class="mission-card">
+              <h3>Operational empathy</h3>
+              <p>
+                We embed alongside your teams to understand the nuance behind each metric and deliver playbooks that
+                reflect it.
+              </p>
+            </article>
+            <article class="mission-card">
+              <h3>Reliable partnership</h3>
+              <p>
+                Dedicated onboarding, enablement, and success specialists ensure LuminaHQ evolves with your programs.
+              </p>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="content-section">
-        <div class="section-header">
-          <h3>Why we exist</h3>
-          <p>Contact center leaders are asked to coach, forecast, report, and innovate at the same time. LuminaHQ eliminates the swivel-chair effort by giving every role a shared workspace that adapts to each campaign, geography, and client requirement.</p>
-        </div>
-        <div class="value-grid">
-          <article class="value-card">
-            <i class="fa-solid fa-compass"></i>
-            <h4>Customer-first design</h4>
-            <p>Every workflow is tested with active operations teams so the UI stays intuitive even as programs scale or pivot.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-people-group"></i>
-            <h4>Human-centered automation</h4>
-            <p>Automation is only valuable when it empowers analysts and supervisors. Our scripts reduce manual steps while keeping humans in control.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-shield-heart"></i>
-            <h4>Secure collaboration</h4>
-            <p>Multi-tenant controls, audit trails, and granular permissions safeguard customer data while keeping teams aligned.</p>
-          </article>
-          <article class="value-card">
-            <i class="fa-solid fa-globe"></i>
-            <h4>Global reach, local roots</h4>
-            <p>We support distributed teams across the Americas while grounding our craft and culture in the Caribbean.</p>
-          </article>
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>The journey so far</h2>
+            <p>
+              LuminaHQ has grown through close collaboration with support teams across industries. Together we have
+              transformed manual spreadsheets into guided journeys that celebrate progress.
+            </p>
+          </div>
+          <div class="timeline">
+            <div class="timeline-step">
+              <strong>2016 – Foundations</strong>
+              Started as a small collective of QA specialists developing tooling to streamline evaluations and
+              calibrations.
+            </div>
+            <div class="timeline-step">
+              <strong>2018 – Coaching unlock</strong>
+              Introduced guided coaching workflows that connected QA results to personalized development paths.
+            </div>
+            <div class="timeline-step">
+              <strong>2021 – Workforce fusion</strong>
+              Unified staffing, attendance, and performance data to create a cohesive operations command center.
+            </div>
+            <div class="timeline-step">
+              <strong>Today – Continuous momentum</strong>
+              Expanding AI assistance, predictive insights, and integrations to keep teams future-ready.
+            </div>
+          </div>
         </div>
       </section>
 
-      <section class="content-section">
-        <div class="section-header">
-          <h3>How LuminaHQ evolved</h3>
-          <p>A cross-functional team of engineers, data analysts, and operations specialists continues to expand LuminaHQ based on live call center feedback.</p>
-        </div>
-        <div class="story-timeline">
-          <article class="story-card">
-            <strong><i class="fa-solid fa-flag"></i> 2019</strong>
-            <h4>Scheduling foundations</h4>
-            <p>Rolled out Google Workspace scripts to automate agent shift updates and broadcast daily coaching plans.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-rocket"></i> 2021</strong>
-            <h4>Unified coaching</h4>
-            <p>Expanded into coaching dashboards, QA data pipelines, and collaboration workflows for hybrid teams.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-shield"></i> 2023</strong>
-            <h4>Enterprise-ready security</h4>
-            <p>Shipped tenant-aware access controls, SSO alignment, and audit logging for compliance-focused partners.</p>
-          </article>
-          <article class="story-card">
-            <strong><i class="fa-solid fa-chart-line"></i> Today</strong>
-            <h4>Predictive intelligence</h4>
-            <p>Integrating forecasting, AI summarization, and proactive alerts so teams anticipate change instead of reacting to it.</p>
-          </article>
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Values we live by</h2>
+            <p>
+              Our values guide how we show up for each other and for our customers. They ensure LuminaHQ remains a
+              trusted partner as the landscape evolves.
+            </p>
+          </div>
+          <div class="values-grid">
+            <article class="card">
+              <h3>Listen deeply</h3>
+              <p>We start by understanding the people behind the process before proposing any change.</p>
+            </article>
+            <article class="card">
+              <h3>Iterate boldly</h3>
+              <p>Constant experimentation lets us deliver measurable improvements every quarter.</p>
+            </article>
+            <article class="card">
+              <h3>Celebrate growth</h3>
+              <p>We highlight the wins that teams achieve together and capture the stories that inspire the next step.</p>
+            </article>
+            <article class="card">
+              <h3>Protect trust</h3>
+              <p>Security, privacy, and accessibility are embedded into every product and partnership decision.</p>
+            </article>
+          </div>
         </div>
       </section>
 
-      <section class="content-section" style="padding-bottom:4.5rem;">
-        <div class="culture-banner">
-          <div>
-            <h4>Inside the LuminaHQ culture</h4>
-            <p style="color:var(--lumina-muted);line-height:1.7;margin-top:0.75rem;">We operate with curiosity, empathy, and a bias toward shipping. Product rituals keep customer teams connected to the builders shaping their tools.</p>
+      <section class="section">
+        <div class="section-content dual-panel">
+          <div class="panel-media">
+            <img
+              class="team-photo"
+              src="https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=1200&q=80"
+              alt="LuminaHQ team workshop"
+              loading="lazy"
+            />
           </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-lightbulb"></i> Weekly design reviews align engineering, QA, and enablement on upcoming experiments.</li>
-              <li><i class="fa-solid fa-person-chalkboard"></i> Immersive onboarding embeds our product team inside partner operations for live feedback.</li>
-              <li><i class="fa-solid fa-hands"></i> Community initiatives reinvest in Jamaican tech talent through mentorship, internships, and open-source learning.</li>
-            </ul>
-          </div>
-          <div>
-            <ul>
-              <li><i class="fa-solid fa-headset"></i> Dedicated customer pods pair product managers with operations leads for faster roadmap alignment.</li>
-              <li><i class="fa-solid fa-leaf"></i> We balance rapid delivery with sustainable workloads to maintain a resilient, creative team.</li>
-            </ul>
+          <div class="panel-copy">
+            <h3>Meet the people behind the platform</h3>
+            <p>
+              Product strategists, data scientists, operations veterans, and service designers collaborate daily to
+              shape LuminaHQ. We carry the same passion for customer experience that defines your teams.
+            </p>
+            <p>
+              When you partner with LuminaHQ, you work with people invested in your success—from onboarding through
+              every new capability release.
+            </p>
+            <div class="navigation-cta">
+              <a class="btn-ghost" href="LandingCapabilities.html">See capabilities</a>
+              <a class="btn-ghost" href="LandingStory.html">Explore customer journey</a>
+            </div>
           </div>
         </div>
       </section>
     </main>
 
-    <footer>
-      <div class="footer-shell">
-        <strong>Ready to explore the workspace?</strong>
-        <div>
-          <a href="<?!= landingCapabilitiesUrl ?>">Discover LuminaHQ capabilities</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#about">Back to landing overview</a>
+    <footer class="footer-shell">
+      <div class="footer-card">
+        <h3>Connect with LuminaHQ</h3>
+        <p>
+          Ready to bring your teams into a smarter workspace? Reach out to discuss how LuminaHQ can transform quality,
+          coaching, and workforce operations.
+        </p>
+        <div class="footer-links">
+          <a href="LandingCapabilities.html">Capabilities overview</a>
+          <a href="LandingCapabilitiesDetail.html">Detailed modules</a>
+          <a href="LandingStory.html">Customer wins</a>
         </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Crafted by Lumina's Innovation Lab in Kingston, Jamaica.</small>
       </div>
     </footer>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -1,670 +1,294 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Explore LuminaHQ Capabilities</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-  <?
-    var loginUrl = buildLoginPageUrl({});
-    var __landingBase = scriptUrl || baseUrl || '';
-    var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
-    var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
-    var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
-  ?>
-  <style>
-    :root {
-      --lumina-navy: #0b1b3f;
-      --lumina-blue: #0478d3;
-      --lumina-blue-dark: #035799;
-      --lumina-cyan: #38bdf8;
-      --lumina-surface: #f6f9ff;
-      --lumina-card: #ffffff;
-      --lumina-muted: #475467;
-      --lumina-border: rgba(15, 23, 42, 0.08);
-      --shadow-card: 0 28px 50px rgba(11, 27, 63, 0.12);
-      --radius-lg: 26px;
-      --radius-md: 18px;
-      --radius-sm: 14px;
-      --transition: all 0.28s ease;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      color: var(--lumina-navy);
-      background: var(--lumina-surface);
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-    }
-
-    a {
-      color: inherit;
-    }
-
-    .page-shell {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-    }
-
-    header {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(16px);
-      background: rgba(255, 255, 255, 0.9);
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-      z-index: 20;
-    }
-
-    .nav-container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 1rem 1.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1rem;
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      text-decoration: none;
-      color: inherit;
-    }
-
-    .brand img {
-      width: 46px;
-      height: 46px;
-    }
-
-    .brand h1 {
-      margin: 0;
-      font-size: 1.25rem;
-      font-weight: 700;
-    }
-
-    .brand span {
-      display: block;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--lumina-muted);
-    }
-
-    .nav-actions {
-      display: flex;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .nav-actions a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 0.6rem 1.2rem;
-      border-radius: 999px;
-      transition: var(--transition);
-      color: var(--lumina-blue-dark);
-      border: 1px solid rgba(4, 120, 211, 0.32);
-      background: rgba(255, 255, 255, 0.92);
-    }
-
-    .nav-actions a.primary {
-      color: #fff;
-      background: var(--lumina-blue);
-      border-color: transparent;
-      box-shadow: 0 18px 30px rgba(4, 120, 211, 0.18);
-    }
-
-    .nav-actions a:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 16px 26px rgba(4, 120, 211, 0.16);
-    }
-
-    .hero {
-      position: relative;
-      padding: clamp(4rem, 5vw + 2rem, 6rem) 1.5rem 4rem;
-      color: rgba(241, 247, 255, 0.96);
-      overflow: hidden;
-    }
-
-    .hero::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      z-index: 0;
-      border-radius: 0 0 48px 48px;
-    }
-
-    .hero::after {
-      content: '';
-      position: absolute;
-      top: -20%;
-      right: -20%;
-      width: 420px;
-      height: 420px;
-      background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 60%);
-      z-index: 0;
-    }
-
-    .hero-inner {
-      position: relative;
-      z-index: 1;
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    }
-
-    .hero-copy h2 {
-      font-size: clamp(2.4rem, 4vw, 3.2rem);
-      margin-bottom: 1.2rem;
-      line-height: 1.1;
-    }
-
-    .hero-copy p {
-      font-size: 1.05rem;
-      line-height: 1.7;
-      max-width: 520px;
-      margin-bottom: 1.6rem;
-    }
-
-    .hero-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      background: rgba(255, 255, 255, 0.18);
-      border-radius: 999px;
-      padding: 0.65rem 1.3rem;
-      font-weight: 600;
-      color: #fff;
-      text-decoration: none;
-      transition: var(--transition);
-      border: 1px solid rgba(255, 255, 255, 0.32);
-      max-width: fit-content;
-    }
-
-    .hero-cta:hover {
-      transform: translateY(-2px);
-      background: rgba(255, 255, 255, 0.24);
-    }
-
-    main {
-      flex: 1;
-    }
-
-    .section {
-      padding: clamp(3.2rem, 5vw, 4.5rem) 1.5rem;
-    }
-
-    .section-shell {
-      max-width: 1120px;
-      margin: 0 auto;
-      display: grid;
-      gap: 2.75rem;
-    }
-
-    .section-header {
-      display: grid;
-      gap: 1rem;
-      max-width: 760px;
-    }
-
-    .section-header h3 {
-      font-size: clamp(2rem, 3.5vw, 2.6rem);
-      margin: 0;
-    }
-
-    .section-header p {
-      margin: 0;
-      font-size: 1.05rem;
-      color: var(--lumina-muted);
-      line-height: 1.8;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.75rem;
-    }
-
-    .module-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-md);
-      padding: 2rem 2.2rem;
-      border: 1px solid var(--lumina-border);
-      box-shadow: var(--shadow-card);
-      display: flex;
-      flex-direction: column;
-      gap: 0.7rem;
-      transition: var(--transition);
-    }
-
-    .module-card:hover {
-      transform: translateY(-6px);
-      box-shadow: 0 32px 70px rgba(11, 27, 63, 0.16);
-    }
-
-    .module-card span {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-size: 0.85rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .module-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .module-card p {
-      margin: 0;
-      line-height: 1.65;
-      color: var(--lumina-muted);
-    }
-
-    .module-card ul {
-      margin: 0.75rem 0 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .capability-matrix {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1.5rem;
-    }
-
-    .matrix-card {
-      background: linear-gradient(145deg, rgba(4, 120, 211, 0.1), rgba(56, 189, 248, 0.08));
-      border-radius: var(--radius-md);
-      padding: 2.1rem 2.3rem;
-      border: 1px solid rgba(4, 120, 211, 0.18);
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .matrix-card h4 {
-      margin: 0;
-      font-size: 1.35rem;
-    }
-
-    .matrix-card p {
-      margin: 0;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .matrix-points {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 0.65rem;
-    }
-
-    .matrix-points li {
-      display: flex;
-      gap: 0.55rem;
-      align-items: flex-start;
-      color: var(--lumina-muted);
-    }
-
-    .matrix-points li i {
-      color: var(--lumina-blue);
-      margin-top: 0.15rem;
-    }
-
-    .integration-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.4rem;
-    }
-
-    .integration-card {
-      background: var(--lumina-card);
-      border-radius: var(--radius-sm);
-      padding: 1.6rem 1.8rem;
-      border: 1px solid var(--lumina-border);
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
-    }
-
-    .integration-card strong {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--lumina-blue-dark);
-    }
-
-    .integration-card ul {
-      margin: 0;
-      padding-left: 1.1rem;
-      color: var(--lumina-muted);
-      line-height: 1.6;
-    }
-
-    .cta-panel {
-      background: linear-gradient(120deg, rgba(11, 27, 63, 0.95), rgba(4, 120, 211, 0.92));
-      color: #fff;
-      border-radius: var(--radius-lg);
-      padding: 3rem 2.5rem;
-      display: grid;
-      gap: 1.5rem;
-      justify-items: start;
-      box-shadow: 0 38px 70px rgba(8, 30, 70, 0.22);
-      text-align: left;
-    }
-
-    .cta-panel h3 {
-      margin: 0;
-      font-size: clamp(2rem, 3.5vw, 2.5rem);
-    }
-
-    .cta-panel p {
-      margin: 0;
-      font-size: 1.05rem;
-      max-width: 520px;
-      line-height: 1.7;
-      color: rgba(226, 232, 240, 0.85);
-    }
-
-    .cta-panel a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      background: #fff;
-      color: var(--lumina-blue-dark);
-      text-decoration: none;
-      padding: 0.75rem 1.5rem;
-      border-radius: 999px;
-      font-weight: 600;
-      transition: var(--transition);
-    }
-
-    .cta-panel a:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 16px 30px rgba(255, 255, 255, 0.25);
-    }
-
-    footer {
-      padding: 2.5rem 1.5rem 3rem;
-      background: #0b1b3f;
-      color: rgba(226, 232, 240, 0.85);
-      margin-top: auto;
-    }
-
-    .footer-shell {
-      max-width: 1120px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .footer-shell a {
-      color: rgba(148, 163, 184, 0.85);
-      text-decoration: none;
-    }
-
-    .footer-shell a:hover {
-      color: #fff;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        position: static;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Explore LuminaHQ Capabilities</title>
+    <link rel="stylesheet" href="LandingSharedStyles.css" />
+    <style>
+      .capability-stack {
+        display: grid;
+        gap: 24px;
       }
 
-      .nav-container {
-        flex-direction: column;
-        align-items: flex-start;
+      .capability-card {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 24px;
+        background: rgba(255, 255, 255, 0.96);
+        border-radius: 26px;
+        padding: 32px;
+        box-shadow: 0 20px 48px rgba(12, 32, 80, 0.2);
       }
-    }
-  </style>
-</head>
 
-<body>
-  <div class="page-shell">
-    <header>
-      <div class="nav-container">
-        <a class="brand" href="<?!= landingHomeUrl ?>">
-          <img src="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png" alt="LuminaHQ logo" loading="lazy">
-          <div>
-            <span>LuminaHQ</span>
-            <h1>Command Center</h1>
+      .capability-card h3 {
+        margin: 0;
+        color: var(--sky-900);
+      }
+
+      .capability-card p {
+        margin: 12px 0 0;
+        color: var(--slate-500);
+        line-height: 1.6;
+      }
+
+      .badge-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 16px;
+      }
+
+      .badge-list span {
+        padding: 10px 16px;
+        border-radius: 999px;
+        background: rgba(76, 141, 255, 0.16);
+        color: var(--sky-600);
+        font-weight: 500;
+        font-size: 0.85rem;
+      }
+
+      .module-grid {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .module-grid .card {
+        background: rgba(255, 255, 255, 0.94);
+      }
+
+      .hero-floating-card ul {
+        margin: 0;
+        padding-left: 18px;
+        color: var(--slate-500);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero-shell">
+        <div class="hero">
+          <div class="hero-grid">
+            <div class="hero-content">
+              <span class="hero-badge">Capabilities</span>
+              <h1>Everything your operations teams need in one workspace</h1>
+              <p>
+                LuminaHQ streamlines dozens of manual processes into intuitive flows. Explore how our modules combine to
+                produce measurable improvements in quality, coaching, and workforce planning.
+              </p>
+              <div class="hero-actions">
+                <a class="btn-primary" href="LandingCapabilitiesDetail.html">Dive into detail</a>
+                <a class="btn-ghost" href="LandingAbout.html">Learn about our team</a>
+              </div>
+              <div class="hero-metrics">
+                <div class="metric-card">
+                  <strong>360°</strong>
+                  <span>coverage of QA, coaching, and workforce cycles</span>
+                </div>
+                <div class="metric-card">
+                  <strong>9</strong>
+                  <span>automation blueprints included on launch</span>
+                </div>
+                <div class="metric-card">
+                  <strong>Unlimited</strong>
+                  <span>custom views powered by your data structure</span>
+                </div>
+              </div>
+            </div>
+            <div class="hero-visual">
+              <img
+                src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
+                alt="Digital dashboards"
+                loading="lazy"
+              />
+              <div class="hero-floating-card">
+                <h3>Platform pillars</h3>
+                <ul>
+                  <li>Unified data foundation that syncs quality, coaching, and staffing signals.</li>
+                  <li>Guided workflows designed by operations experts.</li>
+                  <li>Insight storytelling with shareable narratives.</li>
+                </ul>
+              </div>
+            </div>
           </div>
-        </a>
-        <div class="nav-actions">
-          <a href="<?!= landingAboutUrl ?>"><i class="fa-regular fa-circle-question"></i> About</a>
-          <a class="primary" href="<?!= landingHomeUrl ?>"><i class="fa-solid fa-house"></i> Back to landing</a>
+        </div>
+      </section>
+
+      <div class="partners">
+        <div class="partner-strip">
+          <span>Quality</span>
+          <span>Coaching</span>
+          <span>Analytics</span>
+          <span>Staffing</span>
+          <span>Enablement</span>
         </div>
       </div>
-    </header>
 
-    <main>
-      <section class="hero">
-        <div class="hero-inner">
-          <div class="hero-copy">
-            <h2>Every capability connects frontline execution to leadership insight.</h2>
-            <p>Explore the mission-ready modules that power LuminaHQ. Each capability extends a unified operations graph so every decision reflects what is happening on the floor right now.</p>
-            <a class="hero-cta" href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to experience LuminaHQ</a>
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Capability snapshots</h2>
+            <p>
+              Each module is configured to reflect your programs on day one. Use these snapshots to plan how LuminaHQ
+              aligns with your workflows.
+            </p>
           </div>
-          <div class="hero-visual" aria-hidden="true" style="display:grid;gap:1rem;">
-            <div style="background:rgba(255,255,255,0.12);border-radius:22px;padding:1.4rem 1.6rem;border:1px solid rgba(255,255,255,0.28);display:grid;gap:0.75rem;">
-              <div style="display:flex;align-items:center;justify-content:space-between;">
-                <strong style="font-size:0.95rem;letter-spacing:0.12em;text-transform:uppercase;">Live insights</strong>
-                <span style="display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;"><i class="fa-solid fa-signal"></i> Synced</span>
+          <div class="capability-stack">
+            <div class="capability-card">
+              <div>
+                <h3>Quality intelligence</h3>
+                <p>
+                  Capture evaluations, calibrate analysts, and surface key drivers instantly. LuminaHQ keeps quality
+                  leaders connected to the context behind every score.
+                </p>
+                <div class="badge-list">
+                  <span>Evaluation builder</span>
+                  <span>Calibration studio</span>
+                  <span>Insights stories</span>
+                </div>
               </div>
-              <div style="display:grid;gap:0.6rem;">
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Schedule adherence</span>
-                  <strong>97.4%</strong>
+              <div>
+                <h3>Coaching activations</h3>
+                <p>
+                  Automate coaching cadences and keep commitments visible. Agents sign off on action plans directly
+                  inside LuminaHQ.
+                </p>
+                <div class="badge-list">
+                  <span>Coaching briefs</span>
+                  <span>Task follow-up</span>
+                  <span>Acknowledgments</span>
                 </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>QA coaching cycles</span>
-                  <strong>128</strong>
-                </div>
-                <div style="display:flex;justify-content:space-between;align-items:center;">
-                  <span>Campaign health</span>
-                  <strong>Green</strong>
+              </div>
+              <div>
+                <h3>Workforce precision</h3>
+                <p>
+                  Pair attendance monitoring with schedule modeling to deliver reliable staffing coverage while honoring
+                  agent preferences.
+                </p>
+                <div class="badge-list">
+                  <span>Forecast builder</span>
+                  <span>Attendance center</span>
+                  <span>Shift marketplace</span>
                 </div>
               </div>
             </div>
-            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0.75rem;">
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-calendar-check" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Scheduling</p>
+            <div class="capability-card">
+              <div>
+                <h3>Performance storytelling</h3>
+                <p>
+                  Transform dashboards into narratives that leaders and partners can act on immediately.
+                </p>
+                <div class="badge-list">
+                  <span>Executive digest</span>
+                  <span>Campaign rollups</span>
+                  <span>Shareable reports</span>
+                </div>
               </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chalkboard-user" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Coaching</p>
+              <div>
+                <h3>Knowledge continuity</h3>
+                <p>
+                  Link policy references, training roadmaps, and announcements so teams stay aligned through change.
+                </p>
+                <div class="badge-list">
+                  <span>Resource hub</span>
+                  <span>Launch checklists</span>
+                  <span>Microlearning</span>
+                </div>
               </div>
-              <div style="background:rgba(255,255,255,0.16);border-radius:16px;padding:0.9rem;text-align:center;">
-                <i class="fa-solid fa-chart-line" style="font-size:1.4rem;"></i>
-                <p style="margin:0.6rem 0 0;font-size:0.85rem;">Analytics</p>
+              <div>
+                <h3>Collaboration fabric</h3>
+                <p>
+                  Bring QA analysts, coaches, and leadership into shared conversations without leaving LuminaHQ.
+                </p>
+                <div class="badge-list">
+                  <span>Comment threads</span>
+                  <span>Escalation links</span>
+                  <span>Partner access</span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="section" id="modules">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Core modules that power your operations</h3>
-            <p>Each module is purpose-built for high-volume contact centers. They connect seamlessly but can roll out independently to match the maturity of each campaign.</p>
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Modular architecture</h2>
+            <p>
+              Choose the modules that match your maturity today and expand as your programs evolve. Each component slots
+              into LuminaHQ’s shared data fabric.
+            </p>
           </div>
           <div class="module-grid">
-            <article class="module-card">
-              <span><i class="fa-solid fa-calendar-check"></i> Scheduling</span>
-              <h4>Shift orchestration</h4>
-              <p>Balance coverage with predictive forecasts, automate shift swaps, and trigger exception workflows directly through Google Workspace.</p>
-              <ul>
-                <li>Scenario planning with interval forecasts and adherence overlays.</li>
-                <li>Automated swap approvals, overtime guardrails, and manager alerts.</li>
-                <li>Work-from-home readiness checks tied to equipment and network audits.</li>
-              </ul>
+            <article class="card">
+              <h3>QA Boards</h3>
+              <p>Track evaluations, analyst workload, and trending insights in real time.</p>
             </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-user-graduate"></i> Coaching</span>
-              <h4>Enablement playbooks</h4>
-              <p>Give supervisors guided workflows to assign action plans, capture feedback, and celebrate wins in one place.</p>
-              <ul>
-                <li>Custom coaching templates with digital sign-offs and attachments.</li>
-                <li>Performance heatmaps that highlight the biggest coaching opportunities.</li>
-                <li>Automated nudges that keep follow-ups and reinforcements on schedule.</li>
-              </ul>
+            <article class="card">
+              <h3>Coaching Journeys</h3>
+              <p>Design step-by-step coaching plans with accountability built in.</p>
             </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-shield-heart"></i> Quality</span>
-              <h4>QA intelligence hub</h4>
-              <p>Aggregate evaluator feedback, calibrate teams, and surface QA performance trends with a modern reporting layer.</p>
-              <ul>
-                <li>Weighted scoring with variance alerts across lines of business.</li>
-                <li>Calibration dashboards that preserve historical context and disputes.</li>
-                <li>AI-ready exports that feed deeper analytics or generative summaries.</li>
-              </ul>
+            <article class="card">
+              <h3>Attendance Pulse</h3>
+              <p>Monitor adherence, time-off requests, and schedule exceptions in one view.</p>
             </article>
-            <article class="module-card">
-              <span><i class="fa-solid fa-handshake"></i> Collaboration</span>
-              <h4>Campaign collaboration</h4>
-              <p>Coordinate cross-functional projects, document requirements, and drive accountability across partner teams.</p>
-              <ul>
-                <li>Project boards with owner visibility and SLA checkpoints.</li>
-                <li>Knowledge hubs that capture client requirements and SOP updates.</li>
-                <li>Escalation routing with automated reminders until resolution.</li>
-              </ul>
+            <article class="card">
+              <h3>Executive Dashboards</h3>
+              <p>Provide leaders with curated summaries across programs, campaigns, and vendors.</p>
+            </article>
+            <article class="card">
+              <h3>Enablement Hub</h3>
+              <p>Deliver training, updates, and resources without leaving the LuminaHQ ecosystem.</p>
+            </article>
+            <article class="card">
+              <h3>AI Assist</h3>
+              <p>Automate scoring suggestions, coaching prompts, and workforce alerts with machine intelligence.</p>
             </article>
           </div>
         </div>
       </section>
 
-      <section class="section" id="intelligence">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Intelligence woven into every workflow</h3>
-            <p>LuminaHQ turns raw metrics into proactive guidance. Supervisors, analysts, and executives see the same live picture, filtered through their priorities.</p>
+      <section class="section">
+        <div class="section-content dual-panel">
+          <div class="panel-copy">
+            <h3>Integrate with the tools you already trust</h3>
+            <p>
+              LuminaHQ connects to ticketing, telephony, and BI platforms to complete your operational picture. Our
+              integration framework keeps data synchronized without compromising security.
+            </p>
+            <ul>
+              <li>Native connectors for Zendesk, Salesforce, and Five9.</li>
+              <li>Open APIs and SFTP options for custom data flows.</li>
+              <li>Granular permissions mapped to your governance policies.</li>
+            </ul>
+            <div class="navigation-cta">
+              <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Review full module list</a>
+              <a class="btn-ghost" href="LandingStory.html">See customer outcomes</a>
+            </div>
           </div>
-          <div class="capability-matrix">
-            <article class="matrix-card">
-              <h4>Operational awareness</h4>
-              <p>See how staffing, quality, and coaching interact in real-time.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-signal"></i> Color-coded adherence by site, line of business, or skill group.</li>
-                <li><i class="fa-solid fa-chart-area"></i> Trend analysis that blends historical performance with live data.</li>
-                <li><i class="fa-solid fa-bell"></i> Notifications when service levels or QA thresholds drift.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Guided decisioning</h4>
-              <p>Surface the next best action for every role on the floor.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-route"></i> Prescriptive playbooks for coaching, staffing, and client communication.</li>
-                <li><i class="fa-solid fa-person-chalkboard"></i> Supervisor dashboards tuned for quick huddles.</li>
-                <li><i class="fa-solid fa-gears"></i> Automations triggered by thresholds, statuses, or campaign events.</li>
-              </ul>
-            </article>
-            <article class="matrix-card">
-              <h4>Executive visibility</h4>
-              <p>Translate frontline operations into boardroom clarity.</p>
-              <ul class="matrix-points">
-                <li><i class="fa-solid fa-chart-line"></i> Roll-up scorecards across programs with drill-downs to agent level.</li>
-                <li><i class="fa-solid fa-file-lines"></i> Auto-generated executive briefs summarizing wins and risks.</li>
-                <li><i class="fa-solid fa-globe"></i> Global dashboards that segment by client, region, or outsourcing partner.</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" id="integrations">
-        <div class="section-shell">
-          <div class="section-header">
-            <h3>Works seamlessly with your existing stack</h3>
-            <p>Built on Google Workspace and Apps Script, LuminaHQ plays nicely with your contact center ecosystem, ensuring data stays secure and in sync.</p>
-          </div>
-          <div class="integration-grid">
-            <article class="integration-card">
-              <strong><i class="fa-brands fa-google"></i> Google Workspace native</strong>
-              <ul>
-                <li>Single sign-on with your Google accounts</li>
-                <li>Drive, Sheets, and Docs automations included</li>
-                <li>Calendar sync for schedule updates</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-cloud-arrow-up"></i> Data pipeline ready</strong>
-              <ul>
-                <li>Export-ready datasets for BI platforms</li>
-                <li>Webhook endpoints for real-time mirroring</li>
-                <li>Tenant-aware API keys and logging</li>
-              </ul>
-            </article>
-            <article class="integration-card">
-              <strong><i class="fa-solid fa-lock"></i> Security controls</strong>
-              <ul>
-                <li>Role-based permissions with audit history</li>
-                <li>Granular data residency and retention rules</li>
-                <li>Compliance alignment for SOC 2 readiness</li>
-              </ul>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section" style="padding-bottom:4.5rem;">
-        <div class="section-shell">
-          <div class="cta-panel">
-            <h3>See LuminaHQ in action</h3>
-            <p>Log in to your workspace or request a guided walkthrough to explore how LuminaHQ adapts to the rhythm of your operations.</p>
-            <a href="<?!= loginUrl ?>"><i class="fa-solid fa-right-to-bracket"></i> Login to LuminaHQ</a>
+          <div class="panel-media">
+            <img
+              src="https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1200&q=80"
+              alt="Integration illustration"
+              loading="lazy"
+            />
           </div>
         </div>
       </section>
     </main>
 
-    <footer>
-      <div class="footer-shell">
-        <strong>Looking for our story?</strong>
-        <div>
-          <a href="<?!= landingAboutUrl ?>">Visit the LuminaHQ about page</a> &middot;
-          <a href="<?!= landingHomeUrl ?>#features">Return to landing highlights</a>
+    <footer class="footer-shell">
+      <div class="footer-card">
+        <h3>Take the next step</h3>
+        <p>See how LuminaHQ’s capabilities adapt to your programs with a guided walkthrough.</p>
+        <div class="footer-links">
+          <a href="LandingCapabilitiesDetail.html">Deep dive modules</a>
+          <a href="LandingStory.html">Success stories</a>
+          <a href="Landing.html">Return home</a>
         </div>
-        <small>&copy; <?!= new Date().getFullYear(); ?> LuminaHQ. Built with secure Google Workspace automation.</small>
       </div>
     </footer>
-  </div>
-</body>
-
+  </body>
 </html>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dive Into LuminaHQ Capabilities</title>
+    <link rel="stylesheet" href="LandingSharedStyles.css" />
+    <style>
+      .detail-grid {
+        display: grid;
+        gap: 24px;
+      }
+
+      .detail-card {
+        background: rgba(255, 255, 255, 0.96);
+        border-radius: 26px;
+        box-shadow: 0 20px 48px rgba(15, 31, 69, 0.2);
+        padding: 32px;
+        display: grid;
+        gap: 18px;
+      }
+
+      .detail-card h3 {
+        margin: 0;
+        color: var(--sky-900);
+      }
+
+      .detail-card p {
+        margin: 0;
+        color: var(--slate-500);
+        line-height: 1.65;
+      }
+
+      .detail-card ul {
+        margin: 8px 0 0;
+        padding-left: 18px;
+        color: var(--slate-500);
+      }
+
+      .workflow-grid {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .workflow-step {
+        background: rgba(15, 31, 69, 0.7);
+        border-radius: 24px;
+        padding: 24px;
+        color: rgba(226, 235, 255, 0.92);
+        box-shadow: 0 18px 42px rgba(15, 31, 69, 0.22);
+      }
+
+      .workflow-step strong {
+        display: block;
+        color: var(--white);
+        margin-bottom: 8px;
+        font-size: 1.1rem;
+      }
+
+      .hero-floating-card ol {
+        margin: 0;
+        padding-left: 18px;
+        color: var(--slate-500);
+      }
+
+      .hero-floating-card ol li {
+        margin-bottom: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero-shell">
+        <div class="hero">
+          <div class="hero-grid">
+            <div class="hero-content">
+              <span class="hero-badge">Capability deep dive</span>
+              <h1>Guided workflows that scale with your operation</h1>
+              <p>
+                Peek behind the scenes of LuminaHQ’s modules to see the exact journeys your teams will experience. Each
+                workflow is built from real-world playbooks contributed by operations experts.
+              </p>
+              <div class="hero-actions">
+                <a class="btn-primary" href="LandingCapabilities.html">Return to overview</a>
+                <a class="btn-ghost" href="LandingStory.html">See it in action</a>
+              </div>
+              <div class="hero-metrics">
+                <div class="metric-card">
+                  <strong>4 hrs</strong>
+                  <span>saved per week by QA leaders on reporting</span>
+                </div>
+                <div class="metric-card">
+                  <strong>2x</strong>
+                  <span>increase in coaching follow-through</span>
+                </div>
+                <div class="metric-card">
+                  <strong>98%</strong>
+                  <span>adoption among pilot supervisors</span>
+                </div>
+              </div>
+            </div>
+            <div class="hero-visual">
+              <img
+                src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1200&q=80"
+                alt="Product dashboards"
+                loading="lazy"
+              />
+              <div class="hero-floating-card">
+                <h3>How teams ramp</h3>
+                <ol>
+                  <li>Discover key dashboards in day-one enablement.</li>
+                  <li>Configure workflows with guided onboarding.</li>
+                  <li>Monitor adoption through real-time health checks.</li>
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="partners">
+        <div class="partner-strip">
+          <span>Discover</span>
+          <span>Configure</span>
+          <span>Activate</span>
+          <span>Optimize</span>
+          <span>Celebrate</span>
+        </div>
+      </div>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Workflow spotlights</h2>
+            <p>
+              Dig into the core flows that differentiate LuminaHQ. Each spotlight outlines the decisions, automations,
+              and handoffs built into the experience.
+            </p>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card">
+              <h3>Quality calibration journey</h3>
+              <p>
+                Invite analysts, review sample evaluations, and document consensus in one guided flow that updates QA
+                guidelines instantly.
+              </p>
+              <ul>
+                <li>Auto-select sample interactions based on campaign goals.</li>
+                <li>Capture commentary and decisions directly alongside scorecards.</li>
+                <li>Publish updated rubrics to analysts with one click.</li>
+              </ul>
+            </article>
+            <article class="detail-card">
+              <h3>Coaching momentum planner</h3>
+              <p>
+                Connect QA insights to targeted coaching actions with reminders that keep supervisors and agents aligned.
+              </p>
+              <ul>
+                <li>Launch plans with suggested talking points and resources.</li>
+                <li>Assign follow-up tasks and track acknowledgments automatically.</li>
+                <li>Surface progress and celebrate wins in executive dashboards.</li>
+              </ul>
+            </article>
+            <article class="detail-card">
+              <h3>Workforce assurance loop</h3>
+              <p>
+                Combine attendance monitoring, forecasting, and shift changes into a proactive process that protects SLAs.
+              </p>
+              <ul>
+                <li>Flag adherence risks using predictive alerts.</li>
+                <li>Offer shift swaps through an employee marketplace.</li>
+                <li>Summarize weekly coverage in partner-ready stories.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Activation blueprint</h2>
+            <p>
+              Our onboarding approach combines curated enablement, rapid configuration, and adoption coaching to ensure
+              teams thrive from day one.
+            </p>
+          </div>
+          <div class="workflow-grid">
+            <div class="workflow-step">
+              <strong>Discover & Align</strong>
+              Map your current processes to LuminaHQ journeys with discovery workshops led by operations strategists.
+            </div>
+            <div class="workflow-step">
+              <strong>Configure & Launch</strong>
+              Import data, tailor forms, and activate automations with support from our implementation crew.
+            </div>
+            <div class="workflow-step">
+              <strong>Coach & Celebrate</strong>
+              Monitor adoption, iterate with feedback loops, and share success stories with leadership every month.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-content dual-panel">
+          <div class="panel-media">
+            <img
+              src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+              alt="Analytics detail"
+              loading="lazy"
+            />
+          </div>
+          <div class="panel-copy">
+            <h3>See LuminaHQ in motion</h3>
+            <p>
+              Request a guided tour to experience these workflows firsthand. We’ll show how quality insights surface next
+              to coaching plans, how workforce scenarios play out, and how leadership gets the context they need.
+            </p>
+            <p>
+              Our team tailors each walkthrough to your goals so you can visualize a launch path with confidence.
+            </p>
+            <div class="navigation-cta">
+              <a class="btn-ghost" href="LandingStory.html">Read success stories</a>
+              <a class="btn-ghost" href="Landing.html">Return to landing</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer-shell">
+      <div class="footer-card">
+        <h3>Need a deeper dive?</h3>
+        <p>
+          Connect with LuminaHQ specialists for custom demos, integration planning, and transformation playbooks.
+        </p>
+        <div class="footer-links">
+          <a href="LandingCapabilities.html">Capabilities overview</a>
+          <a href="LandingStory.html">Discover customer wins</a>
+          <a href="LandingAbout.html">Meet the team</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/LandingSharedStyles.css
+++ b/LandingSharedStyles.css
@@ -1,0 +1,423 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+
+:root {
+  --sky-50: #f3f7ff;
+  --sky-100: #e8f0ff;
+  --sky-200: #cfe0ff;
+  --sky-500: #4c8dff;
+  --sky-600: #2f72f0;
+  --sky-900: #0f1b46;
+  --slate-700: #23324f;
+  --slate-500: #4f5d7a;
+  --emerald-400: #4ad4b0;
+  --warning-400: #f3b34c;
+  --white: #ffffff;
+  --body-width: min(1100px, 92vw);
+  --shadow-soft: 0 20px 45px rgba(22, 54, 110, 0.18);
+  --radius-xl: 28px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
+  background: linear-gradient(135deg, #0f74ff 0%, #2a52ff 45%, #1a2a60 100%);
+  color: var(--sky-900);
+  min-height: 100vh;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  width: 100%;
+}
+
+.hero-shell {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 72px 0 48px;
+}
+
+.hero {
+  width: var(--body-width);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(227, 240, 255, 0.94) 100%);
+  border-radius: var(--radius-xl);
+  padding: 56px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(76, 141, 255, 0.18) 0%, rgba(74, 212, 176, 0.08) 60%, transparent 100%);
+  pointer-events: none;
+}
+
+.hero-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 32px;
+  align-items: center;
+}
+
+.hero-content {
+  grid-column: span 6;
+  z-index: 1;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(74, 212, 176, 0.15);
+  color: var(--sky-600);
+  font-weight: 600;
+  margin-bottom: 28px;
+  font-size: 0.95rem;
+}
+
+.hero h1 {
+  font-size: 2.75rem;
+  line-height: 1.15;
+  margin: 0 0 20px;
+  color: var(--sky-900);
+}
+
+.hero p {
+  margin: 0 0 28px;
+  color: var(--slate-500);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--sky-600), #304aff);
+  color: var(--white);
+  padding: 14px 28px;
+  border-radius: 16px;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(37, 92, 221, 0.28);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn-ghost {
+  background: rgba(47, 114, 240, 0.1);
+  color: var(--sky-600);
+  padding: 14px 28px;
+  border-radius: 16px;
+  font-weight: 600;
+  backdrop-filter: blur(6px);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.hero-actions a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 25px rgba(18, 55, 148, 0.12);
+}
+
+.hero-metrics {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.metric-card {
+  min-width: 160px;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: var(--white);
+  box-shadow: 0 8px 20px rgba(36, 74, 147, 0.12);
+}
+
+.metric-card strong {
+  display: block;
+  font-size: 1.5rem;
+  color: var(--sky-600);
+}
+
+.metric-card span {
+  font-size: 0.9rem;
+  color: var(--slate-500);
+}
+
+.hero-visual {
+  grid-column: span 6;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-visual img {
+  width: 100%;
+  border-radius: 28px;
+  box-shadow: 0 25px 60px rgba(15, 33, 80, 0.24);
+}
+
+.hero-floating-card {
+  position: absolute;
+  right: 14%;
+  bottom: -6%;
+  background: var(--white);
+  padding: 18px 22px;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(21, 40, 87, 0.18);
+  width: clamp(220px, 35vw, 260px);
+}
+
+.hero-floating-card h3 {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  color: var(--sky-900);
+}
+
+.hero-floating-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--slate-500);
+}
+
+.partners {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 28px 0 40px;
+}
+
+.partner-strip {
+  width: var(--body-width);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding: 24px 40px;
+  background: rgba(15, 31, 69, 0.32);
+  color: var(--white);
+  border-radius: 20px;
+  backdrop-filter: blur(6px);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.partner-strip span {
+  opacity: 0.7;
+}
+
+.section {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 56px 0;
+}
+
+.section-content {
+  width: var(--body-width);
+  display: grid;
+  gap: 32px;
+}
+
+.section-headline {
+  text-align: left;
+  max-width: 720px;
+  color: var(--white);
+}
+
+.section-headline h2 {
+  margin: 0 0 16px;
+  font-size: 2.1rem;
+}
+
+.section-headline p {
+  margin: 0;
+  color: rgba(226, 235, 255, 0.85);
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 14px 34px rgba(15, 31, 69, 0.16);
+}
+
+.card h3 {
+  margin: 0 0 12px;
+  color: var(--sky-900);
+}
+
+.card p,
+.card ul {
+  margin: 0;
+  color: var(--slate-500);
+  line-height: 1.6;
+}
+
+.card ul {
+  padding-left: 20px;
+  margin-top: 12px;
+}
+
+.card ul li {
+  margin-bottom: 8px;
+}
+
+.dual-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.panel-media {
+  background: linear-gradient(160deg, rgba(74, 212, 176, 0.25), rgba(47, 114, 240, 0.15));
+  border-radius: 30px;
+  padding: 36px;
+  box-shadow: 0 16px 36px rgba(18, 55, 148, 0.18);
+}
+
+.panel-media img {
+  width: 100%;
+  display: block;
+}
+
+.panel-copy h3 {
+  margin: 0 0 16px;
+  color: var(--white);
+}
+
+.panel-copy p {
+  margin: 0 0 12px;
+  color: rgba(226, 235, 255, 0.82);
+  line-height: 1.7;
+}
+
+.panel-copy ul {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: rgba(226, 235, 255, 0.82);
+}
+
+.navigation-cta {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.footer-shell {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 48px 0 72px;
+}
+
+.footer-card {
+  width: var(--body-width);
+  background: rgba(15, 31, 69, 0.72);
+  border-radius: 28px;
+  padding: 36px;
+  color: var(--white);
+  display: grid;
+  gap: 24px;
+}
+
+.footer-card h3 {
+  margin: 0;
+  font-size: 1.7rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.footer-links a {
+  padding: 12px 20px;
+  border-radius: 16px;
+  background: rgba(76, 141, 255, 0.18);
+  color: var(--white);
+  font-weight: 500;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    padding: 48px 32px;
+  }
+
+  .hero-content {
+    grid-column: span 12;
+  }
+
+  .hero-visual {
+    grid-column: span 12;
+  }
+
+  .hero-floating-card {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    margin-top: 24px;
+  }
+
+  .partner-strip {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 36px 24px;
+  }
+
+  .hero h1 {
+    font-size: 2.2rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .partner-strip {
+    font-size: 0.75rem;
+    gap: 12px;
+  }
+}

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Discover the LuminaHQ Story</title>
+    <link rel="stylesheet" href="LandingSharedStyles.css" />
+    <style>
+      .story-grid {
+        display: grid;
+        gap: 24px;
+      }
+
+      .story-card {
+        background: rgba(255, 255, 255, 0.95);
+        padding: 28px;
+        border-radius: 26px;
+        box-shadow: 0 20px 48px rgba(15, 31, 69, 0.22);
+      }
+
+      .story-card h3 {
+        margin: 0 0 12px;
+        color: var(--sky-900);
+      }
+
+      .story-card p {
+        margin: 0;
+        color: var(--slate-500);
+        line-height: 1.7;
+      }
+
+      .testimonial {
+        background: rgba(15, 31, 69, 0.7);
+        color: rgba(226, 235, 255, 0.9);
+        padding: 28px;
+        border-radius: 26px;
+        box-shadow: 0 20px 42px rgba(15, 31, 69, 0.24);
+      }
+
+      .testimonial strong {
+        display: block;
+        color: var(--white);
+        margin-bottom: 12px;
+        font-size: 1.05rem;
+      }
+
+      .milestone-grid {
+        display: grid;
+        gap: 20px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .milestone-card {
+        background: rgba(255, 255, 255, 0.92);
+        border-radius: 22px;
+        padding: 20px;
+        box-shadow: 0 18px 36px rgba(15, 31, 69, 0.18);
+      }
+
+      .milestone-card span {
+        display: block;
+        font-weight: 600;
+        color: var(--sky-600);
+        margin-bottom: 8px;
+      }
+
+      .hero-floating-card blockquote {
+        margin: 0;
+        color: var(--slate-500);
+        font-style: italic;
+        line-height: 1.6;
+      }
+
+      .hero-floating-card cite {
+        display: block;
+        margin-top: 12px;
+        font-style: normal;
+        font-weight: 600;
+        color: var(--sky-600);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero-shell">
+        <div class="hero">
+          <div class="hero-grid">
+            <div class="hero-content">
+              <span class="hero-badge">Customer stories</span>
+              <h1>See how teams transform with LuminaHQ</h1>
+              <p>
+                Operations leaders across industries partner with LuminaHQ to modernize workflows, rally teams, and keep
+                customers delighted. Explore the stories behind their results.
+              </p>
+              <div class="hero-actions">
+                <a class="btn-primary" href="LandingCapabilitiesDetail.html">Review the blueprint</a>
+                <a class="btn-ghost" href="LandingAbout.html">Meet our team</a>
+              </div>
+              <div class="hero-metrics">
+                <div class="metric-card">
+                  <strong>40%</strong>
+                  <span>reduction in manual QA preparation</span>
+                </div>
+                <div class="metric-card">
+                  <strong>25%</strong>
+                  <span>lift in CSAT across partner programs</span>
+                </div>
+                <div class="metric-card">
+                  <strong>3x</strong>
+                  <span>faster rollout of new policy updates</span>
+                </div>
+              </div>
+            </div>
+            <div class="hero-visual">
+              <img
+                src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+                alt="Success metrics"
+                loading="lazy"
+              />
+              <div class="hero-floating-card">
+                <blockquote>
+                  “LuminaHQ has become the connective tissue for our global support teams. We make decisions faster, coach
+                  with confidence, and celebrate the wins we would have missed.”
+                </blockquote>
+                <cite>VP of Customer Care, Growth-stage SaaS</cite>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="partners">
+        <div class="partner-strip">
+          <span>Fintech</span>
+          <span>E-commerce</span>
+          <span>Healthcare</span>
+          <span>SaaS</span>
+          <span>Travel</span>
+        </div>
+      </div>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Stories from the field</h2>
+            <p>
+              Discover how LuminaHQ helps teams tackle unique challenges—from rapid growth to complex regulatory
+              landscapes.
+            </p>
+          </div>
+          <div class="story-grid">
+            <article class="story-card">
+              <h3>Scaling quality in fintech</h3>
+              <p>
+                A digital bank unified QA and coaching across three regions, cutting calibration time in half while
+                maintaining compliance-ready documentation.
+              </p>
+            </article>
+            <article class="story-card">
+              <h3>Elevating retail support</h3>
+              <p>
+                A global retailer connected store, chat, and phone insights for a holistic view of customer experience,
+                boosting CSAT and reducing escalations.
+              </p>
+            </article>
+            <article class="story-card">
+              <h3>Reimagining healthcare operations</h3>
+              <p>
+                A telehealth provider linked coaching to patient outcomes, unlocking personalized development paths for
+                clinicians and agents alike.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-content dual-panel">
+          <div class="panel-copy">
+            <h3>What customers appreciate most</h3>
+            <p>
+              The LuminaHQ experience pairs powerful analytics with empathy for the humans delivering customer care. Our
+              partners cite faster insights, stronger accountability, and space to celebrate wins.
+            </p>
+            <div class="testimonial">
+              <strong>Director of CX, Enterprise Retail</strong>
+              “LuminaHQ bridged the gap between our QA analysts and coaches. We finally have a shared story that keeps the
+              entire org in sync.”
+            </div>
+            <div class="navigation-cta">
+              <a class="btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
+              <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Dive into workflows</a>
+            </div>
+          </div>
+          <div class="panel-media">
+            <img
+              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"
+              alt="Team celebrating"
+              loading="lazy"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-content">
+          <div class="section-headline">
+            <h2>Milestones achieved together</h2>
+            <p>
+              Each partnership unlocks measurable impact. Here are a few milestones reached within the first six months
+              of adopting LuminaHQ.
+            </p>
+          </div>
+          <div class="milestone-grid">
+            <div class="milestone-card">
+              <span>+18 pts QA Accuracy</span>
+              Analysts calibrated faster and improved scoring consistency across programs.
+            </div>
+            <div class="milestone-card">
+              <span>-32% Escalations</span>
+              Coaching journeys targeted the right behaviors and reduced customer friction.
+            </div>
+            <div class="milestone-card">
+              <span>+22% Adherence</span>
+              Workforce precision tools aligned scheduling, attendance, and coaching commitments.
+            </div>
+            <div class="milestone-card">
+              <span>3 Week Launch</span>
+              Teams configured modules rapidly with LuminaHQ specialists guiding every step.
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer-shell">
+      <div class="footer-card">
+        <h3>Ready to write your LuminaHQ story?</h3>
+        <p>
+          Partner with us to craft the next chapter of your operations excellence. We’ll tailor the journey to your
+          programs.
+        </p>
+        <div class="footer-links">
+          <a href="Landing.html">Return home</a>
+          <a href="LandingCapabilitiesDetail.html">Workflow details</a>
+          <a href="LandingAbout.html">Meet LuminaHQ</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- adopt the screenshot-inspired hero and metric layout across the landing, about, capabilities, deep dive, and story pages with standalone markup
- introduce a shared landing stylesheet that captures the gradient background, typography, cards, and responsive behaviors for the new look
- remove the previous landing template partial that conflicted with the requested layout

## Testing
- not run (static HTML updates)

------
https://chatgpt.com/codex/tasks/task_e_68f3e72c3e4c83269551fb9623e4e4a0