### PR TITLE
Fix profile banner overflow

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -149,6 +149,11 @@
     align-items: center;
     gap: clamp(1rem, 2.5vw, 2rem);
     flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .profile-banner__headline > * {
+    min-width: 0;
   }
 
   .profile-banner__avatar {
@@ -170,12 +175,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
+    min-width: 0;
   }
 
   .profile-banner__name {
     font-size: clamp(2rem, 3vw, 2.8rem);
     font-weight: 700;
     color: var(--profile-navy);
+    word-break: break-word;
   }
 
   .profile-banner__role {
@@ -195,6 +202,7 @@
     font-size: 0.95rem;
     font-weight: 600;
     color: rgba(15, 23, 42, 0.65);
+    word-break: break-word;
   }
 
   .profile-banner__chips {
@@ -267,6 +275,7 @@
     flex-wrap: wrap;
     gap: 1rem;
     padding-top: 0.75rem;
+    width: 100%;
   }
 
   .profile-banner__contact {
@@ -279,15 +288,19 @@
     color: var(--profile-navy);
     font-weight: 600;
     font-size: 0.95rem;
+    max-width: 100%;
+    flex: 1 1 220px;
   }
 
   .profile-banner__contact i {
     color: var(--profile-cyan);
   }
 
-  .profile-banner__contact a {
+  .profile-banner__contact a,
+  .profile-banner__contact span {
     color: inherit;
     text-decoration: none;
+    overflow-wrap: anywhere;
   }
 
   .profile-banner__contact a:hover,


### PR DESCRIPTION
## Summary
- prevent the profile banner headline and contacts from stretching the layout by constraining flex children and allowing long text to wrap

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f62baeb2c08326b8d34f8f9c412242