### PR TITLE
Split employment and insurance management into separate user modal tabs

### DIFF
--- a/Users.html
+++ b/Users.html
@@ -1385,6 +1385,18 @@
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="employment-tab" data-bs-toggle="tab" data-bs-target="#employment"
+                                    type="button" role="tab" aria-controls="employment" aria-selected="false">
+                                <i class="fas fa-briefcase me-2"></i><span class="d-none d-sm-inline">Employment</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="insurance-tab" data-bs-toggle="tab" data-bs-target="#insurance"
+                                    type="button" role="tab" aria-controls="insurance" aria-selected="false">
+                                <i class="fas fa-shield-heart me-2"></i><span class="d-none d-sm-inline">Insurance</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
                             <button class="nav-link" id="campaigns-tab" data-bs-toggle="tab" data-bs-target="#campaigns"
                                     type="button" role="tab" aria-controls="campaigns" aria-selected="false">
                                 <i class="fas fa-building me-2"></i><span class="d-none d-sm-inline">Campaigns</span>
@@ -1492,18 +1504,59 @@
                                 </div>
                             </div>
 
-                            <!-- Employment & Benefits Section -->
+                            <!-- System Access Section -->
                             <div class="card mb-4">
                                 <div class="card-header">
-                                    <h6 class="mb-0 fw-bold"><i class="fas fa-briefcase me-2"></i>Employment & Benefits</h6>
+                                    <h6 class="mb-0 fw-bold"><i class="fas fa-shield-alt me-2"></i>System Access & Roles</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="mb-3">
+                                        <label for="roles" class="form-label fw-medium">
+                                            User Roles
+                                            <i class="fas fa-info-circle ms-1" title="Assign roles to define user permissions"></i>
+                                        </label>
+                                        <select class="form-control" id="roles" multiple aria-describedby="rolesHelp"></select>
+                                        <div id="rolesHelp" class="form-text">Select one or more roles for this user. Roles determine available features and permissions.</div>
+                                    </div>
+
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" id="canLogin">
+                                                <label class="form-check-label fw-medium" for="canLogin">
+                                                    <i class="fas fa-sign-in-alt me-2"></i><strong>Enable Login Access</strong>
+                                                    <small class="d-block text-muted">Allow this user to log into the system</small>
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" id="isAdmin">
+                                                <label class="form-check-label fw-medium" for="isAdmin">
+                                                    <i class="fas fa-crown me-2"></i><strong>System Administrator</strong>
+                                                    <small class="d-block text-muted">Grant full system administration privileges</small>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+
+                        <!-- Employment Tab -->
+                        <div class="tab-pane fade" id="employment" role="tabpanel" aria-labelledby="employment-tab">
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <h6 class="mb-0 fw-bold"><i class="fas fa-briefcase me-2"></i>Employment Details</h6>
                                 </div>
                                 <div class="card-body">
                                     <div class="alert alert-modern alert-info border-0 mb-3"
                                          role="alert"
                                          style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(147, 197, 253, 0.05));">
                                         <i class="fas fa-lightbulb me-2"></i>
-                                        <strong>HR Integration:</strong> Track employment status, hire/termination dates, probation periods,
-                                        and insurance eligibility (automatically calculated as 3 months after probation ends).
+                                        <strong>Employment Tracking:</strong> Manage employment status, hire dates, probation periods,
+                                        and termination information from one place.
                                     </div>
 
                                     <div class="row">
@@ -1554,7 +1607,6 @@
                                         </div>
                                     </div>
 
-                                    <!-- Probation & Termination -->
                                     <div class="row">
                                         <div class="col-md-4">
                                             <div class="mb-3">
@@ -1590,8 +1642,24 @@
                                             </div>
                                         </div>
                                     </div>
+                                </div>
+                            </div>
+                        </div>
 
-                                    <!-- Insurance Information -->
+                        <!-- Insurance Tab -->
+                        <div class="tab-pane fade" id="insurance" role="tabpanel" aria-labelledby="insurance-tab">
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <h6 class="mb-0 fw-bold"><i class="fas fa-shield-heart me-2"></i>Insurance Benefits</h6>
+                                </div>
+                                <div class="card-body">
+                                    <div class="alert alert-modern alert-info border-0 mb-3"
+                                         role="alert"
+                                         style="background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(52, 211, 153, 0.08));">
+                                        <i class="fas fa-heartbeat me-2"></i>
+                                        <strong>Benefits Tracking:</strong> Monitor insurance eligibility, enrollment, and card fulfillment.
+                                    </div>
+
                                     <div class="row">
                                         <div class="col-md-4">
                                             <div class="mb-3">
@@ -1610,8 +1678,8 @@
                                                 <label class="form-label fw-medium d-flex justify-content-between align-items-center">
                                                     <span>Insurance Qualification Status</span>
                                                     <span id="eligibilityStatusPill" class="badge bg-secondary">
-                            <i class="fas fa-hourglass-half me-1"></i>Not Qualified
-                          </span>
+                                                        <i class="fas fa-hourglass-half me-1"></i>Not Qualified
+                                                    </span>
                                                 </label>
                                                 <div class="form-text">Automatically determined based on eligibility date and employment status</div>
                                             </div>
@@ -1632,45 +1700,6 @@
                                     </div>
                                 </div>
                             </div>
-
-                            <!-- System Access Section -->
-                            <div class="card mb-4">
-                                <div class="card-header">
-                                    <h6 class="mb-0 fw-bold"><i class="fas fa-shield-alt me-2"></i>System Access & Roles</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div class="mb-3">
-                                        <label for="roles" class="form-label fw-medium">
-                                            User Roles
-                                            <i class="fas fa-info-circle ms-1" title="Assign roles to define user permissions"></i>
-                                        </label>
-                                        <select class="form-control" id="roles" multiple aria-describedby="rolesHelp"></select>
-                                        <div id="rolesHelp" class="form-text">Select one or more roles for this user. Roles determine available features and permissions.</div>
-                                    </div>
-
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="canLogin">
-                                                <label class="form-check-label fw-medium" for="canLogin">
-                                                    <i class="fas fa-sign-in-alt me-2"></i><strong>Enable Login Access</strong>
-                                                    <small class="d-block text-muted">Allow this user to log into the system</small>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="checkbox" id="isAdmin">
-                                                <label class="form-check-label fw-medium" for="isAdmin">
-                                                    <i class="fas fa-crown me-2"></i><strong>System Administrator</strong>
-                                                    <small class="d-block text-muted">Grant full system administration privileges</small>
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
                         </div>
 
                         <!-- Campaigns Tab -->


### PR DESCRIPTION
## Summary
- add dedicated Employment and Insurance tabs to the user management modal for clearer separation
- move the employment and insurance form sections into their respective tab panes with updated helper copy

## Testing
- not run (HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68f5b96c3618832695066cd816fcb3fa