### PR TITLE
Extend landing theme across related pages

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -8,60 +8,296 @@
     <style>
       .highlight-rows {
         display: grid;
-        gap: 18px;
+        gap: 24px;
       }
 
       .highlight-row {
         display: grid;
-        gap: 18px;
+        gap: 24px;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }
 
       .highlight-row .card {
         min-height: 220px;
+        background: linear-gradient(165deg, rgba(255, 255, 255, 0.95), rgba(228, 240, 255, 0.85));
+        position: relative;
+        overflow: hidden;
+      }
+
+      .highlight-row .card::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top right, rgba(76, 141, 255, 0.2), transparent 55%);
+        pointer-events: none;
+      }
+
+      .insight-layout {
+        display: grid;
+        gap: 28px;
+        grid-template-columns: minmax(280px, 1.2fr) minmax(260px, 0.8fr);
+        align-items: stretch;
+      }
+
+      @media (max-width: 860px) {
+        .insight-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .insight-primary {
+        position: relative;
+        overflow: hidden;
+        padding: 32px;
+        background: linear-gradient(145deg, rgba(255, 255, 255, 0.97) 10%, rgba(219, 235, 255, 0.9) 100%);
+      }
+
+      .insight-primary::before {
+        content: '';
+        position: absolute;
+        top: -40px;
+        right: -40px;
+        width: 220px;
+        height: 220px;
+        border-radius: 50%;
+        background: radial-gradient(circle, rgba(151, 195, 255, 0.4), transparent 70%);
+      }
+
+      .insight-primary h3 {
+        margin: 0 0 12px;
+        color: var(--sky-900);
+      }
+
+      .insight-primary p {
+        margin: 0;
+        color: var(--slate-500);
+        line-height: 1.7;
+      }
+
+      .insight-stack {
+        display: grid;
+        gap: 18px;
+      }
+
+      .stack-card {
+        display: grid;
+        gap: 12px;
+        padding: 22px;
+        border-radius: 22px;
+        background: rgba(255, 255, 255, 0.95);
+        color: var(--slate-500);
+        box-shadow: 0 18px 38px rgba(164, 198, 255, 0.24);
+      }
+
+      .stack-card strong {
+        font-size: 1.4rem;
+        color: var(--sky-600);
+      }
+
+      .stack-bar {
+        position: relative;
+        height: 6px;
+        border-radius: 999px;
+        overflow: hidden;
+        background: rgba(173, 210, 255, 0.24);
+      }
+
+      .stack-bar span {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        border-radius: inherit;
+        background: linear-gradient(120deg, rgba(127, 198, 255, 0.95), rgba(77, 157, 255, 0.85));
       }
 
       .phone-section {
         width: 100%;
         display: flex;
         justify-content: center;
-        padding: 48px 0 24px;
+        padding: 64px 0 32px;
+        background: linear-gradient(180deg, rgba(241, 247, 255, 0.6) 0%, rgba(255, 255, 255, 0.96) 95%);
       }
 
       .phone-grid {
         width: var(--body-width);
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 32px;
+        gap: 40px;
         align-items: center;
       }
 
       .phone-mockups {
+        position: relative;
         display: flex;
         justify-content: center;
-        gap: 24px;
+        gap: 28px;
       }
 
-      .phone-mockups img {
-        width: clamp(160px, 38vw, 210px);
-        border-radius: 36px;
-        box-shadow: 0 18px 40px rgba(12, 32, 80, 0.24);
+      .phone-mockups::before {
+        content: '';
+        position: absolute;
+        inset: 20% 12%;
+        border-radius: 38px;
+        background: linear-gradient(160deg, rgba(139, 181, 255, 0.28), rgba(203, 224, 255, 0.32));
+        filter: blur(0.4px);
+        z-index: 0;
+      }
+
+      .phone-device {
+        position: relative;
+        z-index: 1;
+        width: clamp(160px, 32vw, 220px);
+        aspect-ratio: 9 / 18;
+        border-radius: 42px;
+        padding: 14px;
+        background: linear-gradient(155deg, rgba(255, 255, 255, 0.92), rgba(214, 234, 255, 0.85));
+        box-shadow: 0 24px 44px rgba(164, 198, 255, 0.35);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .phone-device--offset {
+        margin-top: 36px;
+      }
+
+      .phone-device__bezel {
+        width: 100%;
+        height: 100%;
+        border-radius: 32px;
+        background: rgba(255, 255, 255, 0.95);
+        padding: 12px;
+        box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.3);
+        display: flex;
+      }
+
+      .phone-device__screen {
+        width: 100%;
+        border-radius: 26px;
+        background: linear-gradient(180deg, rgba(235, 244, 255, 0.95), rgba(255, 255, 255, 0.96));
+        padding: 16px;
+        display: grid;
+        gap: 14px;
+      }
+
+      .phone-widget {
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.25);
+      }
+
+      .phone-widget--header {
+        height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 16px;
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--sky-600);
+      }
+
+      .phone-widget__dot-group {
+        display: flex;
+        gap: 6px;
+      }
+
+      .phone-widget__dot-group span {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: rgba(127, 198, 255, 0.9);
+      }
+
+      .phone-widget--chart {
+        padding: 16px 12px 18px;
+        display: flex;
+        align-items: flex-end;
+        gap: 10px;
+        background: linear-gradient(180deg, rgba(214, 234, 255, 0.65), rgba(255, 255, 255, 0.95));
+      }
+
+      .phone-widget--chart.is-compact {
+        padding: 14px 12px 16px;
+        gap: 8px;
+      }
+
+      .phone-widget--chart span {
+        flex: 1;
+        border-radius: 10px;
+        background: rgba(173, 210, 255, 0.4);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .phone-widget--chart span::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: var(--height);
+        border-radius: inherit;
+        background: linear-gradient(180deg, rgba(111, 176, 255, 0.95), rgba(77, 157, 255, 0.95));
+      }
+
+      .phone-widget--list {
+        padding: 14px 16px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .phone-widget--list span {
+        height: 10px;
+        border-radius: 999px;
+        background: rgba(173, 210, 255, 0.45);
+      }
+
+      .phone-widget--summary {
+        padding: 16px;
+        display: grid;
+        gap: 12px;
+      }
+
+      .phone-widget--summary strong {
+        font-size: 1.4rem;
+        color: var(--sky-600);
+      }
+
+      .phone-widget--summary small {
+        font-size: 0.75rem;
+        color: var(--slate-500);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .phone-widget__pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(111, 176, 255, 0.16);
+        color: var(--sky-600);
+        font-size: 0.75rem;
+        font-weight: 600;
       }
 
       .phone-copy h3 {
-        color: var(--white);
-        margin: 0 0 16px;
+        color: var(--sky-900);
+        margin: 0 0 18px;
       }
 
       .phone-copy p {
-        color: rgba(226, 235, 255, 0.82);
+        color: var(--slate-500);
         line-height: 1.7;
       }
 
       .phone-copy ul {
-        margin: 18px 0 0;
-        padding-left: 18px;
-        color: rgba(226, 235, 255, 0.82);
+        margin: 20px 0 0;
+        padding-left: 20px;
+        color: var(--slate-500);
       }
     </style>
   </head>
@@ -97,17 +333,87 @@
               </div>
             </div>
             <div class="hero-visual">
-              <img
-                src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
-                alt="LuminaHQ analytics overview"
-                loading="lazy"
-              />
-              <div class="hero-floating-card">
-                <h3>Overview snapshot</h3>
-                <p>
-                  Visualize sentiment, QA trends, and staffing forecasts in one glance so leaders can focus on
-                  coaching moments that matter.
-                </p>
+              <div class="hero-visual-frame">
+                <div class="hero-visual-main">
+                  <div class="chart-visual">
+                    <div class="chart-visual__header">
+                      <span>Team analytics</span>
+                      <span class="chart-visual__period">Q2 overview</span>
+                    </div>
+                    <div class="chart-visual__body">
+                      <div class="chart-visual__line" aria-hidden="true">
+                        <svg viewBox="0 0 220 120" role="presentation">
+                          <defs>
+                            <linearGradient id="chartLineFill" x1="0" x2="0" y1="0" y2="1">
+                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.35)" />
+                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
+                            </linearGradient>
+                            <linearGradient id="chartLineStroke" x1="0" x2="1" y1="0" y2="0">
+                              <stop offset="0%" stop-color="#a8d6ff" />
+                              <stop offset="100%" stop-color="#4d9dff" />
+                            </linearGradient>
+                          </defs>
+                          <polygon
+                            points="0,110 0,78 40,52 80,68 120,38 160,50 200,28 220,110"
+                            fill="url(#chartLineFill)"
+                          ></polygon>
+                          <polyline
+                            points="0,78 40,52 80,68 120,38 160,50 200,28"
+                            fill="none"
+                            stroke="url(#chartLineStroke)"
+                            stroke-width="6"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          ></polyline>
+                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
+                            <circle cx="0" cy="78" r="6"></circle>
+                            <circle cx="40" cy="52" r="6"></circle>
+                            <circle cx="80" cy="68" r="6"></circle>
+                            <circle cx="120" cy="38" r="6"></circle>
+                            <circle cx="160" cy="50" r="6"></circle>
+                            <circle cx="200" cy="28" r="6"></circle>
+                          </g>
+                        </svg>
+                      </div>
+                      <div class="chart-visual__bars">
+                        <span style="--height: 46%"></span>
+                        <span style="--height: 72%"></span>
+                        <span style="--height: 58%"></span>
+                        <span style="--height: 82%"></span>
+                        <span style="--height: 64%"></span>
+                      </div>
+                    </div>
+                    <div class="chart-visual__footer">
+                      <span>Support</span>
+                      <span>Sales</span>
+                      <span>Ops</span>
+                      <span>QA</span>
+                      <span>Training</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--top">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Overview</span>
+                    <span class="hero-widget__value">20 day launch</span>
+                  </div>
+                  <p>Onboard teams faster with templated QA programs and guided walkthroughs.</p>
+                  <div class="hero-widget__spark">
+                    <span style="width: 68%"></span>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--bottom">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Performance</span>
+                    <span class="hero-widget__value">+32%</span>
+                  </div>
+                  <p>Agents meeting or exceeding benchmarks this quarter.</p>
+                  <ul>
+                    <li>QA accuracy</li>
+                    <li>Coaching follow-through</li>
+                    <li>Schedule adherence</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>
@@ -132,6 +438,30 @@
               Bring together the insights your analysts, coaches, and workforce leaders rely on. LuminaHQ overlays
               data visualization with contextual playbooks so every decision is grounded in operational reality.
             </p>
