### PR TITLE
Refine landing theme across Lumina pages

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -5,422 +5,73 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LuminaHQ – Grow your operations faster</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
-    <style>
-      .highlight-rows {
-        display: grid;
-        gap: 24px;
-      }
-
-      .highlight-row {
-        display: grid;
-        gap: 24px;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .highlight-row .card {
-        min-height: 220px;
-        background: linear-gradient(165deg, rgba(255, 255, 255, 0.95), rgba(228, 240, 255, 0.85));
-        position: relative;
-        overflow: hidden;
-      }
-
-      .highlight-row .card::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: radial-gradient(circle at top right, rgba(76, 141, 255, 0.2), transparent 55%);
-        pointer-events: none;
-      }
-
-      .insight-layout {
-        display: grid;
-        gap: 28px;
-        grid-template-columns: minmax(280px, 1.2fr) minmax(260px, 0.8fr);
-        align-items: stretch;
-      }
-
-      @media (max-width: 860px) {
-        .insight-layout {
-          grid-template-columns: 1fr;
-        }
-      }
-
-      .insight-primary {
-        position: relative;
-        overflow: hidden;
-        padding: 32px;
-        background: linear-gradient(145deg, rgba(255, 255, 255, 0.97) 10%, rgba(219, 235, 255, 0.9) 100%);
-      }
-
-      .insight-primary::before {
-        content: '';
-        position: absolute;
-        top: -40px;
-        right: -40px;
-        width: 220px;
-        height: 220px;
-        border-radius: 50%;
-        background: radial-gradient(circle, rgba(151, 195, 255, 0.4), transparent 70%);
-      }
-
-      .insight-primary h3 {
-        margin: 0 0 12px;
-        color: var(--sky-900);
-      }
-
-      .insight-primary p {
-        margin: 0;
-        color: var(--slate-500);
-        line-height: 1.7;
-      }
-
-      .insight-stack {
-        display: grid;
-        gap: 18px;
-      }
-
-      .stack-card {
-        display: grid;
-        gap: 12px;
-        padding: 22px;
-        border-radius: 22px;
-        background: rgba(255, 255, 255, 0.95);
-        color: var(--slate-500);
-        box-shadow: 0 18px 38px rgba(164, 198, 255, 0.24);
-      }
-
-      .stack-card strong {
-        font-size: 1.4rem;
-        color: var(--sky-600);
-      }
-
-      .stack-bar {
-        position: relative;
-        height: 6px;
-        border-radius: 999px;
-        overflow: hidden;
-        background: rgba(173, 210, 255, 0.24);
-      }
-
-      .stack-bar span {
-        position: absolute;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        border-radius: inherit;
-        background: linear-gradient(120deg, rgba(127, 198, 255, 0.95), rgba(77, 157, 255, 0.85));
-      }
-
-      .phone-section {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        padding: 64px 0 32px;
-        background: linear-gradient(180deg, rgba(241, 247, 255, 0.6) 0%, rgba(255, 255, 255, 0.96) 95%);
-      }
-
-      .phone-grid {
-        width: var(--body-width);
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 40px;
-        align-items: center;
-      }
-
-      .phone-mockups {
-        position: relative;
-        display: flex;
-        justify-content: center;
-        gap: 28px;
-      }
-
-      .phone-mockups::before {
-        content: '';
-        position: absolute;
-        inset: 20% 12%;
-        border-radius: 38px;
-        background: linear-gradient(160deg, rgba(139, 181, 255, 0.28), rgba(203, 224, 255, 0.32));
-        filter: blur(0.4px);
-        z-index: 0;
-      }
-
-      .phone-device {
-        position: relative;
-        z-index: 1;
-        width: clamp(160px, 32vw, 220px);
-        aspect-ratio: 9 / 18;
-        border-radius: 42px;
-        padding: 14px;
-        background: linear-gradient(155deg, rgba(255, 255, 255, 0.92), rgba(214, 234, 255, 0.85));
-        box-shadow: 0 24px 44px rgba(164, 198, 255, 0.35);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .phone-device--offset {
-        margin-top: 36px;
-      }
-
-      .phone-device__bezel {
-        width: 100%;
-        height: 100%;
-        border-radius: 32px;
-        background: rgba(255, 255, 255, 0.95);
-        padding: 12px;
-        box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.3);
-        display: flex;
-      }
-
-      .phone-device__screen {
-        width: 100%;
-        border-radius: 26px;
-        background: linear-gradient(180deg, rgba(235, 244, 255, 0.95), rgba(255, 255, 255, 0.96));
-        padding: 16px;
-        display: grid;
-        gap: 14px;
-      }
-
-      .phone-widget {
-        border-radius: 18px;
-        background: rgba(255, 255, 255, 0.92);
-        box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.25);
-      }
-
-      .phone-widget--header {
-        height: 44px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 16px;
-        font-size: 0.7rem;
-        font-weight: 600;
-        color: var(--sky-600);
-      }
-
-      .phone-widget__dot-group {
-        display: flex;
-        gap: 6px;
-      }
-
-      .phone-widget__dot-group span {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: rgba(127, 198, 255, 0.9);
-      }
-
-      .phone-widget--chart {
-        padding: 16px 12px 18px;
-        display: flex;
-        align-items: flex-end;
-        gap: 10px;
-        background: linear-gradient(180deg, rgba(214, 234, 255, 0.65), rgba(255, 255, 255, 0.95));
-      }
-
-      .phone-widget--chart.is-compact {
-        padding: 14px 12px 16px;
-        gap: 8px;
-      }
-
-      .phone-widget--chart span {
-        flex: 1;
-        border-radius: 10px;
-        background: rgba(173, 210, 255, 0.4);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .phone-widget--chart span::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: var(--height);
-        border-radius: inherit;
-        background: linear-gradient(180deg, rgba(111, 176, 255, 0.95), rgba(77, 157, 255, 0.95));
-      }
-
-      .phone-widget--list {
-        padding: 14px 16px;
-        display: grid;
-        gap: 10px;
-      }
-
-      .phone-widget--list span {
-        height: 10px;
-        border-radius: 999px;
-        background: rgba(173, 210, 255, 0.45);
-      }
-
-      .phone-widget--summary {
-        padding: 16px;
-        display: grid;
-        gap: 12px;
-      }
-
-      .phone-widget--summary strong {
-        font-size: 1.4rem;
-        color: var(--sky-600);
-      }
-
-      .phone-widget--summary small {
-        font-size: 0.75rem;
-        color: var(--slate-500);
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-      }
-
-      .phone-widget__pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 12px;
-        border-radius: 999px;
-        background: rgba(111, 176, 255, 0.16);
-        color: var(--sky-600);
-        font-size: 0.75rem;
-        font-weight: 600;
-      }
-
-      .phone-copy h3 {
-        color: var(--sky-900);
-        margin: 0 0 18px;
-      }
-
-      .phone-copy p {
-        color: var(--slate-500);
-        line-height: 1.7;
-      }
-
-      .phone-copy ul {
-        margin: 20px 0 0;
-        padding-left: 20px;
-        color: var(--slate-500);
-      }
-    </style>
   </head>
   <body>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <ul class="nav-links">
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingStory.html">Stories</a></li>
+          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+        </ul>
+      </nav>
+    </header>
+
     <main>
-      <section class="hero-shell">
-        <div class="hero">
-          <div class="hero-grid">
-            <div class="hero-content">
-              <span class="hero-badge">LuminaHQ Platform</span>
-              <h1>We help your operations grow faster</h1>
-              <p>
-                LuminaHQ centralizes quality, coaching, and workforce intelligence into one modern command
-                center. Align leaders and agents with AI-assisted workflows that accelerate insights into action.
-              </p>
-              <div class="hero-actions">
-                <a class="btn-primary" href="LandingCapabilities.html">Explore capabilities</a>
-                <a class="btn-ghost" href="LandingStory.html">Discover our story</a>
+      <section class="hero" id="home">
+        <div class="hero-content">
+          <div class="hero-text">
+            <span class="hero-badge">LuminaHQ Platform</span>
+            <h1>We help your operations grow faster</h1>
+            <p>
+              LuminaHQ centralizes quality, coaching, and workforce intelligence into one modern command center. Align
+              leaders and agents with AI-assisted workflows that accelerate insights into action.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="#capabilities">Explore capabilities</a>
+              <a class="btn btn-ghost" href="#story">Discover our story</a>
+            </div>
+            <div class="hero-metrics">
+              <div class="metric-card">
+                <strong>20 days</strong>
+                <span>to deploy and see measurable ROI</span>
               </div>
-              <div class="hero-metrics">
-                <div class="metric-card">
-                  <strong data-counter="20" data-suffix=" days">20 days</strong>
-                  <span>to deploy and see measurable ROI</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="30" data-suffix="%">30%</strong>
-                  <span>coaching completion lift across teams</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="12" data-suffix="+">12+</strong>
-                  <span>modules covering QA, coaching, and staffing</span>
-                </div>
+              <div class="metric-card">
+                <strong>30%</strong>
+                <span>coaching completion lift across teams</span>
+              </div>
+              <div class="metric-card">
+                <strong>12+</strong>
+                <span>modules covering QA, coaching, and staffing</span>
               </div>
             </div>
-            <div class="hero-visual">
-              <div class="hero-visual-frame">
-                <div class="hero-visual-main">
-                  <div class="chart-visual">
-                    <div class="chart-visual__header">
-                      <span>Team analytics</span>
-                      <span class="chart-visual__period">Q2 overview</span>
-                    </div>
-                    <div class="chart-visual__body">
-                      <div class="chart-visual__line" aria-hidden="true">
-                        <svg viewBox="0 0 220 120" role="presentation">
-                          <defs>
-                            <linearGradient id="chartLineFill" x1="0" x2="0" y1="0" y2="1">
-                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.35)" />
-                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
-                            </linearGradient>
-                            <linearGradient id="chartLineStroke" x1="0" x2="1" y1="0" y2="0">
-                              <stop offset="0%" stop-color="#a8d6ff" />
-                              <stop offset="100%" stop-color="#4d9dff" />
-                            </linearGradient>
-                          </defs>
-                          <polygon
-                            points="0,110 0,78 40,52 80,68 120,38 160,50 200,28 220,110"
-                            fill="url(#chartLineFill)"
-                          ></polygon>
-                          <polyline
-                            points="0,78 40,52 80,68 120,38 160,50 200,28"
-                            fill="none"
-                            stroke="url(#chartLineStroke)"
-                            stroke-width="6"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          ></polyline>
-                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
-                            <circle cx="0" cy="78" r="6"></circle>
-                            <circle cx="40" cy="52" r="6"></circle>
-                            <circle cx="80" cy="68" r="6"></circle>
-                            <circle cx="120" cy="38" r="6"></circle>
-                            <circle cx="160" cy="50" r="6"></circle>
-                            <circle cx="200" cy="28" r="6"></circle>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="chart-visual__bars">
-                        <span style="--height: 46%"></span>
-                        <span style="--height: 72%"></span>
-                        <span style="--height: 58%"></span>
-                        <span style="--height: 82%"></span>
-                        <span style="--height: 64%"></span>
-                      </div>
-                    </div>
-                    <div class="chart-visual__footer">
-                      <span>Support</span>
-                      <span>Sales</span>
-                      <span>Ops</span>
-                      <span>QA</span>
-                      <span>Training</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--top">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Overview</span>
-                    <span class="hero-widget__value">20 day launch</span>
-                  </div>
-                  <p>Onboard teams faster with templated QA programs and guided walkthroughs.</p>
-                  <div class="hero-widget__spark">
-                    <span style="width: 68%"></span>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--bottom">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Performance</span>
-                    <span class="hero-widget__value">+32%</span>
-                  </div>
-                  <p>Agents meeting or exceeding benchmarks this quarter.</p>
-                  <ul>
-                    <li>QA accuracy</li>
-                    <li>Coaching follow-through</li>
-                    <li>Schedule adherence</li>
-                  </ul>
-                </div>
-              </div>
+          </div>
+          <div class="hero-visual" aria-hidden="true">
+            <div class="floating-card floating-card-main">
+              <h3>Overview snapshot</h3>
+              <p>
+                Visualize sentiment, QA trends, and staffing forecasts in one glance so leaders can focus on coaching
+                moments that matter.
+              </p>
+              <div
+                style="margin-top: 1.5rem; height: 120px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 10px;"
+              ></div>
+            </div>
+            <div class="floating-card floating-card-small">
+              <div
+                style="height: 100px; background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border-radius: 10px; margin-bottom: 1rem;"
+              ></div>
+              <div
+                style="height: 40px; background: linear-gradient(135deg, #ddd6fe 0%, #c4b5fd 100%); border-radius: 10px;"
+              ></div>
             </div>
           </div>
         </div>
       </section>
 
