### PR TITLE
Ensure shift slot options populate in schedule management

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2447,6 +2447,7 @@
                 this.pendingImportSummary = null;
                 this.lastImportResult = null;
                 this.cachedSchedules = [];
+                this.cachedShiftSlots = [];
                 this.resolvedManagerId = '';
                 this.resolvedCampaignId = '';
                 this.managedUserIds = [];
@@ -3134,6 +3135,8 @@
                     const rawSlots = await this.callServerFunction('clientGetAllShiftSlots');
                     const { slots, metadata } = this.normalizeShiftSlotListResponse(rawSlots);
 
+                    this.cachedShiftSlots = slots;
+                    this.updateShiftSlotSelectors(slots);
                     this.displayShiftSlots(slots);
 
                     const totalSlotsElement = document.getElementById('totalSlots');
@@ -3144,6 +3147,8 @@
                     console.log(`✅ Loaded ${metadata.totalCount} shift slots`);
                 } catch (error) {
                     console.error('❌ Error loading shift slots:', error);
+                    this.cachedShiftSlots = [];
+                    this.updateShiftSlotSelectors([]);
                     this.displayShiftSlots([]);
                     this.showToast(error.message || 'Failed to load shift slots. You may need to create some first.', 'warning');
                 }
@@ -3190,6 +3195,49 @@
                             </div>
                         </div>
                     `).join('');
+            }
+
+            updateShiftSlotSelectors(slots) {
+                if (typeof document === 'undefined') {
+                    return;
+                }
+
+                const select = document.getElementById('scheduleShiftSlots');
+                if (!select) {
+                    return;
+                }
+
+                const previouslySelected = Array.from(select.selectedOptions || []).map(option => option.value);
+                select.innerHTML = '';
+
+                if (!Array.isArray(slots) || slots.length === 0) {
+                    const emptyOption = document.createElement('option');
+                    emptyOption.disabled = true;
+                    emptyOption.selected = true;
+                    emptyOption.textContent = 'No shift slots available';
+                    select.appendChild(emptyOption);
+                    return;
+                }
+
+                const fragment = document.createDocumentFragment();
+                slots.forEach(slot => {
+                    const option = document.createElement('option');
+                    const slotId = this.resolveShiftSlotId(slot);
+                    option.value = slotId || this.buildShiftSlotFallbackValue(slot);
+                    option.textContent = this.buildShiftSlotOptionLabel(slot);
+
+                    if (!option.value) {
+                        option.disabled = true;
+                    }
+
+                    if (previouslySelected.includes(option.value)) {
+                        option.selected = true;
+                    }
+
+                    fragment.appendChild(option);
+                });
+
+                select.appendChild(fragment);
             }
 
             normalizeShiftSlotListResponse(rawSlots) {
@@ -3277,6 +3325,70 @@
                 }
 
                 return emptyResult;
+            }
+
+            resolveShiftSlotId(slot = {}) {
+                const candidates = [
+                    slot.ID, slot.Id, slot.id,
+                    slot.SlotID, slot.SlotId, slot.slotId,
+                    slot.Guid, slot.UUID, slot.Uuid
+                ];
+
+                for (let index = 0; index < candidates.length; index++) {
+                    const candidate = candidates[index];
+                    if (candidate === null || candidate === undefined) {
+                        continue;
+                    }
+
+                    const normalized = String(candidate).trim();
+                    if (normalized) {
+                        return normalized;
+                    }
+                }
+
+                return '';
+            }
+
+            buildShiftSlotFallbackValue(slot = {}) {
+                const name = (slot.Name || slot.SlotName || '').toString().trim();
+                const timeRange = [
+                    this.formatTimeValue(slot.StartTime),
+                    this.formatTimeValue(slot.EndTime)
+                ].filter(Boolean).join('-');
+
+                const descriptor = [name, timeRange].filter(Boolean).join('|');
+                return descriptor;
+            }
+
+            buildShiftSlotOptionLabel(slot = {}) {
+                const parts = [];
+                const name = (slot.Name || slot.SlotName || 'Shift Slot').toString().trim();
+                if (name) {
+                    parts.push(name);
+                }
+
+                const startTime = this.formatTimeValue(slot.StartTime);
+                const endTime = this.formatTimeValue(slot.EndTime);
+                const timeRange = [startTime, endTime].filter(Boolean).join(' - ');
+                if (timeRange) {
+                    parts.push(`(${timeRange})`);
+                }
+
+                const days = Array.isArray(slot.DaysOfWeekArray)
+                    ? this.formatDaysOfWeek(slot.DaysOfWeekArray)
+                    : (typeof slot.DaysOfWeek === 'string'
+                        ? this.formatDaysOfWeek(slot.DaysOfWeek.split(',').map(value => parseInt(value, 10)).filter(day => !isNaN(day)))
+                        : '');
+                if (days) {
+                    parts.push(`• ${days}`);
+                }
+
+                const department = (slot.Department || slot.Team || '').toString().trim();
+                if (department) {
+                    parts.push(`• ${department}`);
+                }
+
+                return parts.join(' ');
             }
 
             async refreshDashboard() {


### PR DESCRIPTION
## Summary
- cache the fetched shift slots and update the assignment selector when data loads or fails
- add helper utilities to resolve slot identifiers, build option labels, and provide stable fallbacks
- surface a friendly empty-state option when no shift slots are available

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5ee9e950c8326a50f49267f370fb8