### PR TITLE
Remove ATT recognition coverage filters

### DIFF
--- a/CallReports.html
+++ b/CallReports.html
@@ -2414,13 +2414,6 @@
   }
 
 
-  function formatCoverageDateLabel(value) {
-    if (!value && value !== 0) return '';
-    const parsed = value instanceof Date ? value : new Date(value);
-    if (!(parsed instanceof Date) || isNaN(parsed)) return '';
-    return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  }
-
   function renderRecognitionHighlights(analytics = {}) {
     const csatCard = document.getElementById('csatRecognitionCard');
     const attCard = document.getElementById('attRecognitionCard');
@@ -2441,14 +2434,12 @@
 
     const repMetrics = Array.isArray(analytics.repMetrics) ? analytics.repMetrics : [];
     const talkBenchmarks = analytics.talkBenchmarks || {};
-    const MIN_ATT_MINUTES = 1;
-    const MAX_ATT_MINUTES = 20000;
     const rawBenchmarkAverage = talkBenchmarks.averageMinutes;
     const parsedBenchmarkAverage = rawBenchmarkAverage === null || rawBenchmarkAverage === undefined
       ? NaN
       : Number(rawBenchmarkAverage);
     const benchmarkAverage = Number.isFinite(parsedBenchmarkAverage)
-      ? Math.min(Math.max(parsedBenchmarkAverage, MIN_ATT_MINUTES), MAX_ATT_MINUTES)
+      ? parsedBenchmarkAverage
       : NaN;
     const benchmarkDisplay = Number.isFinite(benchmarkAverage)
       ? Math.round(benchmarkAverage)
@@ -2509,28 +2500,18 @@
     }
 
     const attEligible = repMetrics
-      .filter(item => item && item.fullWeekCoverage === true)
       .map(item => {
-        const calls = Number(item.qualifyingTalkCalls || 0);
-        const totalMinutes = Number(item.totalTalkWholeMinutes || 0);
+        const calls = Number(item.qualifyingTalkCalls ?? item.totalCalls ?? 0);
+        const totalMinutes = Number(item.totalTalkWholeMinutes ?? item.totalTalk ?? 0);
         const avgTalk = calls > 0 ? totalMinutes / calls : null;
-        const coverageSummary = Array.isArray(item.weeklyCoverageSummary)
-          ? item.weeklyCoverageSummary
-          : [];
         return {
           agent: item.agent || '—',
           calls,
           totalMinutes,
-          avgTalk,
-          coverageSummary,
-          coverageEvaluatedThrough: item.coverageEvaluatedThrough || null
+          avgTalk
         };
       })
-      .filter(entry => {
-        if (entry.avgTalk === null || !Number.isFinite(entry.avgTalk)) return false;
-        if (entry.avgTalk < MIN_ATT_MINUTES || entry.avgTalk > MAX_ATT_MINUTES) return false;
-        return entry.calls > 0;
-      });
+      .filter(entry => entry.avgTalk !== null && Number.isFinite(entry.avgTalk) && entry.calls > 0);
 
     const attLeaders = attEligible
       .slice()
@@ -2546,52 +2527,30 @@
       attCard.classList.add('is-empty');
       attNameEl.textContent = 'Awaiting data';
       attValueEl.textContent = '—';
