### PR TITLE
Add punctuality recognition to attendance dashboard

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -826,6 +826,118 @@
         color: var(--jamaica-gold);
     }
 
+    .attendance-recognition {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .attendance-panel.attendance-panel--auto-height {
+        height: auto;
+    }
+
+    .attendance-recognition-item {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        border-radius: var(--border-radius-sm);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: linear-gradient(135deg, rgba(0, 150, 57, 0.08) 0%, rgba(15, 42, 86, 0.04) 100%);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    }
+
+    .attendance-recognition-item--second {
+        background: linear-gradient(135deg, rgba(15, 42, 86, 0.06) 0%, rgba(96, 125, 139, 0.08) 100%);
+    }
+
+    .attendance-recognition-item--third {
+        background: linear-gradient(135deg, rgba(249, 115, 22, 0.08) 0%, rgba(15, 42, 86, 0.04) 100%);
+    }
+
+    .attendance-recognition-rank {
+        font-weight: 700;
+        font-size: 1.25rem;
+        min-width: 48px;
+        text-align: center;
+        color: var(--primary);
+    }
+
+    .attendance-recognition-rank sup {
+        font-size: 0.55em;
+    }
+
+    .attendance-recognition-item--first .attendance-recognition-rank {
+        color: var(--jamaica-gold);
+    }
+
+    .attendance-recognition-item--second .attendance-recognition-rank {
+        color: #94a3b8;
+    }
+
+    .attendance-recognition-item--third .attendance-recognition-rank {
+        color: #f97316;
+    }
+
+    .attendance-recognition-icon {
+        font-size: 1.5rem;
+        color: var(--primary);
+    }
+
+    .attendance-recognition-item--first .attendance-recognition-icon {
+        color: var(--jamaica-gold);
+    }
+
+    .attendance-recognition-item--second .attendance-recognition-icon {
+        color: #94a3b8;
+    }
+
+    .attendance-recognition-item--third .attendance-recognition-icon {
+        color: #f97316;
+    }
+
+    .attendance-recognition-details {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .attendance-recognition-name {
+        font-weight: 600;
+        color: var(--dark);
+    }
+
+    .attendance-recognition-meta {
+        font-size: 0.8rem;
+        color: #64748b;
+    }
+
+    .attendance-recognition-empty {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        border-radius: var(--border-radius-sm);
+        border: 1px dashed rgba(148, 163, 184, 0.6);
+        background: #f8fafc;
+        color: #475569;
+        font-size: 0.85rem;
+    }
+
+    .attendance-panel-dark .attendance-recognition-item {
+        background: rgba(255, 255, 255, 0.08);
+        border-color: rgba(255, 255, 255, 0.12);
+        box-shadow: none;
+    }
+
+    .attendance-panel-dark .attendance-recognition-name {
+        color: #fff;
+    }
+
+    .attendance-panel-dark .attendance-recognition-meta {
+        color: rgba(255, 255, 255, 0.75);
+    }
+
     .attendance-panel-actions {
         display: flex;
         gap: var(--spacing-xs);
@@ -1459,11 +1571,23 @@
                                 </div>
                             </div>
                             <div class="col-lg-4">
-                                <div class="attendance-panel h-100">
-                                    <div class="attendance-panel-title">Bi-Weekly Attendance</div>
-                                    <div class="attendance-panel-subtitle mb-3">Quickly spot cycle dips in punctuality.</div>
-                                    <div class="attendance-chart">
-                                        <canvas id="attendanceBiWeeklyChart"></canvas>
+                                <div class="d-flex flex-column gap-3 h-100">
+                                    <div class="attendance-panel attendance-panel--auto-height">
+                                        <div class="attendance-panel-title">Punctuality Recognition</div>
+                                        <div class="attendance-panel-subtitle mb-3">Celebrating our most punctual teammates this year.</div>
+                                        <div id="attendancePunctualRecognition" class="attendance-recognition">
+                                            <div class="attendance-recognition-empty">
+                                                <i class="fas fa-medal"></i>
+                                                Recognition updates as attendance is recorded.
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="attendance-panel flex-grow-1 d-flex flex-column">
+                                        <div class="attendance-panel-title">Bi-Weekly Attendance</div>
+                                        <div class="attendance-panel-subtitle mb-3">Quickly spot cycle dips in punctuality.</div>
+                                        <div class="attendance-chart flex-grow-1">
+                                            <canvas id="attendanceBiWeeklyChart"></canvas>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -5090,6 +5214,108 @@
                 }));
                 const yearlyTotals = { present: 0, late: 0, absent: 0, sick: 0, vacation: 0, other: 0 };
                 const biWeeklyBuckets = new Map();
