### PR TITLE
Allow ATT recognition to respect in-progress periods

### DIFF
--- a/CallReportService.js
+++ b/CallReportService.js
@@ -6,6 +6,9 @@
  */
 
 const __PAGE_SIZE_FALLBACK = 50;
+const __QUALIFYING_TALK_MIN_MINUTES = 1;
+const __QUALIFYING_TALK_MAX_MINUTES = 20000;
+const __MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function __ensureDate(value) {
   if (value instanceof Date && !isNaN(value)) return value;
@@ -583,6 +586,11 @@ function getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter) {
   const { startDate, endDate } = __resolveCallReportPeriod(granularity, periodIdentifier);
   const tz = Session.getScriptTimeZone();
 
+  const normalizedStart = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const normalizedEnd = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+
+  const weekRequirements = buildWeekRequirements(normalizedStart, normalizedEnd, tz);
+
   // Filter by date range (CreatedDate, date-only)
   const dateFiltered = __readAllCallReportRows().filter(r => {
     const dt = r.CreatedDate instanceof Date ? r.CreatedDate : new Date(r.CreatedDate);
@@ -602,20 +610,54 @@ function getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter) {
   // repMetrics
   const repMap = {};
   const answerSecondsList = [];
+  let qualifyingTalkMinutesTotal = 0;
+  let qualifyingTalkCallCount = 0;
   filtered.forEach(r => {
     const agent = r.ToSFUser || '—';
-    const talk  = parseFloat(r.TalkTimeMinutes) || 0;
+    const rawTalk = parseFloat(r.TalkTimeMinutes);
+    const talk = isFinite(rawTalk) ? Math.max(0, rawTalk) : 0;
     if (!repMap[agent]) {
       repMap[agent] = {
         totalCalls: 0,
         totalTalk: 0,
+        qualifyingTalkCalls: 0,
+        totalTalkWholeMinutes: 0,
         totalAnswerSeconds: 0,
         answeredCount: 0,
-        fastAnswerCount: 0
+        fastAnswerCount: 0,
+        csatYes: 0,
+        csatNo: 0,
+        csatTotal: 0,
+        weeklyCoverage: Object.create(null)
       };
     }
     repMap[agent].totalCalls += 1;
     repMap[agent].totalTalk  += talk;
+
+    const createdDate = r.CreatedDate instanceof Date ? r.CreatedDate : new Date(r.CreatedDate);
+    if (createdDate instanceof Date && !isNaN(createdDate)) {
+      const dateOnly = new Date(createdDate.getFullYear(), createdDate.getMonth(), createdDate.getDate());
+      const dayOfWeek = dateOnly.getDay();
+      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+        const weekStart = startOfWeek(dateOnly);
+        const weekKey = Utilities.formatDate(weekStart, tz, 'yyyy-MM-dd');
+        if (!repMap[agent].weeklyCoverage[weekKey]) {
+          repMap[agent].weeklyCoverage[weekKey] = { days: Object.create(null) };
+        }
+        const dayKey = new Date(dateOnly.getFullYear(), dateOnly.getMonth(), dateOnly.getDate()).getTime();
+        repMap[agent].weeklyCoverage[weekKey].days[dayKey] = true;
+      }
+    }
+
+    if (talk >= __QUALIFYING_TALK_MIN_MINUTES && talk <= __QUALIFYING_TALK_MAX_MINUTES) {
+      const wholeMinutes = Math.floor(talk);
+      if (wholeMinutes >= __QUALIFYING_TALK_MIN_MINUTES && wholeMinutes <= __QUALIFYING_TALK_MAX_MINUTES) {
+        repMap[agent].qualifyingTalkCalls += 1;
+        repMap[agent].totalTalkWholeMinutes += wholeMinutes;
+        qualifyingTalkCallCount += 1;
+        qualifyingTalkMinutesTotal += wholeMinutes;
+      }
+    }
 
     const answerSeconds = __parseAnswerSeconds(__getAnswerFieldValue(r), r.CreatedDate);
     if (answerSeconds !== null) {
@@ -624,19 +666,44 @@ function getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter) {
       if (answerSeconds <= 30) repMap[agent].fastAnswerCount += 1;
       answerSecondsList.push(answerSeconds);
     }
+
+    const csatValue = (r.CSAT || '').toString().trim().toLowerCase();
+    if (csatValue === 'yes' || csatValue === 'true' || csatValue === '1') {
+      repMap[agent].csatYes += 1;
+      repMap[agent].csatTotal += 1;
+    } else if (csatValue === 'no' || csatValue === 'false' || csatValue === '0') {
+      repMap[agent].csatNo += 1;
+      repMap[agent].csatTotal += 1;
+    }
   });
   const repMetrics = Object.entries(repMap).map(([agent, v]) => {
     const averageAnswerSeconds = v.answeredCount > 0 ? v.totalAnswerSeconds / v.answeredCount : null;
     const fastAnswerRate = v.answeredCount > 0 ? (v.fastAnswerCount / v.answeredCount) * 100 : null;
+    const coverage = evaluateWeekCoverage(v.weeklyCoverage || {}, weekRequirements);
+    const coverageEvaluatedThrough = coverage.evaluatedThrough instanceof Date && !isNaN(coverage.evaluatedThrough)
+      ? coverage.evaluatedThrough.toISOString()
+      : null;
     return {
       agent,
       totalCalls: v.totalCalls,
       totalTalk: v.totalTalk,
+      qualifyingTalkCalls: v.qualifyingTalkCalls,
+      totalTalkWholeMinutes: v.totalTalkWholeMinutes,
+      qualifiedAvgTalkMinutes: v.qualifyingTalkCalls > 0
+        ? v.totalTalkWholeMinutes / v.qualifyingTalkCalls
+        : null,
       totalAnswerSeconds: v.totalAnswerSeconds,
       answeredCount: v.answeredCount,
       averageAnswerSeconds,
       fastAnswerRate,
-      fastAnswerCount: v.fastAnswerCount
+      fastAnswerCount: v.fastAnswerCount,
+      csatYes: v.csatYes,
+      csatNo: v.csatNo,
+      csatTotal: v.csatTotal,
+      csatYesRate: v.csatTotal > 0 ? (v.csatYes / v.csatTotal) * 100 : null,
+      weeklyCoverageSummary: coverage.weekSummaries,
+      fullWeekCoverage: coverage.meetsAllWeeks,
+      coverageEvaluatedThrough
     };
   });
 
@@ -1048,8 +1115,109 @@ function getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter) {
     peakTimeWindows,
     scheduleRecommendations,
     answerTimeStats,
-    callActivityWindow
+    callActivityWindow,
+    talkBenchmarks: {
+      qualifyingCallCount: qualifyingTalkCallCount,
+      totalMinutes: qualifyingTalkMinutesTotal,
+      averageMinutes: qualifyingTalkCallCount > 0
+        ? qualifyingTalkMinutesTotal / qualifyingTalkCallCount
+        : null
+    }
   };
+}
+
+function startOfWeek(date) {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const day = d.getDay();
+  const diff = (day + 6) % 7; // Monday as first day of week
+  d.setDate(d.getDate() - diff);
+  return d;
+}
+
+function buildWeekRequirements(startDate, endDate, tz) {
+  const requirements = [];
+  if (!(startDate instanceof Date) || isNaN(startDate) || !(endDate instanceof Date) || isNaN(endDate)) {
+    return requirements;
+  }
+
+  const today = new Date();
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const evaluationCutoffTime = Math.min(endDate.getTime(), todayMidnight.getTime());
+  const evaluationCutoff = evaluationCutoffTime >= startDate.getTime()
+    ? new Date(evaluationCutoffTime)
+    : null;
+
+  const firstWeekStart = startOfWeek(startDate);
+  for (let cursor = new Date(firstWeekStart); cursor.getTime() <= endDate.getTime(); cursor.setDate(cursor.getDate() + 7)) {
+    const weekStart = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate());
+    const weekEnd = new Date(weekStart.getTime() + (6 * __MS_PER_DAY));
+    const windowStart = weekStart.getTime() < startDate.getTime() ? startDate : weekStart;
+    const windowEnd = weekEnd.getTime() > endDate.getTime() ? endDate : weekEnd;
+    const windowStartMidnight = new Date(windowStart.getFullYear(), windowStart.getMonth(), windowStart.getDate());
+    const windowEndMidnight = new Date(windowEnd.getFullYear(), windowEnd.getMonth(), windowEnd.getDate());
+    const evaluationEndTime = Math.min(windowEndMidnight.getTime(), evaluationCutoffTime);
+
+    let weekdayCount = 0;
+    if (evaluationEndTime >= windowStartMidnight.getTime()) {
+      const evaluationEnd = new Date(evaluationEndTime);
+      for (let dayCursor = new Date(windowStartMidnight.getTime()); dayCursor.getTime() <= evaluationEnd.getTime(); dayCursor.setDate(dayCursor.getDate() + 1)) {
+        const dow = dayCursor.getDay();
+        if (dow === 0 || dow === 6) continue;
+        weekdayCount += 1;
+      }
+    }
+
+    const requiredDays = Math.min(5, Math.max(0, weekdayCount));
+    const weekKey = Utilities.formatDate(weekStart, tz, 'yyyy-MM-dd');
+    requirements.push({
+      weekKey,
+      windowStartTime: windowStartMidnight.getTime(),
+      windowEndTime: windowEndMidnight.getTime(),
+      evaluationEndTime,
+      requiredDays,
+      windowStartLabel: Utilities.formatDate(windowStartMidnight, tz, 'MMM d'),
+      windowEndLabel: Utilities.formatDate(windowEndMidnight, tz, 'MMM d'),
+      evaluationEndLabel: evaluationEndTime >= windowStartMidnight.getTime()
+        ? Utilities.formatDate(new Date(evaluationEndTime), tz, 'MMM d')
+        : Utilities.formatDate(windowStartMidnight, tz, 'MMM d')
+    });
+  }
+
+  requirements.evaluatedThrough = evaluationCutoff;
+  return requirements;
+}
+
+function evaluateWeekCoverage(coverageMap, requirements) {
+  if (!requirements || !requirements.length) {
+    return { weekSummaries: [], meetsAllWeeks: false, evaluatedThrough: null };
+  }
+
+  const evaluationThrough = requirements.evaluatedThrough instanceof Date && !isNaN(requirements.evaluatedThrough)
+    ? new Date(requirements.evaluatedThrough.getTime())
+    : null;
+
+  const weekSummaries = requirements.map(req => {
+    const stored = coverageMap && coverageMap[req.weekKey] ? coverageMap[req.weekKey] : { days: {} };
+    const dayKeys = Object.keys(stored.days || {});
+    const cutoff = Number.isFinite(req.evaluationEndTime) ? req.evaluationEndTime : req.windowEndTime;
+    const actualDays = dayKeys.filter(key => {
+      const numeric = Number(key);
+      if (!Number.isFinite(numeric)) return false;
+      return numeric >= req.windowStartTime && numeric <= cutoff;
+    }).length;
+    return {
+      weekKey: req.weekKey,
+      requiredDays: req.requiredDays,
+      actualDays,
+      meetsRequirement: actualDays >= req.requiredDays,
+      windowStartLabel: req.windowStartLabel,
+      windowEndLabel: req.windowEndLabel,
+      evaluationEndLabel: req.evaluationEndLabel
+    };
+  });
+
+  const meetsAllWeeks = weekSummaries.length > 0 && weekSummaries.every(entry => entry.requiredDays === 0 || entry.meetsRequirement);
+  return { weekSummaries, meetsAllWeeks, evaluatedThrough: evaluationThrough };
 }
 
 /**

--- a/CallReports.html
+++ b/CallReports.html
@@ -421,6 +421,199 @@
         margin-bottom: 0.5rem;
     }
 
+    /* Recognition cards */
+    .recognition-card {
+        position: relative;
+        background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(6, 182, 212, 0.08) 100%);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: var(--radius-xl);
+        padding: 1.75rem 2rem;
+        box-shadow: var(--shadow-md);
+        overflow: hidden;
+        transition: var(--transition-normal);
+        min-height: 220px;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        gap: 1.25rem;
+        height: 100%;
+        align-items: flex-start;
+    }
+
+    .recognition-column {
+        display: flex;
+    }
+
+    .recognition-column .recognition-card {
+        flex: 1 1 auto;
+    }
+
+    .recognition-card::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.12), transparent 55%);
+        pointer-events: none;
+    }
+
+    .recognition-card:hover {
+        transform: translateY(-6px);
+        box-shadow: var(--shadow-2xl);
+        border-color: rgba(37, 99, 235, 0.35);
+    }
+
+    .recognition-card.is-empty {
+        background: linear-gradient(135deg, rgba(148, 163, 184, 0.08) 0%, rgba(226, 232, 240, 0.24) 100%);
+        color: var(--gray-500);
+    }
+
+    .recognition-badge {
+        position: relative;
+        z-index: 1;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: var(--radius-full);
+        background: rgba(37, 99, 235, 0.15);
+        color: var(--primary-dark);
+        font-weight: 600;
+        font-size: 0.85rem;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        margin-bottom: 1.25rem;
+        width: fit-content;
+        box-shadow: var(--shadow-sm);
+    }
+
+    .recognition-card.is-empty .recognition-badge {
+        background: rgba(148, 163, 184, 0.18);
+        color: var(--gray-600);
+    }
+
+    .recognition-agent {
+        position: relative;
+        z-index: 1;
+        font-size: clamp(1.5rem, 3vw, 2.25rem);
+        font-weight: 800;
+        color: var(--gray-800);
+        margin-bottom: 0.25rem;
+        letter-spacing: -0.02em;
+    }
+
+    .recognition-card.is-empty .recognition-agent {
+        color: var(--gray-500);
+    }
+
+    .recognition-stat {
+        position: relative;
+        z-index: 1;
+        font-size: 1.15rem;
+        font-weight: 600;
+        color: var(--primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .recognition-card.is-empty .recognition-stat {
+        color: var(--gray-500);
+    }
+
+    .recognition-meta {
+        position: relative;
+        z-index: 1;
+        color: var(--gray-600);
+        font-size: 0.95rem;
+        line-height: 1.5;
+        max-width: 26rem;
+    }
+
+    .recognition-ranking {
+        list-style: none;
+        margin: 16px 0 0;
+        padding: 12px 0 0;
+        border-top: 1px solid rgba(37, 99, 235, 0.2);
+    }
+
+    .recognition-card.is-empty .recognition-ranking {
+        border-color: rgba(148, 163, 184, 0.25);
+    }
+
+    .recognition-ranking.is-empty {
+        display: none;
+    }
+
+    .recognition-ranking-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 8px 0;
+    }
+
+    .recognition-ranking-item + .recognition-ranking-item {
+        border-top: 1px dashed rgba(37, 99, 235, 0.18);
+    }
+
+    .recognition-card.is-empty .recognition-ranking-item + .recognition-ranking-item {
+        border-color: rgba(148, 163, 184, 0.18);
+    }
+
+    .rank-label {
+        min-width: 48px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        border-radius: var(--radius-full);
+        padding: 6px 0;
+        text-align: center;
+        background: rgba(37, 99, 235, 0.16);
+        color: var(--primary-dark);
+    }
+
+    .recognition-card.is-empty .rank-label {
+        background: rgba(148, 163, 184, 0.2);
+        color: var(--gray-600);
+    }
+
+    .rank-detail {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .rank-name {
+        font-weight: 600;
+        font-size: 1.05rem;
+        color: var(--gray-800);
+    }
+
+    .recognition-card.is-empty .rank-name {
+        color: var(--gray-600);
+    }
+
+    .rank-stat {
+        font-size: 0.85rem;
+        color: var(--gray-600);
+    }
+
+    .recognition-card.is-empty .rank-stat {
+        color: var(--gray-500);
+    }
+
+    .recognition-footer {
+        position: relative;
+        z-index: 1;
+        margin-top: auto;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--gray-500);
+        font-size: 0.85rem;
+    }
+
+    .recognition-footer i {
+        color: var(--accent);
+    }
+
     /* Enhanced Card Styles */
     .card {
         background: var(--gradient-surface);
@@ -780,6 +973,12 @@
         }
 
         .kpi-card {
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .recognition-card {
+            min-height: 0;
             padding: 1.5rem;
             margin-bottom: 1.5rem;
         }
@@ -1261,6 +1460,30 @@
     </div>
 </div>
 
+<!-- Recognition Highlights -->
+<div class="row gx-4 mb-5 animate-fade-in-up" style="animation-delay: 0.15s;" aria-live="polite">
+    <div class="col-lg-6 recognition-column">
+        <div class="recognition-card is-empty" id="csatRecognitionCard">
+            <div class="recognition-badge"><i class="fas fa-star"></i> CSAT Champion</div>
+            <div class="recognition-agent" id="csatChampionName">Awaiting feedback</div>
+            <div class="recognition-stat" id="csatChampionValue">—</div>
+            <div class="recognition-meta" id="csatChampionDetail">Log CSAT surveys so we can spotlight the top three performers.</div>
+            <ul class="recognition-ranking is-empty" id="csatRecognitionList" aria-label="Top CSAT performers"></ul>
+            <div class="recognition-footer"><i class="fas fa-comments"></i><span id="csatChampionFooter">No qualifying responses yet</span></div>
+        </div>
+    </div>
+    <div class="col-lg-6 recognition-column">
+        <div class="recognition-card is-empty" id="attRecognitionCard">
+            <div class="recognition-badge"><i class="fas fa-stopwatch"></i> ATT Ace</div>
+            <div class="recognition-agent" id="attChampionName">Awaiting data</div>
+            <div class="recognition-stat" id="attChampionValue">—</div>
+            <div class="recognition-meta" id="attChampionDetail">Recognition unlocks after maintaining weekday call coverage (Mon–Fri) at least 5 days per week for every week in the month.</div>
+            <ul class="recognition-ranking is-empty" id="attRecognitionList" aria-label="Top average talk time performers"></ul>
+            <div class="recognition-footer"><i class="fas fa-headset"></i><span id="attChampionFooter">No qualifying calls with full weekday coverage yet</span></div>
+        </div>
+    </div>
+</div>
+
 <!-- Enhanced Distribution Charts Row -->
 <div class="row gx-4 mb-5 animate-fade-in-up" style="animation-delay: 0.1s;">
     <!-- Call Distribution (Policy) -->
@@ -1665,6 +1888,7 @@
   function renderEverything(analytics) {
     renderAiInsights(analytics);
     renderKpiCards(analytics);
+    renderRecognitionHighlights(analytics);
     renderPolicyDistChart(analytics.policyDist);
     renderWrapupDistChart(analytics.wrapDist);
     renderCsatChart(analytics.csatDist);
@@ -1965,26 +2189,30 @@
   }
 
   function formatMinutesToReadable(minutes) {
-    const value = Number(minutes) || 0;
-    const absValue = Math.abs(value);
-    const hours = Math.floor(absValue / 60);
-    const remainingMinutes = Math.floor(absValue % 60);
-    const sign = value < 0 ? '-' : '';
+    const numeric = Number(minutes);
+    if (!isFinite(numeric) || numeric === 0) {
+      return '0 min';
+    }
+
+    const sign = numeric < 0 ? '-' : '';
+    const absValue = Math.abs(numeric);
+    const wholeMinutes = Math.floor(absValue);
+
+    if (wholeMinutes === 0) {
+      return `${sign}<1 min`;
+    }
+
+    const hours = Math.floor(wholeMinutes / 60);
+    const remainingMinutes = wholeMinutes % 60;
 
     if (hours > 0) {
+      if (remainingMinutes === 0) {
+        return `${sign}${hours}h`;
+      }
       return `${sign}${hours}h ${remainingMinutes}m`;
     }
 
-    if (absValue >= 1) {
-      const rounded = Math.round(absValue * 10) / 10;
-      return `${sign}${rounded.toLocaleString()} min`;
-    }
-
-    const seconds = Math.round(absValue * 60);
-    if (seconds === 0) {
-      return '0 min';
-    }
-    return `${sign}${seconds} sec`;
+    return `${sign}${wholeMinutes} min`;
   }
 
   function formatSecondsToReadable(seconds) {
@@ -2141,8 +2369,18 @@
 
     const totalTalk = analytics.talkTrend.reduce((sum, o) => sum + o.totalTalk, 0);
     const totalCallCount = analytics.callTrend.reduce((sum, o) => sum + o.callCount, 0);
-    const avgTalkTime = totalCallCount > 0 ? (totalTalk / totalCallCount).toFixed(2) : 0;
-    document.getElementById("kpiAvgTalkTime").textContent = `${avgTalkTime} min`;
+    const talkBenchmarks = analytics.talkBenchmarks || {};
+    const rawBenchmarkAverage = talkBenchmarks.averageMinutes;
+    const benchmarkAverage = rawBenchmarkAverage === null || rawBenchmarkAverage === undefined
+      ? NaN
+      : Number(rawBenchmarkAverage);
+    const avgTalkMinutes = Number.isFinite(benchmarkAverage)
+      ? benchmarkAverage
+      : (totalCallCount > 0 ? totalTalk / totalCallCount : 0);
+    const avgTalkDisplay = avgTalkMinutes > 0
+      ? Math.max(1, Math.round(avgTalkMinutes))
+      : 0;
+    document.getElementById("kpiAvgTalkTime").textContent = `${avgTalkDisplay.toLocaleString()} min`;
 
     const intervalVolume = Array.isArray(analytics.intervalVolume) ? analytics.intervalVolume : [];
     const hourlyVolume = Array.isArray(analytics.hourlyVolume) ? analytics.hourlyVolume : [];
@@ -2174,6 +2412,221 @@
       }, 200);
     });
   }
