### PR TITLE
Load managed roster users in schedule management

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2515,9 +2515,85 @@
                     const currentUserId = this.getCurrentUserId();
                     const campaignId = this.resolvedCampaignId || this.getCurrentCampaignId();
                     console.log('🔐 Resolved manager context:', { managerId: currentUserId, campaignId: campaignId || '(all)' });
-                    const users = await this.callServerFunction('clientGetScheduleUsers', currentUserId, campaignId || null);
 
-                    this.availableUsers = Array.isArray(users) ? users : [];
+                    const scheduleUsers = await this.callServerFunction('clientGetScheduleUsers', currentUserId, campaignId || null);
+                    const rosterResponse = await this.callServerFunction('clientGetManagedUsers', currentUserId);
+
+                    const rosterUsers = (() => {
+                        if (!rosterResponse) {
+                            return [];
+                        }
+                        if (Array.isArray(rosterResponse)) {
+                            return rosterResponse;
+                        }
+                        if (typeof rosterResponse === 'object' && rosterResponse.success === false) {
+                            console.warn('⚠️ Unable to load managed roster:', rosterResponse.error);
+                            return [];
+                        }
+                        if (typeof rosterResponse === 'object' && Array.isArray(rosterResponse.users)) {
+                            return rosterResponse.users;
+                        }
+                        return [];
+                    })();
+
+                    const byId = new Map();
+                    const pushUserRecord = (user) => {
+                        if (!user || typeof user !== 'object') {
+                            return;
+                        }
+
+                        const normalizedId = this.normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+                        if (!normalizedId) {
+                            return;
+                        }
+
+                        const existing = byId.get(normalizedId) || {};
+
+                        const normalized = {
+                            ID: normalizedId,
+                            UserName: user.UserName || user.username || existing.UserName || existing.username || normalizedId,
+                            FullName: user.FullName || user.fullName || existing.FullName || existing.fullName || user.UserName || existing.UserName || normalizedId,
+                            Email: user.Email || user.email || existing.Email || '',
+                            CampaignID: user.CampaignID || user.campaignID || user.campaignId || existing.CampaignID || '',
+                            campaignName: user.campaignName || existing.campaignName || '',
+                            EmploymentStatus: user.EmploymentStatus || existing.EmploymentStatus || 'Active',
+                            HireDate: user.HireDate || existing.HireDate || '',
+                            isActive: typeof user.isActive === 'boolean' ? user.isActive : (typeof existing.isActive === 'boolean' ? existing.isActive : true),
+                            roleNames: Array.isArray(user.roleNames) ? user.roleNames.slice() : (Array.isArray(existing.roleNames) ? existing.roleNames.slice() : [])
+                        };
+
+                        byId.set(normalizedId, normalized);
+                    };
+
+                    (Array.isArray(scheduleUsers) ? scheduleUsers : []).forEach(pushUserRecord);
+                    rosterUsers.forEach(pushUserRecord);
+
+                    this.availableUsers = Array.from(byId.values())
+                        .filter(user => user && user.ID && (user.FullName || user.UserName))
+                        .sort((a, b) => {
+                            const nameA = (a.FullName || a.UserName || '').toLowerCase();
+                            const nameB = (b.FullName || b.UserName || '').toLowerCase();
+                            return nameA.localeCompare(nameB);
+                        });
+
+                    if (!(this.managedUserIdSet instanceof Set)) {
+                        this.managedUserIdSet = new Set();
+                    }
+
+                    rosterUsers.forEach(user => {
+                        const managedId = this.normalizeUserIdValue(user && (user.ID || user.UserID));
+                        if (managedId && managedId !== currentUserId) {
+                            this.managedUserIdSet.add(managedId);
+                        }
+                    });
+
+                    if (this.resolvedManagerId) {
+                        const managerId = this.normalizeUserIdValue(this.resolvedManagerId);
+                        if (managerId && this.managedUserIdSet.has(managerId)) {
+                            this.managedUserIdSet.delete(managerId);
+                        }
+                    }
+
                     const managedSet = this.managedUserIdSet instanceof Set ? this.managedUserIdSet : new Set();
                     if (managedSet.size) {
                         const seen = new Set();
@@ -2529,9 +2605,13 @@
                         });
                         this.visibleManagedCount = seen.size;
                     } else {
-                        this.visibleManagedCount = this.availableUsers.length;
+                        this.visibleManagedCount = this.availableUsers.filter(user => {
+                            const userId = this.normalizeUserIdValue(user && (user.ID || user.UserID));
+                            return userId && userId !== currentUserId;
+                        }).length || this.availableUsers.length;
                     }
