### PR TITLE
Serve daily pivot matrix export as Google Sheet

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -3848,15 +3848,38 @@
         if (result && result.success !== false) {
           this.updateExportProgress(100, 'Export completed successfully!');
 
-          if (result.csvData) {
-            this.downloadCSV(result.csvData, result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.csv`);
+          if (result.spreadsheetUrl) {
+            this.openSpreadsheet(result.spreadsheetUrl);
+          } else if (result.fileData) {
+            this.downloadFile(
+              result.fileData,
+              result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.xlsx`,
+              result.mimeType || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              (result.encoding || '').toLowerCase() === 'base64'
+            );
+          } else if (result.csvData) {
+            this.downloadFile(
+              result.csvData,
+              result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
+              result.mimeType || 'text/csv;charset=utf-8;',
+              false
+            );
           } else if (typeof result === 'string') {
-            this.downloadCSV(result, `attendance_export_${new Date().toISOString().split('T')[0]}.csv`);
+            this.downloadFile(
+              result,
+              `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
+              'text/csv;charset=utf-8;',
+              false
+            );
           }
+
+          const successMessage = result.fileType === 'google_sheet'
+            ? 'Daily pivot matrix opened in Google Sheets.'
+            : 'Export completed successfully!';
 
           setTimeout(() => {
             if (progressModal) progressModal.hide();
-            this.showSuccessMessage('Export completed successfully!');
+            this.showSuccessMessage(successMessage);
           }, 1000);
 
         } else {
@@ -3952,16 +3975,47 @@
       if (statusText) statusText.textContent = status;
     }
 
-    downloadCSV(csvData, filename) {
-      const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
+    downloadFile(data, filename, mimeType, isBase64 = false) {
+      let downloadName = filename || `attendance_export_${new Date().toISOString().split('T')[0]}.${isBase64 ? 'xlsx' : 'csv'}`;
+      const resolvedMimeType = mimeType || (isBase64 ? 'application/octet-stream' : 'text/csv;charset=utf-8;');
+
+      let blob;
+      if (isBase64) {
+        const byteCharacters = atob(data);
+        const byteNumbers = new Array(byteCharacters.length);
+        for (let i = 0; i < byteCharacters.length; i++) {
+          byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        const byteArray = new Uint8Array(byteNumbers);
+        blob = new Blob([byteArray], { type: resolvedMimeType });
+      } else {
+        blob = new Blob([data], { type: resolvedMimeType });
+      }
+
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = filename;
+      a.download = downloadName;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
+    }
+
+    openSpreadsheet(url) {
+      if (!url) {
+        this.showErrorMessage('Google Sheets link unavailable for this export.');
+        return;
+      }
+
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener';
+      anchor.style.display = 'none';
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
     }
 
     showSuccessMessage(message) {


### PR DESCRIPTION
## Summary
- generate the daily pivot matrix as a native Google Sheet and return its shareable link instead of converting to XLSX
- keep the sheet when export succeeds and expose its Drive id, url, and metadata to the client
- teach the export dialog to open Google Sheet exports in a new tab and show a tailored success message while retaining CSV/XLSX fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f815561158832688dfe12e0f9b9010