-      <div class="partners">
+      <div class="partners" id="partners">
         <div class="partner-strip">
           <span>Slack</span>
           <span>Netflix</span>
@@ -430,38 +81,14 @@
         </div>
       </div>
 
-      <section class="section">
+      <section class="section" id="capabilities">
         <div class="section-content">
           <div class="section-headline">
             <h2>Measure impressions, reach, and performance with clarity</h2>
             <p>
-              Bring together the insights your analysts, coaches, and workforce leaders rely on. LuminaHQ overlays
-              data visualization with contextual playbooks so every decision is grounded in operational reality.
+              Bring together the insights your analysts, coaches, and workforce leaders rely on. LuminaHQ overlays data
+              visualization with contextual playbooks so every decision is grounded in operational reality.
             </p>
-          </div>
-          <div class="insight-layout">
-            <article class="card insight-primary">
-              <h3>Real-time reporting hub</h3>
-              <p>
-                Align leaders with dashboards that blend QA narratives, performance milestones, and forecasted
-                staffing needs. Surface anomalies instantly and route follow-up tasks to the right owner with
-                automated playbooks.
-              </p>
-            </article>
-            <div class="insight-stack">
-              <article class="stack-card">
-                <span>Coaching completion</span>
-                <strong>88%</strong>
-                <div class="stack-bar"><span style="width: 88%"></span></div>
-                <small>Coaches logging actionable feedback within 48 hours.</small>
-              </article>
-              <article class="stack-card">
-                <span>Quality alignment</span>
-                <strong>94%</strong>
-                <div class="stack-bar"><span style="width: 94%"></span></div>
-                <small>Evaluations calibrated across regions this month.</small>
-              </article>
-            </div>
           </div>
           <div class="highlight-rows">
             <div class="highlight-row">
@@ -502,7 +129,8 @@
               <article class="card">
                 <h3>Secure collaboration</h3>
                 <p>
-                  Role-based spaces ensure partners, clients, and internal teams have the right context at the right time.
+                  Role-based spaces ensure partners, clients, and internal teams have the right context at the right
+                  time.
                 </p>
               </article>
             </div>
@@ -510,55 +138,28 @@
         </div>
       </section>
 
-      <section class="phone-section">
+      <section class="phone-section" id="story">
         <div class="phone-grid">
-          <div class="phone-mockups">
-            <div class="phone-device">
-              <div class="phone-device__bezel">
-                <div class="phone-device__screen">
-                  <div class="phone-widget phone-widget--header">
-                    <span>Mobile insights</span>
-                    <span class="phone-widget__dot-group">
-                      <span></span>
-                      <span></span>
-                      <span></span>
-                    </span>
-                  </div>
-                  <div class="phone-widget phone-widget--chart">
-                    <span style="--height: 48%"></span>
-                    <span style="--height: 82%"></span>
-                    <span style="--height: 66%"></span>
-                    <span style="--height: 90%"></span>
-                  </div>
-                  <div class="phone-widget phone-widget--list">
-                    <span style="width: 80%"></span>
-                    <span style="width: 65%"></span>
-                    <span style="width: 72%"></span>
-                  </div>
+          <div class="phone-mockups" aria-hidden="true">
+            <div class="phone-mockup">
+              <div class="phone-screen">
+                <div style="padding: 20px">
+                  <div style="height: 60px; background: #ffffff; border-radius: 10px; margin-bottom: 15px"></div>
+                  <div
+                    style="height: 150px; background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%); border-radius: 10px; margin-bottom: 15px"
+                  ></div>
+                  <div style="height: 80px; background: #ffffff; border-radius: 10px"></div>
                 </div>
               </div>
             </div>
-            <div class="phone-device phone-device--offset">
-              <div class="phone-device__bezel">
-                <div class="phone-device__screen">
-                  <div class="phone-widget phone-widget--header">
-                    <span>Team health</span>
-                    <span class="phone-widget__dot-group">
-                      <span></span>
-                      <span></span>
-                      <span></span>
-                    </span>
-                  </div>
-                  <div class="phone-widget phone-widget--chart is-compact">
-                    <span style="--height: 38%"></span>
-                    <span style="--height: 68%"></span>
-                    <span style="--height: 54%"></span>
-                  </div>
-                  <div class="phone-widget phone-widget--summary">
-                    <small>Focus metric</small>
-                    <strong>92%</strong>
-                    <span class="phone-widget__pill">+4.2% vs last week</span>
-                  </div>
+            <div class="phone-mockup">
+              <div class="phone-screen">
+                <div style="padding: 20px">
+                  <div
+                    style="height: 100px; background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%); border-radius: 10px; margin-bottom: 15px"
+                  ></div>
+                  <div style="height: 100px; background: #ffffff; border-radius: 10px; margin-bottom: 15px"></div>
+                  <div style="height: 80px; background: #ffffff; border-radius: 10px"></div>
                 </div>
               </div>
             </div>
@@ -578,20 +179,20 @@
         </div>
       </section>
 
-      <section class="section">
+      <section class="section" id="more">
         <div class="section-content">
           <div class="section-headline">
             <h2>Ready to dive deeper?</h2>
             <p>
-              Explore how LuminaHQ aligns teams from onboarding through continuous optimization. Every page in our
-              landing suite expands on the modules, stories, and playbooks available to your operation.
+              Explore how LuminaHQ aligns teams from onboarding through continuous optimization. Every page in our suite
+              expands on the modules, stories, and playbooks available to your operation.
             </p>
           </div>
           <div class="navigation-cta">
-            <a class="btn-ghost" href="LandingAbout.html">About LuminaHQ</a>
-            <a class="btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
-            <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Dive into details</a>
-            <a class="btn-ghost" href="LandingStory.html">Discover our story</a>
+            <a class="btn btn-ghost" href="LandingAbout.html">About LuminaHQ</a>
+            <a class="btn btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
+            <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Dive into details</a>
+            <a class="btn btn-ghost" href="LandingStory.html">Discover our story</a>
           </div>
         </div>
       </section>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -5,219 +5,58 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About LuminaHQ</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
-    <style>
-      .mission-grid {
-        display: grid;
-        gap: 24px;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      }
-
-      .mission-card {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
-        border-radius: 24px;
-        padding: 26px;
-        box-shadow: 0 20px 44px rgba(158, 198, 255, 0.24);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .mission-card h3 {
-        margin: 0 0 12px;
-        color: var(--sky-900);
-      }
-
-      .mission-card p {
-        margin: 0;
-        color: var(--slate-500);
-        line-height: 1.65;
-      }
-
-      .timeline {
-        display: grid;
-        gap: 18px;
-      }
-
-      .timeline-step {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.9));
-        padding: 26px;
-        border-radius: 24px;
-        color: var(--slate-500);
-        box-shadow: 0 18px 36px rgba(158, 198, 255, 0.22);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .timeline-step strong {
-        display: block;
-        font-size: 1.1rem;
-        margin-bottom: 8px;
-        color: var(--sky-600);
-      }
-
-      .values-grid {
-        display: grid;
-        gap: 18px;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      }
-
-      .values-grid .card {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(228, 240, 255, 0.85));
-        box-shadow: 0 18px 40px rgba(158, 198, 255, 0.2);
-        border: 1px solid rgba(158, 206, 255, 0.2);
-      }
-
-      .about-hero-chipset {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        margin-top: 8px;
-      }
-
-      .about-hero-chipset span {
-        padding: 6px 12px;
-        border-radius: 999px;
-        background: rgba(111, 176, 255, 0.18);
-        color: var(--sky-600);
-        font-weight: 600;
-        font-size: 0.75rem;
-      }
-
-      .values-grid .card p {
-        line-height: 1.65;
-      }
-    </style>
   </head>
   <body>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <ul class="nav-links">
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingStory.html">Stories</a></li>
+          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+        </ul>
+      </nav>
+    </header>
+
     <main>
-      <section class="hero-shell">
-        <div class="hero">
-          <div class="hero-grid">
-            <div class="hero-content">
-              <span class="hero-badge">About LuminaHQ</span>
-              <h1>Building the modern nerve center for operations teams</h1>
-              <p>
-                LuminaHQ began with a simple belief: that quality, coaching, and workforce leaders deserve a single
-                workspace that reflects the pace of their teams. Our mission is to amplify every conversation,
-                evaluation, and schedule with intelligence.
-              </p>
-              <div class="hero-actions">
-                <a class="btn-primary" href="Landing.html">Return to landing</a>
-                <a class="btn-ghost" href="LandingStory.html">Read customer stories</a>
+      <section class="page-hero">
+        <div class="page-hero-content">
+          <div class="page-hero-text">
+            <span class="page-hero-badge">About LuminaHQ</span>
+            <h1>Building the modern nerve center for operations teams</h1>
+            <p>
+              LuminaHQ began with a simple belief: that quality, coaching, and workforce leaders deserve a single
+              workspace that reflects the pace of their teams. Our mission is to amplify every conversation, evaluation,
+              and schedule with intelligence.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="Landing.html">Return to landing</a>
+              <a class="btn btn-ghost" href="LandingStory.html">Read customer stories</a>
+            </div>
+            <div class="hero-metrics">
+              <div class="metric-card">
+                <strong data-counter="50" data-suffix="+">50+</strong>
+                <span>specialists crafting LuminaHQ features</span>
               </div>
-              <div class="hero-metrics">
-                <div class="metric-card">
-                  <strong data-counter="50" data-suffix="+">50+</strong>
-                  <span>specialists crafting LuminaHQ features</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="8" data-suffix=" years">8 years</strong>
-                  <span>supporting global customer operations</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="24" data-suffix="/5">24/5</strong>
-                  <span>product and enablement partnership coverage</span>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="8" data-suffix=" years">8 years</strong>
+                <span>supporting global customer operations</span>
               </div>
-              </div>
-            <div class="hero-visual">
-              <div class="hero-visual-frame">
-                <div class="hero-visual-main">
-                  <div class="chart-visual">
-                    <div class="chart-visual__header">
-                      <span>Team pulse</span>
-                      <span class="chart-visual__period">Culture index</span>
-                    </div>
-                    <div class="chart-visual__body">
-                      <div class="chart-visual__line" aria-hidden="true">
-                        <svg viewBox="0 0 220 120" role="presentation">
-                          <defs>
-                            <linearGradient id="chartLineFillAbout" x1="0" x2="0" y1="0" y2="1">
-                              <stop offset="0%" stop-color="rgba(143, 177, 255, 0.32)" />
-                              <stop offset="100%" stop-color="rgba(143, 177, 255, 0)" />
-                            </linearGradient>
-                            <linearGradient id="chartLineStrokeAbout" x1="0" x2="1" y1="0" y2="0">
-                              <stop offset="0%" stop-color="#a0c9ff" />
-                              <stop offset="100%" stop-color="#4d9dff" />
-                            </linearGradient>
-                          </defs>
-                          <polygon
-                            points="0,110 0,74 44,60 88,50 132,68 176,40 220,52 220,110"
-                            fill="url(#chartLineFillAbout)"
-                          ></polygon>
-                          <polyline
-                            points="0,74 44,60 88,50 132,68 176,40 220,52"
-                            fill="none"
-                            stroke="url(#chartLineStrokeAbout)"
-                            stroke-width="6"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          ></polyline>
-                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
-                            <circle cx="0" cy="74" r="6"></circle>
-                            <circle cx="44" cy="60" r="6"></circle>
-                            <circle cx="88" cy="50" r="6"></circle>
-                            <circle cx="132" cy="68" r="6"></circle>
-                            <circle cx="176" cy="40" r="6"></circle>
-                            <circle cx="220" cy="52" r="6"></circle>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="chart-visual__bars">
-                        <span style="--height: 76%"></span>
-                        <span style="--height: 62%"></span>
-                        <span style="--height: 84%"></span>
-                        <span style="--height: 58%"></span>
-                        <span style="--height: 90%"></span>
-                      </div>
-                    </div>
-                    <div class="chart-visual__footer">
-                      <span>Belonging</span>
-                      <span>Enablement</span>
-                      <span>Growth</span>
-                      <span>Alignment</span>
-                      <span>Trust</span>
-                    </div>
-                  </div>
-                  <div class="hero-insight-grid">
-                    <div class="hero-insight-card">
-                      <strong>92%</strong>
-                      <span>team feel empowered to act on insights</span>
-                    </div>
-                    <div class="hero-insight-card">
-                      <strong>38 countries</strong>
-                      <span>represented across our customer programs</span>
-                      <div class="hero-chip-list about-hero-chipset">
-                        <span>QA</span>
-                        <span>Coaching</span>
-                        <span>Staffing</span>
-                        <span>Analytics</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--top">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">What drives us</span>
-                    <span class="hero-widget__value">Human first</span>
-                  </div>
-                  <ul>
-                    <li>Elevate the craft of quality and coaching professionals.</li>
-                    <li>Create clarity for leaders navigating complex operations.</li>
-                    <li>Design tools that honor the people behind every metric.</li>
-                  </ul>
-                </div>
-                <div class="hero-widget hero-widget--bottom">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Team snapshots</span>
-                    <span class="hero-widget__value">Weekly</span>
-                  </div>
-                  <p>Dedicated guilds align on research, enablement, and implementation.</p>
-                  <div class="hero-chip-list">
-                    <span>Product studio</span>
-                    <span>Ops research</span>
-                    <span>Enablement crew</span>
-                  </div>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="24" data-suffix="/5">24/5</strong>
+                <span>product and enablement partnership coverage</span>
               </div>
             </div>
