### PR TITLE
Improve shift slot creation fallback handling

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -3860,6 +3860,13 @@
                                 await this.loadShiftSlots();
                                 return;
                             }
+
+                            const fallbackMessage = 'The server did not confirm the shift slot creation. We refreshed the schedule so you can verify the new slot manually.';
+                            console.warn('Shift slot creation could not be confirmed due to missing server response.');
+                            this.showToast(fallbackMessage, 'warning');
+                            this.resetShiftSlotForm();
+                            await this.loadShiftSlots();
+                            return;
                         }
 
                         throw new Error(normalized.error || 'Failed to create shift slot');
@@ -4016,7 +4023,85 @@
                     }
 
                     const normalizeString = (value) => (value || '').toString().trim().toLowerCase();
-                    const normalizeTime = (value) => (value || '').toString().trim();
+                    const normalizeTime = (value) => {
+                        if (value === null || value === undefined) {
+                            return '';
+                        }
+
+                        const coerceToTimeTuple = (input) => {
+                            if (input instanceof Date) {
+                                return [input.getHours(), input.getMinutes()];
+                            }
+
+                            const stringValue = input.toString().trim();
+                            if (!stringValue) {
+                                return null;
+                            }
+
+                            const meridiemMatch = stringValue.match(/^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(AM|PM)$/i);
+                            if (meridiemMatch) {
+                                let hours = parseInt(meridiemMatch[1], 10) % 12;
+                                if (meridiemMatch[4].toUpperCase() === 'PM') {
+                                    hours += 12;
+                                }
+                                const minutes = meridiemMatch[2] !== undefined ? parseInt(meridiemMatch[2], 10) : 0;
+                                return [hours, Number.isFinite(minutes) ? minutes : 0];
+                            }
+
+                            const directMatch = stringValue.match(/^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?$/);
+                            if (directMatch) {
+                                const hours = parseInt(directMatch[1], 10);
+                                const minutes = directMatch[2] !== undefined ? parseInt(directMatch[2], 10) : 0;
+                                return [hours, Number.isFinite(minutes) ? minutes : 0];
+                            }
+
+                            const compactMatch = stringValue.match(/^(\d{1,2})(\d{2})$/);
+                            if (compactMatch) {
+                                return [parseInt(compactMatch[1], 10), parseInt(compactMatch[2], 10)];
+                            }
+
+                            const meridiemShortMatch = stringValue.match(/^(\d{1,2})\s*(AM|PM)$/i);
+                            if (meridiemShortMatch) {
+                                let hours = parseInt(meridiemShortMatch[1], 10) % 12;
+                                if (meridiemShortMatch[2].toUpperCase() === 'PM') {
+                                    hours += 12;
+                                }
+                                return [hours, 0];
+                            }
+
+                            const numericValue = Number(stringValue);
+                            if (!Number.isNaN(numericValue)) {
+                                if (numericValue >= 0 && numericValue < 1) {
+                                    const totalMinutes = Math.round(numericValue * 24 * 60);
+                                    return [Math.floor(totalMinutes / 60), totalMinutes % 60];
+                                }
+
+                                const millisDate = new Date(numericValue);
+                                if (!Number.isNaN(millisDate.getTime())) {
+                                    return [millisDate.getUTCHours(), millisDate.getUTCMinutes()];
+                                }
+                            }
+
+                            const parsedDate = new Date(stringValue);
+                            if (!Number.isNaN(parsedDate.getTime())) {
+                                return [parsedDate.getHours(), parsedDate.getMinutes()];
+                            }
+
+                            return null;
+                        };
+
+                        const timeTuple = coerceToTimeTuple(value);
+                        if (!timeTuple) {
+                            return value.toString().trim();
+                        }
+
+                        const [hours, minutes] = timeTuple;
+                        if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+                            return value.toString().trim();
+                        }
+
+                        return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+                    };
                     const normalizeDays = (days) => {
                         if (Array.isArray(days)) {
                             return days.map(day => parseInt(day, 10)).filter(Number.isFinite).sort((a, b) => a - b).join(',');


### PR DESCRIPTION
## Summary
- add a warning-based fallback path when the server omits a response but slot creation likely succeeded
- expand shift slot time normalization to cover additional formats when verifying fallback creations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5dbaf3a9483269c1797ad3bc1069e