+                const recognitionCategories = new Set(['present', 'late', 'absent', 'sick']);
+                const userStatsMap = new Map();
+
+                const scoreDisplayName = (value) => {
+                    const text = (value || '').toString().trim();
+                    if (!text) {
+                        return -Infinity;
+                    }
+                    let score = text.length;
+                    if (/\s/.test(text)) {
+                        score += 10;
+                    }
+                    if (text.includes('@')) {
+                        score -= 5;
+                    }
+                    return score;
+                };
+
+                const chooseDisplayName = (current, candidate) => {
+                    const trimmedCandidate = (candidate || '').toString().trim();
+                    if (!trimmedCandidate) {
+                        return current || '';
+                    }
+                    const trimmedCurrent = (current || '').toString().trim();
+                    if (!trimmedCurrent) {
+                        return trimmedCandidate;
+                    }
+                    const currentScore = scoreDisplayName(trimmedCurrent);
+                    const candidateScore = scoreDisplayName(trimmedCandidate);
+                    return candidateScore > currentScore ? trimmedCandidate : trimmedCurrent;
+                };
+
+                const resolveRecordDisplayName = (record) => {
+                    const candidates = [
+                        record?.fullName,
+                        record?.FullName,
+                        record?.userName,
+                        record?.UserName,
+                        record?.user,
+                        record?.User,
+                        record?.email,
+                        record?.Email
+                    ];
+
+                    for (const candidate of candidates) {
+                        if (typeof candidate === 'string') {
+                            const trimmed = candidate.trim();
+                            if (trimmed) {
+                                return trimmed;
+                            }
+                        }
+                    }
+
+                    return '';
+                };
+
+                const resolveRecordIdentityKey = (record) => {
+                    const idCandidates = [
+                        record?.userId,
+                        record?.UserId,
+                        record?.userID,
+                        record?.UserID,
+                        record?.id,
+                        record?.ID,
+                        record?.username,
+                        record?.userName,
+                        record?.UserName
+                    ];
+
+                    for (const candidate of idCandidates) {
+                        const normalized = this.normalizeUserIdValue(candidate);
+                        if (normalized) {
+                            return `id:${normalized}`;
+                        }
+                    }
+
+                    const emailCandidates = [record?.email, record?.Email];
+                    for (const candidate of emailCandidates) {
+                        const normalizedEmail = this.normalizePersonKey(candidate);
+                        if (normalizedEmail) {
+                            return `email:${normalizedEmail}`;
+                        }
+                    }
+
+                    const nameCandidates = [
+                        record?.fullName,
+                        record?.FullName,
+                        record?.userName,
+                        record?.UserName,
+                        record?.user,
+                        record?.User
+                    ];
+
+                    for (const candidate of nameCandidates) {
+                        const normalizedName = this.normalizePersonKey(candidate);
+                        if (normalizedName) {
+                            return `name:${normalizedName}`;
+                        }
+                    }
+
+                    return '';
+                };
 
                 const parseDate = (value) => {
                     if (value instanceof Date) {
@@ -5140,6 +5366,39 @@
                         yearlyTotals[category] = 0;
                     }
                     yearlyTotals[category] += 1;
+
+                    if (recognitionCategories.has(category)) {
+                        const identityKey = resolveRecordIdentityKey(record);
+                        if (identityKey) {
+                            let userStat = userStatsMap.get(identityKey);
+                            if (!userStat) {
+                                userStat = {
+                                    displayName: '',
+                                    present: 0,
+                                    total: 0,
+                                    late: 0,
+                                    absent: 0,
+                                    sick: 0
+                                };
+                                userStatsMap.set(identityKey, userStat);
+                            }
+
+                            const displayName = resolveRecordDisplayName(record);
+                            userStat.displayName = chooseDisplayName(userStat.displayName, displayName);
+
+                            if (category === 'present') {
+                                userStat.present += 1;
+                            } else if (category === 'late') {
+                                userStat.late += 1;
+                            } else if (category === 'absent') {
+                                userStat.absent += 1;
+                            } else if (category === 'sick') {
+                                userStat.sick += 1;
+                            }
+
+                            userStat.total += 1;
+                        }
+                    }
 
                     const bucketInfo = this.getBiWeeklyBucketKey(date);
                     if (!biWeeklyBuckets.has(bucketInfo.key)) {
@@ -5216,6 +5475,33 @@
                     punctual: sortedBiWeekly.map(bucket => safePercent(bucket.present, bucket.total))
                 };
 
+                const topPunctual = Array.from(userStatsMap.values())
+                    .map(stat => {
+                        const totalTracked = stat.total || 0;
+                        const punctualRate = totalTracked > 0
+                            ? Number(((stat.present / totalTracked) * 100).toFixed(2))
+                            : 0;
+                        const displayName = (stat.displayName || '').toString().trim() || 'Team Member';
+
+                        return {
+                            displayName,
+                            present: stat.present,
+                            total: totalTracked,
+                            punctualRate
+                        };
+                    })
+                    .filter(stat => stat.total > 0)
+                    .sort((a, b) => {
+                        if (b.punctualRate !== a.punctualRate) {
+                            return b.punctualRate - a.punctualRate;
+                        }
+                        if (b.present !== a.present) {
+                            return b.present - a.present;
+                        }
+                        return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' });
+                    })
+                    .slice(0, 3);
+
                 return {
                     year,
                     months,
@@ -5230,6 +5516,7 @@
                         late: monthlyLate
                     },
                     biWeekly,
+                    topPunctual,
                     monthlyAnalysis,
                     yearlyTotals: yearlyTotalsChart
                 };
