### PR TITLE
Enhance attendance calendar employment awareness

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -227,6 +227,12 @@
         box-shadow: none;
     }
 
+    .attendance-calendar__status--inactive {
+        background: rgba(148, 163, 184, 0.5);
+        color: #0f172a;
+        box-shadow: none;
+    }
+
     .attendance-calendar__table-wrapper {
         overflow-x: auto;
         padding: var(--spacing-md);
@@ -304,6 +310,39 @@
         white-space: nowrap;
     }
 
+    .attendance-calendar__participant-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-top: 0.35rem;
+        font-size: 0.75rem;
+        color: rgba(15, 42, 86, 0.65);
+        letter-spacing: 0.01em;
+    }
+
+    .attendance-calendar__participant-meta span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        line-height: 1.3;
+        white-space: normal;
+    }
+
+    .attendance-calendar__participant-meta i {
+        color: rgba(15, 42, 86, 0.5);
+    }
+
+    .attendance-calendar__participant-status {
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: rgba(15, 42, 86, 0.75);
+    }
+
+    .attendance-calendar__participant-dates {
+        color: rgba(15, 42, 86, 0.6);
+    }
+
     .attendance-calendar__table td {
         text-align: center;
         padding: 0.4rem 0.35rem;
@@ -325,6 +364,22 @@
 
     .attendance-calendar__cell--weekend {
         background: rgba(229, 231, 235, 0.6);
+    }
+
+    .attendance-calendar__cell--inactive {
+        background: rgba(226, 232, 240, 0.4);
+        cursor: not-allowed;
+        opacity: 0.65;
+    }
+
+    .attendance-calendar__cell--inactive:hover {
+        transform: none;
+        box-shadow: none;
+        background: rgba(226, 232, 240, 0.4);
+    }
+
+    .attendance-calendar__table tbody tr:hover td.attendance-calendar__cell--inactive {
+        background: rgba(226, 232, 240, 0.4);
     }
 
     .attendance-calendar__table tbody tr:nth-child(odd) td {
@@ -2470,6 +2525,150 @@
                 this.attendanceContextMenuOutsideHandler = null;
                 this.attendanceContextMenuKeyHandler = null;
                 this.attendanceContextMenuFocusTimer = null;
+                this.employmentStartFieldNames = [
+                    'HireDate',
+                    'hireDate',
+                    'Hire_Date',
+                    'hire_date',
+                    'Hire Date',
+                    'hire date',
+                    'DateHired',
+                    'dateHired',
+                    'Date Hired',
+                    'date hired',
+                    'OnboardDate',
+                    'onboardDate',
+                    'Onboard Date',
+                    'onboard date',
+                    'EmploymentStart',
+                    'employmentStart',
+                    'Employment Start',
+                    'employment start',
+                    'EmploymentStartDate',
+                    'employmentStartDate',
+                    'Employment Start Date',
+                    'employment start date',
+                    'StartDate',
+                    'startDate',
+                    'Start Date',
+                    'start date',
+                    'Start_Date',
+                    'start_date',
+                    'OriginalHireDate',
+                    'originalHireDate',
+                    'Original_Hire_Date',
+                    'original_hire_date',
+                    'Original Hire Date',
+                    'original hire date',
+                    'RehireDate',
+                    'rehireDate',
+                    'Rehire_Date',
+                    'rehire_date',
+                    'Rehire Date',
+                    'rehire date',
+                    'EmploymentStartIso',
+                    'employmentStartIso'
+                ];
+                this.employmentEndFieldNames = [
+                    'TerminationDate',
+                    'terminationDate',
+                    'Termination Date',
+                    'termination date',
+                    'EndDate',
+                    'endDate',
+                    'End Date',
+                    'end date',
+                    'End_Date',
+                    'end_date',
+                    'EmploymentEnd',
+                    'employmentEnd',
+                    'Employment End',
+                    'employment end',
+                    'EmploymentEndDate',
+                    'employmentEndDate',
+                    'Employment End Date',
+                    'employment end date',
+                    'DateOfTermination',
+                    'dateOfTermination',
+                    'Date Of Termination',
+                    'date of termination',
+                    'Termination',
+                    'termination',
+                    'Termination_Date',
+                    'termination_date',
+                    'Termination Date',
+                    'termination date',
+                    'SeparationDate',
+                    'separationDate',
+                    'Separation Date',
+                    'separation date',
+                    'Separation_Date',
+                    'separation_date',
+                    'LastWorkingDate',
+                    'lastWorkingDate',
+                    'Last Working Date',
+                    'last working date',
+                    'EmploymentEndIso',
+                    'employmentEndIso'
+                ];
+                this.employmentStatusAliasMap = new Map([
+                    ['active', 'Active'],
+                    ['activated', 'Active'],
+                    ['inactive', 'Inactive'],
+                    ['terminated', 'Terminated'],
+                    ['leave', 'On Leave'],
+                    ['on leave', 'On Leave'],
+                    ['leave of absence', 'On Leave'],
+                    ['pending', 'Pending'],
+                    ['probation', 'Probation'],
+                    ['probationary', 'Probation'],
+                    ['probationary period', 'Probation'],
+                    ['contract', 'Contract'],
+                    ['contract employee', 'Contract'],
+                    ['contractor', 'Contractor'],
+                    ['consultant', 'Consultant'],
+                    ['consultant/contractor', 'Consultant'],
+                    ['full time', 'Full Time'],
+                    ['full-time', 'Full Time'],
+                    ['fulltime', 'Full Time'],
+                    ['part time', 'Part Time'],
+                    ['part-time', 'Part Time'],
+                    ['parttime', 'Part Time'],
+                    ['seasonal', 'Seasonal'],
+                    ['temporary', 'Temporary'],
+                    ['temp', 'Temporary'],
+                    ['suspended', 'Suspended'],
+                    ['retired', 'Retired'],
+                    ['intern', 'Intern']
+                ]);
+                this.employmentStatusActiveSet = new Set([
+                    'active',
+                    'activated',
+                    'on leave',
+                    'pending',
+                    'probation',
+                    'contract',
+                    'contractor',
+                    'consultant',
+                    'full time',
+                    'full-time',
+                    'fulltime',
+                    'part time',
+                    'part-time',
+                    'parttime',
+                    'seasonal',
+                    'temporary',
+                    'temp',
+                    'intern'
+                ]);
+                this.employmentStatusInactiveSet = new Set([
+                    'inactive',
+                    'terminated',
+                    'suspended',
+                    'retired',
+                    'separated',
+                    'disabled'
+                ]);
                 this.attendanceStatusLegend = [
                     { code: 'P', label: 'Punctual', className: 'attendance-calendar__status--present' },
                     { code: 'B', label: 'Bereavement', className: 'attendance-calendar__status--bereavement' },
@@ -5951,11 +6150,10 @@
                     const managerId = this.getCurrentUserId();
                     const campaignId = this.getCurrentCampaignId() || null;
 
+                    const employmentOptions = { includeInactive: true, includeAllEmployment: true };
                     const [attendanceUsersRaw, scheduleUsersRaw] = await Promise.all([
-                        this.callServerFunction('clientGetAttendanceUsers', managerId, campaignId),
-                        Array.isArray(this.availableUsers) && this.availableUsers.length
-                            ? Promise.resolve(this.availableUsers)
-                            : this.callServerFunction('clientGetScheduleUsers', managerId, campaignId)
+                        this.callServerFunction('clientGetAttendanceUsers', managerId, campaignId, employmentOptions),
+                        this.callServerFunction('clientGetScheduleUsers', managerId, campaignId, employmentOptions)
                     ]);
 
                     const scheduleUsers = Array.isArray(scheduleUsersRaw) ? scheduleUsersRaw : [];
@@ -6188,11 +6386,13 @@
                     const userName = (user.UserName || '').toString().trim();
                     const fullName = (user.FullName || '').toString().trim();
                     const email = (user.Email || '').toString().trim();
+                    const employment = this.getEmploymentPeriod(user);
 
                     const metadata = {
                         userName,
                         fullName,
-                        email
+                        email,
+                        employment
                     };
 
                     [userName, fullName, email].forEach(value => {
@@ -6224,14 +6424,86 @@
                     const displayName = metadata && metadata.fullName
                         ? metadata.fullName
                         : (metadata && metadata.userName ? metadata.userName : name);
+                    const employment = metadata && metadata.employment
+                        ? metadata.employment
+                        : { startDate: null, endDate: null, startIso: '', endIso: '', status: '', statusRaw: '', isStatusActive: true };
 
                     return {
                         identifier,
                         displayName,
                         original: name,
-                        recordKeys: Array.from(recordKeySet)
+                        recordKeys: Array.from(recordKeySet),
+                        employmentStart: employment && employment.startDate ? new Date(employment.startDate.getTime()) : null,
+                        employmentEnd: employment && employment.endDate ? new Date(employment.endDate.getTime()) : null,
+                        employmentStartIso: employment && employment.startIso ? employment.startIso : '',
+                        employmentEndIso: employment && employment.endIso ? employment.endIso : '',
+                        employmentStatus: employment && employment.status ? employment.status : '',
+                        employmentStatusRaw: employment && employment.statusRaw ? employment.statusRaw : '',
+                        employmentStatusIsActive: employment && typeof employment.isStatusActive === 'boolean'
+                            ? employment.isStatusActive
+                            : true
                     };
                 });
+            }
+
+            getEmploymentPeriod(user) {
+                if (!user) {
+                    return { startIso: '', endIso: '', startDate: null, endDate: null, status: '', statusRaw: '', isStatusActive: true };
+                }
+
+                const startFieldNames = Array.isArray(this.employmentStartFieldNames)
+                    ? this.employmentStartFieldNames
+                    : [];
+                const endFieldNames = Array.isArray(this.employmentEndFieldNames)
+                    ? this.employmentEndFieldNames
+                    : [];
+
+                const startIso = this.resolveEmploymentIsoDate(user, startFieldNames);
+                const endIso = this.resolveEmploymentIsoDate(user, endFieldNames);
+
+                const startDate = this.parseIsoDateToLocal(startIso);
+                if (startDate instanceof Date && !Number.isNaN(startDate.getTime())) {
+                    startDate.setHours(0, 0, 0, 0);
+                }
+
+                const endDate = this.parseIsoDateToLocal(endIso);
+                if (endDate instanceof Date && !Number.isNaN(endDate.getTime())) {
+                    endDate.setHours(23, 59, 59, 999);
+                }
+
+                const statusCandidates = [
+                    user.employmentStatusCanonical,
+                    user.EmploymentStatusCanonical,
+                    user.employmentStatusNormalized,
+                    user.EmploymentStatusNormalized,
+                    user.employmentStatus,
+                    user.EmploymentStatus,
+                    user.Status,
+                    user.status
+                ];
+                let statusRaw = '';
+                for (let i = 0; i < statusCandidates.length; i++) {
+                    const candidate = statusCandidates[i];
+                    if (candidate) {
+                        statusRaw = candidate;
+                        break;
+                    }
+                }
+
+                const normalizedStatus = this.normalizeEmploymentStatusLabel(statusRaw);
+                const isStatusActive = typeof user.employmentStatusIsActive === 'boolean'
+                    ? user.employmentStatusIsActive
+                    : this.isEmploymentStatusActive(normalizedStatus || statusRaw);
+
+                return {
+                    startIso: startIso || '',
+                    endIso: endIso || '',
+                    startDate: startDate instanceof Date && !Number.isNaN(startDate.getTime()) ? startDate : null,
+                    endDate: endDate instanceof Date && !Number.isNaN(endDate.getTime()) ? endDate : null,
+                    status: normalizedStatus || this.normalizeEmploymentStatusLabel(statusRaw),
+                    statusRaw: statusRaw || '',
+                    isStatusActive
+                };
             }
 
             isUserEmployedDuringMonth(user, year, month) {
@@ -6252,96 +6524,18 @@
                 const monthStartTime = monthStart.getTime();
                 const monthEndTime = monthEnd.getTime();
 
-                const hireIso = this.resolveEmploymentIsoDate(user, [
-                    'HireDate',
-                    'hireDate',
-                    'Hire_Date',
-                    'hire_date',
-                    'Hire Date',
-                    'hire date',
-                    'DateHired',
-                    'dateHired',
-                    'Date Hired',
-                    'date hired',
-                    'OnboardDate',
-                    'onboardDate',
-                    'Onboard Date',
-                    'onboard date',
-                    'EmploymentStart',
-                    'employmentStart',
-                    'Employment Start',
-                    'employment start',
-                    'EmploymentStartDate',
-                    'employmentStartDate',
-                    'Employment Start Date',
-                    'employment start date',
-                    'StartDate',
-                    'startDate',
-                    'Start Date',
-                    'start date',
-                    'Start_Date',
-                    'start_date',
-                    'OriginalHireDate',
-                    'originalHireDate',
-                    'Original_Hire_Date',
-                    'original_hire_date',
-                    'Original Hire Date',
-                    'original hire date',
-                    'RehireDate',
-                    'rehireDate',
-                    'Rehire_Date',
-                    'rehire_date',
-                    'Rehire Date',
-                    'rehire date'
-                ]);
-                const terminationIso = this.resolveEmploymentIsoDate(user, [
-                    'TerminationDate',
-                    'terminationDate',
-                    'Termination Date',
-                    'termination date',
-                    'EndDate',
-                    'endDate',
-                    'End Date',
-                    'end date',
-                    'End_Date',
-                    'end_date',
-                    'EmploymentEnd',
-                    'employmentEnd',
-                    'Employment End',
-                    'employment end',
-                    'EmploymentEndDate',
-                    'employmentEndDate',
-                    'Employment End Date',
-                    'employment end date',
-                    'DateOfTermination',
-                    'dateOfTermination',
-                    'Date Of Termination',
-                    'date of termination',
-                    'Termination',
-                    'termination',
-                    'Termination_Date',
-                    'termination_date',
-                    'Termination Date',
-                    'termination date',
-                    'SeparationDate',
-                    'separationDate',
-                    'Separation Date',
-                    'separation date',
-                    'Separation_Date',
-                    'separation_date',
-                    'LastWorkingDate',
-                    'lastWorkingDate',
-                    'Last Working Date',
-                    'last working date'
-                ]);
-
-                const hireDate = this.parseIsoDateToLocal(hireIso);
+                const employment = this.getEmploymentPeriod(user);
+                const hireDate = employment.startDate instanceof Date ? employment.startDate : this.parseIsoDateToLocal(employment.startIso);
                 if (hireDate && hireDate.getTime() > monthEndTime) {
                     return false;
                 }
 
-                const terminationDate = this.parseIsoDateToLocal(terminationIso);
+                const terminationDate = employment.endDate instanceof Date ? employment.endDate : this.parseIsoDateToLocal(employment.endIso);
                 if (terminationDate && terminationDate.getTime() < monthStartTime) {
+                    return false;
+                }
+
+                if (employment.isStatusActive === false && !terminationDate) {
                     return false;
                 }
 
@@ -6463,6 +6657,66 @@
                 return null;
             }
 
+            renderParticipantEmploymentMeta(entry) {
+                if (!entry) {
+                    return '';
+                }
+
+                const fragments = [];
+                const statusLabel = this.normalizeEmploymentStatusLabel(entry.employmentStatus || entry.employmentStatusRaw || '');
+                if (statusLabel) {
+                    fragments.push(`<span class="attendance-calendar__participant-status"><i class="fas fa-briefcase"></i>${this.escapeHtml(statusLabel)}</span>`);
+                }
+
+                const startLabel = entry.employmentStartIso ? this.formatDate(entry.employmentStartIso) : '';
+                const endLabel = entry.employmentEndIso ? this.formatDate(entry.employmentEndIso) : '';
+                let rangeLabel = '';
+                if (startLabel && endLabel) {
+                    rangeLabel = `${startLabel} – ${endLabel}`;
+                } else if (startLabel) {
+                    rangeLabel = `Since ${startLabel}`;
+                } else if (endLabel) {
+                    rangeLabel = `Ended ${endLabel}`;
+                }
+
+                if (rangeLabel) {
+                    fragments.push(`<span class="attendance-calendar__participant-dates"><i class="fas fa-calendar-alt"></i>${this.escapeHtml(rangeLabel)}</span>`);
+                }
+
+                if (!fragments.length) {
+                    return '';
+                }
+
+                return `<div class="attendance-calendar__participant-meta">${fragments.join('')}</div>`;
+            }
+
+            buildEmploymentInactiveLabel(entry, dateStr) {
+                const safeDate = dateStr || '';
+                const statusLabel = this.normalizeEmploymentStatusLabel(entry?.employmentStatus || entry?.employmentStatusRaw || '');
+                const startLabel = entry?.employmentStartIso ? this.formatDate(entry.employmentStartIso) : '';
+                const endLabel = entry?.employmentEndIso ? this.formatDate(entry.employmentEndIso) : '';
+
+                const detailParts = [];
+                if (statusLabel) {
+                    detailParts.push(`Status: ${statusLabel}`);
+                }
+
+                if (startLabel && endLabel) {
+                    detailParts.push(`${startLabel} – ${endLabel}`);
+                } else if (startLabel) {
+                    detailParts.push(`Start ${startLabel}`);
+                } else if (endLabel) {
+                    detailParts.push(`End ${endLabel}`);
+                }
+
+                const base = safeDate ? `Not employed on ${safeDate}` : 'Not employed';
+                if (!detailParts.length) {
+                    return base;
+                }
+
+                return `${base} (${detailParts.join(' • ')})`;
+            }
+
             generateAttendanceCalendarGrid(userEntries, year, month, daysInMonth, attendanceMap = new Map()) {
                 const monthDate = new Date(year, month - 1, 1);
                 const monthName = monthDate.toLocaleDateString('en-US', { month: 'long' }).toUpperCase();
@@ -6509,11 +6763,17 @@
                     const safeDisplay = this.escapeHtml(entry.displayName || entry.identifier || '');
                     const clickIdentifier = this.escapeForInlineEvent(entry.identifier || entry.original || '');
                     const clickDisplay = this.escapeForInlineEvent(entry.displayName || entry.identifier || '');
+                    const employmentMeta = this.renderParticipantEmploymentMeta(entry);
+                    const normalizedStatus = this.normalizeEmploymentStatusLabel(entry.employmentStatus || entry.employmentStatusRaw || '');
+                    const safeStatusAttr = normalizedStatus ? this.escapeHtml(normalizedStatus) : '';
+                    const employmentRowAttr = safeStatusAttr ? ` data-employment-status="${safeStatusAttr}"` : '';
+                    const employmentActiveAttr = entry.employmentStatusIsActive === false ? ' data-employment-active="false"' : '';
 
                     html += `
-                                        <tr>
+                                        <tr${employmentRowAttr}${employmentActiveAttr}>
                                             <th scope="row" class="attendance-calendar__participant-cell">
                                                 <span class="attendance-calendar__participant-name" title="${safeDisplay}">${safeDisplay}</span>
+                                                ${employmentMeta}
                                             </th>
                     `;
 
@@ -6521,26 +6781,58 @@
                         const dateStr = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
                         const date = new Date(year, month - 1, day);
                         const isWeekend = date.getDay() === 0 || date.getDay() === 6;
-                        const record = this.resolveAttendanceRecord(entry.recordKeys, dateStr, attendanceMap);
+                        const employmentStart = entry && entry.employmentStart instanceof Date ? entry.employmentStart : null;
+                        const employmentEnd = entry && entry.employmentEnd instanceof Date ? entry.employmentEnd : null;
+                        const cellTime = date.getTime();
+                        const employmentStartTime = employmentStart ? employmentStart.getTime() : null;
+                        const employmentEndTime = employmentEnd ? employmentEnd.getTime() : null;
+                        const isEmployedOnDay = (!employmentStartTime || cellTime >= employmentStartTime)
+                            && (!employmentEndTime || cellTime <= employmentEndTime);
+
+                        const cellClasses = ['attendance-calendar__cell'];
+                        if (isWeekend) {
+                            cellClasses.push('attendance-calendar__cell--weekend');
+                        }
+                        if (!isEmployedOnDay) {
+                            cellClasses.push('attendance-calendar__cell--inactive');
+                        }
+
+                        const record = isEmployedOnDay
+                            ? this.resolveAttendanceRecord(entry.recordKeys, dateStr, attendanceMap)
+                            : null;
                         const badge = record ? this.getAttendanceStatusBadge(record.status) : null;
-                        const badgeLabel = badge ? this.escapeHtml(badge.label) : 'Unmarked';
-                        const statusClass = badge ? `attendance-calendar__status ${badge.className}` : 'attendance-calendar__status attendance-calendar__status--empty';
+                        const badgeLabel = badge
+                            ? this.escapeHtml(badge.label)
+                            : this.escapeHtml(isEmployedOnDay ? 'Unmarked' : this.buildEmploymentInactiveLabel(entry, dateStr));
+                        const statusClass = badge
+                            ? `attendance-calendar__status ${badge.className}`
+                            : `attendance-calendar__status ${isEmployedOnDay ? 'attendance-calendar__status--empty' : 'attendance-calendar__status--inactive'}`;
                         const badgeCode = badge && badge.code && badge.code !== '-' ? badge.code : '';
                         const statusContent = badgeCode ? this.escapeHtml(badgeCode) : '&#8211;';
                         const safeIdentifierAttr = this.escapeHtml(entry.identifier || entry.original || '');
                         const safeDateAttr = this.escapeHtml(dateStr);
-                        const safeStatusAttr = badge ? this.escapeHtml(record?.status || '') : '';
+                        const safeStatusAttr = badge && isEmployedOnDay ? this.escapeHtml(record?.status || '') : '';
                         const statusCodeAttr = badgeCode ? this.escapeHtml(badgeCode) : '';
+                        const cellClassAttr = cellClasses.join(' ');
+                        const displayLabel = (entry.displayName || entry.identifier || '').toString();
+                        const cellTitle = this.escapeHtml(isEmployedOnDay
+                            ? `Right-click or tap to mark attendance for ${displayLabel} on ${dateStr}`
+                            : `${displayLabel} • ${this.buildEmploymentInactiveLabel(entry, dateStr)}`);
+                        const inactiveReasonAttr = !isEmployedOnDay ? this.escapeHtml(this.buildEmploymentInactiveLabel(entry, dateStr)) : '';
+                        const employmentAttr = isEmployedOnDay
+                            ? ''
+                            : ` data-attendance-employment="inactive"${inactiveReasonAttr ? ` data-attendance-employment-reason="${inactiveReasonAttr}"` : ''}`;
+                        const interactionAttributes = isEmployedOnDay
+                            ? ` onclick="scheduleManager.showAttendanceContextMenu(event, '${clickIdentifier}', '${dateStr}', '${clickDisplay}')" oncontextmenu="scheduleManager.showAttendanceContextMenu(event, '${clickIdentifier}', '${dateStr}', '${clickDisplay}')"`
+                            : '';
 
                         html += `
-                                            <td class="${isWeekend ? 'attendance-calendar__cell attendance-calendar__cell--weekend' : 'attendance-calendar__cell'}"
+                                            <td class="${cellClassAttr}"
                                                 data-attendance-user="${safeIdentifierAttr}"
                                                 data-attendance-date="${safeDateAttr}"
                                                 data-attendance-status="${safeStatusAttr}"
-                                                data-attendance-status-code="${statusCodeAttr}"
-                                                onclick="scheduleManager.showAttendanceContextMenu(event, '${clickIdentifier}', '${dateStr}', '${clickDisplay}')"
-                                                oncontextmenu="scheduleManager.showAttendanceContextMenu(event, '${clickIdentifier}', '${dateStr}', '${clickDisplay}')"
-                                                title="Right-click or tap to mark attendance for ${safeDisplay} on ${dateStr}">
+                                                data-attendance-status-code="${statusCodeAttr}"${employmentAttr}${interactionAttributes}
+                                                title="${cellTitle}">
                                                 <span class="${statusClass}" title="${badgeLabel}">${statusContent}</span>
                                             </td>
                         `;
@@ -7034,6 +7326,45 @@
                 }
 
                 return '';
+            }
+
+            normalizeEmploymentStatusLabel(status) {
+                const raw = (status === null || typeof status === 'undefined') ? '' : status.toString().trim();
+                if (!raw) {
+                    return '';
+                }
+
+                const lower = raw.toLowerCase();
+                if (this.employmentStatusAliasMap && this.employmentStatusAliasMap.has(lower)) {
+                    return this.employmentStatusAliasMap.get(lower);
+                }
+
+                if (this.employmentStatusAliasMap) {
+                    for (const value of this.employmentStatusAliasMap.values()) {
+                        if (typeof value === 'string' && value.toLowerCase() === lower) {
+                            return value;
+                        }
+                    }
+                }
+
+                return raw;
+            }
+
+            isEmploymentStatusActive(status) {
+                const normalized = (this.normalizeEmploymentStatusLabel(status) || '').toLowerCase();
+                if (!normalized) {
+                    return true;
+                }
+
+                if (this.employmentStatusInactiveSet && this.employmentStatusInactiveSet.has(normalized)) {
+                    return false;
+                }
+
+                if (this.employmentStatusActiveSet && this.employmentStatusActiveSet.has(normalized)) {
+                    return true;
+                }
+
+                return true;
             }
 
             normalizeAttendanceStatusKey(value) {


### PR DESCRIPTION
## Summary
- allow schedule and attendance user fetchers to optionally include inactive agents and normalize their employment dates/status metadata
- surface employment status, hire, and termination ranges on the attendance calendar and hide agents outside their active employment windows
- annotate inactive calendar cells with precise employment reasons while preserving interaction only for days within employment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f617fc3bc883269cf9c7161d85e5bf