-                    console.log(`✅ Loaded ${this.availableUsers.length} users`);
+
+                    console.log(`✅ Loaded ${this.availableUsers.length} users (including ${rosterUsers.length} managed roster entries)`);
 
                     // Update user dropdowns
                     this.updateUserDropdowns();
@@ -4880,6 +4960,8 @@
 
             async loadAttendanceCalendar() {
                 try {
+                    await this.ensureScheduleContext();
+
                     const month = document.getElementById('attendanceMonth').value;
                     const year = document.getElementById('attendanceYear').value;
 
@@ -4892,10 +4974,46 @@
                             </div>
                         `;
 
-                    // Get attendance users
-                    const users = await this.callServerFunction('clientGetAttendanceUsers', this.getCurrentUserId(), this.getCurrentCampaignId() || null);
+                    const managerId = this.getCurrentUserId();
+                    const campaignId = this.getCurrentCampaignId() || null;
 
-                    if (!users || users.length === 0) {
+                    const [attendanceUsersRaw, scheduleUsersRaw] = await Promise.all([
+                        this.callServerFunction('clientGetAttendanceUsers', managerId, campaignId),
+                        Array.isArray(this.availableUsers) && this.availableUsers.length
+                            ? Promise.resolve(this.availableUsers)
+                            : this.callServerFunction('clientGetScheduleUsers', managerId, campaignId)
+                    ]);
+
+                    const scheduleUsers = Array.isArray(scheduleUsersRaw) ? scheduleUsersRaw : [];
+
+                    if (!Array.isArray(this.availableUsers) || !this.availableUsers.length) {
+                        this.availableUsers = scheduleUsers.slice();
+                    }
+
+                    const combinedUsers = [];
+                    const seenUserKeys = new Set();
+
+                    const appendUserName = (name) => {
+                        const normalized = this.normalizePersonKey(name);
+                        if (!normalized || seenUserKeys.has(normalized)) {
+                            return;
+                        }
+                        combinedUsers.push(name);
+                        seenUserKeys.add(normalized);
+                    };
+
+                    scheduleUsers.forEach(user => {
+                        if (!user) {
+                            return;
+                        }
+                        appendUserName(user.UserName || user.FullName || user.Email);
+                    });
+
+                    if (Array.isArray(attendanceUsersRaw)) {
+                        attendanceUsersRaw.forEach(name => appendUserName(name));
+                    }
+
+                    if (combinedUsers.length === 0) {
                         container.innerHTML = `
                                 <div class="text-center py-5 text-muted">
                                     <i class="fas fa-users fa-3x mb-3 opacity-50"></i>
@@ -4907,14 +5025,7 @@
                         return;
                     }
 
-                    let scheduleUsers = [];
-                    try {
-                        scheduleUsers = await this.callServerFunction('clientGetScheduleUsers', this.getCurrentUserId(), this.getCurrentCampaignId() || null);
-                    } catch (metadataError) {
-                        console.warn('Unable to load schedule user metadata for attendance calendar:', metadataError);
-                    }
-
-                    const userEntries = this.buildAttendanceUserEntries(users, Array.isArray(scheduleUsers) ? scheduleUsers : []);
+                    const userEntries = this.buildAttendanceUserEntries(combinedUsers, scheduleUsers);
 
                     const resolvedMonth = parseInt(month, 10);
                     const resolvedYear = parseInt(year, 10);


### PR DESCRIPTION
## Summary
- merge managed roster results with schedule users so managers see their full team
- normalize and deduplicate user records before displaying them in the schedule UI
- update managed counts and metrics based on the resolved roster entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f50f59af208326a2d8114cc4a8bbee