### PR TITLE
Ensure authentication flows rely on PasswordUtilities

### DIFF
--- a/IdentityService.js
+++ b/IdentityService.js
@@ -40,25 +40,16 @@ var IdentityService = (function () {
         Utilities.Charset.UTF_8
       );
 
-      try {
-        const utils = getPasswordUtils();
-        if (utils && typeof utils.digestToHex === 'function') {
-          return utils.digestToHex(digest);
-        }
-      } catch (utilsError) {
-        console.warn('hashToken: falling back to manual hex conversion', utilsError);
+      const utils = getPasswordUtils();
+      if (!utils || typeof utils.digestToHex !== 'function') {
+        throw new Error('Password utilities digestToHex unavailable');
       }
 
-      if (digest && typeof digest.map === 'function') {
-        return digest
-          .map(function (b) { return ('0' + (b & 0xFF).toString(16)).slice(-2); })
-          .join('');
-      }
-    } catch (digestError) {
-      console.warn('hashToken: Failed to compute digest', digestError);
+      return utils.digestToHex(digest);
+    } catch (error) {
+      console.warn('hashToken: Failed to compute digest via password utilities', error);
+      return '';
     }
-
-    return '';
   }
 
   function generateToken() {

--- a/UserService.js
+++ b/UserService.js
@@ -216,24 +216,17 @@ function _userDigestToHex_(digest) {
     return '';
   }
 
-  const utils = _userGetPasswordUtilities_();
-  if (utils && typeof utils.digestToHex === 'function') {
-    try {
-      return utils.digestToHex(digest);
-    } catch (utilsError) {
-      _userLog_('UserService.digestToHex', utilsError, 'warn');
+  try {
+    const utils = _userGetPasswordUtilities_();
+    if (!utils || typeof utils.digestToHex !== 'function') {
+      throw new Error('Password utilities digestToHex unavailable');
     }
-  }
 
-  if (typeof digest.map === 'function') {
-    try {
-      return digest.map(b => ('0' + (b & 0xFF).toString(16)).slice(-2)).join('');
-    } catch (mapError) {
-      _userLog_('UserService.digestToHexFallback', mapError, 'warn');
-    }
+    return utils.digestToHex(digest);
+  } catch (error) {
+    _userLog_('UserService.digestToHex', error, 'error');
+    throw error;
   }
-
-  return '';
 }
 
 function clientGetUserSummaries(context) {


### PR DESCRIPTION
## Summary
- add a helper for safely retrieving the password utilities and remove manual fallbacks in authentication comparisons
- update authentication diagnostics and maintenance helpers to depend on the central password utilities for hashing and verification
- require password utilities for token hashing and digest conversion throughout the identity services

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7bf9136c88326a7f5289718bf61d4