### PR TITLE
Enhance QA dashboard signals and intelligence

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -63,9 +63,10 @@
   }
 
   .qa-shell {
-    max-width: min(1380px, 100%);
-    margin: 0 auto;
-    padding: 1.5rem 1.5rem 3rem;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 1.5rem clamp(1.5rem, 3vw, 2.5rem) 3rem;
   }
 
   .qa-dashboard {
@@ -400,6 +401,80 @@
     border-radius: 999px;
     padding: 0.55rem 1.2rem;
     font-weight: 600;
+  }
+
+  .qa-signal-list {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .qa-signal-item {
+    border-radius: var(--qa-radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    padding: 1rem 1.2rem;
+    background: rgba(255, 255, 255, 0.96);
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .qa-signal-item[data-tone="negative"] {
+    border-color: rgba(239, 68, 68, 0.28);
+    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.08);
+  }
+
+  .qa-signal-item[data-tone="warning"] {
+    border-color: rgba(245, 158, 11, 0.28);
+    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.08);
+  }
+
+  .qa-signal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .qa-signal-title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .qa-signal-badge {
+    border-radius: 999px;
+    padding: 0.25rem 0.65rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--qa-primary);
+  }
+
+  .qa-signal-badge.negative {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--qa-danger);
+  }
+
+  .qa-signal-badge.warning {
+    background: rgba(245, 158, 11, 0.16);
+    color: var(--qa-warning);
+  }
+
+  .qa-signal-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.85rem;
+    color: #475569;
+  }
+
+  .qa-signal-note {
+    font-size: 0.85rem;
+    color: #475569;
+  }
+
+  .qa-signal-empty {
+    text-align: center;
+    font-size: 0.9rem;
+    color: #64748b;
   }
 
   .qa-insight-count {
@@ -753,6 +828,50 @@
     </div>
   </div>
 
+  <div class="row g-4 mt-1" id="qa-signal-row">
+    <div class="col-12 col-xl-5">
+      <div class="card h-100">
+        <div class="card-header">Critical Question Signals</div>
+        <div class="card-body">
+          <div id="qa-question-empty" class="qa-signal-empty">Need more evaluations to surface question-level risk.</div>
+          <div class="qa-signal-list" id="qa-question-signals"></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-xl-4">
+      <div class="card h-100">
+        <div class="card-header">Program Performance</div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-borderless align-middle qa-table">
+              <thead>
+                <tr>
+                  <th>Program</th>
+                  <th class="text-center">Avg Score</th>
+                  <th class="text-center">Pass Rate</th>
+                  <th class="text-center">Evals</th>
+                </tr>
+              </thead>
+              <tbody id="qa-program-body">
+                <tr>
+                  <td colspan="4" class="text-center text-muted py-4">Awaiting data</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-xl-3">
+      <div class="card h-100">
+        <div class="card-header">Quality Signal Radar</div>
+        <div class="card-body">
+          <div class="qa-signal-list" id="qa-signal-radar"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="row g-4 mt-1" id="qa-lower-section">
     <div class="col-12 col-lg-6">
       <div class="card h-100">
@@ -926,6 +1045,10 @@
       openActions: document.getElementById('qa-open-actions'),
       insightsModal: document.getElementById('qaInsightsModal'),
       actionsModal: document.getElementById('qaActionsModal'),
+      questionSignals: document.getElementById('qa-question-signals'),
+      questionEmpty: document.getElementById('qa-question-empty'),
+      programBody: document.getElementById('qa-program-body'),
+      signalRadar: document.getElementById('qa-signal-radar'),
       notesBody: document.getElementById('qa-notes-body'),
       notesMeta: document.getElementById('qa-notes-meta'),
       notesCard: document.getElementById('qa-notes-card')
@@ -1591,6 +1714,141 @@
       });
     }
 
