### PR TITLE
Modernize QA dashboard with AI-first layout

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -37,36 +37,39 @@
   }
 
   var __qaFormUrl = __qaBuildPageUrl('qualityform');
+  var __qaListUrl = __qaBuildPageUrl('qalist');
   var __coachingFormUrl = __qaBuildPageUrl('coachingsheet');
   var __collabFormUrl = __qaBuildPageUrl('qualitycollabform');
 ?>
 
 <style>
   :root {
-    --qa-bg: #f7f9fc;
-    --qa-card-bg: #ffffff;
-    --qa-border: #e5e7eb;
-    --qa-primary: #2563eb;
-    --qa-accent: #0ea5e9;
-    --qa-success: #10b981;
+    --qa-bg: linear-gradient(135deg, #eef2ff 0%, #f8fafc 45%, #f1f5f9 100%);
+    --qa-card-bg: rgba(255, 255, 255, 0.94);
+    --qa-border: rgba(148, 163, 184, 0.3);
+    --qa-primary: #1d4ed8;
+    --qa-accent: #38bdf8;
+    --qa-success: #16a34a;
     --qa-warning: #f59e0b;
     --qa-danger: #ef4444;
-    --qa-muted: #6b7280;
-    --qa-radius-lg: 18px;
+    --qa-muted: #64748b;
+    --qa-radius-lg: 20px;
     --qa-radius-md: 14px;
-    --qa-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
-    --qa-shadow-soft: 0 12px 30px rgba(15, 23, 42, 0.06);
+    --qa-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+    --qa-shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.08);
+    --qa-glow: 0 28px 60px rgba(37, 99, 235, 0.12);
   }
 
   body {
     background: var(--qa-bg);
+    min-height: 100vh;
   }
 
   .qa-shell {
     width: 100%;
     max-width: 100%;
     margin: 0;
-    padding: 1.5rem clamp(1.5rem, 3vw, 2.5rem) 3rem;
+    padding: 2rem clamp(1.5rem, 3vw, 3rem) 3.5rem;
   }
 
   .qa-dashboard {
@@ -78,9 +81,16 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    gap: 1.75rem;
-    margin-bottom: 1.5rem;
+    gap: 1.9rem;
+    margin-bottom: 1.75rem;
     align-items: flex-start;
+    padding: 1.75rem 1.9rem;
+    border-radius: calc(var(--qa-radius-lg) + 6px);
+    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.14), transparent 55%),
+      radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 60%),
+      rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: var(--qa-glow);
   }
 
   .qa-page-header__text {
@@ -110,6 +120,24 @@
     font-size: 0.98rem;
   }
 
+  .qa-ai-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 1rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--qa-primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+  }
+
+  .qa-ai-banner i {
+    font-size: 1rem;
+  }
+
   .qa-page-header__actions {
     display: flex;
     flex-wrap: wrap;
@@ -137,18 +165,20 @@
     border: none;
     border-radius: var(--qa-radius-lg);
     box-shadow: var(--qa-shadow-soft);
+    background: var(--qa-card-bg);
+    backdrop-filter: blur(6px);
   }
 
   .qa-dashboard .card-header {
     background: transparent;
     border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-    padding: 1.25rem 1.75rem 0.75rem;
+    padding: 1.35rem 1.9rem 0.85rem;
     font-weight: 600;
     color: #0f172a;
   }
 
   .qa-dashboard .card-body {
-    padding: 1.75rem;
+    padding: 1.9rem;
   }
 
   .qa-filters {
@@ -198,10 +228,10 @@
 
   .qa-summary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-    gap: 1.25rem;
-    margin-top: 1.25rem;
-    margin-bottom: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    margin-bottom: 1.75rem;
   }
 
   .qa-summary-card {
@@ -318,23 +348,23 @@
 
   .qa-trend-chart-container {
     position: relative;
-    height: 360px;
+    height: 440px;
     width: 100%;
   }
 
   .qa-analytics-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 1.75rem;
   }
 
   .qa-chart-wrapper {
     position: relative;
-    height: 320px;
+    height: 360px;
   }
 
   .qa-chart-wrapper--compact {
-    height: 240px;
+    height: 300px;
   }
 
   .qa-chart-wrapper canvas {
@@ -355,7 +385,7 @@
 
   .qa-gauge-wrapper {
     position: relative;
-    height: 220px;
+    height: 280px;
   }
 
   .qa-gauge-center {
@@ -364,7 +394,7 @@
     display: grid;
     place-items: center;
     font-weight: 700;
-    font-size: 1.65rem;
+    font-size: 1.85rem;
     color: #1e3a8a;
   }
 
@@ -376,14 +406,45 @@
   }
 
   .qa-intelligence-card {
-    background: var(--qa-card-bg);
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(14, 165, 233, 0.08));
     border-radius: var(--qa-radius-lg);