+          </div>
+          <div class="hero-side-card">
+            <h3>What drives us</h3>
+            <p>Dedicated guilds align across research, enablement, and implementation to keep teams future ready.</p>
+            <ul class="detail-list">
+              <li>Elevate the craft of quality and coaching professionals.</li>
+              <li>Create clarity for leaders navigating complex operations.</li>
+              <li>Design tools that honor the people behind every metric.</li>
+            </ul>
           </div>
         </div>
       </section>
@@ -232,32 +71,32 @@
         </div>
       </div>
 
-      <section class="section">
-        <div class="section-content">
-          <div class="section-headline">
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="section-headline section-headline--left">
             <h2>Our mission and promise</h2>
             <p>
-              From the first calibration to enterprise-scale rollouts, LuminaHQ pairs attentive experts with a
-              product built for evolving customer experiences. We map workflows directly to your playbooks so your
-              teams can focus on the human moments.
+              From the first calibration to enterprise-scale rollouts, LuminaHQ pairs attentive experts with a product
+              built for evolving customer experiences. We map workflows directly to your playbooks so your teams can
+              focus on the human moments.
             </p>
           </div>
-          <div class="mission-grid">
-            <article class="mission-card">
+          <div class="feature-grid">
+            <article class="card">
               <h3>Human-centered design</h3>
               <p>
                 Every feature is crafted with direct input from analysts, coaches, and workforce leaders who depend on
                 LuminaHQ each day.
               </p>
             </article>
-            <article class="mission-card">
+            <article class="card">
               <h3>Operational empathy</h3>
               <p>
                 We embed alongside your teams to understand the nuance behind each metric and deliver playbooks that
                 reflect it.
               </p>
             </article>
-            <article class="mission-card">
+            <article class="card">
               <h3>Reliable partnership</h3>
               <p>
                 Dedicated onboarding, enablement, and success specialists ensure LuminaHQ evolves with your programs.
@@ -265,49 +104,48 @@
             </article>
           </div>
         </div>
-      </div>
+      </section>
 
-      <section class="section">
-        <div class="section-content">
-          <div class="section-headline">
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="section-headline section-headline--left">
             <h2>The journey so far</h2>
             <p>
               LuminaHQ has grown through close collaboration with support teams across industries. Together we have
               transformed manual spreadsheets into guided journeys that celebrate progress.
             </p>
           </div>
-          <div class="timeline">
-            <div class="timeline-step">
-              <strong>2016 – Foundations</strong>
-              Started as a small collective of QA specialists developing tooling to streamline evaluations and
-              calibrations.
-            </div>
-            <div class="timeline-step">
-              <strong>2018 – Coaching unlock</strong>
-              Introduced guided coaching workflows that connected QA results to personalized development paths.
-            </div>
-            <div class="timeline-step">
-              <strong>2021 – Workforce fusion</strong>
-              Unified staffing, attendance, and performance data to create a cohesive operations command center.
-            </div>
-            <div class="timeline-step">
-              <strong>Today – Continuous momentum</strong>
-              Expanding AI assistance, predictive insights, and integrations to keep teams future-ready.
-            </div>
+          <div class="timeline-grid">
+            <article class="card">
+              <h3>2016 – Foundations</h3>
+              <p>Started as a collective of QA specialists streamlining evaluations and calibrations.</p>
+            </article>
+            <article class="card">
+              <h3>2018 – Coaching unlock</h3>
+              <p>Introduced guided coaching workflows connecting QA results to personalized development paths.</p>
+            </article>
+            <article class="card">
+              <h3>2021 – Workforce fusion</h3>
+              <p>Unified staffing, attendance, and performance data into a cohesive operations command center.</p>
+            </article>
+            <article class="card">
+              <h3>Today – Continuous momentum</h3>
+              <p>Expanding AI assistance, predictive insights, and integrations to keep teams future-ready.</p>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content">
-          <div class="section-headline">
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="section-headline section-headline--left">
             <h2>Values we live by</h2>
             <p>
-              Our values guide how we show up for each other and for our customers. They ensure LuminaHQ remains a
-              trusted partner as the landscape evolves.
+              Our values guide how we show up for each other and for our customers. They ensure LuminaHQ remains a trusted
+              partner as the landscape evolves.
             </p>
           </div>
-          <div class="values-grid">
+          <div class="feature-grid">
             <article class="card">
               <h3>Listen deeply</h3>
               <p>We start by understanding the people behind the process before proposing any change.</p>
@@ -328,33 +166,37 @@
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content dual-panel">
-          <div class="panel-media">
-            <img
-              class="team-photo"
-              src="https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=1200&q=80"
-              alt="LuminaHQ team workshop"
-              loading="lazy"
-            />
-          </div>
-          <div class="panel-copy">
-            <h3>Meet the people behind the platform</h3>
-            <p>
-              Product strategists, data scientists, operations veterans, and service designers collaborate daily to
-              shape LuminaHQ. We carry the same passion for customer experience that defines your teams.
-            </p>
-            <p>
-              When you partner with LuminaHQ, you work with people invested in your success—from onboarding through
-              every new capability release.
-            </p>
-            <div class="navigation-cta">
-              <a class="btn-ghost" href="LandingCapabilities.html">See capabilities</a>
-              <a class="btn-ghost" href="LandingStory.html">Explore customer journey</a>
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="split-grid">
+            <div class="image-frame">
+              <img
+                src="https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=1200&q=80"
+                alt="LuminaHQ team workshop"
+                loading="lazy"
+              />
+            </div>
+            <div>
+              <div class="section-headline section-headline--left" style="margin-bottom: 1.5rem">
+                <h2>Meet the people behind the platform</h2>
+                <p>
+                  Product strategists, data scientists, operations veterans, and service designers collaborate daily to
+                  shape LuminaHQ. We carry the same passion for customer experience that defines your teams.
+                </p>
+              </div>
+              <p>
+                When you partner with LuminaHQ, you work with people invested in your success—from onboarding through
+                every new capability release.
+              </p>
+              <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
+                <a class="btn btn-ghost" href="LandingCapabilities.html">See capabilities</a>
+                <a class="btn btn-ghost" href="LandingStory.html">Explore customer journey</a>
+              </div>
             </div>
           </div>
         </div>
       </section>
+    </main>
 
     <footer class="footer-shell">
       <div class="footer-card">

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -5,192 +5,57 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Explore LuminaHQ Capabilities</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
-    <style>
-      .capability-stack {
-        display: grid;
-        gap: 24px;
-      }
-
-      .capability-card {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 24px;
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
-        border-radius: 26px;
-        padding: 32px;
-        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .capability-card h3 {
-        margin: 0;
-        color: var(--sky-900);
-      }
-
-      .capability-card p {
-        margin: 12px 0 0;
-        color: var(--slate-500);
-        line-height: 1.6;
-      }
-
-      .badge-list {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-        margin-top: 16px;
-      }
-
-      .badge-list span {
-        padding: 10px 16px;
-        border-radius: 999px;
-        background: rgba(76, 141, 255, 0.16);
-        color: var(--sky-600);
-        font-weight: 500;
-        font-size: 0.85rem;
-      }
-
-      .module-grid {
-        display: grid;
-        gap: 24px;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      }
-
-      .module-grid .card {
-        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(224, 237, 255, 0.88));
-        border: 1px solid rgba(158, 206, 255, 0.2);
-      }
-
-      .module-grid .card h3 {
-        color: var(--sky-900);
-      }
-    </style>
   </head>
   <body>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <ul class="nav-links">
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingStory.html">Stories</a></li>
+          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+        </ul>
+      </nav>
+    </header>
+
     <main>
-      <section class="hero-shell">
-        <div class="hero">
-          <div class="hero-grid">
-            <div class="hero-content">
-              <span class="hero-badge">Capabilities</span>
-              <h1>Everything your operations teams need in one workspace</h1>
-              <p>
-                LuminaHQ streamlines dozens of manual processes into intuitive flows. Explore how our modules combine to
-                produce measurable improvements in quality, coaching, and workforce planning.
-              </p>
-              <div class="hero-actions">
-                <a class="btn-primary" href="LandingCapabilitiesDetail.html">Dive into detail</a>
-                <a class="btn-ghost" href="LandingAbout.html">Learn about our team</a>
+      <section class="page-hero">
+        <div class="page-hero-content">
+          <div class="page-hero-text">
+            <span class="page-hero-badge">Capabilities</span>
+            <h1>Everything your operations teams need in one workspace</h1>
+            <p>
+              LuminaHQ streamlines dozens of manual processes into intuitive flows. Explore how our modules combine to
+              produce measurable improvements in quality, coaching, and workforce planning.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="LandingCapabilitiesDetail.html">Dive into detail</a>
+              <a class="btn btn-ghost" href="LandingAbout.html">Learn about our team</a>
+            </div>
+            <div class="hero-metrics">
+              <div class="metric-card">
+                <strong data-counter="360" data-suffix="°">360°</strong>
+                <span>coverage of QA, coaching, and workforce cycles</span>
               </div>
-              <div class="hero-metrics">
-                <div class="metric-card">
-                  <strong data-counter="360" data-suffix="°">360°</strong>
-                  <span>coverage of QA, coaching, and workforce cycles</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="9">9</strong>
-                  <span>automation blueprints included on launch</span>
-                </div>
-                <div class="metric-card">
-                  <strong>Unlimited</strong>
-                  <span>custom views powered by your data structure</span>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="9">9</strong>
+                <span>automation blueprints included on launch</span>
               </div>
-              </div>
-            <div class="hero-visual">
-              <div class="hero-visual-frame">
-                <div class="hero-visual-main">
-                  <div class="chart-visual">
-                    <div class="chart-visual__header">
-                      <span>Capability coverage</span>
-                      <span class="chart-visual__period">Launch snapshot</span>
-                    </div>
-                    <div class="chart-visual__body">
-                      <div class="chart-visual__line" aria-hidden="true">
-                        <svg viewBox="0 0 220 120" role="presentation">
-                          <defs>
-                            <linearGradient id="chartLineFillCapabilities" x1="0" x2="0" y1="0" y2="1">
-                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.32)" />
-                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
-                            </linearGradient>
-                            <linearGradient id="chartLineStrokeCapabilities" x1="0" x2="1" y1="0" y2="0">
-                              <stop offset="0%" stop-color="#8fc8ff" />
-                              <stop offset="100%" stop-color="#4d9dff" />
-                            </linearGradient>
-                          </defs>
-                          <polygon
-                            points="0,110 0,82 40,70 80,58 120,66 160,48 200,54 220,110"
-                            fill="url(#chartLineFillCapabilities)"
-                          ></polygon>
-                          <polyline
-                            points="0,82 40,70 80,58 120,66 160,48 200,54"
-                            fill="none"
-                            stroke="url(#chartLineStrokeCapabilities)"
-                            stroke-width="6"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          ></polyline>
-                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
-                            <circle cx="0" cy="82" r="6"></circle>
-                            <circle cx="40" cy="70" r="6"></circle>
-                            <circle cx="80" cy="58" r="6"></circle>
-                            <circle cx="120" cy="66" r="6"></circle>
-                            <circle cx="160" cy="48" r="6"></circle>
-                            <circle cx="200" cy="54" r="6"></circle>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="chart-visual__bars">
-                        <span style="--height: 78%"></span>
-                        <span style="--height: 64%"></span>
-                        <span style="--height: 88%"></span>
-                        <span style="--height: 72%"></span>
-                        <span style="--height: 60%"></span>
-                      </div>
-                    </div>
-                    <div class="chart-visual__footer">
-                      <span>QA</span>
-                      <span>Coaching</span>
-                      <span>Workforce</span>
-                      <span>Analytics</span>
-                      <span>Enablement</span>
-                    </div>
-                  </div>
-                  <div class="hero-insight-grid">
-                    <div class="hero-insight-card">
-                      <strong>25 playbooks</strong>
-                      <span>preconfigured for fast-tracked implementations</span>
-                    </div>
-                    <div class="hero-insight-card">
-                      <strong>9 automations</strong>
-                      <span>activate out of the box for launch teams</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--top">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Platform pillars</span>
-                    <span class="hero-widget__value">Unified</span>
-                  </div>
-                  <ul>
-                    <li>Data foundation syncing quality, coaching, and staffing.</li>
-                    <li>Guided workflows designed by operations experts.</li>
-                    <li>Insight storytelling with shareable narratives.</li>
-                  </ul>
-                </div>
-                <div class="hero-widget hero-widget--bottom">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Launch focus</span>
-                    <span class="hero-widget__value">30 days</span>
-                  </div>
-                  <p>Template packs unlock immediate value with minimal configuration.</p>
-                  <div class="hero-chip-list">
-                    <span>Guided enablement</span>
-                    <span>Automation boosts</span>
-                    <span>Executive briefs</span>
-                  </div>
-                </div>
+              <div class="metric-card">
+                <strong>Unlimited</strong>
+                <span>custom views powered by your data structure</span>
               </div>
             </div>
