### PR TITLE
Route schedule and campaign sheets away from main workbook

### DIFF
--- a/UserService.js
+++ b/UserService.js
@@ -491,24 +491,104 @@ if (typeof invalidateCache !== 'function') {
 }
 if (typeof ensureSheetWithHeaders !== 'function') {
   function ensureSheetWithHeaders(name, headers) {
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
-    let sh = ss.getSheetByName(name);
-    if (!sh) {
-      sh = ss.insertSheet(name);
-      sh.getRange(1, 1, 1, headers.length).setValues([headers]);
-      sh.setFrozenRows(1);
-    } else {
-      const lastCol = sh.getLastColumn();
-      const row = lastCol ? sh.getRange(1, 1, 1, lastCol).getValues()[0] : [];
-      const hdrs = row.map(String);
-      // append any missing headers
-      let changed = false;
-      headers.forEach(h => {
-        if (hdrs.indexOf(h) === -1) { hdrs.push(h); changed = true; }
-      });
-      if (changed) sh.getRange(1, 1, 1, hdrs.length).setValues([hdrs]);
+    const sheetName = String(name || '').trim();
+    if (!sheetName) {
+      throw new Error('Sheet name is required');
     }
-    return sh;
+
+    const headerArray = Array.isArray(headers) ? headers : [];
+    const lowerName = sheetName.toLowerCase();
+
+    const scheduleSheetNames = {
+      'schedules': true,
+      'schedule': true,
+      'agentschedules': true,
+      'schedulegeneration': true,
+      'generatedschedules': true,
+      'scheduleadherence': true
+    };
+
+    const campaignSheetNames = {
+      'quality': true,
+      'attendancelog': true,
+      'coachingrecords': true
+    };
+
+    function ensureInSpreadsheet(ss) {
+      if (!ss) {
+        throw new Error('Spreadsheet handle is required');
+      }
+
+      let sh = ss.getSheetByName(sheetName);
+      if (!sh) {
+        sh = ss.insertSheet(sheetName);
+        if (headerArray.length) {
+          sh.getRange(1, 1, 1, headerArray.length).setValues([headerArray]);
+          sh.setFrozenRows(1);
+        }
+        return sh;
+      }
+
+      if (headerArray.length) {
+        const lastCol = sh.getLastColumn();
+        const row = lastCol ? sh.getRange(1, 1, 1, lastCol).getValues()[0] : [];
+        const hdrs = row.map(String);
+        let changed = false;
+        headerArray.forEach(h => {
+          if (hdrs.indexOf(h) === -1) {
+            hdrs.push(h);
+            changed = true;
+          }
+        });
+        if (changed) {
+          sh.getRange(1, 1, 1, hdrs.length).setValues([hdrs]);
+        }
+        if (sh.getFrozenRows() < 1) {
+          sh.setFrozenRows(1);
+        }
+      }
+
+      return sh;
+    }
+
+    if (scheduleSheetNames[lowerName]) {
+      if (typeof ensureScheduleSheetWithHeaders === 'function') {
+        try {
+          return ensureScheduleSheetWithHeaders(sheetName, headerArray);
+        } catch (scheduleError) {
+          console.warn('ensureSheetWithHeaders: schedule delegation failed', scheduleError);
+        }
+      }
+
+      if (typeof getScheduleSpreadsheet === 'function') {
+        try {
+          return ensureInSpreadsheet(getScheduleSpreadsheet());
+        } catch (scheduleFallbackError) {
+          console.warn('ensureSheetWithHeaders: unable to ensure schedule sheet via schedule spreadsheet', scheduleFallbackError);
+        }
+      }
+    }
+
+    if (campaignSheetNames[lowerName]) {
+      if (typeof ensureCampaignSheetWithHeaders === 'function') {
+        try {
+          return ensureCampaignSheetWithHeaders(sheetName, headerArray);
+        } catch (campaignError) {
+          console.warn('ensureSheetWithHeaders: campaign delegation failed', campaignError);
+        }
+      }
+
+      if (typeof getIBTRSpreadsheet === 'function') {
+        try {
+          return ensureInSpreadsheet(getIBTRSpreadsheet());
+        } catch (campaignFallbackError) {
+          console.warn('ensureSheetWithHeaders: unable to ensure campaign sheet via campaign spreadsheet', campaignFallbackError);
+        }
+      }
+    }
+
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    return ensureInSpreadsheet(ss);
   }
 }
 if (typeof readSheet !== 'function') {


### PR DESCRIPTION
## Summary
- update the ensureSheetWithHeaders fallback to normalize names and route schedule sheets to the dedicated schedule spreadsheet
- delegate campaign-centric sheets such as Quality, AttendanceLog, and CoachingRecords to the campaign spreadsheet when available while preserving header management

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f54d113cc483269918f106fabf6856