+          </div>
+          <div class="insight-layout">
+            <article class="card insight-primary">
+              <h3>Real-time reporting hub</h3>
+              <p>
+                Align leaders with dashboards that blend QA narratives, performance milestones, and forecasted
+                staffing needs. Surface anomalies instantly and route follow-up tasks to the right owner with
+                automated playbooks.
+              </p>
+            </article>
+            <div class="insight-stack">
+              <article class="stack-card">
+                <span>Coaching completion</span>
+                <strong>88%</strong>
+                <div class="stack-bar"><span style="width: 88%"></span></div>
+                <small>Coaches logging actionable feedback within 48 hours.</small>
+              </article>
+              <article class="stack-card">
+                <span>Quality alignment</span>
+                <strong>94%</strong>
+                <div class="stack-bar"><span style="width: 94%"></span></div>
+                <small>Evaluations calibrated across regions this month.</small>
+              </article>
+            </div>
           </div>
           <div class="highlight-rows">
             <div class="highlight-row">
@@ -183,16 +513,55 @@
       <section class="phone-section">
         <div class="phone-grid">
           <div class="phone-mockups">
-            <img
-              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=500&q=80"
-              alt="Lumina mobile insights"
-              loading="lazy"
-            />
-            <img
-              src="https://images.unsplash.com/photo-1516321497487-e288fb19713f?auto=format&fit=crop&w=500&q=80"
-              alt="Lumina coaching mobile"
-              loading="lazy"
-            />
+            <div class="phone-device">
+              <div class="phone-device__bezel">
+                <div class="phone-device__screen">
+                  <div class="phone-widget phone-widget--header">
+                    <span>Mobile insights</span>
+                    <span class="phone-widget__dot-group">
+                      <span></span>
+                      <span></span>
+                      <span></span>
+                    </span>
+                  </div>
+                  <div class="phone-widget phone-widget--chart">
+                    <span style="--height: 48%"></span>
+                    <span style="--height: 82%"></span>
+                    <span style="--height: 66%"></span>
+                    <span style="--height: 90%"></span>
+                  </div>
+                  <div class="phone-widget phone-widget--list">
+                    <span style="width: 80%"></span>
+                    <span style="width: 65%"></span>
+                    <span style="width: 72%"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="phone-device phone-device--offset">
+              <div class="phone-device__bezel">
+                <div class="phone-device__screen">
+                  <div class="phone-widget phone-widget--header">
+                    <span>Team health</span>
+                    <span class="phone-widget__dot-group">
+                      <span></span>
+                      <span></span>
+                      <span></span>
+                    </span>
+                  </div>
+                  <div class="phone-widget phone-widget--chart is-compact">
+                    <span style="--height: 38%"></span>
+                    <span style="--height: 68%"></span>
+                    <span style="--height: 54%"></span>
+                  </div>
+                  <div class="phone-widget phone-widget--summary">
+                    <small>Focus metric</small>
+                    <strong>92%</strong>
+                    <span class="phone-widget__pill">+4.2% vs last week</span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
           <div class="phone-copy">
             <h3>Designed for every screen size</h3>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -13,15 +13,22 @@
       }
 
       .mission-card {
-        background: rgba(255, 255, 255, 0.96);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
         border-radius: 24px;
-        padding: 24px;
-        box-shadow: 0 18px 38px rgba(16, 34, 84, 0.18);
+        padding: 26px;
+        box-shadow: 0 20px 44px rgba(158, 198, 255, 0.24);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .mission-card h3 {
         margin: 0 0 12px;
         color: var(--sky-900);
+      }
+
+      .mission-card p {
+        margin: 0;
+        color: var(--slate-500);
+        line-height: 1.65;
       }
 
       .timeline {
@@ -30,18 +37,19 @@
       }
 
       .timeline-step {
-        background: rgba(15, 31, 69, 0.65);
-        padding: 24px;
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.9));
+        padding: 26px;
         border-radius: 24px;