+    function renderQuestionSignals(signals) {
+      if (!dom.questionSignals) return;
+
+      const items = Array.isArray(signals) ? signals : [];
+      dom.questionSignals.innerHTML = '';
+
+      if (dom.questionEmpty) {
+        dom.questionEmpty.classList.toggle('d-none', items.length > 0);
+      }
+
+      if (!items.length) {
+        return;
+      }
+
+      items.forEach(signal => {
+        const container = document.createElement('div');
+        container.className = 'qa-signal-item';
+
+        const tone = signal.severity === 'negative'
+          ? 'negative'
+          : (signal.severity === 'warning' ? 'warning' : '');
+        if (tone) {
+          container.dataset.tone = tone;
+        }
+
+        const header = document.createElement('div');
+        header.className = 'qa-signal-header';
+
+        const title = document.createElement('div');
+        title.className = 'qa-signal-title';
+        title.textContent = `${signal.shortLabel || ''} · ${signal.question || ''}`;
+
+        const badge = document.createElement('span');
+        badge.className = `qa-signal-badge ${tone}`.trim();
+        badge.textContent = `${typeof signal.passRate === 'number' ? signal.passRate : '--'}% pass`;
+
+        header.appendChild(title);
+        header.appendChild(badge);
+        container.appendChild(header);
+
+        const meta = document.createElement('div');
+        meta.className = 'qa-signal-meta';
+        meta.innerHTML = `
+          <span><i class="fa-solid fa-circle-check text-success me-1"></i>${signal.yesCount || 0} yes</span>
+          <span><i class="fa-solid fa-circle-xmark text-danger me-1"></i>${signal.noCount || 0} no</span>
+          <span><i class="fa-solid fa-circle-minus text-muted me-1"></i>${signal.naCount || 0} n/a</span>`;
+        container.appendChild(meta);
+
+        if (signal.primaryNote) {
+          const note = document.createElement('div');
+          note.className = 'qa-signal-note';
+          note.innerHTML = `<i class="fa-solid fa-quote-left me-2 text-primary"></i>${escapeHtml(signal.primaryNote)}`;
+          container.appendChild(note);
+        }
+
+        dom.questionSignals.appendChild(container);
+      });
+    }
+
+    function renderProgramMetrics(programs) {
+      if (!dom.programBody) return;
+
+      const items = Array.isArray(programs) ? programs : [];
+      dom.programBody.innerHTML = '';
+
+      if (!items.length) {
+        const row = document.createElement('tr');
+        row.innerHTML = '<td colspan="4" class="text-center text-muted py-4">No program performance metrics yet.</td>';
+        dom.programBody.appendChild(row);
+        return;
+      }
+
+      items.slice(0, 6).forEach(program => {
+        const tone = program.severity === 'negative'
+          ? 'negative'
+          : (program.severity === 'warning' ? 'warning' : '');
+        const badgeClass = tone;
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>
+            <div class="fw-semibold">${escapeHtml(program.name || 'Unassigned')}</div>
+            <div class="text-muted small">${program.share ? program.share + '% of volume' : ''}</div>
+          </td>
+          <td class="text-center fw-semibold">${program.avgScore || 0}%</td>
+          <td class="text-center">
+            <span class="qa-signal-badge ${badgeClass}">${program.passRate || 0}%</span>
+          </td>
+          <td class="text-center fw-semibold">${program.evaluations || 0}</td>`;
+        dom.programBody.appendChild(row);
+      });
+    }
+
+    function renderSignalHighlights(signals) {
+      if (!dom.signalRadar) return;
+
+      const items = Array.isArray(signals) ? signals : [];
+      dom.signalRadar.innerHTML = '';
+
+      if (!items.length) {
+        const empty = document.createElement('div');
+        empty.className = 'qa-signal-item';
+        empty.innerHTML = '<div class="qa-signal-title">AI monitoring</div><div class="qa-signal-note text-muted">No anomalies detected for the selected filters.</div>';
+        dom.signalRadar.appendChild(empty);
+        return;
+      }
+
+      items.forEach(signal => {
+        const item = document.createElement('div');
+        item.className = 'qa-signal-item';
+        if (signal.tone === 'negative' || signal.tone === 'urgent') {
+          item.dataset.tone = 'negative';
+        } else if (signal.tone === 'warning') {
+          item.dataset.tone = 'warning';
+        }
+
+        const header = document.createElement('div');
+        header.className = 'qa-signal-header';
+        const title = document.createElement('div');
+        title.className = 'qa-signal-title';
+        const icon = signal.icon || 'fa-signal';
+        title.innerHTML = `<i class="fa-solid ${icon} me-2"></i>${escapeHtml(signal.title || '')}`;
+        header.appendChild(title);
+        item.appendChild(header);
+
+        if (signal.text) {
+          const note = document.createElement('div');
+          note.className = 'qa-signal-note';
+          note.textContent = signal.text;
+          item.appendChild(note);
+        }
+
+        dom.signalRadar.appendChild(item);
+      });
+    }
+
     function createDeltaBadge(delta) {
       if (delta === null || delta === undefined || Number.isNaN(delta)) {
         return '<span class="qa-delta-badge neutral">--</span>';
@@ -1783,6 +2041,10 @@
       renderDistributionChart(agents);
       renderAgents(agents.slice(0, 8));
       renderLatestEvaluation(response.latestEvaluation || null);
+
+      renderQuestionSignals(response.questionSignals || []);
+      renderProgramMetrics(response.programMetrics || []);
+      renderSignalHighlights(response.qualitySignals || []);
 
       if (dom.intelSummary) {
         dom.intelSummary.textContent = response.intelligenceSummary

--- a/QAService.js
+++ b/QAService.js
@@ -956,6 +956,13 @@ function clientGetQADashboardSnapshot(request = {}) {
     const prevCategoryMetrics = computeCategoryMetrics_(prevFiltered);
     const categorySummary = summarizeCategoryChange_(categoryMetrics, prevCategoryMetrics);
 
+    const questionMetrics = computeQuestionPerformance_(filtered.length ? filtered : records);
+    const questionSignals = buildQuestionSignalHighlights_(questionMetrics);
+
+    const programMetrics = computeProgramMetrics_(filtered.length ? filtered : records, {
+      totalRecords: records.length
+    });
+
     const agentDisplayLookup = buildAgentDisplayLookup_(records);
 
     const { profiles } = calculateAgentProfiles_(filtered, { displayLookup: agentDisplayLookup });
@@ -995,7 +1002,17 @@ function clientGetQADashboardSnapshot(request = {}) {
       prevCategoryMetrics,
       kpis,
       granularity: context.granularity,
-      agentLookup: agentDisplayLookup
+      agentLookup: agentDisplayLookup,
+      questionMetrics,
+      programMetrics,
+      trendAnalysis
+    });
+
+    const qualitySignals = buildQualitySignals_({
+      questionSignals,
+      programMetrics,
+      kpis,
+      trendAnalysis
     });
 
     const summary = Object.assign({}, kpis, {
@@ -1042,6 +1059,7 @@ function clientGetQADashboardSnapshot(request = {}) {
       actions: (intelligence && intelligence.actions) ? intelligence.actions : [],
       nextBest: intelligence ? intelligence.nextBest : null,
       intelligenceSummary: intelligence ? intelligence.summary : '',
+      qualitySignals,
       metadata: {
         generatedAt: new Date().toISOString(),
         totalRecords: records.length
@@ -1050,7 +1068,9 @@ function clientGetQADashboardSnapshot(request = {}) {
       latestEvaluation,
       availableAgents,
       agentOptions,
-      agentNameLookup
+      agentNameLookup,
+      questionSignals,
+      programMetrics
     };
   } catch (error) {
     console.error('clientGetQADashboardSnapshot failed:', error);
@@ -1462,7 +1482,10 @@ function buildAIIntelligenceAnalysis_(payload) {
     prevCategoryMetrics = {},
     kpis = {},
     granularity,
-    agentLookup = {}
+    agentLookup = {},
+    questionMetrics = [],
+    programMetrics = [],
+    trendAnalysis = null
   } = payload || {};
 
   const totalEvaluations = filtered.length;
@@ -1631,6 +1654,57 @@ function buildAIIntelligenceAnalysis_(payload) {
     });
   }
 
+  const highImpactQuestion = Array.isArray(questionMetrics)
+    ? questionMetrics.find(metric => metric.severity && metric.severity !== 'positive')
+    : null;
+
+  if (highImpactQuestion) {
+    base.actions.push({
+      icon: 'fa-triangle-exclamation',
+      tone: 'urgent',
+      title: `Stabilize ${highImpactQuestion.shortLabel}`,
+      text: `${highImpactQuestion.passRate}% pass with ${highImpactQuestion.noCount} misses. Launch calibration or targeted coaching.`
+    });
+
+    if (highImpactQuestion.primaryNote) {
+      base.insights.push({
+        icon: 'fa-microphone-lines',
+        tone: 'negative',
+        title: `${highImpactQuestion.shortLabel} risk driver`,
+        text: highImpactQuestion.primaryNote
+      });
+    }
+  }
+
+  const atRiskProgram = Array.isArray(programMetrics)
+    ? programMetrics.find(program => program.severity && program.severity !== 'positive')
+    : null;
+
+  if (atRiskProgram) {
+    base.actions.push({
+      icon: 'fa-diagram-project',
+      tone: 'urgent',
+      title: `Stabilize ${atRiskProgram.name}`,
+      text: `${atRiskProgram.passRate}% pass across ${atRiskProgram.evaluations} evaluations. Align QA and operations immediately.`
+    });
+
+    base.insights.push({
+      icon: 'fa-network-wired',
+      tone: 'negative',
+      title: `${atRiskProgram.name} underperforming`,
+      text: `Average score ${atRiskProgram.avgScore}% with ${atRiskProgram.agentCoverage} agents impacted.`
+    });
+  }
+
+  if (trendAnalysis && trendAnalysis.forecast) {
+    base.insights.push({
+      icon: 'fa-chart-line',
+      tone: trendAnalysis.health === 'risk' ? 'negative' : trendAnalysis.health === 'improving' ? 'positive' : '',
+      title: `Forecast ${trendAnalysis.health === 'risk' ? 'signals risk' : trendAnalysis.health === 'improving' ? 'shows lift' : 'steady'}`,
+      text: `Projected avg ${trendAnalysis.forecast.avg}% and pass ${trendAnalysis.forecast.pass}% next ${trendAnalysis.nextLabel}.`
+    });
+  }
+
   if (!base.insights.length) {
     base.insights.push({
       icon: 'fa-lightbulb',
@@ -1644,6 +1718,57 @@ function buildAIIntelligenceAnalysis_(payload) {
   base.nextBest = base.actions.length ? base.actions[0] : null;
 
   return base;
+}
+
+function buildQualitySignals_(payload = {}) {
+  const {
+    questionSignals = [],
+    programMetrics = [],
+    kpis = {},
+    trendAnalysis = null
+  } = payload;
+
+  const signals = [];
+
+  const primaryQuestion = questionSignals.find(signal => signal.severity !== 'positive');
+  if (primaryQuestion) {
+    signals.push({
+      icon: 'fa-circle-exclamation',
+      tone: primaryQuestion.severity === 'negative' ? 'negative' : 'warning',
+      title: `${primaryQuestion.shortLabel} at ${primaryQuestion.passRate}%`,
+      text: `${primaryQuestion.noCount} negative responses out of ${primaryQuestion.totalResponses}.`
+    });
+  }
+
+  const riskProgram = programMetrics.find(program => program.severity === 'negative');
+  if (riskProgram) {
+    signals.push({
+      icon: 'fa-sitemap',
+      tone: 'negative',
+      title: `${riskProgram.name} degradation`,
+      text: `Average ${riskProgram.avgScore}% quality with ${riskProgram.passRate}% pass rate.`
+    });
+  }
+
+  if (typeof kpis.coverage === 'number' && kpis.coverage < 80) {
+    signals.push({
+      icon: 'fa-user-shield',
+      tone: 'warning',
+      title: 'Coverage below 80%',
+      text: `Only ${kpis.coverage}% of the agent population has been evaluated.`
+    });
+  }
+
+  if (trendAnalysis && trendAnalysis.health === 'risk') {
+    signals.push({
+      icon: 'fa-arrow-trend-down',
+      tone: 'negative',
+      title: 'Declining trajectory',
+      text: trendAnalysis.summary
+    });
+  }
+
+  return signals;
 }
 
 function calculateAgentProfiles_(records, options = {}) {
@@ -1867,6 +1992,208 @@ function summarizeCategoryChange_(currentMetrics, previousMetrics) {
 
   details.sort((a, b) => b.avgScore - a.avgScore);
   return details;
+}
+
+function computeQuestionPerformance_(records) {
+  const questionText = qaQuestionText_();
+  const weights = qaWeights_();
+  const metrics = [];
+
+  Object.keys(questionText).forEach(key => {
+    let yesCount = 0;
+    let noCount = 0;
+    let naCount = 0;
+    const notes = [];
+
+    (records || []).forEach(record => {
+      if (!record || !record.raw) {
+        return;
+      }
+
+      const raw = record.raw;
+      const answerRaw = getAnswerValue_(raw, key);
+      if (answerRaw === undefined || answerRaw === null || answerRaw === '') {
+        return;
+      }
+
+      const answer = String(answerRaw).trim().toLowerCase();
+      if (answer === 'yes') {
+        yesCount += 1;
+      } else if (answer === 'no') {
+        noCount += 1;
+        const note = getQuestionNoteValue_(raw, key);
+        if (note) {
+          notes.push(String(note));
+        }
+      } else {
+        naCount += 1;
+      }
+    });
+
+    const total = yesCount + noCount + naCount;
+    const passRate = total ? Math.round((yesCount / total) * 100) : 0;
+    const failRate = total ? Math.round((noCount / total) * 100) : 0;
+    const weight = weights[key] || weights[key.toLowerCase()] || 0;
+    const impactScore = Math.round((failRate / 100) * Math.max(weight, 1) * total);
+    const cleanedNotes = summarizeNotes_(notes);
+
+    metrics.push({
+      key,
+      question: questionText[key],
+      shortLabel: key.toUpperCase(),
+      passRate,
+      failRate,
+      yesCount,
+      noCount,
+      naCount,
+      totalResponses: total,
+      weight,
+      impactScore,
+      notes: cleanedNotes,
+      primaryNote: cleanedNotes.length ? cleanedNotes[0] : '',
+      severity: determineSeverityFromRate_(passRate)
+    });
+  });
+
+  return metrics.sort((a, b) => {
+    if (a.severity === b.severity) {
+      return b.impactScore - a.impactScore;
+    }
+    const order = { negative: 2, warning: 1, positive: 0 };
+    return (order[b.severity] || 0) - (order[a.severity] || 0);
+  });
+}
+
+function buildQuestionSignalHighlights_(metrics) {
+  if (!Array.isArray(metrics)) {
+    return [];
+  }
+
+  return metrics
+    .filter(metric => metric.totalResponses > 0)
+    .slice(0, 6);
+}
+
+function summarizeNotes_(notes) {
+  if (!Array.isArray(notes) || !notes.length) {
+    return [];
+  }
+
+  const seen = new Set();
+  const result = [];
+
+  notes.forEach(note => {
+    const cleaned = String(note || '').trim();
+    if (!cleaned) {
+      return;
+    }
+    const normalized = cleaned.toLowerCase();
+    if (seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    const truncated = cleaned.length > 160 ? `${cleaned.slice(0, 157)}…` : cleaned;
+    result.push(truncated);
+  });
+
+  return result.slice(0, 3);
+}
+
+function determineSeverityFromRate_(passRate) {
+  if (typeof passRate !== 'number') {
+    return 'positive';
+  }
+  if (passRate >= 92) {
+    return 'positive';
+  }
+  if (passRate >= 85) {
+    return 'warning';
+  }
+  return 'negative';
+}
+
+function computeProgramMetrics_(records, options = {}) {
+  const aggregates = {};
+  const totalUniverse = Number(options.totalRecords) || 0;
+
+  (records || []).forEach(record => {
+    if (!record) {
+      return;
+    }
+
+    const name = resolveProgramNameFromRecord_(record) || 'Unassigned';
+    if (!aggregates[name]) {
+      aggregates[name] = {
+        evaluations: 0,
+        scoreSum: 0,
+        passCount: 0,
+        agents: new Set()
+      };
+    }
+
+    const bucket = aggregates[name];
+    bucket.evaluations += 1;
+    bucket.scoreSum += record.percentage || 0;
+    if (record.pass) {
+      bucket.passCount += 1;
+    }
+    if (record.agent) {
+      bucket.agents.add(record.agent);
+    }
+  });
+
+  return Object.keys(aggregates).map(name => {
+    const bucket = aggregates[name];
+    const avgScore = bucket.evaluations
+      ? Math.round((bucket.scoreSum / bucket.evaluations) * 100)
+      : 0;
+    const passRate = bucket.evaluations
+      ? Math.round((bucket.passCount / bucket.evaluations) * 100)
+      : 0;
+    const share = totalUniverse
+      ? Math.round((bucket.evaluations / totalUniverse) * 100)
+      : 0;
+
+    return {
+      name,
+      evaluations: bucket.evaluations,
+      avgScore,
+      passRate,
+      agentCoverage: bucket.agents.size,
+      share,
+      severity: determineSeverityFromRate_(passRate)
+    };
+  }).sort((a, b) => {
+    if (a.severity === b.severity) {
+      return b.evaluations - a.evaluations;
+    }
+    const order = { negative: 2, warning: 1, positive: 0 };
+    return (order[b.severity] || 0) - (order[a.severity] || 0);
+  }).slice(0, 8);
+}
+
+function resolveProgramNameFromRecord_(record) {
+  if (!record) {
+    return '';
+  }
+
+  const raw = record.raw || {};
+  const programField = getRecordFieldValue_(raw, [
+    'Program',
+    'Program Name',
+    'ProgramName',
+    'Campaign',
+    'Campaign Name',
+    'Line Of Business',
+    'LineOfBusiness',
+    'LOB'
+  ]);
+
+  if (programField) {
+    return String(programField).trim();
+  }
+
+  return record.campaign || '';
 }
 
 function computeCategoryMetrics_(records) {


### PR DESCRIPTION
## Summary
- add a critical signal row to the QA dashboard highlighting question risk, program performance, and AI radar insights
- compute question- and program-level quality metrics on the server and expose them alongside existing summaries
- expand intelligence generation to react to failing questions, weak programs, and trend forecasts
- align the QA dashboard body layout with the global banner width for consistent presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f61c7620808326837ccff24205f2e6