+          </div>
+          <div class="hero-side-card">
+            <h3>Platform pillars</h3>
+            <p>Templates and automations accelerate deployment while honoring your unique workflows.</p>
+            <ul class="detail-list">
+              <li>Data foundation syncing quality, coaching, and staffing.</li>
+              <li>Guided workflows designed by operations experts.</li>
+              <li>Insight storytelling with shareable narratives.</li>
+            </ul>
           </div>
         </div>
       </section>
@@ -205,8 +70,8 @@
         </div>
       </div>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Capability snapshots</h2>
             <p>
@@ -214,86 +79,55 @@
               aligns with your workflows.
             </p>
           </div>
-          <div class="capability-stack">
-            <div class="capability-card">
-              <div>
-                <h3>Quality intelligence</h3>
-                <p>
-                  Capture evaluations, calibrate analysts, and surface key drivers instantly. LuminaHQ keeps quality
-                  leaders connected to the context behind every score.
-                </p>
-                <div class="badge-list">
-                  <span>Evaluation builder</span>
-                  <span>Calibration studio</span>
-                  <span>Insights stories</span>
-                </div>
-              </div>
-              <div>
-                <h3>Coaching activations</h3>
-                <p>
-                  Automate coaching cadences and keep commitments visible. Agents sign off on action plans directly
-                  inside LuminaHQ.
-                </p>
-                <div class="badge-list">
-                  <span>Coaching briefs</span>
-                  <span>Task follow-up</span>
-                  <span>Acknowledgments</span>
-                </div>
-              </div>
-              <div>
-                <h3>Workforce precision</h3>
-                <p>
-                  Pair attendance monitoring with schedule modeling to deliver reliable staffing coverage while honoring
-                  agent preferences.
-                </p>
-                <div class="badge-list">
-                  <span>Forecast builder</span>
-                  <span>Attendance center</span>
-                  <span>Shift marketplace</span>
-                </div>
-              </div>
-            </div>
-            <div class="capability-card">
-              <div>
-                <h3>Performance storytelling</h3>
-                <p>
-                  Transform dashboards into narratives that leaders and partners can act on immediately.
-                </p>
-                <div class="badge-list">
-                  <span>Executive digest</span>
-                  <span>Campaign rollups</span>
-                  <span>Shareable reports</span>
-                </div>
-              </div>
-              <div>
-                <h3>Knowledge continuity</h3>
-                <p>
-                  Link policy references, training roadmaps, and announcements so teams stay aligned through change.
-                </p>
-                <div class="badge-list">
-                  <span>Resource hub</span>
-                  <span>Launch checklists</span>
-                  <span>Microlearning</span>
-                </div>
-              </div>
-              <div>
-                <h3>Collaboration fabric</h3>
-                <p>
-                  Bring QA analysts, coaches, and leadership into shared conversations without leaving LuminaHQ.
-                </p>
-                <div class="badge-list">
-                  <span>Comment threads</span>
-                  <span>Escalation links</span>
-                  <span>Partner access</span>
-                </div>
-              </div>
-            </div>
+          <div class="feature-grid">
+            <article class="card">
+              <h3>Quality intelligence</h3>
+              <p>
+                Capture evaluations, calibrate analysts, and surface key drivers instantly so quality leaders stay
+                connected to the context behind every score.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Coaching activations</h3>
+              <p>
+                Automate coaching cadences and keep commitments visible. Agents sign off on action plans directly inside
+                LuminaHQ.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Workforce precision</h3>
+              <p>
+                Pair attendance monitoring with schedule modeling to deliver reliable staffing coverage while honoring
+                agent preferences.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Performance storytelling</h3>
+              <p>
+                Transform dashboards into narratives that leaders and partners can act on immediately across programs and
+                vendors.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Knowledge continuity</h3>
+              <p>
+                Link policy references, training roadmaps, and announcements so teams stay aligned through change and
+                growth.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Collaboration fabric</h3>
+              <p>
+                Bring QA analysts, coaches, and leadership into shared conversations without leaving the LuminaHQ
+                workspace.
+              </p>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Modular architecture</h2>
             <p>
@@ -301,7 +135,7 @@
               into LuminaHQ’s shared data fabric.
             </p>
           </div>
-          <div class="module-grid">
+          <div class="feature-grid">
             <article class="card">
               <h3>QA Boards</h3>
               <p>Track evaluations, analyst workload, and trending insights in real time.</p>
@@ -330,30 +164,66 @@
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content dual-panel">
-          <div class="panel-copy">
-            <h3>Integrate with the tools you already trust</h3>
-            <p>
-              LuminaHQ connects to ticketing, telephony, and BI platforms to complete your operational picture. Our
-              integration framework keeps data synchronized without compromising security.
-            </p>
-            <ul>
-              <li>Native connectors for Zendesk, Salesforce, and Five9.</li>
-              <li>Open APIs and SFTP options for custom data flows.</li>
-              <li>Granular permissions mapped to your governance policies.</li>
-            </ul>
-            <div class="navigation-cta">
-              <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Review full module list</a>
-              <a class="btn-ghost" href="LandingStory.html">See customer outcomes</a>
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="split-grid">
+            <div>
+              <div class="section-headline section-headline--left" style="margin-bottom: 1.5rem">
+                <h2>Integrate with the tools you already trust</h2>
+                <p>
+                  LuminaHQ connects to ticketing, telephony, and BI platforms to complete your operational picture. Our
+                  integration framework keeps data synchronized without compromising security.
+                </p>
+              </div>
+              <ul class="detail-list">
+                <li>Native connectors for Zendesk, Salesforce, and Five9.</li>
+                <li>Open APIs and SFTP options for custom data flows.</li>
+                <li>Granular permissions mapped to your governance policies.</li>
+              </ul>
+              <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
+                <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Review full module list</a>
+                <a class="btn btn-ghost" href="LandingStory.html">See customer outcomes</a>
+              </div>
+            </div>
+            <div class="image-frame">
+              <img
+                src="https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1200&q=80"
+                alt="Integration illustration"
+                loading="lazy"
+              />
             </div>
           </div>
-          <div class="panel-media">
-            <img
-              src="https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1200&q=80"
-              alt="Integration illustration"
-              loading="lazy"
-            />
+        </div>
+      </section>
+
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="section-headline">
+            <h2>Plan your rollout</h2>
+            <p>
+              Ensure every launch is purposeful with coordinated steps for enablement, analytics, and leadership. These
+              checklists help teams adopt LuminaHQ quickly.
+            </p>
+          </div>
+          <div class="list-columns">
+            <div>
+              <h3 style="margin-bottom: 1rem">Implementation essentials</h3>
+              <ul class="detail-list">
+                <li>Import historical QA and coaching data for instant baselines.</li>
+                <li>Configure automation blueprints mapped to your escalation paths.</li>
+                <li>Align role permissions with governance and compliance policies.</li>
+                <li>Publish enablement packs tailored to each program cohort.</li>
+              </ul>
+            </div>
+            <div>
+              <h3 style="margin-bottom: 1rem">Success metrics</h3>
+              <ul class="detail-list">
+                <li>Monitor coaching completion lift and quality improvement trends.</li>
+                <li>Track attendance stability and schedule adherence week over week.</li>
+                <li>Review executive dashboards for campaign-level insights.</li>
+                <li>Capture feedback from analysts and leaders for iterative updates.</li>
+              </ul>
+            </div>
           </div>
         </div>
       </section>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -5,192 +5,57 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dive Into LuminaHQ Capabilities</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
-    <style>
-      .detail-grid {
-        display: grid;
-        gap: 24px;
-      }
-
-      .detail-card {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(219, 235, 255, 0.88));
-        border-radius: 26px;
-        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
-        padding: 32px;
-        display: grid;
-        gap: 18px;
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .detail-card h3 {
-        margin: 0;
-        color: var(--sky-900);
-      }
-
-      .detail-card p {
-        margin: 0;
-        color: var(--slate-500);
-        line-height: 1.65;
-      }
-
-      .detail-card ul {
-        margin: 8px 0 0;
-        padding-left: 18px;
-        color: var(--slate-500);
-      }
-
-      .workflow-grid {
-        display: grid;
-        gap: 24px;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      }
-
-      .workflow-step {
-        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.88));
-        border-radius: 24px;
-        padding: 26px;
-        color: var(--slate-500);
-        box-shadow: 0 18px 42px rgba(158, 198, 255, 0.24);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .workflow-step strong {
-        display: block;
-        color: var(--sky-600);
-        margin-bottom: 10px;
-        font-size: 1.05rem;
-      }
-
-      .workflow-step:last-child {
-        border-style: dashed;
-      }
-    </style>
   </head>
   <body>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <ul class="nav-links">
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingStory.html">Stories</a></li>
+          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+        </ul>
+      </nav>
+    </header>
+
     <main>
-      <section class="hero-shell">
-        <div class="hero">
-          <div class="hero-grid">
-            <div class="hero-content">
-              <span class="hero-badge">Capability deep dive</span>
-              <h1>Guided workflows that scale with your operation</h1>
-              <p>
-                Peek behind the scenes of LuminaHQ’s modules to see the exact journeys your teams will experience. Each
-                workflow is built from real-world playbooks contributed by operations experts.
-              </p>
-              <div class="hero-actions">
-                <a class="btn-primary" href="LandingCapabilities.html">Return to overview</a>
-                <a class="btn-ghost" href="LandingStory.html">See it in action</a>
+      <section class="page-hero">
+        <div class="page-hero-content">
+          <div class="page-hero-text">
+            <span class="page-hero-badge">Capability deep dive</span>
+            <h1>Guided workflows that scale with your operation</h1>
+            <p>
+              Peek behind the scenes of LuminaHQ’s modules to see the journeys your teams will experience. Each workflow
+              is built from real-world playbooks contributed by operations experts.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="LandingCapabilities.html">Return to overview</a>
+              <a class="btn btn-ghost" href="LandingStory.html">See it in action</a>
+            </div>
+            <div class="hero-metrics">
+              <div class="metric-card">
+                <strong data-counter="4" data-suffix=" hrs">4 hrs</strong>
+                <span>saved per week by QA leaders on reporting</span>
               </div>
-              <div class="hero-metrics">
-                <div class="metric-card">
-                  <strong data-counter="4" data-suffix=" hrs">4 hrs</strong>
-                  <span>saved per week by QA leaders on reporting</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="2" data-suffix="x">2x</strong>
-                  <span>increase in coaching follow-through</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="98" data-suffix="%">98%</strong>
-                  <span>adoption among pilot supervisors</span>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="2" data-suffix="x">2x</strong>
+                <span>increase in coaching follow-through</span>
               </div>