-    border: 1px solid rgba(37, 99, 235, 0.16);
-    padding: 1.5rem;
-    box-shadow: var(--qa-shadow-soft);
+    border: 1px solid rgba(37, 99, 235, 0.24);
+    padding: 1.75rem;
+    box-shadow: var(--qa-glow);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.1rem;
+    color: #0f172a;
+  }
+
+  .qa-ai-metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+  }
+
+  .qa-ai-metric {
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: var(--qa-radius-md);
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  }
+
+  .qa-ai-metric__label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--qa-muted);
+    margin-bottom: 0.35rem;
+  }
+
+  .qa-ai-metric__value {
+    font-weight: 700;
+    font-size: 1.15rem;
+    color: #0f172a;
   }
 
   .qa-intelligence-card__summary {
@@ -424,6 +485,73 @@
     height: 100%;
     flex: 1 1 220px;
     min-width: 220px;
+  }
+
+  .qa-ai-insight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.1rem;
+  }
+
+  .qa-ai-insight-card {
+    position: relative;
+    border-radius: var(--qa-radius-lg);
+    padding: 1.35rem 1.4rem 1.4rem;
+    background: linear-gradient(160deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.08));
+    border: 1px solid rgba(37, 99, 235, 0.22);
+    box-shadow: var(--qa-shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    overflow: hidden;
+  }
+
+  .qa-ai-insight-card[data-tone="positive"] {
+    border-color: rgba(16, 185, 129, 0.35);
+    background: linear-gradient(160deg, rgba(16, 185, 129, 0.14), rgba(37, 99, 235, 0.08));
+  }
+
+  .qa-ai-insight-card[data-tone="negative"] {
+    border-color: rgba(239, 68, 68, 0.35);
+    background: linear-gradient(160deg, rgba(239, 68, 68, 0.12), rgba(37, 99, 235, 0.08));
+  }
+
+  .qa-ai-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.75);
+    color: var(--qa-primary);
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+    width: fit-content;
+  }
+
+  .qa-ai-chip i {
+    font-size: 0.9rem;
+  }
+
+  .qa-ai-insight-card strong {
+    font-size: 1.05rem;
+  }
+
+  .qa-ai-insight-card p {
+    margin-bottom: 0;
+    color: #1e293b;
+  }
+
+  .qa-ai-insight-empty {
+    margin-top: 0.5rem;
+    padding: 1.1rem 1.25rem;
+    text-align: center;
+    border-radius: var(--qa-radius-md);
+    border: 1px dashed rgba(148, 163, 184, 0.45);
+    background: rgba(255, 255, 255, 0.65);
+    color: #64748b;
+    font-size: 0.9rem;
   }
 
   .qa-recognition-item:hover {
@@ -786,11 +914,19 @@
     .qa-action-item {
       grid-template-columns: 36px 1fr;
     }
+
+    .qa-trend-chart-container {
+      height: 360px;
+    }
   }
 
   @media (max-width: 768px) {
     .qa-page-header__actions {
       width: 100%;
+    }
+
+    .qa-page-header {
+      padding: 1.35rem 1.4rem;
     }
   }
 </style>
@@ -810,11 +946,19 @@
       <p class="qa-page-header__summary mb-0" id="qa-context-summary" data-banner-description>
         Monitor live quality health, trending scores, and AI-powered recommendations across your teams.
       </p>
+      <div class="qa-ai-banner" id="qa-ai-signal">
+        <i class="fa-solid fa-robot"></i>
+        AI is synthesizing your quality telemetry in real time.
+      </div>
     </div>
     <div class="qa-page-header__actions" data-banner-source>
       <a class="btn btn-primary" href="<?= __qaFormUrl ?>" data-banner-action data-banner-icon="fa-solid fa-clipboard-check" data-banner-variant="primary">
         <i class="fa-solid fa-clipboard-check"></i>
         <span>QA Form</span>
+      </a>
+      <a class="btn btn-outline-info" href="<?= __qaListUrl ?>" data-banner-action data-banner-icon="fa-solid fa-list-check" data-banner-variant="secondary">
+        <i class="fa-solid fa-list-check"></i>
+        <span>QA List</span>
       </a>
       <a class="btn btn-outline-primary" href="<?= __coachingFormUrl ?>" data-banner-action data-banner-icon="fa-solid fa-file-signature" data-banner-variant="secondary">
         <i class="fa-solid fa-file-signature"></i>