-      attDetailEl.textContent = 'Maintain weekday coverage (Mon–Fri) at least 5 days per week across every week in the month to earn recognition.';
-      attFooterEl.textContent = 'No qualifying calls with full weekday coverage yet';
+      attDetailEl.textContent = 'Log calls with talk time data so we can spotlight the top performers.';
+      attFooterEl.textContent = 'No qualifying talk time records yet';
       updateRankingList(attListEl, []);
     } else {
       const champion = attLeaders[0];
       const championAvg = Math.round(champion.avgTalk);
       const championCalls = champion.calls === 1 ? '1 qualifying call' : `${champion.calls} qualifying calls`;
       const championMinutes = `${champion.totalMinutes.toLocaleString()} total minutes`;
-      const coverageWeeks = Array.isArray(champion.coverageSummary)
-        ? champion.coverageSummary.filter(week => week.requiredDays > 0).length
-        : 0;
-      const coverageWeeksMet = Array.isArray(champion.coverageSummary)
-        ? champion.coverageSummary.filter(week => week.requiredDays > 0 && week.meetsRequirement).length
-        : 0;
-        const coverageLabel = coverageWeeks > 0
-          ? `Maintained weekday call coverage (Mon–Fri) across ${coverageWeeksMet}/${coverageWeeks} week${coverageWeeks === 1 ? '' : 's'} this period.`
-          : '';
-        const teamAverageLabel = benchmarkDisplay !== null
-          ? `Team average: ${benchmarkDisplay} min.`
-          : '';
-        const evaluatedThroughLabel = formatCoverageDateLabel(champion.coverageEvaluatedThrough);
       attCard.classList.remove('is-empty');
       attNameEl.textContent = champion.agent;
       attValueEl.textContent = `${championAvg} min avg`;
-        const detailParts = [`${championCalls} (${championMinutes}).`];
-        if (coverageLabel) detailParts.push(coverageLabel);
-        if (evaluatedThroughLabel) detailParts.push(`Coverage evaluated through ${evaluatedThroughLabel}.`);
-        if (teamAverageLabel) detailParts.push(teamAverageLabel);
-        attDetailEl.textContent = detailParts.join(' ').replace(/\s+/g, ' ').trim();
-        attFooterEl.textContent = evaluatedThroughLabel
-          ? `Ranked by lowest average talk time • Coverage tracked through ${evaluatedThroughLabel}`
-          : 'Ranked by lowest average talk time with full weekday coverage';
-        updateRankingList(attListEl, attLeaders, entry => {
-          const avgLabel = `${Math.round(entry.avgTalk)} min avg`;
-          const callLabel = entry.calls === 1 ? '1 call' : `${entry.calls} calls`;
-          const totalLabel = `${entry.totalMinutes.toLocaleString()} total minutes`;
-          const coverageSummary = Array.isArray(entry.coverageSummary) ? entry.coverageSummary : [];
-          const coverageWeeksTotal = coverageSummary.filter(week => Number(week.requiredDays || 0) > 0).length;
-          const coverageWeeksMet = coverageSummary.filter(week => Number(week.requiredDays || 0) > 0 && week.meetsRequirement).length;
-          const coverageNote = coverageWeeksTotal > 0
-            ? ` • Coverage ${coverageWeeksMet}/${coverageWeeksTotal} weeks`
-            : '';
-          const evaluatedLabel = formatCoverageDateLabel(entry.coverageEvaluatedThrough);
-          const evaluationNote = evaluatedLabel ? ` (through ${evaluatedLabel})` : '';
-          return `${avgLabel} • ${callLabel} (${totalLabel})${coverageNote}${evaluationNote}`;
-        });
+      const teamAverageLabel = benchmarkDisplay !== null
+        ? `Team average: ${benchmarkDisplay} min.`
+        : '';
+      const detailParts = [`${championCalls} (${championMinutes}).`];
+      if (teamAverageLabel) detailParts.push(teamAverageLabel);
+      attDetailEl.textContent = detailParts.join(' ').replace(/\s+/g, ' ').trim();
+      attFooterEl.textContent = 'Ranked by lowest average talk time';
+      updateRankingList(attListEl, attLeaders, entry => {
+        const avgLabel = `${Math.round(entry.avgTalk)} min avg`;
+        const callLabel = entry.calls === 1 ? '1 call' : `${entry.calls} calls`;
+        const totalLabel = `${entry.totalMinutes.toLocaleString()} total minutes`;
+        return `${avgLabel} • ${callLabel} (${totalLabel})`;
+      });
     }
 
     function updateRankingList(listEl, entries, formatter) {


### PR DESCRIPTION
## Summary
- remove weekday coverage and talk time bounds from the ATT Ace recognition logic
- streamline ATT Ace detail and footer messaging to match the unrestricted leaderboard
- rely on standard talk time inputs so the recognition updates alongside CSAT champion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f82c070f48832683512e2ed779f4a3