-        color: rgba(226, 235, 255, 0.9);
-        box-shadow: 0 18px 36px rgba(15, 31, 69, 0.2);
+        color: var(--slate-500);
+        box-shadow: 0 18px 36px rgba(158, 198, 255, 0.22);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .timeline-step strong {
         display: block;
-        font-size: 1.2rem;
+        font-size: 1.1rem;
         margin-bottom: 8px;
-        color: var(--white);
+        color: var(--sky-600);
       }
 
       .values-grid {
@@ -51,19 +59,29 @@
       }
 
       .values-grid .card {
-        background: rgba(255, 255, 255, 0.92);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(228, 240, 255, 0.85));
+        box-shadow: 0 18px 40px rgba(158, 198, 255, 0.2);
+        border: 1px solid rgba(158, 206, 255, 0.2);
       }
 
-      .team-photo {
-        width: 100%;
-        border-radius: 30px;
-        box-shadow: 0 20px 44px rgba(12, 32, 80, 0.22);
+      .about-hero-chipset {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 8px;
       }
 
-      .hero-floating-card ul {
-        margin: 0;
-        padding-left: 18px;
-        color: var(--slate-500);
+      .about-hero-chipset span {
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(111, 176, 255, 0.18);
+        color: var(--sky-600);
+        font-weight: 600;
+        font-size: 0.75rem;
+      }
+
+      .values-grid .card p {
+        line-height: 1.65;
       }
     </style>
   </head>
@@ -98,20 +116,106 @@
                   <span>product and enablement partnership coverage</span>
                 </div>
               </div>
-            </div>
+              </div>
             <div class="hero-visual">
-              <img
-                src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
-                alt="Team collaboration"
-                loading="lazy"
-              />
-              <div class="hero-floating-card">
-                <h3>What drives us</h3>
-                <ul>
-                  <li>Elevate the craft of quality and coaching professionals.</li>
-                  <li>Create clarity for leaders navigating complex operations.</li>
-                  <li>Design tools that honor the people behind every metric.</li>
-                </ul>
+              <div class="hero-visual-frame">
+                <div class="hero-visual-main">
+                  <div class="chart-visual">
+                    <div class="chart-visual__header">
+                      <span>Team pulse</span>
+                      <span class="chart-visual__period">Culture index</span>
+                    </div>
+                    <div class="chart-visual__body">
+                      <div class="chart-visual__line" aria-hidden="true">
+                        <svg viewBox="0 0 220 120" role="presentation">
+                          <defs>
+                            <linearGradient id="chartLineFillAbout" x1="0" x2="0" y1="0" y2="1">
+                              <stop offset="0%" stop-color="rgba(143, 177, 255, 0.32)" />
+                              <stop offset="100%" stop-color="rgba(143, 177, 255, 0)" />
+                            </linearGradient>
+                            <linearGradient id="chartLineStrokeAbout" x1="0" x2="1" y1="0" y2="0">
+                              <stop offset="0%" stop-color="#a0c9ff" />
+                              <stop offset="100%" stop-color="#4d9dff" />
+                            </linearGradient>
+                          </defs>
+                          <polygon
+                            points="0,110 0,74 44,60 88,50 132,68 176,40 220,52 220,110"
+                            fill="url(#chartLineFillAbout)"
+                          ></polygon>
+                          <polyline
+                            points="0,74 44,60 88,50 132,68 176,40 220,52"
+                            fill="none"
+                            stroke="url(#chartLineStrokeAbout)"
+                            stroke-width="6"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          ></polyline>
+                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
+                            <circle cx="0" cy="74" r="6"></circle>
+                            <circle cx="44" cy="60" r="6"></circle>
+                            <circle cx="88" cy="50" r="6"></circle>
+                            <circle cx="132" cy="68" r="6"></circle>
+                            <circle cx="176" cy="40" r="6"></circle>
+                            <circle cx="220" cy="52" r="6"></circle>
+                          </g>
+                        </svg>
+                      </div>
+                      <div class="chart-visual__bars">
+                        <span style="--height: 76%"></span>
+                        <span style="--height: 62%"></span>
+                        <span style="--height: 84%"></span>
+                        <span style="--height: 58%"></span>
+                        <span style="--height: 90%"></span>
+                      </div>
+                    </div>
+                    <div class="chart-visual__footer">
+                      <span>Belonging</span>
+                      <span>Enablement</span>
+                      <span>Growth</span>
+                      <span>Alignment</span>
+                      <span>Trust</span>
+                    </div>
+                  </div>
+                  <div class="hero-insight-grid">
+                    <div class="hero-insight-card">
+                      <strong>92%</strong>
+                      <span>team feel empowered to act on insights</span>
+                    </div>
+                    <div class="hero-insight-card">
+                      <strong>38 countries</strong>
+                      <span>represented across our customer programs</span>
+                      <div class="hero-chip-list about-hero-chipset">
+                        <span>QA</span>
+                        <span>Coaching</span>
+                        <span>Staffing</span>
+                        <span>Analytics</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--top">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">What drives us</span>
+                    <span class="hero-widget__value">Human first</span>
+                  </div>
+                  <ul>
+                    <li>Elevate the craft of quality and coaching professionals.</li>
+                    <li>Create clarity for leaders navigating complex operations.</li>
+                    <li>Design tools that honor the people behind every metric.</li>
+                  </ul>
+                </div>
+                <div class="hero-widget hero-widget--bottom">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Team snapshots</span>
+                    <span class="hero-widget__value">Weekly</span>
+                  </div>
+                  <p>Dedicated guilds align on research, enablement, and implementation.</p>
+                  <div class="hero-chip-list">
+                    <span>Product studio</span>
+                    <span>Ops research</span>
+                    <span>Enablement crew</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -15,10 +15,11 @@
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         gap: 24px;
-        background: rgba(255, 255, 255, 0.96);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
         border-radius: 26px;
         padding: 32px;
-        box-shadow: 0 20px 48px rgba(12, 32, 80, 0.2);
+        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .capability-card h3 {
@@ -55,13 +56,12 @@
       }
 
       .module-grid .card {
-        background: rgba(255, 255, 255, 0.94);
+        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(224, 237, 255, 0.88));
+        border: 1px solid rgba(158, 206, 255, 0.2);
       }
 
-      .hero-floating-card ul {
-        margin: 0;
-        padding-left: 18px;
-        color: var(--slate-500);
+      .module-grid .card h3 {
+        color: var(--sky-900);
       }
     </style>
   </head>
@@ -95,20 +95,100 @@
                   <span>custom views powered by your data structure</span>
                 </div>
               </div>
-            </div>
+              </div>
             <div class="hero-visual">
-              <img
-                src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
-                alt="Digital dashboards"
-                loading="lazy"
-              />
-              <div class="hero-floating-card">
-                <h3>Platform pillars</h3>
-                <ul>
-                  <li>Unified data foundation that syncs quality, coaching, and staffing signals.</li>
-                  <li>Guided workflows designed by operations experts.</li>
-                  <li>Insight storytelling with shareable narratives.</li>
-                </ul>
+              <div class="hero-visual-frame">
+                <div class="hero-visual-main">
+                  <div class="chart-visual">
+                    <div class="chart-visual__header">
+                      <span>Capability coverage</span>
+                      <span class="chart-visual__period">Launch snapshot</span>
+                    </div>
+                    <div class="chart-visual__body">
+                      <div class="chart-visual__line" aria-hidden="true">
+                        <svg viewBox="0 0 220 120" role="presentation">
+                          <defs>
+                            <linearGradient id="chartLineFillCapabilities" x1="0" x2="0" y1="0" y2="1">
+                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.32)" />
+                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
+                            </linearGradient>
+                            <linearGradient id="chartLineStrokeCapabilities" x1="0" x2="1" y1="0" y2="0">
+                              <stop offset="0%" stop-color="#8fc8ff" />
+                              <stop offset="100%" stop-color="#4d9dff" />
+                            </linearGradient>
+                          </defs>
+                          <polygon
+                            points="0,110 0,82 40,70 80,58 120,66 160,48 200,54 220,110"
+                            fill="url(#chartLineFillCapabilities)"
+                          ></polygon>
+                          <polyline
+                            points="0,82 40,70 80,58 120,66 160,48 200,54"
+                            fill="none"
+                            stroke="url(#chartLineStrokeCapabilities)"
+                            stroke-width="6"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          ></polyline>
+                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
+                            <circle cx="0" cy="82" r="6"></circle>
+                            <circle cx="40" cy="70" r="6"></circle>
+                            <circle cx="80" cy="58" r="6"></circle>
+                            <circle cx="120" cy="66" r="6"></circle>
+                            <circle cx="160" cy="48" r="6"></circle>
+                            <circle cx="200" cy="54" r="6"></circle>
+                          </g>
+                        </svg>
+                      </div>
+                      <div class="chart-visual__bars">
+                        <span style="--height: 78%"></span>
+                        <span style="--height: 64%"></span>
+                        <span style="--height: 88%"></span>
+                        <span style="--height: 72%"></span>
+                        <span style="--height: 60%"></span>
+                      </div>
+                    </div>
+                    <div class="chart-visual__footer">
+                      <span>QA</span>
+                      <span>Coaching</span>
+                      <span>Workforce</span>
+                      <span>Analytics</span>
+                      <span>Enablement</span>
+                    </div>
+                  </div>
+                  <div class="hero-insight-grid">
+                    <div class="hero-insight-card">
+                      <strong>25 playbooks</strong>
+                      <span>preconfigured for fast-tracked implementations</span>
+                    </div>
+                    <div class="hero-insight-card">
+                      <strong>9 automations</strong>
+                      <span>activate out of the box for launch teams</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--top">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Platform pillars</span>
+                    <span class="hero-widget__value">Unified</span>
+                  </div>
+                  <ul>
+                    <li>Data foundation syncing quality, coaching, and staffing.</li>
+                    <li>Guided workflows designed by operations experts.</li>
+                    <li>Insight storytelling with shareable narratives.</li>
+                  </ul>
+                </div>
+                <div class="hero-widget hero-widget--bottom">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Launch focus</span>
+                    <span class="hero-widget__value">30 days</span>
+                  </div>
+                  <p>Template packs unlock immediate value with minimal configuration.</p>
+                  <div class="hero-chip-list">
+                    <span>Guided enablement</span>
+                    <span>Automation boosts</span>
+                    <span>Executive briefs</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -12,12 +12,13 @@
       }
 
       .detail-card {
-        background: rgba(255, 255, 255, 0.96);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
         border-radius: 26px;
-        box-shadow: 0 20px 48px rgba(15, 31, 69, 0.2);
+        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
         padding: 32px;
         display: grid;
         gap: 18px;
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .detail-card h3 {
@@ -44,28 +45,23 @@
       }
 
       .workflow-step {
-        background: rgba(15, 31, 69, 0.7);
+        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.88));
         border-radius: 24px;