+
+
+  function formatCoverageDateLabel(value) {
+    if (!value && value !== 0) return '';
+    const parsed = value instanceof Date ? value : new Date(value);
+    if (!(parsed instanceof Date) || isNaN(parsed)) return '';
+    return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  function renderRecognitionHighlights(analytics = {}) {
+    const csatCard = document.getElementById('csatRecognitionCard');
+    const attCard = document.getElementById('attRecognitionCard');
+    const csatNameEl = document.getElementById('csatChampionName');
+    const csatValueEl = document.getElementById('csatChampionValue');
+    const csatDetailEl = document.getElementById('csatChampionDetail');
+    const csatFooterEl = document.getElementById('csatChampionFooter');
+    const csatListEl = document.getElementById('csatRecognitionList');
+    const attNameEl = document.getElementById('attChampionName');
+    const attValueEl = document.getElementById('attChampionValue');
+    const attDetailEl = document.getElementById('attChampionDetail');
+    const attFooterEl = document.getElementById('attChampionFooter');
+    const attListEl = document.getElementById('attRecognitionList');
+
+    if (!csatCard || !attCard) {
+      return;
+    }
+
+    const repMetrics = Array.isArray(analytics.repMetrics) ? analytics.repMetrics : [];
+    const talkBenchmarks = analytics.talkBenchmarks || {};
+    const MIN_ATT_MINUTES = 1;
+    const MAX_ATT_MINUTES = 20000;
+    const rawBenchmarkAverage = talkBenchmarks.averageMinutes;
+    const parsedBenchmarkAverage = rawBenchmarkAverage === null || rawBenchmarkAverage === undefined
+      ? NaN
+      : Number(rawBenchmarkAverage);
+    const benchmarkAverage = Number.isFinite(parsedBenchmarkAverage)
+      ? Math.min(Math.max(parsedBenchmarkAverage, MIN_ATT_MINUTES), MAX_ATT_MINUTES)
+      : NaN;
+    const benchmarkDisplay = Number.isFinite(benchmarkAverage)
+      ? Math.round(benchmarkAverage)
+      : null;
+
+    const csatEligible = repMetrics
+      .map(item => {
+        const yes = Number(item.csatYes ?? 0);
+        const no = Number(item.csatNo ?? 0);
+        const total = Number(item.csatTotal ?? (yes + no));
+        const rate = total > 0 ? Number(item.csatYesRate ?? ((yes / total) * 100)) : null;
+        return {
+          agent: item.agent || '—',
+          yes,
+          no,
+          total,
+          rate
+        };
+      })
+      .filter(entry => entry.total > 0 && entry.yes > 0 && Number.isFinite(entry.rate));
+
+    const csatLeaders = csatEligible
+      .slice()
+      .sort((a, b) => {
+        if (b.yes !== a.yes) return b.yes - a.yes;
+        if (b.rate !== a.rate) return b.rate - a.rate;
+        if (b.total !== a.total) return b.total - a.total;
+        return a.agent.localeCompare(b.agent);
+      })
+      .slice(0, 3);
+
+    if (!csatLeaders.length) {
+      csatCard.classList.add('is-empty');
+      csatNameEl.textContent = 'Awaiting feedback';
+      csatValueEl.textContent = '—';
+      csatDetailEl.textContent = 'Log CSAT surveys so we can spotlight the top three performers.';
+      csatFooterEl.textContent = 'No qualifying responses yet';
+      updateRankingList(csatListEl, []);
+    } else {
+      const champion = csatLeaders[0];
+      csatCard.classList.remove('is-empty');
+      csatNameEl.textContent = champion.agent;
+      csatValueEl.textContent = `${champion.yes.toLocaleString()} Yes`;
+      const rateDisplay = Math.round(champion.rate);
+      const totalLabel = champion.total === 1
+        ? '1 survey'
+        : `${champion.total.toLocaleString()} surveys`;
+      csatDetailEl.textContent = `${rateDisplay}% positive across ${totalLabel}.`;
+      csatFooterEl.textContent = 'Ranked by positive CSAT volume';
+      updateRankingList(csatListEl, csatLeaders, entry => {
+        const yesLabel = `${entry.yes.toLocaleString()} Yes`;
+        const rateLabel = `${Math.round(entry.rate)}% positive`;
+        const totalLabelInner = entry.total === 1
+          ? '1 survey'
+          : `${entry.total.toLocaleString()} surveys`;
+        return `${yesLabel} • ${rateLabel} (${totalLabelInner})`;
+      });
+    }
+
+    const attEligible = repMetrics
+      .filter(item => item && item.fullWeekCoverage === true)
+      .map(item => {
+        const calls = Number(item.qualifyingTalkCalls || 0);
+        const totalMinutes = Number(item.totalTalkWholeMinutes || 0);
+        const avgTalk = calls > 0 ? totalMinutes / calls : null;
+        const coverageSummary = Array.isArray(item.weeklyCoverageSummary)
+          ? item.weeklyCoverageSummary
+          : [];
+        return {
+          agent: item.agent || '—',
+          calls,
+          totalMinutes,
+          avgTalk,
+          coverageSummary,
+          coverageEvaluatedThrough: item.coverageEvaluatedThrough || null
+        };
+      })
+      .filter(entry => {
+        if (entry.avgTalk === null || !Number.isFinite(entry.avgTalk)) return false;
+        if (entry.avgTalk < MIN_ATT_MINUTES || entry.avgTalk > MAX_ATT_MINUTES) return false;
+        return entry.calls > 0;
+      });
+
+    const attLeaders = attEligible
+      .slice()
+      .sort((a, b) => {
+        if (a.avgTalk !== b.avgTalk) return a.avgTalk - b.avgTalk;
+        if (b.calls !== a.calls) return b.calls - a.calls;
+        if (b.totalMinutes !== a.totalMinutes) return b.totalMinutes - a.totalMinutes;
+        return a.agent.localeCompare(b.agent);
+      })
+      .slice(0, 3);
+
+    if (!attLeaders.length) {
+      attCard.classList.add('is-empty');
+      attNameEl.textContent = 'Awaiting data';
+      attValueEl.textContent = '—';
+      attDetailEl.textContent = 'Maintain weekday coverage (Mon–Fri) at least 5 days per week across every week in the month to earn recognition.';
+      attFooterEl.textContent = 'No qualifying calls with full weekday coverage yet';
+      updateRankingList(attListEl, []);
+    } else {
+      const champion = attLeaders[0];
+      const championAvg = Math.round(champion.avgTalk);
+      const championCalls = champion.calls === 1 ? '1 qualifying call' : `${champion.calls} qualifying calls`;
+      const championMinutes = `${champion.totalMinutes.toLocaleString()} total minutes`;
+      const coverageWeeks = Array.isArray(champion.coverageSummary)
+        ? champion.coverageSummary.filter(week => week.requiredDays > 0).length
+        : 0;
+      const coverageWeeksMet = Array.isArray(champion.coverageSummary)
+        ? champion.coverageSummary.filter(week => week.requiredDays > 0 && week.meetsRequirement).length
+        : 0;
+        const coverageLabel = coverageWeeks > 0
+          ? `Maintained weekday call coverage (Mon–Fri) across ${coverageWeeksMet}/${coverageWeeks} week${coverageWeeks === 1 ? '' : 's'} this period.`
+          : '';
+        const teamAverageLabel = benchmarkDisplay !== null
+          ? `Team average: ${benchmarkDisplay} min.`
+          : '';
+        const evaluatedThroughLabel = formatCoverageDateLabel(champion.coverageEvaluatedThrough);
+      attCard.classList.remove('is-empty');
+      attNameEl.textContent = champion.agent;
+      attValueEl.textContent = `${championAvg} min avg`;
+        const detailParts = [`${championCalls} (${championMinutes}).`];
+        if (coverageLabel) detailParts.push(coverageLabel);
+        if (evaluatedThroughLabel) detailParts.push(`Coverage evaluated through ${evaluatedThroughLabel}.`);
+        if (teamAverageLabel) detailParts.push(teamAverageLabel);
+        attDetailEl.textContent = detailParts.join(' ').replace(/\s+/g, ' ').trim();
+        attFooterEl.textContent = evaluatedThroughLabel
+          ? `Ranked by lowest average talk time • Coverage tracked through ${evaluatedThroughLabel}`
+          : 'Ranked by lowest average talk time with full weekday coverage';
+        updateRankingList(attListEl, attLeaders, entry => {
+          const avgLabel = `${Math.round(entry.avgTalk)} min avg`;
+          const callLabel = entry.calls === 1 ? '1 call' : `${entry.calls} calls`;
+          const totalLabel = `${entry.totalMinutes.toLocaleString()} total minutes`;
+          const coverageSummary = Array.isArray(entry.coverageSummary) ? entry.coverageSummary : [];
+          const coverageWeeksTotal = coverageSummary.filter(week => Number(week.requiredDays || 0) > 0).length;
+          const coverageWeeksMet = coverageSummary.filter(week => Number(week.requiredDays || 0) > 0 && week.meetsRequirement).length;
+          const coverageNote = coverageWeeksTotal > 0
+            ? ` • Coverage ${coverageWeeksMet}/${coverageWeeksTotal} weeks`
+            : '';
+          const evaluatedLabel = formatCoverageDateLabel(entry.coverageEvaluatedThrough);
+          const evaluationNote = evaluatedLabel ? ` (through ${evaluatedLabel})` : '';
+          return `${avgLabel} • ${callLabel} (${totalLabel})${coverageNote}${evaluationNote}`;
+        });
+    }
+
+    function updateRankingList(listEl, entries, formatter) {
+      if (!listEl) return;
+      listEl.innerHTML = '';
+      if (!entries || !entries.length) {
+        listEl.classList.add('is-empty');
+        return;
+      }
+      listEl.classList.remove('is-empty');
+      const rankLabels = ['1st', '2nd', '3rd'];
+      entries.forEach((entry, index) => {
+        const li = document.createElement('li');
+        li.className = 'recognition-ranking-item';
+        const rankEl = document.createElement('span');
+        rankEl.className = 'rank-label';
+        rankEl.textContent = rankLabels[index] || `${index + 1}th`;
+        const detailEl = document.createElement('div');
+        detailEl.className = 'rank-detail';
+        const nameEl = document.createElement('span');
+        nameEl.className = 'rank-name';
+        nameEl.textContent = entry.agent;
+        const statEl = document.createElement('span');
+        statEl.className = 'rank-stat';
+        statEl.textContent = typeof formatter === 'function'
+          ? formatter(entry, index)
+          : '';
+        detailEl.appendChild(nameEl);
+        detailEl.appendChild(statEl);
+        li.appendChild(rankEl);
+        li.appendChild(detailEl);
+        listEl.appendChild(li);
+      });
+    }
+    }
 
   // Enhanced chart options function
   function getEnhancedChartOptions(type, title) {


### PR DESCRIPTION
## Summary
- adjust the ATT coverage evaluation to stop counting future weekdays and to surface the actual evaluation cutoff with each agent metric
- surface the coverage cutoff date in the ATT recognition card and ranking details so non-weekly filters show in-progress data with clear context

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6b7238ee08326a980a7ee38ef42cd