### PR TITLE
Normalize schedule period handling across service and utilities

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -19,6 +19,126 @@ const SCHEDULE_SETTINGS = (typeof getScheduleConfig === 'function')
       CACHE_DURATION: 300
     };
 
+const DEFAULT_SCHEDULE_TIME_ZONE = (typeof Session !== 'undefined' && typeof Session.getScriptTimeZone === 'function')
+  ? Session.getScriptTimeZone()
+  : 'UTC';
+
+function resolveSchedulePeriodStart(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  if (!record || typeof record !== 'object') {
+    return '';
+  }
+
+  const candidates = [
+    record.PeriodStart,
+    record.StartDate,
+    record.ScheduleStart,
+    record.AssignmentStart,
+    record.Date,
+    record.ScheduleDate,
+    record.Day
+  ];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const normalized = normalizeDateForSheet(candidates[i], timeZone);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+function resolveSchedulePeriodEnd(record, fallbackStart = '', timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  if (!record || typeof record !== 'object') {
+    return '';
+  }
+
+  const candidates = [
+    record.PeriodEnd,
+    record.EndDate,
+    record.ScheduleEnd,
+    record.AssignmentEnd,
+    record.Date,
+    record.ScheduleDate,
+    record.Day,
+    fallbackStart
+  ];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const normalized = normalizeDateForSheet(candidates[i], timeZone);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+function resolveSchedulePeriodStartDate(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const start = resolveSchedulePeriodStart(record, timeZone);
+  if (!start) {
+    return null;
+  }
+
+  const startDate = new Date(start);
+  return isNaN(startDate.getTime()) ? null : startDate;
+}
+
+function resolveSchedulePeriodEndDate(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const start = resolveSchedulePeriodStart(record, timeZone);
+  const end = resolveSchedulePeriodEnd(record, start, timeZone);
+  if (!end) {
+    return null;
+  }
+
+  const endDate = new Date(end);
+  return isNaN(endDate.getTime()) ? null : endDate;
+}
+
+function normalizeSchedulePeriodRecord(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  if (!record || typeof record !== 'object') {
+    return record;
+  }
+
+  const normalizedStart = resolveSchedulePeriodStart(record, timeZone);
+  const normalizedEnd = resolveSchedulePeriodEnd(record, normalizedStart, timeZone);
+
+  if (!normalizedStart && !normalizedEnd) {
+    return record;
+  }
+
+  const normalizedRecord = Object.assign({}, record);
+
+  if (normalizedStart) {
+    normalizedRecord.PeriodStart = normalizedStart;
+    normalizedRecord.Date = normalizedStart;
+  }
+
+  if (normalizedEnd) {
+    normalizedRecord.PeriodEnd = normalizedEnd;
+  }
+
+  return normalizedRecord;
+}
+
+function buildScheduleCompositeKey(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const normalizedRecord = normalizeSchedulePeriodRecord(record, timeZone);
+  const userPart = normalizeUserKey(
+    (normalizedRecord && (normalizedRecord.UserName || normalizedRecord.UserID || normalizedRecord.userName || normalizedRecord.userId))
+      || ''
+  );
+
+  const start = normalizedRecord ? normalizedRecord.PeriodStart || '' : '';
+  const end = normalizedRecord ? normalizedRecord.PeriodEnd || start : '';
+
+  return `${userPart}::${start}::${end}`;
+}
+
+function getSchedulePeriodSortValue(record, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const startDate = resolveSchedulePeriodStartDate(record, timeZone);
+  return startDate ? startDate.getTime() : 0;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // USER MANAGEMENT FUNCTIONS - Integrated with MainUtilities
 // ────────────────────────────────────────────────────────────────────────────
@@ -975,28 +1095,25 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
 
     console.log(`⏰ Working with ${shiftSlots.length} shift slot(s)`);
 
-    // Generate schedules
+    // Prepare schedule generation tracking
     const generatedSchedules = [];
     const conflicts = [];
     const dstChanges = [];
 
-    // Loop through each date
-    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-      const currentDate = new Date(d);
-      const dateStr = Utilities.formatDate(currentDate, Session.getScriptTimeZone(), 'yyyy-MM-dd');
-      const dayOfWeek = currentDate.getDay(); // 0 = Sunday, 1 = Monday, etc.
+    // Generate schedules for the entire period
+    const timeZone = Session.getScriptTimeZone();
+    const periodStartStr = Utilities.formatDate(start, timeZone, 'yyyy-MM-dd');
+    const periodEndStr = Utilities.formatDate(end, timeZone, 'yyyy-MM-dd');
 
-      console.log(`📅 Processing date: ${dateStr} (Day: ${dayOfWeek})`);
-
-      // Check for holidays using ScheduleUtilities
-      const isHoliday = checkIfHoliday(dateStr);
-      if (isHoliday && !options.includeHolidays) {
-        console.log(`🎉 Skipping holiday: ${dateStr}`);
-        continue;
+    const dstStatusByDate = {};
+    [periodStartStr, periodEndStr].forEach(dateStr => {
+      if (!dateStr || dstStatusByDate[dateStr]) {
+        return;
       }
 
-      // Check DST status using ScheduleUtilities
       const dstStatus = checkDSTStatus(dateStr);
+      dstStatusByDate[dateStr] = dstStatus;
+
       if (dstStatus.isDSTChange) {
         dstChanges.push({
           date: dateStr,
@@ -1004,98 +1121,98 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
           adjustment: dstStatus.timeAdjustment
         });
       }
+    });
 
-      // Generate schedules for each user
-      usersToSchedule.forEach(userName => {
-        try {
-          // Get suitable shift slots for this user and day from the selected/available slots
-          const suitableSlots = shiftSlots.filter(slot => {
-            if (!slot.IsActive) return false;
-
-            // Check if slot is active on this day of week
-            const daysOfWeek = slot.DaysOfWeek ? slot.DaysOfWeek.split(',').map(d => parseInt(d)) : [1, 2, 3, 4, 5];
-            return daysOfWeek.includes(dayOfWeek);
-          });
-
-          if (suitableSlots.length === 0) {
-            console.log(`⚠️ No suitable slots for ${userName} on ${dateStr} from selected slots`);
-            conflicts.push({
-              user: userName,
-              date: dateStr,
-              error: 'No suitable shift slots available for this day from selected slots',
-              type: 'NO_SUITABLE_SLOTS'
-            });
-            return;
+    usersToSchedule.forEach(userName => {
+      try {
+        const suitableSlots = shiftSlots.filter(slot => {
+          if (slot.IsActive === false) {
+            return false;
           }
+          return true;
+        });
 
-          // Select best suitable slot (can be enhanced with more logic)
-          // For now, prefer slots with higher capacity or priority
-          const selectedSlot = suitableSlots.sort((a, b) => {
-            const priorityA = a.Priority || 2;
-            const priorityB = b.Priority || 2;
-            if (priorityA !== priorityB) return priorityB - priorityA; // Higher priority first
-            
-            const capacityA = a.MaxCapacity || 10;
-            const capacityB = b.MaxCapacity || 10;
-            return capacityB - capacityA; // Higher capacity first
-          })[0];
-
-          // Check for conflicts using ScheduleUtilities
-          const existingSchedule = checkExistingSchedule(userName, dateStr);
-          if (existingSchedule && !options.overrideExisting) {
-            conflicts.push({
-              user: userName,
-              date: dateStr,
-              error: 'User already has a schedule for this date',
-              type: 'USER_DOUBLE_BOOKING'
-            });
-            return;
-          }
-
-          // Create schedule record using ScheduleUtilities time functions
-          const schedule = {
-            ID: Utilities.getUuid(),
-            UserID: getUserIdByName(userName),
-            UserName: userName,
-            Date: dateStr,
-            SlotID: selectedSlot.ID,
-            SlotName: selectedSlot.Name,
-            StartTime: selectedSlot.StartTime,
-            EndTime: selectedSlot.EndTime,
-            OriginalStartTime: selectedSlot.StartTime,
-            OriginalEndTime: selectedSlot.EndTime,
-            BreakStart: calculateBreakStart(selectedSlot),
-            BreakEnd: calculateBreakEnd(selectedSlot),
-            LunchStart: calculateLunchStart(selectedSlot),
-            LunchEnd: calculateLunchEnd(selectedSlot),
-            IsDST: dstStatus.isDST,
-            Status: 'PENDING',
-            GeneratedBy: generatedBy,
-            ApprovedBy: null,
-            NotificationSent: false,
-            CreatedAt: new Date(),
-            UpdatedAt: new Date(),
-            RecurringScheduleID: null,
-            SwapRequestID: null,
-            Priority: options.priority || 2,
-            Notes: options.notes || `Generated from selected slot: ${selectedSlot.Name}`,
-            Location: selectedSlot.Location || '',
-            Department: selectedSlot.Department || ''
-          };
-
-          generatedSchedules.push(schedule);
-          console.log(`✅ Generated schedule for ${userName} on ${dateStr} using slot: ${selectedSlot.Name}`);
-
-        } catch (userError) {
+        if (suitableSlots.length === 0) {
+          console.log(`⚠️ No active slots available for ${userName} in the requested period`);
           conflicts.push({
             user: userName,
-            date: dateStr,
-            error: userError.message,
-            type: 'GENERATION_ERROR'
+            periodStart: periodStartStr,
+            periodEnd: periodEndStr,
+            error: 'No active shift slots available for this period',
+            type: 'NO_SLOT'
           });
+          return;
         }
-      });
-    }
+
+        const selectedSlot = suitableSlots.sort((a, b) => {
+          const priorityA = a.Priority || 2;
+          const priorityB = b.Priority || 2;
+          if (priorityA !== priorityB) return priorityB - priorityA;
+
+          const capacityA = a.MaxCapacity || 10;
+          const capacityB = b.MaxCapacity || 10;
+          return capacityB - capacityA;
+        })[0];
+
+        const existingSchedule = checkExistingSchedule(userName, periodStartStr, periodEndStr);
+        if (existingSchedule && !options.overrideExisting) {
+          conflicts.push({
+            user: userName,
+            periodStart: periodStartStr,
+            periodEnd: periodEndStr,
+            existingScheduleId: existingSchedule.ID,
+            error: 'User already has a schedule in this period',
+            type: 'USER_DOUBLE_BOOKING'
+          });
+          return;
+        }
+
+        const schedule = {
+          ID: Utilities.getUuid(),
+          UserID: getUserIdByName(userName),
+          UserName: userName,
+          Date: periodStartStr,
+          PeriodStart: periodStartStr,
+          PeriodEnd: periodEndStr,
+          SlotID: selectedSlot.ID,
+          SlotName: selectedSlot.Name,
+          StartTime: selectedSlot.StartTime,
+          EndTime: selectedSlot.EndTime,
+          OriginalStartTime: selectedSlot.StartTime,
+          OriginalEndTime: selectedSlot.EndTime,
+          BreakStart: calculateBreakStart(selectedSlot),
+          BreakEnd: calculateBreakEnd(selectedSlot),
+          LunchStart: calculateLunchStart(selectedSlot),
+          LunchEnd: calculateLunchEnd(selectedSlot),
+          IsDST: (dstStatusByDate[periodStartStr] && dstStatusByDate[periodStartStr].isDST) || false,
+          Status: 'PENDING',
+          GeneratedBy: generatedBy,
+          ApprovedBy: null,
+          NotificationSent: false,
+          CreatedAt: new Date(),
+          UpdatedAt: new Date(),
+          RecurringScheduleID: null,
+          SwapRequestID: null,
+          Priority: options.priority || 2,
+          Notes: options.notes || `Generated from selected slot: ${selectedSlot.Name}`,
+          Location: selectedSlot.Location || '',
+          Department: selectedSlot.Department || ''
+        };
+
+        const normalizedSchedule = normalizeSchedulePeriodRecord(schedule, timeZone);
+        generatedSchedules.push(normalizedSchedule);
+        console.log(`✅ Generated schedule for ${userName} from ${periodStartStr} to ${periodEndStr} using slot: ${selectedSlot.Name}`);
+
+      } catch (userError) {
+        conflicts.push({
+          user: userName,
+          periodStart: periodStartStr,
+          periodEnd: periodEndStr,
+          error: userError.message,
+          type: 'GENERATION_ERROR'
+        });
+      }
+    });
 
     // Save generated schedules using ScheduleUtilities
     if (generatedSchedules.length > 0) {
@@ -1109,7 +1226,9 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
       generated: generatedSchedules.length,
       conflicts: conflicts,
       dstChanges: dstChanges,
-      message: `Successfully generated ${generatedSchedules.length} schedules using ${shiftSlots.length} shift slot(s)`,
+      message: `Successfully generated ${generatedSchedules.length} schedules for period ${periodStartStr} to ${periodEndStr} using ${shiftSlots.length} shift slot(s)`,
+      periodStart: periodStartStr,
+      periodEnd: periodEndStr,
       schedules: generatedSchedules.slice(0, 10), // Return first 10 for preview
       userCount: usersToSchedule.length,
       shiftSlotsUsed: shiftSlots.length,
@@ -1141,8 +1260,14 @@ function saveSchedulesToSheet(schedules) {
     const sheet = ensureScheduleSheetWithHeaders(SCHEDULE_GENERATION_SHEET, SCHEDULE_GENERATION_HEADERS);
 
     schedules.forEach(schedule => {
+      const normalized = normalizeSchedulePeriodRecord(schedule);
       // Create row data using proper header order from ScheduleUtilities
-      const rowData = SCHEDULE_GENERATION_HEADERS.map(header => schedule[header] || '');
+      const rowData = SCHEDULE_GENERATION_HEADERS.map(header => {
+        if (normalized && Object.prototype.hasOwnProperty.call(normalized, header)) {
+          return normalized[header];
+        }
+        return '';
+      });
       sheet.appendRow(rowData);
     });
 
@@ -1177,19 +1302,37 @@ function clientGetAllSchedules(filters = {}) {
       }
     }
 
-    console.log(`📊 Total schedules in sheet: ${schedules.length}`);
+    const normalizedSchedules = schedules.map(record => normalizeSchedulePeriodRecord(record));
 
-    let filteredSchedules = schedules;
+    console.log(`📊 Total schedules in sheet: ${normalizedSchedules.length}`);
+
+    let filteredSchedules = normalizedSchedules.slice();
 
     // Apply filters
     if (filters.startDate) {
       const startDate = new Date(filters.startDate);
-      filteredSchedules = filteredSchedules.filter(s => new Date(s.Date) >= startDate);
+      if (!isNaN(startDate.getTime())) {
+        filteredSchedules = filteredSchedules.filter(s => {
+          const scheduleEnd = resolveSchedulePeriodEndDate(s) || resolveSchedulePeriodStartDate(s);
+          if (!scheduleEnd) {
+            return true;
+          }
+          return scheduleEnd >= startDate;
+        });
+      }
     }
 
     if (filters.endDate) {
       const endDate = new Date(filters.endDate);
-      filteredSchedules = filteredSchedules.filter(s => new Date(s.Date) <= endDate);
+      if (!isNaN(endDate.getTime())) {
+        filteredSchedules = filteredSchedules.filter(s => {
+          const scheduleStart = resolveSchedulePeriodStartDate(s);
+          if (!scheduleStart) {
+            return true;
+          }
+          return scheduleStart <= endDate;
+        });
+      }
     }
 
     if (filters.userId) {
@@ -1208,8 +1351,8 @@ function clientGetAllSchedules(filters = {}) {
       filteredSchedules = filteredSchedules.filter(s => s.Department === filters.department);
     }
 
-    // Sort by date (newest first)
-    filteredSchedules.sort((a, b) => new Date(b.Date) - new Date(a.Date));
+    // Sort by period start (newest first)
+    filteredSchedules.sort((a, b) => getSchedulePeriodSortValue(b) - getSchedulePeriodSortValue(a));
 
     console.log(`✅ Returning ${filteredSchedules.length} filtered schedules`);
 
@@ -1233,9 +1376,9 @@ function clientGetAllSchedules(filters = {}) {
 }
 
 /**
- * Import schedules from uploaded data
+ * Core schedule import implementation shared by all callers
  */
-function clientImportSchedules(importRequest = {}) {
+function internalClientImportSchedules(importRequest = {}) {
   try {
     const schedules = Array.isArray(importRequest.schedules) ? importRequest.schedules : [];
     if (schedules.length === 0) {
@@ -1243,112 +1386,89 @@ function clientImportSchedules(importRequest = {}) {
     }
 
     const metadata = importRequest.metadata || {};
-    const timeZone = typeof Session !== 'undefined' ? Session.getScriptTimeZone() : 'UTC';
+    const timeZone = DEFAULT_SCHEDULE_TIME_ZONE;
     const now = new Date();
     const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
 
     const userLookup = buildScheduleUserLookup();
     const normalizedNew = schedules
       .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
-      .filter(record => record);
+      .filter(record => record)
+      .map(record => normalizeSchedulePeriodRecord(record, timeZone));
 
     if (normalizedNew.length === 0) {
       throw new Error('No valid schedules were found in the uploaded file.');
     }
 
     const existingRecords = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
+    const normalizedExisting = existingRecords.map(record => normalizeSchedulePeriodRecord(record, timeZone));
     const replaceExisting = metadata.replaceExisting === true;
 
-    const dateObjects = normalizedNew
-      .map(record => new Date(record.Date))
-      .filter(date => !isNaN(date.getTime()));
+    let minStart = null;
+    let maxEnd = null;
 
-    let minDate = null;
-    let maxDate = null;
-    if (dateObjects.length > 0) {
-      minDate = new Date(Math.min.apply(null, dateObjects));
-      maxDate = new Date(Math.max.apply(null, dateObjects));
-    }
+    normalizedNew.forEach(record => {
+      const startDate = resolveSchedulePeriodStartDate(record, timeZone);
+      const endDate = resolveSchedulePeriodEndDate(record, timeZone) || startDate;
+
+      if (startDate && (!minStart || startDate < minStart)) {
+        minStart = new Date(startDate);
+      }
+      if (endDate && (!maxEnd || endDate > maxEnd)) {
+        maxEnd = new Date(endDate);
+      }
+    });
 
     if (metadata.startDate) {
       metadata.startDate = normalizeDateForSheet(metadata.startDate, timeZone);
-    } else if (metadata.startWeekDate) {
-      metadata.startDate = normalizeDateForSheet(metadata.startWeekDate, timeZone);
     }
-
     if (metadata.endDate) {
       metadata.endDate = normalizeDateForSheet(metadata.endDate, timeZone);
-    } else if (metadata.endWeekDate) {
-      metadata.endDate = normalizeDateForSheet(metadata.endWeekDate, timeZone);
+    }
+    if (metadata.startWeekDate) {
+      metadata.startWeekDate = normalizeDateForSheet(metadata.startWeekDate, timeZone);
+    }
+    if (metadata.endWeekDate) {
+      metadata.endWeekDate = normalizeDateForSheet(metadata.endWeekDate, timeZone);
     }
 
-    const newKeys = new Set(normalizedNew.map(record => `${normalizeUserKey(record.UserName || record.UserID)}::${record.Date}`));
+    if (!metadata.startDate && metadata.startWeekDate) {
+      metadata.startDate = metadata.startWeekDate;
+    }
+    if (!metadata.endDate && metadata.endWeekDate) {
+      metadata.endDate = metadata.endWeekDate;
+    }
+
+    const newKeys = new Set(normalizedNew.map(record => buildScheduleCompositeKey(record, timeZone)));
     let replacedCount = 0;
 
-    const retainedRecords = existingRecords.filter(existing => {
-      const existingDate = normalizeDateForSheet(existing.Date, timeZone);
-      if (!existingDate) {
-        return true;
-      }
-
-      const key = `${normalizeUserKey(existing.UserName || existing.UserID)}::${existingDate}`;
-
-      if (replaceExisting && minDate && maxDate) {
-        const existingDateObj = new Date(existingDate);
-        if (!isNaN(existingDateObj.getTime()) && existingDateObj >= minDate && existingDateObj <= maxDate) {
-          replacedCount++;
-          return false;
-        }
-      }
-
+    const retainedRecords = normalizedExisting.filter(existing => {
+      const key = buildScheduleCompositeKey(existing, timeZone);
       if (newKeys.has(key)) {
         replacedCount++;
         return false;
       }
 
+      if (replaceExisting && minStart && maxEnd) {
+        const existingStart = resolveSchedulePeriodStartDate(existing, timeZone);
+        const existingEnd = resolveSchedulePeriodEndDate(existing, timeZone) || existingStart;
+        if (existingStart && existingEnd && existingEnd >= minStart && existingStart <= maxEnd) {
+          replacedCount++;
+          return false;
+        }
+      }
+
       return true;
     });
-
-    const normalizedMin = minDate ? normalizeDateForSheet(minDate, timeZone) : '';
-    const normalizedMax = maxDate ? normalizeDateForSheet(maxDate, timeZone) : '';
-
-    const summary = typeof metadata.summary === 'object' && metadata.summary !== null ? metadata.summary : {};
-    if (metadata.startDate && !summary.startDate) {
-      summary.startDate = metadata.startDate;
-    } else if (normalizedMin && !summary.startDate) {
-      summary.startDate = normalizedMin;
-    }
-    if (metadata.endDate && !summary.endDate) {
-      summary.endDate = metadata.endDate;
-    } else if (normalizedMax && !summary.endDate) {
-      summary.endDate = normalizedMax;
-    }
-    if (typeof summary.totalAssignments !== 'number') {
-      summary.totalAssignments = normalizedNew.length;
-    }
-    if (typeof summary.totalShifts !== 'number') {
-      summary.totalShifts = normalizedNew.length;
-    }
-    if (typeof summary.dayCount !== 'number' || summary.dayCount <= 0) {
-      summary.dayCount = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-    }
-    metadata.summary = summary;
-
-    if (!metadata.dayCount) {
-      const computedDays = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-      if (computedDays) {
-        metadata.dayCount = computedDays;
-      }
-    }
 
     const combinedRecords = retainedRecords.concat(normalizedNew);
 
     combinedRecords.sort((a, b) => {
-      const dateA = new Date(a.Date || 0);
-      const dateB = new Date(b.Date || 0);
-      if (dateA.getTime() !== dateB.getTime()) {
-        return dateA - dateB;
+      const diff = getSchedulePeriodSortValue(a, timeZone) - getSchedulePeriodSortValue(b, timeZone);
+      if (diff !== 0) {
+        return diff;
       }
+
       const nameA = (a.UserName || '').toString();
       const nameB = (b.UserName || '').toString();
       return nameA.localeCompare(nameB);
@@ -1357,14 +1477,65 @@ function clientImportSchedules(importRequest = {}) {
     writeToScheduleSheet(SCHEDULE_GENERATION_SHEET, combinedRecords);
     invalidateScheduleCaches();
 
+    const normalizedStart = minStart ? normalizeDateForSheet(minStart, timeZone) : '';
+    const normalizedEnd = maxEnd ? normalizeDateForSheet(maxEnd, timeZone) : '';
+
+    const summary = typeof metadata.summary === 'object' && metadata.summary !== null
+      ? metadata.summary
+      : {};
+
+    if (metadata.startDate && !summary.startDate) {
+      summary.startDate = metadata.startDate;
+    } else if (normalizedStart && !summary.startDate) {
+      summary.startDate = normalizedStart;
+    }
+
+    if (metadata.endDate && !summary.endDate) {
+      summary.endDate = metadata.endDate;
+    } else if (normalizedEnd && !summary.endDate) {
+      summary.endDate = normalizedEnd;
+    }
+
+    if (typeof summary.totalAssignments !== 'number') {
+      summary.totalAssignments = normalizedNew.length;
+    }
+    if (typeof summary.totalShifts !== 'number') {
+      summary.totalShifts = normalizedNew.length;
+    }
+
+    const daySpan = calculateDaySpanCount(metadata.startDate, metadata.endDate, minStart, maxEnd);
+    if ((typeof summary.dayCount !== 'number' || summary.dayCount <= 0) && daySpan) {
+      summary.dayCount = daySpan;
+    }
+
+    const weekSpan = calculateWeekSpanCount(
+      metadata.startWeekDate || metadata.startDate,
+      metadata.endWeekDate || metadata.endDate,
+      minStart,
+      maxEnd
+    );
+    if ((typeof summary.weekCount !== 'number' || summary.weekCount <= 0) && weekSpan) {
+      summary.weekCount = weekSpan;
+    }
+
+    metadata.summary = summary;
+
+    if (!metadata.dayCount && daySpan) {
+      metadata.dayCount = daySpan;
+    }
+
+    if (!metadata.weekCount && weekSpan) {
+      metadata.weekCount = weekSpan;
+    }
+
     return {
       success: true,
       importedCount: normalizedNew.length,
       replacedCount,
       totalAfterImport: combinedRecords.length,
       range: {
-        start: normalizedMin,
-        end: normalizedMax
+        start: normalizedStart,
+        end: normalizedEnd
       },
       metadata
     };
@@ -1377,6 +1548,13 @@ function clientImportSchedules(importRequest = {}) {
       error: error.message
     };
   }
+}
+
+/**
+ * Import schedules from uploaded data
+ */
+function clientImportSchedules(importRequest = {}) {
+  return internalClientImportSchedules(importRequest);
 }
 
 /**
@@ -1472,435 +1650,6 @@ function clientFetchScheduleSheetData(request = {}) {
   } catch (error) {
     console.error('❌ Error fetching schedule data from Google Sheets:', error);
     safeWriteError('clientFetchScheduleSheetData', error);
-    return {
-      success: false,
-      error: error.message
-    };
-  }
-}
-
-/**
- * Import schedules from uploaded data
- */
-function clientImportSchedules(importRequest = {}) {
-  try {
-    const schedules = Array.isArray(importRequest.schedules) ? importRequest.schedules : [];
-    if (schedules.length === 0) {
-      throw new Error('No schedules were provided for import.');
-    }
-
-    const metadata = importRequest.metadata || {};
-    const timeZone = typeof Session !== 'undefined' ? Session.getScriptTimeZone() : 'UTC';
-    const now = new Date();
-    const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
-
-    const userLookup = buildScheduleUserLookup();
-    const normalizedNew = schedules
-      .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
-      .filter(record => record);
-
-    if (normalizedNew.length === 0) {
-      throw new Error('No valid schedules were found in the uploaded file.');
-    }
-
-    const existingRecords = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    const replaceExisting = metadata.replaceExisting === true;
-
-    const dateObjects = normalizedNew
-      .map(record => new Date(record.Date))
-      .filter(date => !isNaN(date.getTime()));
-
-    let minDate = null;
-    let maxDate = null;
-    if (dateObjects.length > 0) {
-      minDate = new Date(Math.min.apply(null, dateObjects));
-      maxDate = new Date(Math.max.apply(null, dateObjects));
-    }
-
-    if (metadata.startDate) {
-      metadata.startDate = normalizeDateForSheet(metadata.startDate, timeZone);
-    } else if (metadata.startWeekDate) {
-      metadata.startDate = normalizeDateForSheet(metadata.startWeekDate, timeZone);
-    }
-
-    if (metadata.endDate) {
-      metadata.endDate = normalizeDateForSheet(metadata.endDate, timeZone);
-    } else if (metadata.endWeekDate) {
-      metadata.endDate = normalizeDateForSheet(metadata.endWeekDate, timeZone);
-    }
-
-    const newKeys = new Set(normalizedNew.map(record => `${normalizeUserKey(record.UserName || record.UserID)}::${record.Date}`));
-    let replacedCount = 0;
-
-    const retainedRecords = existingRecords.filter(existing => {
-      const existingDate = normalizeDateForSheet(existing.Date, timeZone);
-      if (!existingDate) {
-        return true;
-      }
-
-      const key = `${normalizeUserKey(existing.UserName || existing.UserID)}::${existingDate}`;
-
-      if (replaceExisting && minDate && maxDate) {
-        const existingDateObj = new Date(existingDate);
-        if (!isNaN(existingDateObj.getTime()) && existingDateObj >= minDate && existingDateObj <= maxDate) {
-          replacedCount++;
-          return false;
-        }
-      }
-
-      if (newKeys.has(key)) {
-        replacedCount++;
-        return false;
-      }
-
-      return true;
-    });
-
-    const normalizedMin = minDate ? normalizeDateForSheet(minDate, timeZone) : '';
-    const normalizedMax = maxDate ? normalizeDateForSheet(maxDate, timeZone) : '';
-
-    const summary = typeof metadata.summary === 'object' && metadata.summary !== null ? metadata.summary : {};
-    if (metadata.startDate && !summary.startDate) {
-      summary.startDate = metadata.startDate;
-    } else if (normalizedMin && !summary.startDate) {
-      summary.startDate = normalizedMin;
-    }
-    if (metadata.endDate && !summary.endDate) {
-      summary.endDate = metadata.endDate;
-    } else if (normalizedMax && !summary.endDate) {
-      summary.endDate = normalizedMax;
-    }
-    if (typeof summary.totalAssignments !== 'number') {
-      summary.totalAssignments = normalizedNew.length;
-    }
-    if (typeof summary.totalShifts !== 'number') {
-      summary.totalShifts = normalizedNew.length;
-    }
-    if (typeof summary.dayCount !== 'number' || summary.dayCount <= 0) {
-      summary.dayCount = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-    }
-    metadata.summary = summary;
-
-    if (!metadata.dayCount) {
-      const computedDays = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-      if (computedDays) {
-        metadata.dayCount = computedDays;
-      }
-    }
-
-    const combinedRecords = retainedRecords.concat(normalizedNew);
-
-    combinedRecords.sort((a, b) => {
-      const dateA = new Date(a.Date || 0);
-      const dateB = new Date(b.Date || 0);
-      if (dateA.getTime() !== dateB.getTime()) {
-        return dateA - dateB;
-      }
-      const nameA = (a.UserName || '').toString();
-      const nameB = (b.UserName || '').toString();
-      return nameA.localeCompare(nameB);
-    });
-
-    writeToScheduleSheet(SCHEDULE_GENERATION_SHEET, combinedRecords);
-    invalidateScheduleCaches();
-
-    return {
-      success: true,
-      importedCount: normalizedNew.length,
-      replacedCount,
-      totalAfterImport: combinedRecords.length,
-      range: {
-        start: normalizedMin,
-        end: normalizedMax
-      },
-      metadata
-    };
-
-  } catch (error) {
-    console.error('❌ Error importing schedules:', error);
-    safeWriteError('clientImportSchedules', error);
-    return {
-      success: false,
-      error: error.message
-    };
-  }
-}
-
-/**
- * Import schedules from uploaded data
- */
-function clientImportSchedules(importRequest = {}) {
-  try {
-    const schedules = Array.isArray(importRequest.schedules) ? importRequest.schedules : [];
-    if (schedules.length === 0) {
-      throw new Error('No schedules were provided for import.');
-    }
-
-    const metadata = importRequest.metadata || {};
-    const timeZone = typeof Session !== 'undefined' ? Session.getScriptTimeZone() : 'UTC';
-    const now = new Date();
-    const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
-
-    const userLookup = buildScheduleUserLookup();
-    const normalizedNew = schedules
-      .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
-      .filter(record => record);
-
-    if (normalizedNew.length === 0) {
-      throw new Error('No valid schedules were found in the uploaded file.');
-    }
-
-    const existingRecords = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    const replaceExisting = metadata.replaceExisting === true;
-
-    const dateObjects = normalizedNew
-      .map(record => new Date(record.Date))
-      .filter(date => !isNaN(date.getTime()));
-
-    let minDate = null;
-    let maxDate = null;
-    if (dateObjects.length > 0) {
-      minDate = new Date(Math.min.apply(null, dateObjects));
-      maxDate = new Date(Math.max.apply(null, dateObjects));
-    }
-
-    if (metadata.startDate) {
-      metadata.startDate = normalizeDateForSheet(metadata.startDate, timeZone);
-    } else if (metadata.startWeekDate) {
-      metadata.startDate = normalizeDateForSheet(metadata.startWeekDate, timeZone);
-    }
-
-    if (metadata.endDate) {
-      metadata.endDate = normalizeDateForSheet(metadata.endDate, timeZone);
-    } else if (metadata.endWeekDate) {
-      metadata.endDate = normalizeDateForSheet(metadata.endWeekDate, timeZone);
-    }
-
-    const newKeys = new Set(normalizedNew.map(record => `${normalizeUserKey(record.UserName || record.UserID)}::${record.Date}`));
-    let replacedCount = 0;
-
-    const retainedRecords = existingRecords.filter(existing => {
-      const existingDate = normalizeDateForSheet(existing.Date, timeZone);
-      if (!existingDate) {
-        return true;
-      }
-
-      const key = `${normalizeUserKey(existing.UserName || existing.UserID)}::${existingDate}`;
-
-      if (replaceExisting && minDate && maxDate) {
-        const existingDateObj = new Date(existingDate);
-        if (!isNaN(existingDateObj.getTime()) && existingDateObj >= minDate && existingDateObj <= maxDate) {
-          replacedCount++;
-          return false;
-        }
-      }
-
-      if (newKeys.has(key)) {
-        replacedCount++;
-        return false;
-      }
-
-      return true;
-    });
-
-    const normalizedMin = minDate ? normalizeDateForSheet(minDate, timeZone) : '';
-    const normalizedMax = maxDate ? normalizeDateForSheet(maxDate, timeZone) : '';
-
-    const summary = typeof metadata.summary === 'object' && metadata.summary !== null ? metadata.summary : {};
-    if (metadata.startDate && !summary.startDate) {
-      summary.startDate = metadata.startDate;
-    } else if (normalizedMin && !summary.startDate) {
-      summary.startDate = normalizedMin;
-    }
-    if (metadata.endDate && !summary.endDate) {
-      summary.endDate = metadata.endDate;
-    } else if (normalizedMax && !summary.endDate) {
-      summary.endDate = normalizedMax;
-    }
-    if (typeof summary.totalAssignments !== 'number') {
-      summary.totalAssignments = normalizedNew.length;
-    }
-    if (typeof summary.totalShifts !== 'number') {
-      summary.totalShifts = normalizedNew.length;
-    }
-    if (typeof summary.dayCount !== 'number' || summary.dayCount <= 0) {
-      summary.dayCount = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-    }
-    metadata.summary = summary;
-
-    if (!metadata.dayCount) {
-      const computedDays = calculateDaySpanCount(metadata.startDate, metadata.endDate, minDate, maxDate);
-      if (computedDays) {
-        metadata.dayCount = computedDays;
-      }
-    }
-
-    const combinedRecords = retainedRecords.concat(normalizedNew);
-
-    combinedRecords.sort((a, b) => {
-      const dateA = new Date(a.Date || 0);
-      const dateB = new Date(b.Date || 0);
-      if (dateA.getTime() !== dateB.getTime()) {
-        return dateA - dateB;
-      }
-      const nameA = (a.UserName || '').toString();
-      const nameB = (b.UserName || '').toString();
-      return nameA.localeCompare(nameB);
-    });
-
-    writeToScheduleSheet(SCHEDULE_GENERATION_SHEET, combinedRecords);
-    invalidateScheduleCaches();
-
-    return {
-      success: true,
-      importedCount: normalizedNew.length,
-      replacedCount,
-      totalAfterImport: combinedRecords.length,
-      range: {
-        start: normalizedMin,
-        end: normalizedMax
-      },
-      metadata
-    };
-
-  } catch (error) {
-    console.error('❌ Error importing schedules:', error);
-    safeWriteError('clientImportSchedules', error);
-    return {
-      success: false,
-      error: error.message
-    };
-  }
-}
-
-/**
- * Import schedules from uploaded data
- */
-function clientImportSchedules(importRequest = {}) {
-  try {
-    const schedules = Array.isArray(importRequest.schedules) ? importRequest.schedules : [];
-    if (schedules.length === 0) {
-      throw new Error('No schedules were provided for import.');
-    }
-
-    const metadata = importRequest.metadata || {};
-    const timeZone = typeof Session !== 'undefined' ? Session.getScriptTimeZone() : 'UTC';
-    const now = new Date();
-    const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
-
-    const userLookup = buildScheduleUserLookup();
-    const normalizedNew = schedules
-      .map(raw => normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, timeZone))
-      .filter(record => record);
-
-    if (normalizedNew.length === 0) {
-      throw new Error('No valid schedules were found in the uploaded file.');
-    }
-
-    const existingRecords = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    const replaceExisting = metadata.replaceExisting === true;
-
-    const dateObjects = normalizedNew
-      .map(record => new Date(record.Date))
-      .filter(date => !isNaN(date.getTime()));
-
-    let minDate = null;
-    let maxDate = null;
-    if (dateObjects.length > 0) {
-      minDate = new Date(Math.min.apply(null, dateObjects));
-      maxDate = new Date(Math.max.apply(null, dateObjects));
-    }
-
-    if (metadata.startWeekDate) {
-      metadata.startWeekDate = normalizeDateForSheet(metadata.startWeekDate, timeZone);
-    }
-    if (metadata.endWeekDate) {
-      metadata.endWeekDate = normalizeDateForSheet(metadata.endWeekDate, timeZone);
-    }
-
-    const newKeys = new Set(normalizedNew.map(record => `${normalizeUserKey(record.UserName || record.UserID)}::${record.Date}`));
-    let replacedCount = 0;
-
-    const retainedRecords = existingRecords.filter(existing => {
-      const existingDate = normalizeDateForSheet(existing.Date, timeZone);
-      if (!existingDate) {
-        return true;
-      }
-
-      const key = `${normalizeUserKey(existing.UserName || existing.UserID)}::${existingDate}`;
-
-      if (replaceExisting && minDate && maxDate) {
-        const existingDateObj = new Date(existingDate);
-        if (!isNaN(existingDateObj.getTime()) && existingDateObj >= minDate && existingDateObj <= maxDate) {
-          replacedCount++;
-          return false;
-        }
-      }
-
-      if (newKeys.has(key)) {
-        replacedCount++;
-        return false;
-      }
-
-      return true;
-    });
-
-    const normalizedMin = minDate ? normalizeDateForSheet(minDate, timeZone) : '';
-    const normalizedMax = maxDate ? normalizeDateForSheet(maxDate, timeZone) : '';
-
-    const summary = typeof metadata.summary === 'object' && metadata.summary !== null ? metadata.summary : {};
-    if (normalizedMin && !summary.startDate) {
-      summary.startDate = normalizedMin;
-    }
-    if (normalizedMax && !summary.endDate) {
-      summary.endDate = normalizedMax;
-    }
-    if (typeof summary.totalAssignments !== 'number') {
-      summary.totalAssignments = normalizedNew.length;
-    }
-    if (typeof summary.totalShifts !== 'number') {
-      summary.totalShifts = normalizedNew.length;
-    }
-    metadata.summary = summary;
-
-    if (!metadata.weekCount) {
-      const computedWeeks = calculateWeekSpanCount(metadata.startWeekDate, metadata.endWeekDate, minDate, maxDate);
-      if (computedWeeks) {
-        metadata.weekCount = computedWeeks;
-      }
-    }
-
-    const combinedRecords = retainedRecords.concat(normalizedNew);
-
-    combinedRecords.sort((a, b) => {
-      const dateA = new Date(a.Date || 0);
-      const dateB = new Date(b.Date || 0);
-      if (dateA.getTime() !== dateB.getTime()) {
-        return dateA - dateB;
-      }
-      const nameA = (a.UserName || '').toString();
-      const nameB = (b.UserName || '').toString();
-      return nameA.localeCompare(nameB);
-    });
-
-    writeToScheduleSheet(SCHEDULE_GENERATION_SHEET, combinedRecords);
-    invalidateScheduleCaches();
-
-    return {
-      success: true,
-      importedCount: normalizedNew.length,
-      replacedCount,
-      totalAfterImport: combinedRecords.length,
-      range: {
-        start: normalizedMin,
-        end: normalizedMax
-      },
-      metadata
-    };
-
-  } catch (error) {
-    console.error('❌ Error importing schedules:', error);
-    safeWriteError('clientImportSchedules', error);
     return {
       success: false,
       error: error.message
@@ -2433,19 +2182,24 @@ function clientAddManualShiftSlots(request = {}) {
 
     const buildRecordKeys = (record) => {
       const keys = [];
-      const date = normalizeDateForSheet(record && record.Date, timeZone);
-      if (!date) {
+      const normalized = normalizeSchedulePeriodRecord(record, timeZone);
+      const start = normalized && normalized.PeriodStart ? normalized.PeriodStart : '';
+      const end = normalized && normalized.PeriodEnd ? normalized.PeriodEnd : start;
+
+      if (!start) {
         return keys;
       }
 
+      const periodKey = `${start}::${end}`;
+
       const idKey = normalizeUserIdValue(record && record.UserID);
       if (idKey) {
-        keys.push(`id::${idKey}::${date}`);
+        keys.push(`id::${idKey}::${periodKey}`);
       }
 
       const nameKey = normalizeUserKey(record && (record.UserName || record.FullName || record.UserID));
       if (nameKey) {
-        keys.push(`name::${nameKey}::${date}`);
+        keys.push(`name::${nameKey}::${periodKey}`);
       }
 
       return keys;
@@ -3094,12 +2848,42 @@ function getUserIdByName(userName) {
 }
 
 /**
- * Check if schedule exists for user on date - uses ScheduleUtilities
+ * Check if schedule exists for user within a period - uses ScheduleUtilities
  */
-function checkExistingSchedule(userName, date) {
+function checkExistingSchedule(userName, periodStart, periodEnd) {
   try {
     const schedules = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    return schedules.find(s => s.UserName === userName && s.Date === date);
+    const normalizeDate = (typeof normalizeScheduleDate === 'function')
+      ? normalizeScheduleDate
+      : value => {
+          if (!value) {
+            return null;
+          }
+          const date = new Date(value);
+          return isNaN(date.getTime()) ? null : date;
+        };
+
+    const requestedStart = normalizeDate(periodStart);
+    const requestedEnd = normalizeDate(periodEnd || periodStart);
+
+    if (!requestedStart || !requestedEnd) {
+      return null;
+    }
+
+    return schedules.find(schedule => {
+      if (schedule.UserName !== userName) {
+        return false;
+      }
+
+      const existingStart = normalizeDate(schedule.PeriodStart || schedule.Date);
+      const existingEnd = normalizeDate(schedule.PeriodEnd || schedule.Date || schedule.PeriodStart);
+
+      if (!existingStart || !existingEnd) {
+        return false;
+      }
+
+      return existingStart <= requestedEnd && existingEnd >= requestedStart;
+    }) || null;
   } catch (error) {
     console.warn('Error checking existing schedule:', error);
     return null;
@@ -3124,10 +2908,32 @@ function normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, time
     return null;
   }
 
-  const dateStr = normalizeDateForSheet(raw.Date, timeZone);
+  const periodStart = normalizeDateForSheet(
+    raw.PeriodStart
+      || raw.StartDate
+      || raw.AssignmentStart
+      || raw.ScheduleStart
+      || raw.Date
+      || raw.ScheduleDate,
+    timeZone
+  );
+
+  const dateStr = normalizeDateForSheet(raw.Date || raw.ScheduleDate || periodStart, timeZone);
+  const periodEnd = normalizeDateForSheet(
+    raw.PeriodEnd
+      || raw.EndDate
+      || raw.AssignmentEnd
+      || raw.ScheduleEnd
+      || raw.Date
+      || raw.ScheduleDate
+      || periodStart,
+    timeZone
+  );
+
+  const primaryDate = periodStart || dateStr;
   const userName = (raw.UserName || '').toString().trim();
 
-  if (!userName || !dateStr) {
+  if (!userName || !primaryDate) {
     return null;
   }
 
@@ -3165,7 +2971,9 @@ function normalizeImportedScheduleRecord(raw, metadata, userLookup, nowIso, time
     ID: raw.ID || Utilities.getUuid(),
     UserID: raw.UserID || (matchedUser ? matchedUser.ID : ''),
     UserName: matchedUser ? (matchedUser.UserName || matchedUser.FullName) : userName,
-    Date: dateStr,
+    Date: primaryDate,
+    PeriodStart: periodStart || primaryDate,
+    PeriodEnd: periodEnd || primaryDate,
     SlotID: raw.SlotID || '',
     SlotName: raw.SlotName || `Imported ${raw.SourceDayLabel || 'Shift'}`,
     StartTime: raw.StartTime || '',
@@ -3380,6 +3188,7 @@ function convertLegacyScheduleRecord(raw) {
   const userName = resolve(['UserName', 'Agent', 'AgentName', 'Name', 'User']);
   const userId = resolve(['UserID', 'UserId', 'AgentID', 'AgentId', 'EmployeeID']);
   const scheduleDate = resolve(['Date', 'ScheduleDate', 'ShiftDate', 'Day']);
+  const scheduleEnd = resolve(['PeriodEnd', 'EndDate', 'ShiftEndDate', 'AssignmentEnd', 'ScheduleEnd'], scheduleDate);
   const slotName = resolve(['SlotName', 'Shift', 'ShiftName', 'Schedule']);
 
   const timezone = (typeof Session !== 'undefined' && Session.getScriptTimeZone)
@@ -3404,11 +3213,16 @@ function convertLegacyScheduleRecord(raw) {
     ? Utilities.getUuid()
     : `legacy-schedule-${Math.random().toString(36).slice(2)}`;
 
+  const normalizedStart = normalizeDate(scheduleDate);
+  const normalizedEnd = normalizeDate(scheduleEnd) || normalizedStart;
+
   return {
     ID: resolve(['ID', 'ScheduleID', 'Schedule Id', 'RecordID'], uuid),
     UserID: userId || normalizeUserIdValue(userName),
     UserName: userName || userId,
-    Date: normalizeDate(scheduleDate),
+    Date: normalizedStart,
+    PeriodStart: normalizedStart,
+    PeriodEnd: normalizedEnd,
     SlotID: resolve(['SlotID', 'ShiftID', 'TemplateID'], ''),
     SlotName: slotName || 'Shift',
     StartTime: resolve(['StartTime', 'Start', 'ShiftStart', 'Begin']),

--- a/ScheduleUtilities.js
+++ b/ScheduleUtilities.js
@@ -199,6 +199,111 @@ const SCHEDULE_SHEET_REGISTRY = Object.freeze({
   HOLIDAYS: HOLIDAYS_SHEET
 });
 
+function getScheduleTimeZone() {
+  if (typeof DEFAULT_SCHEDULE_TIME_ZONE !== 'undefined') {
+    return DEFAULT_SCHEDULE_TIME_ZONE;
+  }
+
+  if (typeof Session !== 'undefined' && typeof Session.getScriptTimeZone === 'function') {
+    try {
+      return Session.getScriptTimeZone();
+    } catch (error) {
+      console.warn('Unable to resolve script time zone:', error && error.message ? error.message : error);
+    }
+  }
+
+  return 'UTC';
+}
+
+function normalizeScheduleRowPeriod(record, timeZone) {
+  if (!record || typeof record !== 'object') {
+    return record;
+  }
+
+  const resolveDateString = (value) => {
+    if (typeof normalizeDateForSheet === 'function') {
+      const normalized = normalizeDateForSheet(value, timeZone);
+      if (normalized) {
+        return normalized;
+      }
+    }
+
+    if (value instanceof Date && !isNaN(value.getTime())) {
+      return Utilities.formatDate(value, timeZone, 'yyyy-MM-dd');
+    }
+
+    if (typeof value === 'number') {
+      const numericDate = new Date(value);
+      if (!isNaN(numericDate.getTime())) {
+        return Utilities.formatDate(numericDate, timeZone, 'yyyy-MM-dd');
+      }
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return '';
+      }
+
+      if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        return trimmed;
+      }
+
+      const parsed = new Date(trimmed);
+      if (!isNaN(parsed.getTime())) {
+        return Utilities.formatDate(parsed, timeZone, 'yyyy-MM-dd');
+      }
+
+      const maybeNumber = Number(trimmed);
+      if (!Number.isNaN(maybeNumber) && maybeNumber > 0) {
+        const baseDate = new Date('1899-12-30T00:00:00Z');
+        baseDate.setDate(baseDate.getDate() + maybeNumber);
+        return Utilities.formatDate(baseDate, timeZone, 'yyyy-MM-dd');
+      }
+    }
+
+    return '';
+  };
+
+  const start = resolveDateString(
+    record.PeriodStart
+      || record.StartDate
+      || record.ScheduleStart
+      || record.AssignmentStart
+      || record.Date
+      || record.ScheduleDate
+      || record.Day
+  );
+
+  const end = resolveDateString(
+    record.PeriodEnd
+      || record.EndDate
+      || record.ScheduleEnd
+      || record.AssignmentEnd
+      || record.Date
+      || record.ScheduleDate
+      || record.Day
+      || start
+  );
+
+  if (!start && !end) {
+    return record;
+  }
+
+  const normalized = Object.assign({}, record);
+
+  if (start) {
+    normalized.PeriodStart = start;
+    normalized.Date = start;
+  }
+
+  if (end) {
+    normalized.PeriodEnd = end;
+  }
+
+  return normalized;
+}
+
 function getScheduleSheetNames() {
   return Object.assign({}, SCHEDULE_SHEET_REGISTRY);
 }
@@ -677,6 +782,15 @@ function readScheduleSheet(sheetName) {
     const cacheKey = `schedule_${sheetName}`;
     const cached = getFromCache(cacheKey);
     if (cached) {
+      const timeZone = getScheduleTimeZone();
+      if (Array.isArray(cached)) {
+        const normalizedCache = cached.map(row => normalizeScheduleRowPeriod(row, timeZone));
+        const requiresUpdate = cached.some(row => row && !row.PeriodStart && (row.Date || row.StartDate || row.ScheduleDate));
+        if (requiresUpdate) {
+          setInCache(cacheKey, normalizedCache);
+        }
+        return normalizedCache;
+      }
       return cached;
     }
 
@@ -694,6 +808,7 @@ function readScheduleSheet(sheetName) {
     }
 
     const headers = data[0];
+    const timeZone = getScheduleTimeZone();
     const rows = data.slice(1).map(row => {
       const obj = {};
       headers.forEach((header, index) => {
@@ -702,9 +817,11 @@ function readScheduleSheet(sheetName) {
       return obj;
     });
 
+    const normalizedRows = rows.map(row => normalizeScheduleRowPeriod(row, timeZone));
+
     // Cache the result
-    setInCache(cacheKey, rows);
-    return rows;
+    setInCache(cacheKey, normalizedRows);
+    return normalizedRows;
 
   } catch (error) {
     console.error(`Error reading schedule sheet ${sheetName}:`, error);
@@ -735,7 +852,9 @@ function writeToScheduleSheet(sheetName, data) {
 
     // Write rows if provided
     if (Array.isArray(data) && data.length > 0) {
-      const rows = data.map(obj => headers.map(h => (obj[h] !== undefined ? obj[h] : '')));
+      const timeZone = getScheduleTimeZone();
+      const normalizedData = data.map(obj => normalizeScheduleRowPeriod(obj, timeZone));
+      const rows = normalizedData.map(obj => headers.map(h => (obj && obj[h] !== undefined ? obj[h] : '')));
       sheet.getRange(2, 1, rows.length, headers.length).setValues(rows);
     }
 


### PR DESCRIPTION
## Summary
- centralize schedule period normalization helpers and apply them to schedule generation, list filtering, and import workflows
- update import normalization, legacy conversion, and manual slot assignment to persist period-based schedules while removing redundant clientImportSchedules definitions
- normalize schedule rows when reading or writing through ScheduleUtilities so cached data honors PeriodStart/PeriodEnd fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6b4dc2f9c8326a024a7c01e68ae87