### PR TITLE
Handle missing campaign name in topbar insights

### DIFF
--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -115,6 +115,9 @@
     }
 
     var locale = navigator.language || 'en-US';
+    var campaignDisplayValue = (typeof campaignNameValue !== 'undefined' && campaignNameValue)
+      ? campaignNameValue
+      : '';
 
     function safeText(value, fallback) {
       if (value === null || typeof value === 'undefined') {
@@ -390,7 +393,7 @@
         },
         {
           label: 'Campaign',
-          value: safeText(campaignNameValue, 'No campaign'),
+          value: safeText(campaignDisplayValue, 'No campaign'),
           hint: 'CampaignService.js',
           icon: 'fas fa-bullhorn'
         }


### PR DESCRIPTION
## Summary
- guard the topbar insight builder against an undefined `campaignNameValue`
- reuse a sanitized fallback when rendering the campaign insight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8286435008326bfa99f72da490a84