### PR TITLE
Fix compliance calculations in attendance summary

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -3092,11 +3092,18 @@
     }
 
     calculateComplianceScore(user) {
+      const breakDays = Number.isFinite(user?.exceededBreakDays) ? user.exceededBreakDays : 0;
+      const lunchDays = Number.isFinite(user?.exceededLunchDays) ? user.exceededLunchDays : 0;
+      const weeklyOverages = Number.isFinite(user?.exceededWeeklyCount) ? user.exceededWeeklyCount : 0;
+
       let score = 100;
-      score -= (user.exceededBreakDays || 0) * 5;
-      score -= (user.exceededLunchDays || 0) * 5;
-      score -= (user.exceededWeeklyCount || 0) * 10;
-      return Math.max(0, score);
+      score -= breakDays * 5;
+      score -= lunchDays * 5;
+      score -= weeklyOverages * 10;
+      if (!Number.isFinite(score)) {
+        score = 0;
+      }
+      return Math.max(0, Math.round(score));
     }
 
     getComplianceStatusBadge(score) {


### PR DESCRIPTION
## Summary
- track break, lunch, and weekly overages per employee when building attendance analytics
- surface the corrected counts to the Employee Attendance Summary table and compliance exports
- harden compliance score calculations on both the service and client to use the new metrics safely

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f6c4eda248832698c6e499f79d24a7