@@ -921,6 +1065,16 @@
             <div class="qa-gauge-center" id="qa-gauge-value">--</div>
           </div>
           <div class="qa-gauge-subtext">Average QA Score</div>
+          <div class="qa-ai-metric-grid">
+            <div class="qa-ai-metric">
+              <span class="qa-ai-metric__label">AI Confidence</span>
+              <span class="qa-ai-metric__value" id="qa-ai-confidence">--</span>
+            </div>
+            <div class="qa-ai-metric">
+              <span class="qa-ai-metric__label">Projected Trend</span>
+              <span class="qa-ai-metric__value" id="qa-ai-projection">--</span>
+            </div>
+          </div>
           <div class="qa-chart-wrapper qa-chart-wrapper--compact mt-4">
             <canvas id="qa-outcome-chart"></canvas>
             <div class="qa-chart-empty d-none" id="qa-outcome-empty">Awaiting evaluation data.</div>
@@ -943,6 +1097,24 @@
           <button type="button" class="btn btn-primary" id="qa-open-actions" data-bs-toggle="modal" data-bs-target="#qaActionsModal">
             <i class="fa-solid fa-list-check me-2"></i>View Recommendations
           </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4 mt-1" id="qa-intelligence-row">
+    <div class="col-12">
+      <div class="card h-100">
+        <div class="card-header d-flex align-items-center gap-2">
+          <i class="fa-solid fa-brain-circuit text-primary" aria-hidden="true"></i>
+          <span>AI Highlights</span>
+        </div>
+        <div class="card-body">
+          <div class="qa-ai-insight-grid" id="qa-insight-highlights" aria-live="polite"></div>
+          <div class="qa-ai-insight-empty" id="qa-insight-highlights-empty">
+            <i class="fa-solid fa-robot me-2" aria-hidden="true"></i>
+            <span>Real-time AI narratives will appear once fresh QA data is processed.</span>
+          </div>
         </div>
       </div>
     </div>
@@ -1199,6 +1371,11 @@
       categoryEmpty: document.getElementById('qa-category-empty'),
       agentEmpty: document.getElementById('qa-agent-empty'),
       distributionEmpty: document.getElementById('qa-distribution-empty'),
+      aiSignal: document.getElementById('qa-ai-signal'),
+      aiConfidence: document.getElementById('qa-ai-confidence'),
+      aiProjection: document.getElementById('qa-ai-projection'),
+      insightHighlights: document.getElementById('qa-insight-highlights'),
+      insightHighlightsEmpty: document.getElementById('qa-insight-highlights-empty'),
       openInsights: document.getElementById('qa-open-insights'),
       openActions: document.getElementById('qa-open-actions'),
       insightsModal: document.getElementById('qaInsightsModal'),
@@ -1298,6 +1475,89 @@
         return '--';
       }
       return new Intl.NumberFormat().format(value);