-              </div>
-            <div class="hero-visual">
-              <div class="hero-visual-frame">
-                <div class="hero-visual-main">
-                  <div class="chart-visual">
-                    <div class="chart-visual__header">
-                      <span>Workflow health</span>
-                      <span class="chart-visual__period">Pilot readiness</span>
-                    </div>
-                    <div class="chart-visual__body">
-                      <div class="chart-visual__line" aria-hidden="true">
-                        <svg viewBox="0 0 220 120" role="presentation">
-                          <defs>
-                            <linearGradient id="chartLineFillCapDetail" x1="0" x2="0" y1="0" y2="1">
-                              <stop offset="0%" stop-color="rgba(111, 176, 255, 0.32)" />
-                              <stop offset="100%" stop-color="rgba(111, 176, 255, 0)" />
-                            </linearGradient>
-                            <linearGradient id="chartLineStrokeCapDetail" x1="0" x2="1" y1="0" y2="0">
-                              <stop offset="0%" stop-color="#9ecbff" />
-                              <stop offset="100%" stop-color="#4d9dff" />
-                            </linearGradient>
-                          </defs>
-                          <polygon
-                            points="0,110 0,88 44,74 88,64 132,50 176,58 220,46 220,110"
-                            fill="url(#chartLineFillCapDetail)"
-                          ></polygon>
-                          <polyline
-                            points="0,88 44,74 88,64 132,50 176,58 220,46"
-                            fill="none"
-                            stroke="url(#chartLineStrokeCapDetail)"
-                            stroke-width="6"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          ></polyline>
-                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
-                            <circle cx="0" cy="88" r="6"></circle>
-                            <circle cx="44" cy="74" r="6"></circle>
-                            <circle cx="88" cy="64" r="6"></circle>
-                            <circle cx="132" cy="50" r="6"></circle>
-                            <circle cx="176" cy="58" r="6"></circle>
-                            <circle cx="220" cy="46" r="6"></circle>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="chart-visual__bars">
-                        <span style="--height: 66%"></span>
-                        <span style="--height: 74%"></span>
-                        <span style="--height: 82%"></span>
-                        <span style="--height: 58%"></span>
-                        <span style="--height: 90%"></span>
-                      </div>
-                    </div>
-                    <div class="chart-visual__footer">
-                      <span>Enablement</span>
-                      <span>Configuration</span>
-                      <span>Adoption</span>
-                      <span>Feedback</span>
-                      <span>Outcomes</span>
-                    </div>
-                  </div>
-                  <div class="hero-insight-grid">
-                    <div class="hero-insight-card">
-                      <strong>Day 10</strong>
-                      <span>first executive story delivered to stakeholders</span>
-                    </div>
-                    <div class="hero-insight-card">
-                      <strong>Week 4</strong>
-                      <span>full automation review with success managers</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--top">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">How teams ramp</span>
-                    <span class="hero-widget__value">Guided</span>
-                  </div>
-                  <ol class="hero-ordered">
-                    <li>Discover key dashboards in day-one enablement.</li>
-                    <li>Configure workflows with guided onboarding.</li>
-                    <li>Monitor adoption through real-time health checks.</li>
-                  </ol>
-                </div>
-                <div class="hero-widget hero-widget--bottom">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Enablement squad</span>
-                    <span class="hero-widget__value">Always on</span>
-                  </div>
-                  <p>Specialists partner with supervisors to fine-tune schedules, QA rubrics, and playbooks.</p>
-                  <div class="hero-chip-list">
-                    <span>Implementation</span>
-                    <span>Change management</span>
-                    <span>Ongoing calibrations</span>
-                  </div>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="98" data-suffix="%">98%</strong>
+                <span>adoption among pilot supervisors</span>
               </div>
             </div>
+          </div>
+          <div class="hero-side-card">
+            <h3>How teams ramp</h3>
+            <p>Enablement squads guide every step, ensuring workflows launch smoothly and stay aligned.</p>
+            <ol class="numbered-list">
+              <li>Discover key dashboards during day-one onboarding.</li>
+              <li>Configure forms and automations with guided sessions.</li>
+              <li>Monitor adoption and optimize with weekly health reviews.</li>
+            </ol>
           </div>
         </div>
       </section>
@@ -205,8 +70,8 @@
         </div>
       </div>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Workflow spotlights</h2>
             <p>
@@ -214,36 +79,36 @@
               and handoffs built into the experience.
             </p>
           </div>
-          <div class="detail-grid">
-            <article class="detail-card">
+          <div class="feature-grid">
+            <article class="card">
               <h3>Quality calibration journey</h3>
               <p>
                 Invite analysts, review sample evaluations, and document consensus in one guided flow that updates QA
                 guidelines instantly.
               </p>
-              <ul>
+              <ul class="detail-list">
                 <li>Auto-select sample interactions based on campaign goals.</li>
                 <li>Capture commentary and decisions directly alongside scorecards.</li>
                 <li>Publish updated rubrics to analysts with one click.</li>
               </ul>
             </article>
-            <article class="detail-card">
+            <article class="card">
               <h3>Coaching momentum planner</h3>
               <p>
                 Connect QA insights to targeted coaching actions with reminders that keep supervisors and agents aligned.
               </p>
-              <ul>
+              <ul class="detail-list">
                 <li>Launch plans with suggested talking points and resources.</li>
                 <li>Assign follow-up tasks and track acknowledgments automatically.</li>
                 <li>Surface progress and celebrate wins in executive dashboards.</li>
               </ul>
             </article>
-            <article class="detail-card">
+            <article class="card">
               <h3>Workforce assurance loop</h3>
               <p>
                 Combine attendance monitoring, forecasting, and shift changes into a proactive process that protects SLAs.
               </p>
-              <ul>
+              <ul class="detail-list">
                 <li>Flag adherence risks using predictive alerts.</li>
                 <li>Offer shift swaps through an employee marketplace.</li>
                 <li>Summarize weekly coverage in partner-ready stories.</li>
@@ -253,8 +118,8 @@
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Activation blueprint</h2>
             <p>
@@ -262,44 +127,50 @@
               teams thrive from day one.
             </p>
           </div>
-          <div class="workflow-grid">
-            <div class="workflow-step">
-              <strong>Discover & Align</strong>
-              Map your current processes to LuminaHQ journeys with discovery workshops led by operations strategists.
-            </div>
-            <div class="workflow-step">
-              <strong>Configure & Launch</strong>
-              Import data, tailor forms, and activate automations with support from our implementation crew.
-            </div>
-            <div class="workflow-step">
-              <strong>Coach & Celebrate</strong>
-              Monitor adoption, iterate with feedback loops, and share success stories with leadership every month.
-            </div>
+          <div class="feature-grid">
+            <article class="card">
+              <h3>Discover & Align</h3>
+              <p>Map current processes to LuminaHQ journeys with discovery workshops led by operations strategists.</p>
+            </article>
+            <article class="card">
+              <h3>Configure & Launch</h3>
+              <p>Import data, tailor forms, and activate automations with support from our implementation crew.</p>
+            </article>
+            <article class="card">
+              <h3>Coach & Celebrate</h3>
+              <p>Monitor adoption, iterate with feedback loops, and share success stories with leadership every month.</p>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content dual-panel">
-          <div class="panel-media">
-            <img
-              src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
-              alt="Analytics detail"
-              loading="lazy"
-            />
-          </div>
-          <div class="panel-copy">
-            <h3>See LuminaHQ in motion</h3>
-            <p>
-              Request a guided tour to experience these workflows firsthand. We’ll show how quality insights surface next
-              to coaching plans, how workforce scenarios play out, and how leadership gets the context they need.
-            </p>
-            <p>
-              Our team tailors each walkthrough to your goals so you can visualize a launch path with confidence.
-            </p>
-            <div class="navigation-cta">
-              <a class="btn-ghost" href="LandingStory.html">Read success stories</a>
-              <a class="btn-ghost" href="Landing.html">Return to landing</a>
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="split-grid">
+            <div>
+              <div class="section-headline section-headline--left" style="margin-bottom: 1.5rem">
+                <h2>Enablement squad, always on</h2>
+                <p>
+                  Specialists partner with supervisors to fine-tune schedules, QA rubrics, and coaching playbooks. You’re
+                  never alone when optimizing LuminaHQ.
+                </p>
+              </div>
+              <ul class="detail-list">
+                <li>Weekly calibration reviews ensure metrics match evolving priorities.</li>
+                <li>Change-management resources keep stakeholders informed and confident.</li>
+                <li>Automation audits identify new opportunities for time savings.</li>
+              </ul>
+              <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
+                <a class="btn btn-ghost" href="LandingStory.html">Read success stories</a>
+                <a class="btn btn-ghost" href="Landing.html">Return to landing</a>
+              </div>
+            </div>
+            <div class="image-frame">
+              <img
+                src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+                alt="Analytics detail"
+                loading="lazy"
+              />
             </div>
           </div>
         </div>