-        padding: 24px;
-        color: rgba(226, 235, 255, 0.92);
-        box-shadow: 0 18px 42px rgba(15, 31, 69, 0.22);
+        padding: 26px;
+        color: var(--slate-500);
+        box-shadow: 0 18px 42px rgba(158, 198, 255, 0.24);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .workflow-step strong {
         display: block;
-        color: var(--white);
-        margin-bottom: 8px;
-        font-size: 1.1rem;
+        color: var(--sky-600);
+        margin-bottom: 10px;
+        font-size: 1.05rem;
       }
 
-      .hero-floating-card ol {
-        margin: 0;
-        padding-left: 18px;
-        color: var(--slate-500);
-      }
-
-      .hero-floating-card ol li {
-        margin-bottom: 6px;
+      .workflow-step:last-child {
+        border-style: dashed;
       }
     </style>
   </head>
@@ -99,20 +95,100 @@
                   <span>adoption among pilot supervisors</span>
                 </div>
               </div>
-            </div>
+              </div>
             <div class="hero-visual">
-              <img
-                src="https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1200&q=80"
-                alt="Product dashboards"
-                loading="lazy"
-              />
-              <div class="hero-floating-card">
-                <h3>How teams ramp</h3>
-                <ol>
-                  <li>Discover key dashboards in day-one enablement.</li>
-                  <li>Configure workflows with guided onboarding.</li>
-                  <li>Monitor adoption through real-time health checks.</li>
-                </ol>
+              <div class="hero-visual-frame">
+                <div class="hero-visual-main">
+                  <div class="chart-visual">
+                    <div class="chart-visual__header">
+                      <span>Workflow health</span>
+                      <span class="chart-visual__period">Pilot readiness</span>
+                    </div>
+                    <div class="chart-visual__body">
+                      <div class="chart-visual__line" aria-hidden="true">
+                        <svg viewBox="0 0 220 120" role="presentation">
+                          <defs>
+                            <linearGradient id="chartLineFillCapDetail" x1="0" x2="0" y1="0" y2="1">
+                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.32)" />
+                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
+                            </linearGradient>
+                            <linearGradient id="chartLineStrokeCapDetail" x1="0" x2="1" y1="0" y2="0">
+                              <stop offset="0%" stop-color="#9ecbff" />
+                              <stop offset="100%" stop-color="#4d9dff" />
+                            </linearGradient>
+                          </defs>
+                          <polygon
+                            points="0,110 0,88 44,74 88,64 132,50 176,58 220,46 220,110"
+                            fill="url(#chartLineFillCapDetail)"
+                          ></polygon>
+                          <polyline
+                            points="0,88 44,74 88,64 132,50 176,58 220,46"
+                            fill="none"
+                            stroke="url(#chartLineStrokeCapDetail)"
+                            stroke-width="6"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          ></polyline>
+                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
+                            <circle cx="0" cy="88" r="6"></circle>
+                            <circle cx="44" cy="74" r="6"></circle>
+                            <circle cx="88" cy="64" r="6"></circle>
+                            <circle cx="132" cy="50" r="6"></circle>
+                            <circle cx="176" cy="58" r="6"></circle>
+                            <circle cx="220" cy="46" r="6"></circle>
+                          </g>
+                        </svg>
+                      </div>
+                      <div class="chart-visual__bars">
+                        <span style="--height: 66%"></span>
+                        <span style="--height: 74%"></span>
+                        <span style="--height: 82%"></span>
+                        <span style="--height: 58%"></span>
+                        <span style="--height: 90%"></span>
+                      </div>
+                    </div>
+                    <div class="chart-visual__footer">
+                      <span>Enablement</span>
+                      <span>Configuration</span>
+                      <span>Adoption</span>
+                      <span>Feedback</span>
+                      <span>Outcomes</span>
+                    </div>
+                  </div>
+                  <div class="hero-insight-grid">
+                    <div class="hero-insight-card">
+                      <strong>Day 10</strong>
+                      <span>first executive story delivered to stakeholders</span>
+                    </div>
+                    <div class="hero-insight-card">
+                      <strong>Week 4</strong>
+                      <span>full automation review with success managers</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--top">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">How teams ramp</span>
+                    <span class="hero-widget__value">Guided</span>
+                  </div>
+                  <ol class="hero-ordered">
+                    <li>Discover key dashboards in day-one enablement.</li>
+                    <li>Configure workflows with guided onboarding.</li>
+                    <li>Monitor adoption through real-time health checks.</li>
+                  </ol>
+                </div>
+                <div class="hero-widget hero-widget--bottom">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Enablement squad</span>
+                    <span class="hero-widget__value">Always on</span>
+                  </div>
+                  <p>Specialists partner with supervisors to fine-tune schedules, QA rubrics, and playbooks.</p>
+                  <div class="hero-chip-list">
+                    <span>Implementation</span>
+                    <span>Change management</span>
+                    <span>Ongoing calibrations</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/LandingInteractions.js
+++ b/LandingInteractions.js
@@ -11,7 +11,7 @@
     var revealSelector =
       '.metric-card, .card, .mission-card, .timeline-step, .values-grid .card, .workflow-card, ' +
       '.detail-card, .module-card, .story-card, .persona-card, .playbook-card, .stack-card, ' +