+    }
+
+    function updateAiSignal(summary) {
+      if (!dom.aiSignal) {
+        return;
+      }
+
+      let message = 'AI is monitoring your quality telemetry.';
+
+      if (summary && typeof summary.avg === 'number' && !Number.isNaN(summary.avg)) {
+        const avgScore = Math.round(summary.avg);
+        const avgDelta = summary && summary.delta && typeof summary.delta.avg === 'number'
+          ? Math.round(summary.delta.avg * 10) / 10
+          : null;
+
+        if (avgScore >= 92) {
+          message = `AI projects sustained excellence with an average QA score of ${avgScore}%.`;
+        } else if (avgScore >= 85) {
+          message = `AI anticipates steady performance with an average QA score of ${avgScore}%.`;
+        } else if (avgScore >= 75) {
+          message = `AI flags growth opportunities — average QA score is ${avgScore}% and trending for optimization.`;
+        } else {
+          message = `AI is prioritizing recovery playbooks — average QA score is ${avgScore}% and needs attention.`;
+        }
+
+        if (avgDelta !== null && !Number.isNaN(avgDelta) && Math.abs(avgDelta) >= 0.5) {
+          const momentum = avgDelta > 0 ? 'upward momentum' : 'downward pressure';
+          const indicator = avgDelta > 0 ? '▲' : '▼';
+          message += ` Current momentum shows ${momentum} ${indicator} ${Math.abs(avgDelta)} pts vs prior.`;
+        }
+      }
+
+      dom.aiSignal.textContent = message;
+    }
+
+    function updateAiHealthMetrics(summary, trend) {
+      if (dom.aiConfidence) {
+        let confidenceText = '--';
+        if (summary && typeof summary.evaluations === 'number' && !Number.isNaN(summary.evaluations)) {
+          if (summary.evaluations >= 100) {
+            confidenceText = 'High';
+          } else if (summary.evaluations >= 40) {
+            confidenceText = 'Medium';
+          } else if (summary.evaluations > 0) {
+            confidenceText = 'Developing';
+          } else {
+            confidenceText = 'Awaiting data';
+          }
+        } else {
+          confidenceText = 'Awaiting data';
+        }
+        dom.aiConfidence.textContent = confidenceText;
+      }
+
+      if (dom.aiProjection) {
+        let projectionText = 'Awaiting history';
+        const series = trend && Array.isArray(trend.series) ? trend.series : [];
+        if (series.length >= 2) {
+          const latest = series[series.length - 1];
+          const previous = series[series.length - 2];
+          if (latest && previous && typeof latest.avgScore === 'number' && typeof previous.avgScore === 'number') {
+            const delta = Math.round((latest.avgScore - previous.avgScore) * 10) / 10;
+            if (delta > 1) {
+              projectionText = `Accelerating ▲ ${delta} pts`;
+            } else if (delta < -1) {
+              projectionText = `Cooling ▼ ${Math.abs(delta)} pts`;
+            } else {
+              projectionText = `Stabilizing at ${Math.round(latest.avgScore)}%`;
+            }
+          }
+        } else if (summary && summary.delta && typeof summary.delta.avg === 'number') {
+          const delta = Math.round(summary.delta.avg * 10) / 10;
+          if (delta > 0.5) {
+            projectionText = `Climbing ▲ ${delta} pts`;
+          } else if (delta < -0.5) {
+            projectionText = `Softening ▼ ${Math.abs(delta)} pts`;
+          } else {
+            projectionText = 'Holding steady';
+          }
+        }
+
+        dom.aiProjection.textContent = projectionText;
+      }
     }
 
     function getOrdinalSuffix(value) {
@@ -1413,6 +1673,8 @@
         const agents = formatNumber(summary.agents);
         dom.contextSummary.textContent = `Tracking ${evaluations} evaluation${summary.evaluations === 1 ? '' : 's'} across ${agents} agent${summary.agents === 1 ? '' : 's'} this period.`;
       }
+
+      updateAiSignal(summary);
     }
 
     function renderTrend(trend, granularity) {
@@ -1938,6 +2200,47 @@
       });
     }
 
+    function renderInsightHighlights(insights) {
+      if (!dom.insightHighlights) {
+        return;
+      }
+
+      const highlights = Array.isArray(insights) ? insights.slice(0, 3) : [];
+      dom.insightHighlights.innerHTML = '';
+      const hasHighlights = highlights.length > 0;
+
+      if (dom.insightHighlightsEmpty) {
+        dom.insightHighlightsEmpty.classList.toggle('d-none', hasHighlights);
+      }
+
+      if (!hasHighlights) {
+        return;
+      }
+
+      highlights.forEach(item => {
+        const card = document.createElement('div');
+        card.className = 'qa-ai-insight-card';
+        if (item.tone) {
+          card.dataset.tone = item.tone;
+        }
+
+        const chip = document.createElement('span');
+        chip.className = 'qa-ai-chip';
+        chip.innerHTML = `<i class="fa-solid ${item.icon || 'fa-lightbulb'}"></i><span>${escapeHtml(item.tag || 'AI Insight')}</span>`;
+
+        const title = document.createElement('strong');
+        title.textContent = item.title || 'AI Insight';
+
+        const description = document.createElement('p');
+        description.innerHTML = item.text || '';
+
+        card.appendChild(chip);
+        card.appendChild(title);
+        card.appendChild(description);
+        dom.insightHighlights.appendChild(card);
+      });
+    }
+
     function renderInsights(insights) {
       if (!dom.insights) return;
       const items = Array.isArray(insights) ? insights : [];
@@ -1945,6 +2248,8 @@
       if (dom.insightCount) {
         dom.insightCount.textContent = `${items.length} AI insight${items.length === 1 ? '' : 's'}`;
       }
+
+      renderInsightHighlights(items);
 
       dom.insights.innerHTML = '';
       if (!items.length) {
@@ -2348,6 +2653,7 @@
 
       renderGauge(summary);
       renderOutcomeChart(summary);
+      updateAiHealthMetrics(summary, trend);
 
       const categories = response.categories || [];
       renderCategoryChart(categories);


### PR DESCRIPTION
## Summary
- refresh the QA Dashboard styling with a modernized shell, gradient hero, and enlarged chart canvases for visual consistency
- surface inline AI intelligence with a live signal banner, health metrics, and highlight cards fed by existing insight data
- expand AI-driven messaging by updating confidence and projection logic tied to dashboard summaries and trend history

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f804d9eeb88326995bb8d4293c5f33