--- a/LandingSharedStyles.html
+++ b/LandingSharedStyles.html
@@ -1,743 +1,832 @@
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
-
-:root {
-  --sky-50: #f6faff;
-  --sky-100: #edf5ff;
-  --sky-200: #dcecff;
-  --sky-300: #c7e1ff;
-  --sky-400: #9ec7ff;
-  --sky-500: #6fb0ff;
-  --sky-600: #4d9dff;
-  --sky-900: #123a62;
-  --slate-700: #2a3b57;
-  --slate-500: #566684;
-  --emerald-400: #4ad4b0;
-  --warning-400: #f3b34c;
-  --white: #ffffff;
-  --body-width: min(1100px, 92vw);
-  --shadow-soft: 0 20px 45px rgba(22, 54, 110, 0.18);
-  --radius-xl: 28px;
-  font-size: 16px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  margin: 0;
-  padding: 0;
-  font-family: 'Poppins', 'Segoe UI', Arial, sans-serif;
-  background: linear-gradient(180deg, var(--sky-50) 0%, var(--white) 65%);
-  color: var(--sky-900);
-  min-height: 100vh;
-}
-
-body {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-body::before,
-body::after {
-  content: '';
-  position: fixed;
-  z-index: -1;
-  border-radius: 50%;
-  filter: blur(0.4px);
-  opacity: 0.7;
-}
-
-body::before {
-  width: 760px;
-  height: 760px;
-  background: radial-gradient(circle at 22% 28%, rgba(158, 206, 255, 0.2) 0%, rgba(255, 255, 255, 0.6) 45%, transparent 75%);
-  top: -220px;
-  left: -160px;
-}
-
-body::after {
-  width: 620px;
-  height: 620px;
-  background: radial-gradient(circle at 78% 72%, rgba(173, 210, 255, 0.28) 0%, rgba(255, 255, 255, 0.55) 55%, transparent 80%);
-  bottom: -200px;
-  right: -120px;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-main {
-  width: 100%;
-}
-
-.hero-shell {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 72px 0 48px;
-}
-
-.hero {
-  width: var(--body-width);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98) 0%, rgba(233, 242, 255, 0.93) 100%);
-  border-radius: 36px;
-  padding: 64px 64px 56px;
-  box-shadow: 0 26px 70px rgba(66, 118, 188, 0.14);
-  position: relative;
-  overflow: hidden;
-}
-
-.hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(125deg, rgba(158, 206, 255, 0.16) 0%, rgba(210, 232, 255, 0.2) 45%, transparent 100%);
-  pointer-events: none;
-}
-
-.hero::after {
-  content: '';
-  position: absolute;
-  width: 340px;
-  height: 340px;
-  background: radial-gradient(circle at center, rgba(189, 221, 255, 0.36) 0%, rgba(189, 221, 255, 0) 70%);
-  top: -120px;
-  right: -120px;
-  pointer-events: none;
-}
-
-.hero-grid {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 32px;
-  align-items: center;
-}
-
-.hero-content {
-  grid-column: span 6;
-  z-index: 1;
-}
-
-.hero-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 18px;
-  border-radius: 999px;
-  background: rgba(124, 182, 255, 0.16);
-  color: var(--sky-600);
-  font-weight: 600;
-  margin-bottom: 28px;
-  font-size: 0.95rem;
-}
-
-.hero h1 {
-  font-size: 2.75rem;
-  line-height: 1.15;
-  margin: 0 0 20px;
-  color: var(--sky-900);
-}
-
-.hero p {
-  margin: 0 0 28px;
-  color: var(--slate-500);
-  font-size: 1.05rem;
-  line-height: 1.7;
-}
-
-.hero-actions {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  margin-bottom: 32px;
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, #8fc8ff, #4d9dff);
-  color: var(--white);
-  padding: 14px 28px;
-  border-radius: 16px;
-  font-weight: 600;
-  box-shadow: 0 12px 26px rgba(125, 181, 255, 0.32);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn-ghost {
-  background: rgba(255, 255, 255, 0.85);
-  color: var(--sky-600);
-  padding: 14px 28px;
-  border-radius: 16px;
-  font-weight: 600;
-  border: 1px solid rgba(109, 167, 255, 0.35);
-  box-shadow: 0 10px 18px rgba(164, 198, 255, 0.22);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
-}
-
-.hero-actions a:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 14px 25px rgba(18, 55, 148, 0.12);
-}
-
-.hero-metrics {
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-}
-
-.metric-card {
-  min-width: 160px;
-  padding: 18px 22px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 16px 34px rgba(164, 198, 255, 0.26);
-  position: relative;
-  overflow: hidden;
-}
-
-.metric-card::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(158, 206, 255, 0.24), transparent 60%);
-  pointer-events: none;
-}
-
-.metric-card strong {
-  display: block;
-  font-size: 1.5rem;
-  color: var(--sky-600);
-}
-
-.metric-card span {
-  font-size: 0.9rem;
-  color: var(--slate-500);
-}
-
-.hero-visual {
-  grid-column: span 6;
-  position: relative;
-  z-index: 1;
-}
-
-.hero-visual-frame {
-  position: relative;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(233, 242, 255, 0.92));
-  padding: 32px;
-  border-radius: 28px;
-  box-shadow: 0 24px 56px rgba(139, 186, 255, 0.24);
-  overflow: hidden;
-}
-
-.hero-visual-frame::before {
-  content: '';
-  position: absolute;
-  inset: 18% -40% -24% 45%;
-  background: radial-gradient(circle at top left, rgba(173, 210, 255, 0.22), transparent 70%);
-  pointer-events: none;
-}
-
-.hero-visual-main {
-  position: relative;
-  border-radius: 22px;
-  overflow: hidden;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(229, 241, 255, 0.95));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 22px 48px rgba(139, 186, 255, 0.3);
-}
-
-.hero-visual-main img {
-  width: 100%;
-  display: block;
-}
-
-.hero-widget {
-  position: absolute;
-  background: rgba(255, 255, 255, 0.97);
-  border-radius: 20px;
-  padding: 18px 20px;
-  box-shadow: 0 20px 42px rgba(158, 198, 255, 0.25);
-  width: clamp(220px, 32vw, 260px);
-  display: grid;
-  gap: 12px;
-}
-
-.hero-widget--top {
-  top: -36px;
-  left: -24px;
-}
-
-.hero-widget--bottom {
-  bottom: -36px;
-  right: -18px;
-}
-
-.hero-widget__meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.85rem;
-  color: var(--slate-500);
-}
-
-.hero-widget__label {
-  font-weight: 600;
-  color: var(--sky-600);
-}
-
-.hero-widget__value {
-  font-weight: 600;
-  color: var(--sky-900);
-}
-
-.hero-widget p {
-  margin: 0;
-  color: var(--slate-500);
-  font-size: 0.9rem;
-  line-height: 1.6;
-}
-
-.hero-widget ul {
-  margin: 0;
-  padding-left: 18px;
-  color: var(--slate-500);
-  font-size: 0.88rem;
-  display: grid;
-  gap: 6px;
-}
-
-.hero-ordered {
-  margin: 0;
-  padding-left: 20px;
-  color: var(--slate-500);
-  font-size: 0.88rem;
-  display: grid;
-  gap: 6px;
-}
-
-.hero-ordered li {
-  margin: 0;
-}
-
-.hero-insight-grid {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  width: min(220px, 38%);
-  display: grid;
-  gap: 12px;
-  pointer-events: none;
-}
-
-.hero-insight-card {
-  display: grid;
-  gap: 6px;
-  padding: 16px 18px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: 0 18px 36px rgba(158, 198, 255, 0.22);
-  pointer-events: auto;
-}
-
-.hero-insight-card strong {
-  font-size: 1.1rem;
-  color: var(--sky-600);
-}
-
-.hero-insight-card span {
-  color: var(--slate-500);
-  font-size: 0.85rem;
-  line-height: 1.5;
-}
-
-.hero-chip-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.hero-chip-list span {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(143, 177, 255, 0.2);
-  color: var(--sky-600);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.hero-widget__spark {
-  position: relative;
-  height: 6px;
-  background: rgba(173, 210, 255, 0.24);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.hero-widget__spark span {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  background: linear-gradient(120deg, rgba(127, 198, 255, 0.95), rgba(77, 157, 255, 0.85));
-  border-radius: inherit;
-}
-
-.chart-visual {
-  position: relative;
-  display: grid;
-  gap: 20px;
-  padding: 26px 28px 28px;
-  border-radius: 22px;
-  background: linear-gradient(165deg, rgba(255, 255, 255, 0.98), rgba(233, 242, 255, 0.88));
-  border: 1px solid rgba(158, 206, 255, 0.35);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-}
-
-.chart-visual::after {
-  content: '';
-  position: absolute;
-  inset: 16px;
-  border-radius: 18px;
-  pointer-events: none;
-  background: radial-gradient(circle at top right, rgba(158, 206, 255, 0.2), transparent 70%);
-  opacity: 0.7;
-}
-
-.chart-visual__header {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--sky-600);
-}
-
-.chart-visual__period {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--slate-500);
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 999px;
-  padding: 6px 12px;
-  box-shadow: 0 8px 18px rgba(158, 206, 255, 0.3);
-}
-
-.chart-visual__body {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  gap: 20px;
-}
-
-.chart-visual__line {
-  background: linear-gradient(180deg, rgba(227, 240, 255, 0.65) 0%, rgba(255, 255, 255, 0.95) 100%);
-  border-radius: 18px;
-  padding: 16px 14px 10px;
-  box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.3);
-}
-
-.chart-visual__line svg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.chart-visual__bars {
-  display: flex;
-  gap: 14px;
-  align-items: flex-end;
-  padding: 16px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: inset 0 0 0 1px rgba(158, 206, 255, 0.28);
-}
-
-.chart-visual__bars span {
-  flex: 1;
-  display: block;
-  height: 110px;
-  border-radius: 12px;
-  position: relative;
-  overflow: hidden;
-  background: rgba(173, 210, 255, 0.35);
-}
-
-.chart-visual__bars span::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: var(--height);
-  border-radius: inherit;
-  background: linear-gradient(180deg, rgba(111, 176, 255, 0.9), rgba(77, 157, 255, 0.95));
-  box-shadow: inset 0 -4px 6px rgba(55, 135, 230, 0.2);
-}
-
-.chart-visual__footer {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 8px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--slate-500);
-  text-align: center;
-}
-
-.partners {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin: 28px 0 40px;
-}
-
-.partner-strip {
-  width: var(--body-width);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 24px;
-  padding: 24px 40px;
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--slate-500);
-  border-radius: 20px;
-  box-shadow: 0 14px 34px rgba(173, 210, 255, 0.25);
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.partner-strip span {
-  opacity: 0.6;
-}
-
-.will-reveal {
-  opacity: 0;
-  transform: translateY(26px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
-}
-
-.will-reveal.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.section {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 56px 0;
-}
-
-.section-content {
-  width: var(--body-width);
-  display: grid;
-  gap: 32px;
-}
-
-.section-headline {
-  text-align: left;
-  max-width: 720px;
-  color: var(--sky-900);
-}
-
-.section-headline h2 {
-  margin: 0 0 16px;
-  font-size: 2.1rem;
-}
-
-.section-headline p {
-  margin: 0;
-  color: var(--slate-500);
-  line-height: 1.7;
-}
-
-.card-grid {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.card {
-  background: rgba(255, 255, 255, 0.96);
-  border-radius: 28px;
-  padding: 28px;
-  box-shadow: 0 16px 38px rgba(164, 198, 255, 0.2);
-}
-
-.card h3 {
-  margin: 0 0 12px;
-  color: var(--sky-900);
-}
-
-.card p,
-.card ul {
-  margin: 0;
-  color: var(--slate-500);
-  line-height: 1.65;
-}
-
-.card ul {
-  padding-left: 20px;
-  margin-top: 12px;
-}
-
-.card ul li {
-  margin-bottom: 8px;
-}
-
-.dual-panel {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 32px;
-  align-items: center;
-}
-
-.panel-media {
-  background: linear-gradient(160deg, rgba(203, 224, 255, 0.6), rgba(255, 255, 255, 0.95));
-  border-radius: 30px;
-  padding: 36px;
-  box-shadow: 0 16px 36px rgba(158, 191, 255, 0.22);
-}
-
-.panel-media img {
-  width: 100%;
-  display: block;
-}
-
-.panel-copy h3 {
-  margin: 0 0 16px;
-  color: var(--sky-900);
-}
-
-.panel-copy p {
-  margin: 0 0 12px;
-  color: var(--slate-500);
-  line-height: 1.7;
-}
-
-.panel-copy ul {
-  margin: 12px 0 0;
-  padding-left: 18px;
-  color: var(--slate-500);
-}
-
-.navigation-cta {
-  display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-
-.footer-shell {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 48px 0 72px;
-}
-
-.footer-card {
-  width: var(--body-width);
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 28px;
-  padding: 36px;
-  color: var(--sky-900);
-  display: grid;
-  gap: 24px;
-  box-shadow: 0 18px 40px rgba(158, 191, 255, 0.22);
-}
-
-.footer-card h3 {
-  margin: 0;
-  font-size: 1.7rem;
-}
-
-.footer-links {
-  display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-
-.footer-links a {
-  padding: 12px 20px;
-  border-radius: 16px;
-  background: rgba(143, 177, 255, 0.2);
-  color: var(--sky-600);
-  font-weight: 500;
-}
-
-@media (max-width: 1024px) {
-  .hero {
-    padding: 48px 32px;
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
   }
 
-  .hero-content {
-    grid-column: span 12;
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+      Cantarell, sans-serif;
+    color: #1a1a1a;
+    background: #f8f9fa;
+    overflow-x: hidden;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  ul {
+    list-style: none;
+  }
+
+  header.site-header {
+    background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+    padding: 1rem 2rem;
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: 1000;
+    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
+  }
+
+  .site-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  .logo {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #ffffff;
+    font-size: 1.8rem;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+  }
+
+  .logo img {
+    height: 40px;
+    width: auto;
+  }
+
+  .nav-links {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+  }
+
+  .nav-links a {
+    color: #ffffff;
+    font-weight: 500;
+    transition: opacity 0.3s ease;
+  }
+
+  .nav-links a:hover,
+  .nav-links a:focus {
+    opacity: 0.8;
+  }
+
+  .nav-cta {
+    background: rgba(255, 255, 255, 0.2);
+    padding: 0.6rem 1.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    backdrop-filter: blur(10px);
+  }
+
+  main {
+    margin-top: 86px;
+  }
+
+  .hero,
+  .page-hero {
+    background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+    padding: 150px 2rem 120px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .page-hero {
+    padding-top: 120px;
+    padding-bottom: 90px;
+  }
+
+  .hero::before,
+  .page-hero::before {
+    content: '';
+    position: absolute;
+    width: 150%;
+    height: 150%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
+    top: -50%;
+    left: -25%;
+    animation: pulse 15s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.5;
+    }
+
+    50% {
+      transform: scale(1.1);
+      opacity: 0.3;
+    }
+  }
+
+  .hero-content,
+  .page-hero-content {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 4rem;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+  }
+
+  .hero-text,
+  .page-hero-text {
+    color: #ffffff;
+  }
+
+  .hero-badge,
+  .page-hero-badge {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    padding: 0.5rem 1.2rem;
+    border-radius: 50px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  .hero-text h1,
+  .page-hero-text h1 {
+    font-size: clamp(2.4rem, 4vw, 3.5rem);
+    margin-bottom: 1.5rem;
+    line-height: 1.2;
+    font-weight: 800;
+  }
+
+  .hero-text p,
+  .page-hero-text p {
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 1.15rem;
+    margin-bottom: 2rem;
+    line-height: 1.7;
+    max-width: 560px;
+  }
+
+  .cta-buttons {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 3rem;
+  }
+
+  .btn {
+    padding: 1rem 2rem;
+    border-radius: 10px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    border: none;
+    font-size: 1rem;
+    display: inline-block;
+    text-decoration: none;
+  }
+
+  .btn-primary {
+    background: #ffffff;
+    color: #0ea5e9;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  }
+
+  .btn-primary:hover,
+  .btn-primary:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: #ffffff;
+    border: 2px solid #ffffff;
+  }
+
+  .btn-ghost:hover,
+  .btn-ghost:focus {
+    background: rgba(255, 255, 255, 0.1);
+    transform: translateY(-2px);
+  }
+
+  .hero-metrics,
+  .page-hero-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .hero-side-card {
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    padding: 2.25rem;
+    backdrop-filter: blur(12px);
+    color: #ffffff;
+  }
+
+  .hero-side-card h3 {
+    font-size: 1.4rem;
+    margin-bottom: 1rem;
+  }
+
+  .hero-side-card p {
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.7;
+    margin-bottom: 1.5rem;
+  }
+
+  .hero-side-card .detail-list li {
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .hero-side-card .detail-list li::before {
+    color: #ffffff;
+  }
+
+  .hero-side-card .numbered-list li {
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .hero-side-card .numbered-list li::before {
+    color: #ffffff;
+  }
+
+  .quote-text {
+    font-style: italic;
+    line-height: 1.6;
+    color: #475467;
+  }
+
+  .quote-cite {
+    display: block;
+    margin-top: 0.75rem;
+    font-weight: 600;
+    color: #0284c7;
+  }
+
+  .hero-side-card .quote-text {
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  .hero-side-card .quote-cite {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .metric-card,
+  .page-metric-card {
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(10px);
+    padding: 1.5rem;
+    border-radius: 15px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+  }
+
+  .metric-card strong,
+  .page-metric-card strong {
+    display: block;
+    font-size: 2rem;
+    color: #ffffff;
+    margin-bottom: 0.5rem;
+    font-weight: 700;
+  }
+
+  .metric-card span,
+  .page-metric-card span {
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.95rem;
+    line-height: 1.4;
   }
 
   .hero-visual {
-    grid-column: span 12;
-  }
-
-  .hero-widget {
     position: relative;
-    inset: auto;
-    margin-top: 24px;
+    height: 600px;
   }
 
-  .hero-visual-frame {
-    padding: 28px;
+  .floating-card {
+    background: #ffffff;
+    border-radius: 20px;
+    padding: 2rem;
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.2);
+    position: absolute;
+    animation: float 4s ease-in-out infinite;
   }
 
-  .hero-insight-grid {
-    position: relative;
-    top: auto;
-    right: auto;
-    width: 100%;
-    margin-top: 18px;
-    pointer-events: auto;
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0px) rotate(-2deg);
+    }
+
+    50% {
+      transform: translateY(-25px) rotate(-2deg);
+    }
+  }
+
+  .floating-card-main {
+    width: min(450px, 100%);
+    left: 0;
+    top: 50px;
+  }
+
+  .floating-card-small {
+    width: min(280px, 60%);
+    right: 0;
+    top: 150px;
+    animation-delay: 1s;
+  }
+
+  .floating-card h3 {
+    color: #1a1a1a;
+    margin-bottom: 1rem;
+    font-size: 1.3rem;
+  }
+
+  .floating-card p {
+    color: #666666;
+    line-height: 1.6;
+    font-size: 0.95rem;
+  }
+
+  .partners {
+    padding: 3rem 2rem;
+    background: #ffffff;
+    border-top: 1px solid #e5e7eb;
   }
 
   .partner-strip {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    gap: 3rem;
     flex-wrap: wrap;
-    justify-content: center;
-  }
-}
-
-@media (max-width: 640px) {
-  .hero {
-    padding: 36px 24px;
   }
 
-  .hero h1 {
-    font-size: 2.2rem;
+  .partner-strip span {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: #9ca3af;
+    opacity: 0.6;
+    transition: opacity 0.3s ease;
   }
 
-  .hero-actions {
+  .partner-strip span:hover,
+  .partner-strip span:focus {
+    opacity: 1;
+  }
+
+  .section,
+  .page-section {
+    padding: 100px 2rem;
+  }
+
+  .section:nth-of-type(even),
+  .page-section:nth-of-type(even) {
+    background: linear-gradient(180deg, #f8f9fa 0%, #ffffff 100%);
+  }
+
+  .section-content,
+  .page-section-content {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .section-headline {
+    text-align: center;
+    margin-bottom: 4rem;
+  }
+
+  .section-headline h2 {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    color: #1a1a1a;
+    margin-bottom: 1.5rem;
+    font-weight: 800;
+  }
+
+  .section-headline p {
+    color: #666666;
+    font-size: 1.15rem;
+    line-height: 1.8;
+    max-width: 700px;
+    margin: 0 auto;
+  }
+
+  .section-headline.section-headline--left {
+    text-align: left;
+  }
+
+  .section-headline.section-headline--left p {
+    margin-left: 0;
+  }
+
+  .highlight-rows {
+    display: grid;
+    gap: 2rem;
+  }
+
+  .highlight-row {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .card {
+    background: #ffffff;
+    border-radius: 20px;
+    padding: 2.5rem;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+    border: 1px solid #e5e7eb;
+    transition: all 0.3s ease;
+    min-height: 220px;
+    display: flex;
     flex-direction: column;
+    gap: 1rem;
   }
 
-  .partner-strip {
-    font-size: 0.75rem;
-    gap: 12px;
+  .card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12);
   }
 
-  .hero-widget {
+  .card h3 {
+    color: #1a1a1a;
+    font-size: 1.4rem;
+    font-weight: 700;
+  }
+
+  .card p {
+    color: #666666;
+    line-height: 1.7;
+  }
+
+  .card strong {
+    font-size: 1.5rem;
+    color: #0284c7;
+  }
+
+  .feature-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .feature-grid .card {
+    min-height: 0;
+  }
+
+  .split-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 3rem;
+    align-items: center;
+  }
+
+  .split-grid p {
+    color: #444444;
+    line-height: 1.7;
+  }
+
+  .badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .badge-list span {
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    background: rgba(14, 165, 233, 0.12);
+    color: #0284c7;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .detail-list {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .detail-list li {
+    position: relative;
+    padding-left: 1.75rem;
+    color: #475467;
+    line-height: 1.6;
+  }
+
+  .detail-list li::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: #0ea5e9;
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+
+  .numbered-list {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+    counter-reset: item;
+  }
+
+  .numbered-list li {
+    list-style: none;
+    position: relative;
+    padding-left: 2.1rem;
+    color: #475467;
+    line-height: 1.6;
+  }
+
+  .numbered-list li::before {
+    counter-increment: item;
+    content: counter(item) '.';
+    position: absolute;
+    left: 0;
+    font-weight: 600;
+    color: #0ea5e9;
+  }
+
+  .phone-section {
+    background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+    padding: 100px 2rem;
+  }
+
+  .phone-grid {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 4rem;
+    align-items: center;
+  }
+
+  .phone-mockups {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+  }
+
+  .phone-mockup {
+    width: 200px;
+    background: #ffffff;
+    border-radius: 35px;
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.3);
+    padding: 12px;
+    animation: float 3s ease-in-out infinite;
+  }
+
+  .phone-mockup:nth-child(2) {
+    animation-delay: 0.5s;
+    margin-top: 30px;
+  }
+
+  .phone-screen {
     width: 100%;
+    height: 400px;
+    background: linear-gradient(180deg, #f5f5f5 0%, #e5e7eb 100%);
+    border-radius: 25px;
+    overflow: hidden;
   }
-}
 
+  .phone-copy {
+    color: #ffffff;
+  }
+
+  .phone-copy h3 {
+    font-size: clamp(1.8rem, 3vw, 2.2rem);
+    margin-bottom: 1.5rem;
+    font-weight: 700;
+  }
+
+  .phone-copy p {
+    color: rgba(255, 255, 255, 0.95);
+    line-height: 1.8;
+    margin-bottom: 1.5rem;
+  }
+
+  .phone-copy ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  .phone-copy li {
+    padding: 0.8rem 0;
+    padding-left: 2rem;
+    position: relative;
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.6;
+  }
+
+  .phone-copy li::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.2rem;
+  }
+
+  .navigation-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 3rem;
+  }
+
+  .navigation-cta .btn-ghost {
+    color: #0ea5e9;
+    border-color: #0ea5e9;
+  }
+
+  .navigation-cta .btn-ghost:hover,
+  .navigation-cta .btn-ghost:focus {
+    background: rgba(14, 165, 233, 0.12);
+    color: #0284c7;
+  }
+
+  .footer-shell {
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+    padding: 80px 2rem;
+  }
+
+  .footer-card {
+    max-width: 800px;
+    margin: 0 auto;
+    text-align: center;
+    color: #ffffff;
+  }
+
+  .footer-card h3 {
+    font-size: clamp(2rem, 3vw, 2.5rem);
+    margin-bottom: 1.5rem;
+    font-weight: 700;
+  }
+
+  .footer-card p {
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.1rem;
+    line-height: 1.7;
+    margin-bottom: 2.5rem;
+  }
+
+  .footer-links {
+    display: flex;
+    gap: 2rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .footer-links a {
+    color: rgba(255, 255, 255, 0.8);
+    font-weight: 500;
+    transition: color 0.3s ease;
+  }
+
+  .footer-links a:hover,
+  .footer-links a:focus {
+    color: #0ea5e9;
+  }
+
+  .intro-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .stat-block {
+    background: #ffffff;
+    border-radius: 18px;
+    padding: 2rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 12px 36px rgba(15, 23, 42, 0.08);
+  }
+
+  .stat-block strong {
+    display: block;
+    font-size: 1.8rem;
+    color: #0284c7;
+    margin-bottom: 0.5rem;
+  }
+
+  .stat-block p {
+    color: #4b5563;
+    line-height: 1.6;
+  }
+
+  .list-columns {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .list-columns ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .list-columns li {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #e5e7eb;
+    color: #475467;
+  }
+
+  .timeline-grid {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .image-frame {
+    border-radius: 24px;
+    overflow: hidden;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+  }
+
+  .image-frame img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  @media (max-width: 1024px) {
+    .hero-content,
+    .page-hero-content,
+    .phone-grid {
+      grid-template-columns: 1fr;
+      text-align: center;
+    }
+
+    .hero-visual {
+      height: 420px;
+    }
+
+    .floating-card-main {
+      position: relative;
+      left: 50%;
+      top: 0;
+      transform: translateX(-50%);
+    }
+
+    .floating-card-small {
+      display: none;
+    }
+
+    .hero-metrics,
+    .page-hero-metrics {
+      grid-template-columns: 1fr;
+    }
+
+    .phone-mockups {
+      order: -1;
+    }
+  }
+
+  @media (max-width: 768px) {
+    header.site-header {
+      padding: 1rem 1.25rem;
+    }
+
+    .nav-links {
+      display: none;
+    }
+
+    .hero,
+    .page-hero {
+      padding: 120px 1.5rem 80px;
+    }
+
+    .hero-text h1,
+    .page-hero-text h1 {
+      font-size: 2.4rem;
+    }
+
+    .cta-buttons {
+      flex-direction: column;
+    }
+
+    .section,
+    .page-section,
+    .phone-section {
+      padding: 72px 1.5rem;
+    }
+
+    .phone-mockup {
+      width: 150px;
+    }
+
+    .phone-screen {
+      height: 300px;
+    }
+  }
 </style>

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -5,215 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Discover the LuminaHQ Story</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
-    <style>
-      .story-grid {
-        display: grid;
-        gap: 24px;
-      }
-
-      .story-card {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(224, 237, 255, 0.9));
-        padding: 28px;
-        border-radius: 26px;
-        box-shadow: 0 20px 48px rgba(158, 198, 255, 0.24);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .story-card h3 {
-        margin: 0 0 12px;
-        color: var(--sky-900);
-      }
-
-      .story-card p {
-        margin: 0;
-        color: var(--slate-500);
-        line-height: 1.7;
-      }
-
-      .testimonial {
-        background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(219, 235, 255, 0.9));
-        color: var(--slate-500);
-        padding: 28px;
-        border-radius: 26px;
-        box-shadow: 0 20px 42px rgba(158, 198, 255, 0.22);
-        border: 1px solid rgba(158, 206, 255, 0.25);
-      }
-
-      .testimonial strong {
-        display: block;
-        color: var(--sky-600);
-        margin-bottom: 12px;
-        font-size: 1.05rem;
-      }
-
-      .milestone-grid {
-        display: grid;
-        gap: 20px;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .milestone-card {
-        background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(224, 237, 255, 0.88));
-        border-radius: 22px;
-        padding: 20px;
-        box-shadow: 0 18px 36px rgba(158, 198, 255, 0.2);
-        border: 1px solid rgba(158, 206, 255, 0.2);
-      }
-
-      .milestone-card span {
-        display: block;
-        font-weight: 600;
-        color: var(--sky-600);
-        margin-bottom: 8px;
-      }
-
-      .panel-media {
-        display: grid;
-        gap: 18px;
-      }
-
-      .hero-quote {
-        margin: 0;
-        color: var(--slate-500);
-        font-style: italic;
-        line-height: 1.6;
-      }
-
-      .hero-quote__cite {
-        display: block;
-        margin-top: 12px;
-        font-style: normal;
-        font-weight: 600;
-        color: var(--sky-600);
-        font-size: 0.9rem;
-      }
-    </style>
   </head>
   <body>
+    <header class="site-header">
+      <nav class="site-nav">
+        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <ul class="nav-links">
+          <li><a href="LandingCapabilities.html">Capabilities</a></li>
+          <li><a href="LandingAbout.html">About</a></li>
+          <li><a href="LandingStory.html">Stories</a></li>
+          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+        </ul>
+      </nav>
+    </header>
+
     <main>
-      <section class="hero-shell">
-        <div class="hero">
-          <div class="hero-grid">
-            <div class="hero-content">
-              <span class="hero-badge">Customer stories</span>
-              <h1>See how teams transform with LuminaHQ</h1>
-              <p>
-                Operations leaders across industries partner with LuminaHQ to modernize workflows, rally teams, and keep
-                customers delighted. Explore the stories behind their results.
-              </p>
-              <div class="hero-actions">
-                <a class="btn-primary" href="LandingCapabilitiesDetail.html">Review the blueprint</a>
-                <a class="btn-ghost" href="LandingAbout.html">Meet our team</a>
+      <section class="page-hero">
+        <div class="page-hero-content">
+          <div class="page-hero-text">
+            <span class="page-hero-badge">Customer stories</span>
+            <h1>See how teams transform with LuminaHQ</h1>
+            <p>
+              Operations leaders across industries partner with LuminaHQ to modernize workflows, rally teams, and keep
+              customers delighted. Explore the stories behind their results.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="LandingCapabilitiesDetail.html">Review the blueprint</a>
+              <a class="btn btn-ghost" href="LandingAbout.html">Meet our team</a>
+            </div>
+            <div class="hero-metrics">
+              <div class="metric-card">
+                <strong data-counter="40" data-suffix="%">40%</strong>
+                <span>reduction in manual QA preparation</span>
               </div>
-              <div class="hero-metrics">
-                <div class="metric-card">
-                  <strong data-counter="40" data-suffix="%">40%</strong>
-                  <span>reduction in manual QA preparation</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="25" data-suffix="%">25%</strong>
-                  <span>lift in CSAT across partner programs</span>
-                </div>
-                <div class="metric-card">
-                  <strong data-counter="3" data-suffix="x">3x</strong>
-                  <span>faster rollout of new policy updates</span>
-                </div>
+              <div class="metric-card">
+                <strong data-counter="25" data-suffix="%">25%</strong>
+                <span>lift in CSAT across partner programs</span>
               </div>
+              <div class="metric-card">
+                <strong data-counter="3" data-suffix="x">3x</strong>
+                <span>faster rollout of new policy updates</span>
               </div>
-            <div class="hero-visual">
-              <div class="hero-visual-frame">
-                <div class="hero-visual-main">
-                  <div class="chart-visual">
-                    <div class="chart-visual__header">
-                      <span>Story impact</span>
-                      <span class="chart-visual__period">Customer wins</span>
-                    </div>
-                    <div class="chart-visual__body">
-                      <div class="chart-visual__line" aria-hidden="true">
-                        <svg viewBox="0 0 220 120" role="presentation">
-                          <defs>
-                            <linearGradient id="chartLineFillStory" x1="0" x2="0" y1="0" y2="1">
-                              <stop offset="0%" stop-color="rgba(143, 177, 255, 0.32)" />
-                              <stop offset="100%" stop-color="rgba(143, 177, 255, 0)" />
-                            </linearGradient>
-                            <linearGradient id="chartLineStrokeStory" x1="0" x2="1" y1="0" y2="0">
-                              <stop offset="0%" stop-color="#9fc9ff" />
-                              <stop offset="100%" stop-color="#4d9dff" />
-                            </linearGradient>
-                          </defs>
-                          <polygon
-                            points="0,110 0,84 44,68 88,76 132,52 176,62 220,40 220,110"
-                            fill="url(#chartLineFillStory)"
-                          ></polygon>
-                          <polyline
-                            points="0,84 44,68 88,76 132,52 176,62 220,40"
-                            fill="none"
-                            stroke="url(#chartLineStrokeStory)"
-                            stroke-width="6"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                          ></polyline>
-                          <g fill="#fff" stroke="#4d9dff" stroke-width="3">
-                            <circle cx="0" cy="84" r="6"></circle>
-                            <circle cx="44" cy="68" r="6"></circle>
-                            <circle cx="88" cy="76" r="6"></circle>
-                            <circle cx="132" cy="52" r="6"></circle>
-                            <circle cx="176" cy="62" r="6"></circle>
-                            <circle cx="220" cy="40" r="6"></circle>
-                          </g>
-                        </svg>
-                      </div>
-                      <div class="chart-visual__bars">
-                        <span style="--height: 72%"></span>
-                        <span style="--height: 64%"></span>
-                        <span style="--height: 86%"></span>
-                        <span style="--height: 78%"></span>
-                        <span style="--height: 92%"></span>
-                      </div>
-                    </div>
-                    <div class="chart-visual__footer">
-                      <span>Fintech</span>
-                      <span>Retail</span>
-                      <span>Healthcare</span>
-                      <span>SaaS</span>
-                      <span>Travel</span>
-                    </div>
-                  </div>
-                  <div class="hero-insight-grid">
-                    <div class="hero-insight-card">
-                      <strong>150K+</strong>
-                      <span>agents impacted by LuminaHQ stories</span>
-                    </div>
-                    <div class="hero-insight-card">
-                      <strong>4.8 / 5</strong>
-                      <span>average customer sentiment across partners</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="hero-widget hero-widget--top">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Customer voice</span>
-                    <span class="hero-widget__value">Global</span>
-                  </div>
-                  <blockquote class="hero-quote">
-                    “LuminaHQ has become the connective tissue for our support teams. We coach with confidence and celebrate
-                    wins we once missed.”
-                  </blockquote>
-                  <span class="hero-quote__cite">VP of Customer Care, Growth-stage SaaS</span>
-                </div>
-                <div class="hero-widget hero-widget--bottom">
-                  <div class="hero-widget__meta">
-                    <span class="hero-widget__label">Story formats</span>
-                    <span class="hero-widget__value">Dynamic</span>
-                  </div>
-                  <div class="hero-chip-list">
-                    <span>Executive digest</span>
-                    <span>Program spotlight</span>
-                    <span>Weekly win</span>
-                  </div>
-                  <p>Each format highlights the why behind the metrics with narrative prompts and callouts.</p>
-                </div>
-              </div>
+            </div>
+          </div>
+          <div class="hero-side-card">
+            <h3>Customer voice</h3>
+            <p class="quote-text">
+              “LuminaHQ has become the connective tissue for our support teams. We coach with confidence and celebrate wins
+              we once missed.”
+            </p>
+            <span class="quote-cite">VP of Customer Care, Growth-stage SaaS</span>
+            <div class="badge-list" style="margin-top: 1.5rem">
+              <span>Executive digest</span>
+              <span>Program spotlight</span>
+              <span>Weekly win</span>
             </div>
           </div>
         </div>
@@ -229,8 +74,8 @@
         </div>
       </div>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Stories from the field</h2>
             <p>
@@ -238,22 +83,22 @@
               landscapes.
             </p>
           </div>
-          <div class="story-grid">
-            <article class="story-card">
+          <div class="feature-grid">
+            <article class="card">
               <h3>Scaling quality in fintech</h3>
               <p>
                 A digital bank unified QA and coaching across three regions, cutting calibration time in half while
                 maintaining compliance-ready documentation.
               </p>
             </article>
-            <article class="story-card">
+            <article class="card">
               <h3>Elevating retail support</h3>
               <p>
                 A global retailer connected store, chat, and phone insights for a holistic view of customer experience,
                 boosting CSAT and reducing escalations.
               </p>
             </article>
-            <article class="story-card">
+            <article class="card">
               <h3>Reimagining healthcare operations</h3>
               <p>
                 A telehealth provider linked coaching to patient outcomes, unlocking personalized development paths for
@@ -264,60 +109,66 @@
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content dual-panel">
-          <div class="panel-copy">
-            <h3>What customers appreciate most</h3>
-            <p>
-              The LuminaHQ experience pairs powerful analytics with empathy for the humans delivering customer care. Our
-              partners cite faster insights, stronger accountability, and space to celebrate wins.
-            </p>
-            <div class="testimonial">
-              <strong>Director of CX, Enterprise Retail</strong>
-              “LuminaHQ bridged the gap between our QA analysts and coaches. We finally have a shared story that keeps the
-              entire org in sync.”
+      <section class="page-section">
+        <div class="page-section-content">
+          <div class="split-grid">
+            <div>
+              <div class="section-headline section-headline--left" style="margin-bottom: 1.5rem">
+                <h2>What customers appreciate most</h2>
+                <p>
+                  The LuminaHQ experience pairs powerful analytics with empathy for the humans delivering customer care.
+                  Partners cite faster insights, stronger accountability, and space to celebrate wins.
+                </p>
+              </div>
+              <div class="card" style="background: rgba(255, 255, 255, 0.92); border: none; box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12)">
+                <strong>Director of CX, Enterprise Retail</strong>
+                <p>
+                  “LuminaHQ bridged the gap between our QA analysts and coaches. We finally have a shared story that keeps
+                  the entire org in sync.”
+                </p>
+              </div>
+              <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
+                <a class="btn btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
+                <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Dive into workflows</a>
+              </div>
             </div>
-            <div class="navigation-cta">
-              <a class="btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
-              <a class="btn-ghost" href="LandingCapabilitiesDetail.html">Dive into workflows</a>
+            <div class="image-frame">
+              <img
+                src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"
+                alt="Team celebrating"
+                loading="lazy"
+              />
             </div>
-          </div>
-          <div class="panel-media">
-            <img
-              src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"
-              alt="Team celebrating"
-              loading="lazy"
-            />
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-content">
+      <section class="page-section">
+        <div class="page-section-content">
           <div class="section-headline">
             <h2>Milestones achieved together</h2>
             <p>
-              Each partnership unlocks measurable impact. Here are a few milestones reached within the first six months
-              of adopting LuminaHQ.
+              Each partnership unlocks measurable impact. Here are a few milestones reached within the first six months of
+              adopting LuminaHQ.
             </p>
           </div>
-          <div class="milestone-grid">
-            <div class="milestone-card">
-              <span>+18 pts QA Accuracy</span>
-              Analysts calibrated faster and improved scoring consistency across programs.
-            </div>
-            <div class="milestone-card">
-              <span>-32% Escalations</span>
-              Coaching journeys targeted the right behaviors and reduced customer friction.
-            </div>
-            <div class="milestone-card">
-              <span>+22% Adherence</span>
-              Workforce precision tools aligned scheduling, attendance, and coaching commitments.
-            </div>
-            <div class="milestone-card">
-              <span>3 Week Launch</span>
-              Teams configured modules rapidly with LuminaHQ specialists guiding every step.
-            </div>
+          <div class="feature-grid">
+            <article class="card">
+              <strong>+18 pts QA Accuracy</strong>
+              <p>Analysts calibrated faster and improved scoring consistency across programs.</p>
+            </article>
+            <article class="card">
+              <strong>-32% Escalations</strong>
+              <p>Coaching journeys targeted the right behaviors and reduced customer friction.</p>
+            </article>
+            <article class="card">
+              <strong>+22% Adherence</strong>
+              <p>Workforce precision tools aligned scheduling, attendance, and coaching commitments.</p>
+            </article>
+            <article class="card">
+              <strong>3 Week Launch</strong>
+              <p>Teams configured modules rapidly with LuminaHQ specialists guiding every step.</p>
+            </article>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the shared landing stylesheet with the new gradient-driven theme so navigation, hero, and section patterns are consistent
- rebuild the main Landing page with the new hero, partner, highlight, device, and CTA sections from the updated design
- update the About, Capabilities, Capabilities Detail, and Story pages to share the same navigation, hero treatment, and section styling as the new theme

## Testing
- Not run (HTML/CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f4f86f533c8326b2a27743c0d9eb48