-      '.panel-copy, .panel-media, .phone-mockups img, .hero-floating-card';
+      '.panel-copy, .panel-media, .phone-mockups img, .hero-widget, .hero-insight-card';
 
     var $revealables = $(revealSelector);
 

--- a/LandingSharedStyles.css
+++ b/LandingSharedStyles.css
@@ -1,14 +1,16 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 
 :root {
-  --sky-50: #f3f7ff;
-  --sky-100: #e8f0ff;
-  --sky-200: #cfe0ff;
-  --sky-500: #4c8dff;
-  --sky-600: #2f72f0;
-  --sky-900: #0f1b46;
-  --slate-700: #23324f;
-  --slate-500: #4f5d7a;
+  --sky-50: #f6faff;
+  --sky-100: #edf5ff;
+  --sky-200: #dcecff;
+  --sky-300: #c7e1ff;
+  --sky-400: #9ec7ff;
+  --sky-500: #6fb0ff;
+  --sky-600: #4d9dff;
+  --sky-900: #123a62;
+  --slate-700: #2a3b57;
+  --slate-500: #566684;
   --emerald-400: #4ad4b0;
   --warning-400: #f3b34c;
   --white: #ffffff;
@@ -27,7 +29,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
-  background: linear-gradient(135deg, #0f74ff 0%, #2a52ff 45%, #1a2a60 100%);
+  background: linear-gradient(180deg, var(--sky-50) 0%, var(--white) 65%);
   color: var(--sky-900);
   min-height: 100vh;
 }
@@ -45,23 +47,23 @@ body::after {
   z-index: -1;
   border-radius: 50%;
   filter: blur(0.4px);
-  opacity: 0.85;
+  opacity: 0.7;
 }
 
 body::before {
-  width: 720px;
-  height: 720px;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.45) 0%, rgba(89, 152, 255, 0.2) 55%, transparent 75%);
-  top: -200px;
-  left: -180px;
+  width: 760px;
+  height: 760px;
+  background: radial-gradient(circle at 22% 28%, rgba(158, 206, 255, 0.2) 0%, rgba(255, 255, 255, 0.6) 45%, transparent 75%);
+  top: -220px;
+  left: -160px;
 }
 
 body::after {
   width: 620px;
   height: 620px;
-  background: radial-gradient(circle at center, rgba(74, 212, 176, 0.28) 0%, rgba(24, 48, 112, 0.08) 65%, transparent 80%);
-  bottom: -220px;
-  right: -140px;
+  background: radial-gradient(circle at 78% 72%, rgba(173, 210, 255, 0.28) 0%, rgba(255, 255, 255, 0.55) 55%, transparent 80%);
+  bottom: -200px;
+  right: -120px;
 }
 
 a {
@@ -86,10 +88,10 @@ main {
 
 .hero {
   width: var(--body-width);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(227, 240, 255, 0.94) 100%);
-  border-radius: var(--radius-xl);
-  padding: 56px;
-  box-shadow: var(--shadow-soft);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98) 0%, rgba(233, 242, 255, 0.93) 100%);
+  border-radius: 36px;
+  padding: 64px 64px 56px;
+  box-shadow: 0 26px 70px rgba(66, 118, 188, 0.14);
   position: relative;
   overflow: hidden;
 }