@@ -5975,6 +6262,8 @@
 
                     this.refreshAttendanceDashboard();
                 }
+
+                this.renderAttendancePunctualRecognition(Array.isArray(data.topPunctual) ? data.topPunctual : []);
             }
 
             updateAttendanceMonthlyPercentChart(monthIndex) {
@@ -5997,6 +6286,63 @@
                 if (valueDisplay) {
                     valueDisplay.textContent = `${percentValue.toFixed(2)}%`;
                 }
+            }
+
+            renderAttendancePunctualRecognition(entries) {
+                const container = document.getElementById('attendancePunctualRecognition');
+                if (!container) {
+                    return;
+                }
+
+                const safeEntries = Array.isArray(entries)
+                    ? entries.filter(entry => entry && typeof entry === 'object')
+                    : [];
+
+                if (!safeEntries.length) {
+                    container.innerHTML = `
+                        <div class="attendance-recognition-empty">
+                            <i class="fas fa-medal"></i>
+                            Recognition updates as attendance is recorded.
+                        </div>
+                    `;
+                    return;
+                }
+
+                const ordinalSuffix = (value) => {
+                    if (value === 1) return 'st';
+                    if (value === 2) return 'nd';
+                    if (value === 3) return 'rd';
+                    return 'th';
+                };
+
+                const html = safeEntries.slice(0, 3).map((entry, index) => {
+                    const rank = index + 1;
+                    const suffix = ordinalSuffix(rank);
+                    const rankHtml = `${rank}<sup>${suffix}</sup>`;
+                    const safeName = this.escapeHtml(entry.displayName || entry.name || entry.identifier || 'Team Member');
+                    const present = Number(entry.present) || 0;
+                    const total = Number(entry.total) || 0;
+                    const punctualRate = Number.isFinite(entry.punctualRate)
+                        ? entry.punctualRate.toFixed(2)
+                        : '0.00';
+                    const meta = this.escapeHtml(`On time for ${present} of ${total} tracked shifts (${punctualRate}%)`);
+                    const tierClass = ['first', 'second', 'third'][index] || 'other';
+
+                    return `
+                        <div class="attendance-recognition-item attendance-recognition-item--${tierClass}">
+                            <div class="attendance-recognition-rank" aria-hidden="true">${rankHtml}</div>
+                            <div class="attendance-recognition-icon" aria-hidden="true">
+                                <i class="fas fa-medal"></i>
+                            </div>
+                            <div class="attendance-recognition-details">
+                                <div class="attendance-recognition-name">${safeName}</div>
+                                <div class="attendance-recognition-meta">${meta}</div>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
+
+                container.innerHTML = html;
             }
 
             handleAttendanceDashboardUserFilterChange(rawValue) {


### PR DESCRIPTION
## Summary
- add punctuality recognition styling and auto-height panel for the attendance dashboard
- surface a new recognition panel beside bi-weekly attendance to highlight the top three punctual teammates
- compute punctuality leaders from attendance records and render them whenever dashboard data refreshes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6c43978d48326adf0ffae6a1182be