@@ -98,17 +100,17 @@ main {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(76, 141, 255, 0.18) 0%, rgba(74, 212, 176, 0.08) 60%, transparent 100%);
+  background: linear-gradient(125deg, rgba(158, 206, 255, 0.16) 0%, rgba(210, 232, 255, 0.2) 45%, transparent 100%);
   pointer-events: none;
 }
 
 .hero::after {
   content: '';
   position: absolute;
-  width: 360px;
-  height: 360px;
-  background: radial-gradient(circle at center, rgba(74, 212, 176, 0.22) 0%, rgba(74, 212, 176, 0) 70%);
-  top: -160px;
+  width: 340px;
+  height: 340px;
+  background: radial-gradient(circle at center, rgba(189, 221, 255, 0.36) 0%, rgba(189, 221, 255, 0) 70%);
+  top: -120px;
   right: -120px;
   pointer-events: none;
 }
@@ -132,7 +134,7 @@ main {
   gap: 10px;
   padding: 10px 18px;
   border-radius: 999px;
-  background: rgba(74, 212, 176, 0.15);
+  background: rgba(124, 182, 255, 0.16);
   color: var(--sky-600);
   font-weight: 600;
   margin-bottom: 28px;
@@ -161,23 +163,24 @@ main {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--sky-600), #304aff);
+  background: linear-gradient(135deg, #8fc8ff, #4d9dff);
   color: var(--white);
   padding: 14px 28px;
   border-radius: 16px;
   font-weight: 600;
-  box-shadow: 0 12px 24px rgba(37, 92, 221, 0.28);
+  box-shadow: 0 12px 26px rgba(125, 181, 255, 0.32);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .btn-ghost {
-  background: rgba(47, 114, 240, 0.1);
+  background: rgba(255, 255, 255, 0.85);
   color: var(--sky-600);
   padding: 14px 28px;
   border-radius: 16px;
   font-weight: 600;
-  backdrop-filter: blur(6px);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid rgba(109, 167, 255, 0.35);
+  box-shadow: 0 10px 18px rgba(164, 198, 255, 0.22);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .hero-actions a:hover {
@@ -193,10 +196,20 @@ main {
 
 .metric-card {
   min-width: 160px;
-  padding: 16px 18px;
+  padding: 18px 22px;
   border-radius: 20px;
-  background: var(--white);
-  box-shadow: 0 8px 20px rgba(36, 74, 147, 0.12);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 16px 34px rgba(164, 198, 255, 0.26);
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(158, 206, 255, 0.24), transparent 60%);
+  pointer-events: none;
 }
 
 .metric-card strong {
@@ -216,34 +229,272 @@ main {
   z-index: 1;
 }
 
-.hero-visual img {
-  width: 100%;
+.hero-visual-frame {
+  position: relative;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(233, 242, 255, 0.92));
+  padding: 32px;
   border-radius: 28px;
-  box-shadow: 0 25px 60px rgba(15, 33, 80, 0.24);
+  box-shadow: 0 24px 56px rgba(139, 186, 255, 0.24);
+  overflow: hidden;
 }
 
-.hero-floating-card {
+.hero-visual-frame::before {
+  content: '';
   position: absolute;
-  right: 14%;
-  bottom: -6%;
-  background: var(--white);
-  padding: 18px 22px;
-  border-radius: 20px;
-  box-shadow: 0 18px 40px rgba(21, 40, 87, 0.18);
-  width: clamp(220px, 35vw, 260px);
-  animation: floatCard 6s ease-in-out infinite;
+  inset: 18% -40% -24% 45%;
+  background: radial-gradient(circle at top left, rgba(173, 210, 255, 0.22), transparent 70%);
+  pointer-events: none;
 }
 
-.hero-floating-card h3 {
-  margin: 0 0 12px;
-  font-size: 1.05rem;
+.hero-visual-main {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(229, 241, 255, 0.95));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 22px 48px rgba(139, 186, 255, 0.3);
+}
+
+.hero-visual-main img {
+  width: 100%;
+  display: block;
+}
+
+.hero-widget {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.97);
+  border-radius: 20px;
+  padding: 18px 20px;
+  box-shadow: 0 20px 42px rgba(158, 198, 255, 0.25);
+  width: clamp(220px, 32vw, 260px);
+  display: grid;
+  gap: 12px;
+}
+
+.hero-widget--top {
+  top: -36px;
+  left: -24px;
+}
+
+.hero-widget--bottom {
+  bottom: -36px;
+  right: -18px;
+}
+
+.hero-widget__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--slate-500);
+}
+
+.hero-widget__label {
+  font-weight: 600;
+  color: var(--sky-600);
+}
+
+.hero-widget__value {
+  font-weight: 600;
   color: var(--sky-900);
 }
 
-.hero-floating-card p {
+.hero-widget p {
   margin: 0;
-  font-size: 0.9rem;
   color: var(--slate-500);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.hero-widget ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--slate-500);
+  font-size: 0.88rem;
+  display: grid;
+  gap: 6px;
+}
+
+.hero-ordered {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--slate-500);
+  font-size: 0.88rem;
+  display: grid;
+  gap: 6px;
+}
+
+.hero-ordered li {
+  margin: 0;
+}
+
+.hero-insight-grid {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: min(220px, 38%);
+  display: grid;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.hero-insight-card {
+  display: grid;
+  gap: 6px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 18px 36px rgba(158, 198, 255, 0.22);
+  pointer-events: auto;
+}
+
+.hero-insight-card strong {
+  font-size: 1.1rem;
+  color: var(--sky-600);
+}
+
+.hero-insight-card span {
+  color: var(--slate-500);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.hero-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hero-chip-list span {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(143, 177, 255, 0.2);
+  color: var(--sky-600);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.hero-widget__spark {
+  position: relative;
+  height: 6px;
+  background: rgba(173, 210, 255, 0.24);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.hero-widget__spark span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: linear-gradient(120deg, rgba(127, 198, 255, 0.95), rgba(77, 157, 255, 0.85));
+  border-radius: inherit;
+}
+
+.chart-visual {
+  position: relative;
+  display: grid;
+  gap: 20px;
+  padding: 26px 28px 28px;
+  border-radius: 22px;
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.98), rgba(233, 242, 255, 0.88));
+  border: 1px solid rgba(158, 206, 255, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.chart-visual::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border-radius: 18px;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, rgba(158, 206, 255, 0.2), transparent 70%);
+  opacity: 0.7;
+}
+
+.chart-visual__header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--sky-600);
+}
+
+.chart-visual__period {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--slate-500);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+  padding: 6px 12px;
+  box-shadow: 0 8px 18px rgba(158, 206, 255, 0.3);
+}
+
+.chart-visual__body {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 20px;
+}
+
+.chart-visual__line {
+  background: linear-gradient(180deg, rgba(227, 240, 255, 0.65) 0%, rgba(255, 255, 255, 0.95) 100%);
+  border-radius: 18px;
+  padding: 16px 14px 10px;
+  box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.3);
+}
+
+.chart-visual__line svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.chart-visual__bars {
+  display: flex;
+  gap: 14px;
+  align-items: flex-end;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.28);
+}
+
+.chart-visual__bars span {
+  flex: 1;
+  display: block;
+  height: 110px;
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  background: rgba(173, 210, 255, 0.35);
+}
+
+.chart-visual__bars span::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: var(--height);
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(111, 176, 255, 0.9), rgba(77, 157, 255, 0.95));
+  box-shadow: inset 0 -4px 6px rgba(55, 135, 230, 0.2);
+}
+
+.chart-visual__footer {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--slate-500);
+  text-align: center;
 }
 
 .partners {
@@ -260,17 +511,17 @@ main {
   align-items: center;
   gap: 24px;
   padding: 24px 40px;
-  background: rgba(15, 31, 69, 0.32);
-  color: var(--white);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--slate-500);
   border-radius: 20px;
-  backdrop-filter: blur(6px);
+  box-shadow: 0 14px 34px rgba(173, 210, 255, 0.25);
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
 .partner-strip span {
-  opacity: 0.7;
+  opacity: 0.6;
 }
 
 .will-reveal {
@@ -282,16 +533,6 @@ main {
 .will-reveal.is-visible {
   opacity: 1;
   transform: translateY(0);
-}
-
-@keyframes floatCard {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
 }
 
 .section {
@@ -310,7 +551,7 @@ main {
 .section-headline {
   text-align: left;
   max-width: 720px;
-  color: var(--white);
+  color: var(--sky-900);
 }
 
 .section-headline h2 {
@@ -320,7 +561,7 @@ main {
 
 .section-headline p {
   margin: 0;
-  color: rgba(226, 235, 255, 0.85);
+  color: var(--slate-500);
   line-height: 1.7;
 }
 
@@ -331,10 +572,10 @@ main {
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 24px;
-  padding: 24px;
-  box-shadow: 0 14px 34px rgba(15, 31, 69, 0.16);
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: 0 16px 38px rgba(164, 198, 255, 0.2);
 }
 
 .card h3 {
@@ -346,7 +587,7 @@ main {
 .card ul {
   margin: 0;
   color: var(--slate-500);
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
 .card ul {
@@ -366,10 +607,10 @@ main {
 }
 
 .panel-media {
-  background: linear-gradient(160deg, rgba(74, 212, 176, 0.25), rgba(47, 114, 240, 0.15));
+  background: linear-gradient(160deg, rgba(203, 224, 255, 0.6), rgba(255, 255, 255, 0.95));
   border-radius: 30px;
   padding: 36px;
-  box-shadow: 0 16px 36px rgba(18, 55, 148, 0.18);
+  box-shadow: 0 16px 36px rgba(158, 191, 255, 0.22);
 }
 
 .panel-media img {
@@ -379,19 +620,19 @@ main {
 
 .panel-copy h3 {
   margin: 0 0 16px;
-  color: var(--white);
+  color: var(--sky-900);
 }
 
 .panel-copy p {
   margin: 0 0 12px;
-  color: rgba(226, 235, 255, 0.82);
+  color: var(--slate-500);
   line-height: 1.7;
 }
 
 .panel-copy ul {
   margin: 12px 0 0;
   padding-left: 18px;
-  color: rgba(226, 235, 255, 0.82);
+  color: var(--slate-500);
 }
 
 .navigation-cta {
@@ -409,12 +650,13 @@ main {
 
 .footer-card {
   width: var(--body-width);
-  background: rgba(15, 31, 69, 0.72);
+  background: rgba(255, 255, 255, 0.9);
   border-radius: 28px;
   padding: 36px;
-  color: var(--white);
+  color: var(--sky-900);
   display: grid;
   gap: 24px;
+  box-shadow: 0 18px 40px rgba(158, 191, 255, 0.22);
 }
 
 .footer-card h3 {
@@ -431,8 +673,8 @@ main {
 .footer-links a {
   padding: 12px 20px;
   border-radius: 16px;
-  background: rgba(76, 141, 255, 0.18);
-  color: var(--white);
+  background: rgba(143, 177, 255, 0.2);
+  color: var(--sky-600);
   font-weight: 500;
 }
 
@@ -449,11 +691,23 @@ main {
     grid-column: span 12;
   }
 
-  .hero-floating-card {
+  .hero-widget {
     position: relative;
-    right: auto;
-    bottom: auto;
+    inset: auto;
     margin-top: 24px;
+  }
+
+  .hero-visual-frame {
+    padding: 28px;
+  }
+
+  .hero-insight-grid {
+    position: relative;
+    top: auto;
+    right: auto;
+    width: 100%;
+    margin-top: 18px;
+    pointer-events: auto;
   }
 
   .partner-strip {
@@ -478,5 +732,9 @@ main {
   .partner-strip {
     font-size: 0.75rem;
     gap: 12px;
+  }
+
+  .hero-widget {
+    width: 100%;
   }
 }

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -12,10 +12,11 @@
       }
 
       .story-card {
-        background: rgba(255, 255, 255, 0.95);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(224, 237, 255, 0.9));
         padding: 28px;
         border-radius: 26px;
-        box-shadow: 0 20px 48px rgba(15, 31, 69, 0.22);
+        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .story-card h3 {
@@ -30,16 +31,17 @@
       }
 
       .testimonial {
-        background: rgba(15, 31, 69, 0.7);
-        color: rgba(226, 235, 255, 0.9);
+        background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.9));
+        color: var(--slate-500);
         padding: 28px;
         border-radius: 26px;
-        box-shadow: 0 20px 42px rgba(15, 31, 69, 0.24);
+        box-shadow: 0 20px 42px rgba(158, 198, 255, 0.22);
+        border: 1px solid rgba(158, 206, 255, 0.25);
       }
 
       .testimonial strong {
         display: block;
-        color: var(--white);
+        color: var(--sky-600);
         margin-bottom: 12px;
         font-size: 1.05rem;
       }
@@ -51,10 +53,11 @@
       }
 
       .milestone-card {
-        background: rgba(255, 255, 255, 0.92);
+        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(224, 237, 255, 0.88));
         border-radius: 22px;
         padding: 20px;
-        box-shadow: 0 18px 36px rgba(15, 31, 69, 0.18);
+        box-shadow: 0 18px 36px rgba(158, 198, 255, 0.2);
+        border: 1px solid rgba(158, 206, 255, 0.2);
       }
 
       .milestone-card span {
@@ -64,19 +67,25 @@
         margin-bottom: 8px;
       }
 
-      .hero-floating-card blockquote {
+      .panel-media {
+        display: grid;
+        gap: 18px;
+      }
+
+      .hero-quote {
         margin: 0;
         color: var(--slate-500);
         font-style: italic;
         line-height: 1.6;
       }
 
-      .hero-floating-card cite {
+      .hero-quote__cite {
         display: block;
         margin-top: 12px;
         font-style: normal;
         font-weight: 600;
         color: var(--sky-600);
+        font-size: 0.9rem;
       }
     </style>
   </head>
@@ -110,19 +119,100 @@
                   <span>faster rollout of new policy updates</span>
                 </div>
               </div>
-            </div>
+              </div>
             <div class="hero-visual">
-              <img
-                src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
-                alt="Success metrics"
-                loading="lazy"
-              />
-              <div class="hero-floating-card">
-                <blockquote>
-                  “LuminaHQ has become the connective tissue for our global support teams. We make decisions faster, coach
-                  with confidence, and celebrate the wins we would have missed.”
-                </blockquote>
-                <cite>VP of Customer Care, Growth-stage SaaS</cite>
+              <div class="hero-visual-frame">
+                <div class="hero-visual-main">
+                  <div class="chart-visual">
+                    <div class="chart-visual__header">
+                      <span>Story impact</span>
+                      <span class="chart-visual__period">Customer wins</span>
+                    </div>
+                    <div class="chart-visual__body">
+                      <div class="chart-visual__line" aria-hidden="true">
+                        <svg viewBox="0 0 220 120" role="presentation">
+                          <defs>
+                            <linearGradient id="chartLineFillStory" x1="0" x2="0" y1="0" y2="1">
+                              <stop offset="0%" stop-color="rgba(143, 177, 255, 0.32)" />
+                              <stop offset="100%" stop-color="rgba(143, 177, 255, 0)" />
+                            </linearGradient>
+                            <linearGradient id="chartLineStrokeStory" x1="0" x2="1" y1="0" y2="0">
+                              <stop offset="0%" stop-color="#9fc9ff" />
+                              <stop offset="100%" stop-color="#4d9dff" />
+                            </linearGradient>
+                          </defs>
+                          <polygon
+                            points="0,110 0,84 44,68 88,76 132,52 176,62 220,40 220,110"
+                            fill="url(#chartLineFillStory)"
+                          ></polygon>
+                          <polyline
+                            points="0,84 44,68 88,76 132,52 176,62 220,40"
+                            fill="none"
+                            stroke="url(#chartLineStrokeStory)"
+                            stroke-width="6"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          ></polyline>
+                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
+                            <circle cx="0" cy="84" r="6"></circle>
+                            <circle cx="44" cy="68" r="6"></circle>
+                            <circle cx="88" cy="76" r="6"></circle>
+                            <circle cx="132" cy="52" r="6"></circle>
+                            <circle cx="176" cy="62" r="6"></circle>
+                            <circle cx="220" cy="40" r="6"></circle>
+                          </g>
+                        </svg>
+                      </div>
+                      <div class="chart-visual__bars">
+                        <span style="--height: 72%"></span>
+                        <span style="--height: 64%"></span>
+                        <span style="--height: 86%"></span>
+                        <span style="--height: 78%"></span>
+                        <span style="--height: 92%"></span>
+                      </div>
+                    </div>
+                    <div class="chart-visual__footer">
+                      <span>Fintech</span>
+                      <span>Retail</span>
+                      <span>Healthcare</span>
+                      <span>SaaS</span>
+                      <span>Travel</span>
+                    </div>
+                  </div>
+                  <div class="hero-insight-grid">
+                    <div class="hero-insight-card">
+                      <strong>150K+</strong>
+                      <span>agents impacted by LuminaHQ stories</span>
+                    </div>
+                    <div class="hero-insight-card">
+                      <strong>4.8 / 5</strong>
+                      <span>average customer sentiment across partners</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="hero-widget hero-widget--top">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Customer voice</span>
+                    <span class="hero-widget__value">Global</span>
+                  </div>
+                  <blockquote class="hero-quote">
+                    “LuminaHQ has become the connective tissue for our support teams. We coach with confidence and celebrate
+                    wins we once missed.”
+                  </blockquote>
+                  <span class="hero-quote__cite">VP of Customer Care, Growth-stage SaaS</span>
+                </div>
+                <div class="hero-widget hero-widget--bottom">
+                  <div class="hero-widget__meta">
+                    <span class="hero-widget__label">Story formats</span>
+                    <span class="hero-widget__value">Dynamic</span>
+                  </div>
+                  <div class="hero-chip-list">
+                    <span>Executive digest</span>
+                    <span>Program spotlight</span>
+                    <span>Weekly win</span>
+                  </div>
+                  <p>Each format highlights the why behind the metrics with narrative prompts and callouts.</p>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- update the shared landing styles with reusable chart, insight, and widget treatments that match the refreshed light-blue palette
- rebuild the about, capabilities, detail, and story heroes to showcase inline analytics composites and floating widgets instead of photography
- refresh supporting sections and reveal interactions so timelines, cards, and testimonials align with the new gradients and soft shadows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4bcf8202483269391deb875f17c15