### PR TITLE
Refactor schedule workflows for range-based assignments

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -506,97 +506,109 @@ function clientGetManagedUsersList(managerId) {
  */
 function clientCreateShiftSlot(slotData) {
   try {
-    console.log('🕒 Creating shift slot:', slotData);
+    console.log('🕒 Creating shift slot (range-based model):', slotData);
 
-    // Validate required fields
-    if (!slotData.name || !slotData.startTime || !slotData.endTime) {
-      return {
-        success: false,
-        error: 'Slot name, start time, and end time are required'
-      };
+    const rawName = slotData && (slotData.name || slotData.slotName || slotData.SlotName);
+    const slotName = rawName ? String(rawName).trim() : '';
+    const rawCampaign = slotData && (slotData.campaign || slotData.Campaign || slotData.department || slotData.Department || '');
+    const campaign = rawCampaign ? String(rawCampaign).trim() : '';
+    const rawLocation = slotData && (slotData.location || slotData.Location || 'Office');
+    const location = rawLocation ? String(rawLocation).trim() : 'Office';
+    const startMinutes = parseTimeToMinutes(slotData && slotData.startTime ? slotData.startTime : slotData && slotData.StartTime);
+    const endMinutes = parseTimeToMinutes(slotData && slotData.endTime ? slotData.endTime : slotData && slotData.EndTime);
+    const daysArray = normalizeDayTokens(
+      (slotData && slotData.daysOfWeek)
+        || (slotData && slotData.DaysOfWeek)
+        || (slotData && slotData.days)
+        || 'Mon,Tue,Wed,Thu,Fri'
+    );
+
+    if (!slotName) {
+      return { success: false, error: 'Slot name is required.' };
+    }
+    if (!campaign) {
+      return { success: false, error: 'Campaign/Department selection is required for the slot.' };
+    }
+    if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
+      return { success: false, error: 'Start and end times must be valid 12-hour time values.' };
+    }
+    if (startMinutes === endMinutes) {
+      return { success: false, error: 'Start time and end time cannot be the same.' };
+    }
+    if (!Array.isArray(daysArray) || daysArray.length === 0) {
+      return { success: false, error: 'Select at least one day of the week for the shift slot.' };
     }
 
-    // Use ScheduleUtilities validation
-    const validation = validateShiftSlot(slotData);
-    if (!validation.isValid) {
-      return {
-        success: false,
-        error: validation.errors.join('; ')
-      };
+    const slots = loadShiftSlotsNormalized();
+    const normalizedName = slotName.toLowerCase();
+    const normalizedCampaign = campaign.toLowerCase();
+    const duplicate = slots.find(slot =>
+      slot && String(slot.Campaign || '').toLowerCase() === normalizedCampaign && String(slot.SlotName || '').toLowerCase() === normalizedName && slot.Status !== 'Archived'
+    );
+    if (duplicate) {
+      return { success: false, error: 'A shift slot with this name already exists for the selected campaign.' };
     }
 
-    // Use ScheduleUtilities to ensure sheet exists with proper headers
-    const sheet = ensureScheduleSheetWithHeaders(SHIFT_SLOTS_SHEET, SHIFT_SLOTS_HEADERS);
+    const actor = resolveCurrentActorEmail();
     const now = new Date();
     const slotId = Utilities.getUuid();
 
-    const toNumber = (value, fallback = '') => {
-      if (value === null || value === undefined || value === '') {
-        return fallback;
-      }
-
-      const num = Number(value);
-      return Number.isFinite(num) ? num : fallback;
+    const defaults = {
+      priority: Number(slotData && slotData.priority) || 2,
+      maxCapacity: Number(slotData && slotData.maxCapacity) || Number(slotData && slotData.MaxCapacity) || null,
+      minCoverage: Number(slotData && slotData.minCoverage) || Number(slotData && slotData.MinCoverage) || null,
+      breakDuration: Number(slotData && slotData.breakDuration) || Number(slotData && slotData.BreakDuration) || 15,
+      break1Duration: Number(slotData && slotData.break1Duration) || Number(slotData && slotData.Break1Duration) || 15,
+      break2Duration: Number(slotData && slotData.break2Duration) || Number(slotData && slotData.Break2Duration) || 0,
+      lunchDuration: Number(slotData && slotData.lunchDuration) || Number(slotData && slotData.LunchDuration) || 30,
+      enableStaggeredBreaks: Boolean(slotData && (slotData.enableStaggeredBreaks ?? slotData.EnableStaggeredBreaks ?? true)),
+      breakGroups: Number(slotData && slotData.breakGroups) || Number(slotData && slotData.BreakGroups) || 3,
+      staggerInterval: Number(slotData && slotData.staggerInterval) || Number(slotData && slotData.StaggerInterval) || 15,
+      minCoveragePct: Number(slotData && slotData.minCoveragePct) || Number(slotData && slotData.MinCoveragePct) || null,
+      enableOvertime: Boolean(slotData && (slotData.enableOvertime ?? slotData.EnableOvertime ?? false)),
+      maxDailyOT: Number(slotData && slotData.maxDailyOT) || Number(slotData && slotData.MaxDailyOT) || 0,
+      maxWeeklyOT: Number(slotData && slotData.maxWeeklyOT) || Number(slotData && slotData.MaxWeeklyOT) || 0,
+      otApproval: slotData && (slotData.otApproval || slotData.OTApproval) || '',
+      otRate: Number(slotData && slotData.otRate) || Number(slotData && slotData.OTRate) || 1.5,
+      otPolicy: slotData && (slotData.otPolicy || slotData.OTPolicy) || '',
+      allowSwaps: Boolean(slotData && (slotData.allowSwaps ?? slotData.AllowSwaps ?? true)),
+      weekendPremium: Boolean(slotData && (slotData.weekendPremium ?? slotData.WeekendPremium ?? false)),
+      holidayPremium: Boolean(slotData && (slotData.holidayPremium ?? slotData.HolidayPremium ?? true)),
+      autoAssignment: Boolean(slotData && (slotData.autoAssignment ?? slotData.AutoAssignment ?? false)),
+      restPeriod: Number(slotData && slotData.restPeriod) || Number(slotData && slotData.RestPeriod) || 0,
+      notificationLead: Number(slotData && slotData.notificationLead) || Number(slotData && slotData.NotificationLead) || 0,
+      handoverTime: Number(slotData && slotData.handoverTime) || Number(slotData && slotData.HandoverTime) || 0,
+      overtimePolicy: slotData && (slotData.overtimePolicy || slotData.OvertimePolicy) || '',
+      location: location
     };
 
-    const toBoolean = (value, fallback = false) => {
-      if (typeof value === 'boolean') return value;
-      if (typeof value === 'number') return value !== 0;
-      if (typeof value === 'string') {
-        const normalized = value.trim().toLowerCase();
-        if (!normalized) return fallback;
-        return ['true', 'yes', '1', 'y'].includes(normalized);
-      }
-      return fallback;
-    };
-
-    // Process days of week
-    let daysOfWeek = '1,2,3,4,5'; // Default to weekdays
-    if (slotData.daysOfWeek && Array.isArray(slotData.daysOfWeek)) {
-      daysOfWeek = slotData.daysOfWeek.join(',');
-    }
-
-    const daysOfWeekArray = daysOfWeek
-      .split(',')
-      .map(value => parseInt(value, 10))
-      .filter(value => !isNaN(value));
-
-    const generationDefaults = buildGenerationDefaultsFromSource(slotData) || null;
-    const serializedDefaults = generationDefaults ? JSON.stringify(generationDefaults) : '';
-
-    const slotRecord = {
-      ID: slotId,
-      Name: slotData.name,
-      StartTime: slotData.startTime,
-      EndTime: slotData.endTime,
-      DaysOfWeek: daysOfWeek,
-      Department: slotData.department || 'General',
-      Location: slotData.location || 'Office',
-      Priority: toNumber(slotData.priority, 2),
-      Description: slotData.description || '',
-      IsActive: toBoolean(slotData.isActive, true),
-      CreatedBy: slotData.createdBy || 'System',
+    const normalizedSlot = {
+      SlotId: slotId,
+      SlotName: slotName,
+      Campaign: campaign,
+      Location: location,
+      StartTime: formatMinutesToTime12Hour(startMinutes),
+      EndTime: formatMinutesToTime12Hour(endMinutes),
+      StartMinutes: startMinutes,
+      EndMinutes: endMinutes,
+      DaysOfWeekArray: daysArray,
+      DaysCSV: convertDayIndexesToCsv(daysArray),
+      Description: slotData && (slotData.description || slotData.Description) || '',
+      Notes: slotData && (slotData.notes || slotData.Notes) || '',
+      Status: 'Active',
       CreatedAt: now,
+      CreatedBy: slotData && (slotData.createdBy || slotData.CreatedBy) || actor,
       UpdatedAt: now,
-      GenerationDefaults: serializedDefaults
+      UpdatedBy: actor,
+      GenerationDefaults: defaults
     };
 
-    // Create row data using proper header order
-    const rowData = SHIFT_SLOTS_HEADERS.map(header =>
-      Object.prototype.hasOwnProperty.call(slotRecord, header) ? slotRecord[header] : ''
-    );
-    sheet.appendRow(rowData);
-    SpreadsheetApp.flush();
+    const updatedSlots = slots.concat([normalizedSlot]);
+    writeShiftSlotsNormalized(updatedSlots);
+    logScheduleAudit('CREATE', 'ShiftSlot', slotId, null, normalizedSlot, 'Shift slot created', { campaign, location });
 
-    // Invalidate cache
-    invalidateScheduleCaches();
-
-    console.log('✅ Shift slot created successfully:', slotId);
-
-    const responseSlot = Object.assign({}, slotRecord, {
-      GenerationDefaults: generationDefaults,
-      DaysOfWeekArray: daysOfWeekArray
-    });
+    const responseSlot = normalizeShiftSlotRecord(convertSlotRecordToRow(normalizedSlot));
+    responseSlot.GenerationDefaults = defaults;
 
     return {
       success: true,
@@ -736,6 +748,614 @@ function buildManagedUserSet(managerId) {
   return managedUserIds;
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// SHIFT & ASSIGNMENT HELPERS (NEW DATA MODEL)
+// ────────────────────────────────────────────────────────────────────────────
+
+function ensureShiftSlotSheet_() {
+  return ensureScheduleSheetWithHeaders(SHIFT_SLOTS_SHEET, SHIFT_SLOTS_HEADERS);
+}
+
+function ensureShiftAssignmentSheet_() {
+  return ensureScheduleSheetWithHeaders(SHIFT_ASSIGNMENTS_SHEET, SHIFT_ASSIGNMENTS_HEADERS);
+}
+
+function parseSlotGenerationDefaults_(rawValue) {
+  if (!rawValue) {
+    return {};
+  }
+
+  if (typeof rawValue === 'object') {
+    return rawValue || {};
+  }
+
+  if (typeof rawValue === 'string') {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return {};
+    }
+    try {
+      return JSON.parse(trimmed) || {};
+    } catch (error) {
+      console.warn('Unable to parse slot defaults JSON:', error);
+    }
+  }
+
+  return {};
+}
+
+function serializeSlotGenerationDefaults_(defaults) {
+  if (!defaults || typeof defaults !== 'object') {
+    return '';
+  }
+  try {
+    return JSON.stringify(defaults);
+  } catch (error) {
+    console.warn('Unable to serialize generation defaults:', error);
+    return '';
+  }
+}
+
+function normalizeSlotStatus_(status, fallbackActive = true) {
+  if (status === null || typeof status === 'undefined') {
+    return fallbackActive ? 'Active' : 'Archived';
+  }
+
+  if (typeof status === 'boolean') {
+    return status ? 'Active' : 'Archived';
+  }
+
+  const normalized = String(status).trim().toLowerCase();
+  if (!normalized) {
+    return fallbackActive ? 'Active' : 'Archived';
+  }
+
+  if (['archived', 'inactive', 'disabled'].includes(normalized)) {
+    return 'Archived';
+  }
+
+  return 'Active';
+}
+
+function normalizeShiftSlotRecord(row) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const slotId = row.SlotId || row.SlotID || row.ID || row.Id || row.id || '';
+  const startTime = row.StartTime || row.Start || row.Start_Time || '';
+  const endTime = row.EndTime || row.End || row.End_Time || '';
+  const daysCsv = row.DaysCSV || row.DaysOfWeek || row.Days || '';
+  const defaults = parseSlotGenerationDefaults_(row.GenerationDefaults);
+  const daysOfWeekArray = convertCsvToDayIndexes(daysCsv);
+  const startMinutes = parseTimeToMinutes(startTime);
+  const endMinutes = parseTimeToMinutes(endTime);
+  const status = normalizeSlotStatus_(row.Status !== undefined ? row.Status : row.IsActive !== false);
+
+  const slot = {
+    ID: slotId,
+    SlotId: slotId,
+    SlotName: row.SlotName || row.Name || '',
+    Name: row.SlotName || row.Name || '',
+    Campaign: row.Campaign || row.Department || '',
+    Department: row.Campaign || row.Department || '',
+    Location: row.Location || defaults.location || 'Office',
+    StartTime: startTime || (Number.isFinite(startMinutes) ? formatMinutesToTime12Hour(startMinutes) : ''),
+    EndTime: endTime || (Number.isFinite(endMinutes) ? formatMinutesToTime12Hour(endMinutes) : ''),
+    StartMinutes: Number.isFinite(startMinutes) ? startMinutes : null,
+    EndMinutes: Number.isFinite(endMinutes) ? endMinutes : null,
+    DaysCSV: convertDayIndexesToCsv(daysOfWeekArray),
+    DaysOfWeek: convertDayIndexesToCsv(daysOfWeekArray),
+    DaysOfWeekArray: daysOfWeekArray,
+    Description: row.Description || '',
+    Notes: row.Notes || '',
+    Status: status,
+    IsActive: status !== 'Archived',
+    CreatedAt: row.CreatedAt || '',
+    CreatedBy: row.CreatedBy || '',
+    UpdatedAt: row.UpdatedAt || '',
+    UpdatedBy: row.UpdatedBy || '',
+    GenerationDefaults: defaults,
+    Priority: defaults.priority,
+    MaxCapacity: defaults.maxCapacity,
+    MinCoverage: defaults.minCoverage,
+    BreakDuration: defaults.breakDuration,
+    Break1Duration: defaults.break1Duration,
+    Break2Duration: defaults.break2Duration,
+    LunchDuration: defaults.lunchDuration,
+    EnableStaggeredBreaks: defaults.enableStaggeredBreaks,
+    BreakGroups: defaults.breakGroups,
+    StaggerInterval: defaults.staggerInterval,
+    MinCoveragePct: defaults.minCoveragePct,
+    EnableOvertime: defaults.enableOvertime,
+    MaxDailyOT: defaults.maxDailyOT,
+    MaxWeeklyOT: defaults.maxWeeklyOT,
+    OTApproval: defaults.otApproval,
+    OTRate: defaults.otRate,
+    OTPolicy: defaults.otPolicy,
+    AllowSwaps: defaults.allowSwaps,
+    WeekendPremium: defaults.weekendPremium,
+    HolidayPremium: defaults.holidayPremium,
+    AutoAssignment: defaults.autoAssignment,
+    RestPeriod: defaults.restPeriod,
+    NotificationLead: defaults.notificationLead,
+    HandoverTime: defaults.handoverTime,
+    OvertimePolicy: defaults.overtimePolicy
+  };
+
+  return slot;
+}
+
+function convertSlotRecordToRow(slot) {
+  if (!slot || typeof slot !== 'object') {
+    return null;
+  }
+
+  const defaults = Object.assign({}, slot.GenerationDefaults || {});
+
+  const headerRow = {
+    SlotId: slot.SlotId || slot.ID || Utilities.getUuid(),
+    SlotName: slot.SlotName || slot.Name || '',
+    Campaign: slot.Campaign || slot.Department || '',
+    Location: slot.Location || defaults.location || 'Office',
+    StartTime: slot.StartTime || (Number.isFinite(slot.StartMinutes) ? formatMinutesToTime12Hour(slot.StartMinutes) : ''),
+    EndTime: slot.EndTime || (Number.isFinite(slot.EndMinutes) ? formatMinutesToTime12Hour(slot.EndMinutes) : ''),
+    DaysCSV: convertDayIndexesToCsv(slot.DaysOfWeekArray || slot.DaysOfWeek || slot.DaysCSV || []),
+    Description: slot.Description || '',
+    Notes: slot.Notes || '',
+    Status: normalizeSlotStatus_(slot.Status, slot.IsActive !== false),
+    CreatedAt: slot.CreatedAt || '',
+    CreatedBy: slot.CreatedBy || '',
+    UpdatedAt: slot.UpdatedAt || '',
+    UpdatedBy: slot.UpdatedBy || '',
+    GenerationDefaults: serializeSlotGenerationDefaults_(defaults)
+  };
+
+  return headerRow;
+}
+
+function loadShiftSlotsNormalized() {
+  const rawRows = readScheduleSheet(SHIFT_SLOTS_SHEET) || [];
+  if (!rawRows.length) {
+    return [];
+  }
+
+  return rawRows
+    .map(normalizeShiftSlotRecord)
+    .filter(Boolean)
+    .map(slot => {
+      if (!slot.CreatedAt) {
+        slot.CreatedAt = new Date();
+      }
+      return slot;
+    });
+}
+
+function writeShiftSlotsNormalized(slots) {
+  const records = Array.isArray(slots) ? slots : [];
+  const rows = records
+    .map(convertSlotRecordToRow)
+    .filter(Boolean);
+  writeToScheduleSheet(SHIFT_SLOTS_SHEET, rows);
+  invalidateScheduleCaches();
+}
+
+function buildSlotLookupById(slots) {
+  const lookup = new Map();
+  (slots || []).forEach(slot => {
+    if (!slot || !slot.SlotId) {
+      return;
+    }
+    lookup.set(String(slot.SlotId), slot);
+  });
+  return lookup;
+}
+
+function buildUserLookupById_() {
+  const users = readSheet(USERS_SHEET) || [];
+  const map = new Map();
+  users.forEach(user => {
+    if (!user || !user.ID) {
+      return;
+    }
+    map.set(String(user.ID), user);
+  });
+  return map;
+}
+
+function buildUserLookupByName_() {
+  const users = readSheet(USERS_SHEET) || [];
+  const map = new Map();
+  users.forEach(user => {
+    if (!user) {
+      return;
+    }
+    const candidates = [user.UserName, user.Username, user.FullName, user.Email]
+      .map(value => normalizeUserKey(value))
+      .filter(Boolean);
+    candidates.forEach(key => {
+      if (!map.has(key)) {
+        map.set(key, user);
+      }
+    });
+  });
+  return map;
+}
+
+function normalizeAssignmentStatus_(status) {
+  if (!status) {
+    return 'PENDING';
+  }
+  const normalized = String(status).trim().toUpperCase();
+  if (['APPROVED', 'REJECTED', 'ARCHIVED', 'PENDING'].includes(normalized)) {
+    return normalized;
+  }
+  return 'PENDING';
+}
+
+function parsePremiumCsv_(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.map(v => String(v).trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.split(/[\s,;|]+/g).map(v => v.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function serializePremiumCsv_(premiums) {
+  if (!premiums || !premiums.length) {
+    return '';
+  }
+  const unique = Array.from(new Set(premiums.map(p => String(p).trim()).filter(Boolean)));
+  return unique.join(',');
+}
+
+function normalizeShiftAssignmentRecord(row, slotLookup, userLookupById, userLookupByName) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const assignmentId = row.AssignmentId || row.ID || row.Id || row.id || '';
+  const slotId = row.SlotId || row.SlotID || row.slotId || '';
+  const slot = slotLookup.get(String(slotId)) || null;
+  const userId = row.UserId || row.UserID || row.userId || row.ID_User || '';
+  const status = normalizeAssignmentStatus_(row.Status);
+  const premiums = parsePremiumCsv_(row.Premiums);
+  const breaksConfig = parseSlotGenerationDefaults_(row.BreaksConfigJSON || row.BreaksConfig || row.BreakConfiguration);
+  const startDate = normalizeDateForSheet(row.StartDate || row.PeriodStart || row.Date || row.ScheduleStart, DEFAULT_SCHEDULE_TIME_ZONE);
+  const endDate = normalizeDateForSheet(row.EndDate || row.PeriodEnd || row.ScheduleEnd || row.AssignmentEnd || row.End, DEFAULT_SCHEDULE_TIME_ZONE) || startDate;
+
+  let userRecord = userLookupById.get(String(userId));
+  if (!userRecord && row.UserName) {
+    const nameKey = normalizeUserKey(row.UserName);
+    if (nameKey && userLookupByName.has(nameKey)) {
+      userRecord = userLookupByName.get(nameKey);
+    }
+  }
+
+  const assignment = {
+    AssignmentId: assignmentId,
+    ID: assignmentId,
+    SlotId: slotId,
+    SlotName: slot ? slot.SlotName : (row.SlotName || ''),
+    UserId: userId,
+    UserName: row.UserName || (userRecord && (userRecord.UserName || userRecord.FullName)) || '',
+    Campaign: row.Campaign || (slot && slot.Campaign) || '',
+    StartDate: startDate,
+    EndDate: endDate,
+    Status: status,
+    AllowSwap: row.AllowSwap === true || String(row.AllowSwap || '').toLowerCase() === 'true',
+    Premiums: premiums,
+    BreaksConfigJSON: breaksConfig,
+    OvertimeMinutes: Number(row.OvertimeMinutes) || 0,
+    RestPeriodHours: Number(row.RestPeriodHours) || 0,
+    NotificationLeadHours: Number(row.NotificationLeadHours) || 0,
+    HandoverMinutes: Number(row.HandoverMinutes) || 0,
+    Notes: row.Notes || '',
+    CreatedAt: row.CreatedAt || '',
+    CreatedBy: row.CreatedBy || '',
+    UpdatedAt: row.UpdatedAt || '',
+    UpdatedBy: row.UpdatedBy || '',
+    RollbackGroupId: row.RollbackGroupId || '',
+    Slot: slot || null,
+    UserRecord: userRecord || null
+  };
+
+  if (slot) {
+    assignment.Location = slot.Location;
+    assignment.StartTime = slot.StartTime;
+    assignment.EndTime = slot.EndTime;
+    assignment.DaysCSV = slot.DaysCSV;
+    assignment.DaysOfWeekArray = slot.DaysOfWeekArray;
+  }
+
+  return assignment;
+}
+
+function loadShiftAssignmentsNormalized() {
+  const slotList = loadShiftSlotsNormalized();
+  const slotLookup = buildSlotLookupById(slotList);
+  const usersById = buildUserLookupById_();
+  const usersByName = buildUserLookupByName_();
+  const rows = readScheduleSheet(SHIFT_ASSIGNMENTS_SHEET) || [];
+  if (!rows.length) {
+    return [];
+  }
+
+  return rows
+    .map(row => normalizeShiftAssignmentRecord(row, slotLookup, usersById, usersByName))
+    .filter(Boolean);
+}
+
+function serializeAssignmentRecord_(assignment) {
+  if (!assignment || typeof assignment !== 'object') {
+    return null;
+  }
+
+  const row = {
+    AssignmentId: assignment.AssignmentId || assignment.ID || Utilities.getUuid(),
+    UserId: assignment.UserId || (assignment.UserRecord && assignment.UserRecord.ID) || '',
+    Campaign: assignment.Campaign || (assignment.Slot && assignment.Slot.Campaign) || '',
+    SlotId: assignment.SlotId || (assignment.Slot && assignment.Slot.SlotId) || '',
+    StartDate: assignment.StartDate || '',
+    EndDate: assignment.EndDate || assignment.StartDate || '',
+    Status: normalizeAssignmentStatus_(assignment.Status),
+    AllowSwap: assignment.AllowSwap ? true : false,
+    Premiums: serializePremiumCsv_(assignment.Premiums),
+    BreaksConfigJSON: serializeSlotGenerationDefaults_(assignment.BreaksConfigJSON || assignment.breaksConfiguration || {}),
+    OvertimeMinutes: Number(assignment.OvertimeMinutes) || 0,
+    RestPeriodHours: Number(assignment.RestPeriodHours) || 0,
+    NotificationLeadHours: Number(assignment.NotificationLeadHours) || 0,
+    HandoverMinutes: Number(assignment.HandoverMinutes) || 0,
+    Notes: assignment.Notes || '',
+    CreatedAt: assignment.CreatedAt || new Date(),
+    CreatedBy: assignment.CreatedBy || resolveCurrentActorEmail(),
+    UpdatedAt: assignment.UpdatedAt || new Date(),
+    UpdatedBy: assignment.UpdatedBy || resolveCurrentActorEmail(),
+    RollbackGroupId: assignment.RollbackGroupId || ''
+  };
+
+  return row;
+}
+
+function writeShiftAssignments(assignments) {
+  const rows = (assignments || [])
+    .map(serializeAssignmentRecord_)
+    .filter(Boolean);
+  writeToScheduleSheet(SHIFT_ASSIGNMENTS_SHEET, rows);
+  invalidateScheduleCaches();
+}
+
+function appendShiftAssignments(newAssignments) {
+  const sheet = ensureShiftAssignmentSheet_();
+  const rows = (newAssignments || []).map(serializeAssignmentRecord_).filter(Boolean);
+  if (!rows.length) {
+    return;
+  }
+  const headerCount = SHIFT_ASSIGNMENTS_HEADERS.length;
+  const values = rows.map(row => SHIFT_ASSIGNMENTS_HEADERS.map(header => row[header] !== undefined ? row[header] : ''));
+  sheet.insertRowsAfter(sheet.getLastRow() || 1, values.length);
+  sheet.getRange(sheet.getLastRow() - values.length + 1, 1, values.length, headerCount).setValues(values);
+  invalidateScheduleCaches();
+}
+
+function updateAssignmentsByIds_(assignmentIds, updater) {
+  const ids = Array.isArray(assignmentIds) ? assignmentIds.filter(Boolean).map(String) : [];
+  if (!ids.length) {
+    return { updated: [], assignments: [] };
+  }
+
+  const idSet = new Set(ids);
+  const assignments = loadShiftAssignmentsNormalized();
+  const updated = [];
+  let changed = false;
+
+  assignments.forEach(assignment => {
+    if (!assignment || !idSet.has(String(assignment.AssignmentId))) {
+      return;
+    }
+    const before = Object.assign({}, assignment);
+    updater(assignment, before);
+    updated.push({ before, after: assignment });
+    changed = true;
+  });
+
+  if (changed) {
+    writeShiftAssignments(assignments);
+  }
+
+  return { updated, assignments };
+}
+
+function normalizeCoverageTarget_(options = {}, slotDefaults = {}) {
+  const capacity = Number(options.capacity && options.capacity.max);
+  const slotCapacity = Number(slotDefaults.maxCapacity);
+  let maxCapacity = Number.isFinite(capacity) && capacity > 0 ? capacity : null;
+  if (Number.isFinite(slotCapacity) && slotCapacity > 0) {
+    maxCapacity = maxCapacity ? Math.min(maxCapacity, slotCapacity) : slotCapacity;
+  }
+
+  const minCoverage = Number(options.capacity && options.capacity.min);
+  const slotMinCoverage = Number(slotDefaults.minCoverage);
+  let minimum = Number.isFinite(minCoverage) && minCoverage > 0 ? minCoverage : null;
+  if (Number.isFinite(slotMinCoverage) && slotMinCoverage > 0) {
+    minimum = minimum ? Math.max(minimum, slotMinCoverage) : slotMinCoverage;
+  }
+
+  const minCoveragePct = Number(options.breaks && options.breaks.minCoveragePct);
+  const slotMinCoveragePct = Number(slotDefaults.minCoveragePct);
+  let minimumPct = Number.isFinite(minCoveragePct) ? minCoveragePct : null;
+  if (Number.isFinite(slotMinCoveragePct)) {
+    minimumPct = Number.isFinite(minimumPct) ? Math.max(minimumPct, slotMinCoveragePct) : slotMinCoveragePct;
+  }
+
+  return {
+    maxCapacity: maxCapacity,
+    minCoverage: minimum,
+    minCoveragePct: minimumPct
+  };
+}
+
+function computeMinimumCoverageTarget_(target) {
+  if (!target) {
+    return 0;
+  }
+
+  const minAbsolute = Number(target.minCoverage);
+  const capacity = Number(target.maxCapacity);
+  const minPct = Number(target.minCoveragePct);
+
+  let minimum = Number.isFinite(minAbsolute) ? minAbsolute : 0;
+  if (Number.isFinite(minPct) && Number.isFinite(capacity) && capacity > 0) {
+    const pctRequirement = Math.ceil((minPct / 100) * capacity);
+    minimum = Math.max(minimum, pctRequirement);
+  }
+  return minimum;
+}
+
+function buildHolidayLookup_(startDate, endDate) {
+  const holidays = readScheduleSheet(HOLIDAYS_SHEET) || [];
+  if (!holidays.length) {
+    return new Map();
+  }
+
+  const lookup = new Map();
+  const start = startDate ? new Date(startDate) : null;
+  const end = endDate ? new Date(endDate) : null;
+
+  holidays.forEach(row => {
+    if (!row || !row.Date) {
+      return;
+    }
+    const dateStr = normalizeDateForSheet(row.Date, DEFAULT_SCHEDULE_TIME_ZONE);
+    if (!dateStr) {
+      return;
+    }
+    const dateObj = new Date(dateStr);
+    if ((start && dateObj < start) || (end && dateObj > end)) {
+      return;
+    }
+    if (!lookup.has(dateStr)) {
+      lookup.set(dateStr, []);
+    }
+    lookup.get(dateStr).push({
+      date: dateStr,
+      name: row.Name || row.HolidayName || '',
+      region: row.Region || 'Jamaica',
+      isWorkingDayOverride: row.IsWorkingDayOverride === true || String(row.IsWorkingDayOverride || '').toLowerCase() === 'true',
+      notes: row.Notes || ''
+    });
+  });
+
+  return lookup;
+}
+
+function isWeekendDay_(dateStr) {
+  if (!dateStr) {
+    return false;
+  }
+  const date = new Date(dateStr + 'T00:00:00');
+  const day = date.getDay();
+  return day === 0 || day === 6;
+}
+
+function expandAssignmentToDays_(assignment, slot) {
+  const startDate = new Date(assignment.StartDate + 'T00:00:00');
+  const endDate = new Date(assignment.EndDate + 'T00:00:00');
+  const days = [];
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    return days;
+  }
+  const slotDays = slot && Array.isArray(slot.DaysOfWeekArray) ? slot.DaysOfWeekArray : [];
+  const cursor = new Date(startDate.getTime());
+  while (cursor <= endDate) {
+    const dayIndex = cursor.getDay();
+    if (slotDays.length === 0 || slotDays.includes(dayIndex)) {
+      const iso = Utilities.formatDate(cursor, DEFAULT_SCHEDULE_TIME_ZONE, 'yyyy-MM-dd');
+      days.push(iso);
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return days;
+}
+
+function buildAssignmentCoverage_(assignments, slotLookup, startDate, endDate) {
+  const coverage = new Map();
+  (assignments || []).forEach(assignment => {
+    const slot = slotLookup.get(String(assignment.SlotId));
+    const days = expandAssignmentToDays_(assignment, slot);
+    days.forEach(dateStr => {
+      if (!coverage.has(dateStr)) {
+        coverage.set(dateStr, { count: 0, bySlot: new Map() });
+      }
+      const entry = coverage.get(dateStr);
+      entry.count += 1;
+      const slotCount = entry.bySlot.get(assignment.SlotId) || 0;
+      entry.bySlot.set(assignment.SlotId, slotCount + 1);
+    });
+  });
+  return coverage;
+}
+
+function collectAttendanceConflicts_(users, startDate, endDate) {
+  try {
+    if (typeof clientGetAttendanceDataRange !== 'function') {
+      return new Map();
+    }
+    const response = clientGetAttendanceDataRange(startDate, endDate, null);
+    if (!response || !response.success) {
+      return new Map();
+    }
+    const conflictStatuses = new Set(['PTO', 'Leave', 'Vacation', 'Sick Leave', 'Holiday', 'Absent']);
+    const map = new Map();
+    (response.records || []).forEach(record => {
+      const userName = record.User || record.UserName || record.Agent;
+      const normalizedUser = normalizeUserKey(userName);
+      if (!normalizedUser || !conflictStatuses.has(String(record.State || record.Status || '').trim())) {
+        return;
+      }
+      if (!map.has(normalizedUser)) {
+        map.set(normalizedUser, []);
+      }
+      map.get(normalizedUser).push(record);
+    });
+    return map;
+  } catch (error) {
+    console.warn('Unable to collect attendance conflicts:', error);
+    return new Map();
+  }
+}
+
+function computeRestPeriodViolation_(existingAssignments, userId, startDate, restPeriodHours) {
+  if (!restPeriodHours || restPeriodHours <= 0) {
+    return null;
+  }
+  const restMs = restPeriodHours * 60 * 60 * 1000;
+  const start = new Date(startDate + 'T00:00:00');
+  if (isNaN(start.getTime())) {
+    return null;
+  }
+  const windowStart = new Date(start.getTime() - restMs);
+  const conflicts = [];
+  existingAssignments.forEach(assignment => {
+    if (!assignment || assignment.UserId !== userId) {
+      return;
+    }
+    const assignmentEnd = new Date(assignment.EndDate + 'T23:59:59');
+    if (assignmentEnd >= windowStart && assignmentEnd <= start) {
+      conflicts.push(assignment);
+    }
+  });
+  if (!conflicts.length) {
+    return null;
+  }
+  return conflicts[0];
+}
+
 function isUserConsideredActive(user) {
   if (!user) {
     return false;
@@ -765,287 +1385,100 @@ function isUserConsideredActive(user) {
  */
 function clientGetAllShiftSlots() {
   try {
-    console.log('📊 Getting all shift slots');
+    console.log('📊 Getting all shift slots (range-based model)');
 
-    const aggregatedSlots = [];
-    const seenIds = new Set();
-    const seenComposite = new Set();
-    const sourceNames = new Set();
+    let slots = loadShiftSlotsNormalized();
+    const sources = new Set(['ShiftSlots']);
 
-    const resolveSlotId = slot => {
-      const candidates = [
-        slot.ID, slot.Id, slot.id,
-        slot.SlotID, slot.SlotId, slot.slotId,
-        slot.Guid, slot.UUID, slot.Uuid
-      ];
-      for (let i = 0; i < candidates.length; i++) {
-        const candidate = candidates[i];
-        if (candidate === undefined || candidate === null) {
-          continue;
-        }
-        const normalized = String(candidate).trim();
-        if (normalized) {
-          return normalized;
-        }
-      }
-      return '';
-    };
-
-    const registerSlot = (slot, source) => {
-      if (!slot || typeof slot !== 'object') {
-        return;
-      }
-
-      const normalizedSlot = { ...slot };
-      const slotId = resolveSlotId(normalizedSlot);
-      if (slotId) {
-        if (seenIds.has(slotId)) {
-          // Merge any additional properties from the new slot into the existing one
-          const existingIndex = aggregatedSlots.findIndex(item => resolveSlotId(item) === slotId);
-          if (existingIndex >= 0) {
-            aggregatedSlots[existingIndex] = Object.assign({}, aggregatedSlots[existingIndex], normalizedSlot);
-          }
-          return;
-        }
-        normalizedSlot.ID = slotId;
-        seenIds.add(slotId);
-      } else {
-        const compositeKey = [
-          normalizedSlot.Name || normalizedSlot.SlotName || '',
-          normalizedSlot.StartTime || normalizedSlot.Start || '',
-          normalizedSlot.EndTime || normalizedSlot.End || ''
-        ].map(value => String(value || '').trim().toLowerCase()).join('|');
-
-        if (compositeKey && seenComposite.has(compositeKey)) {
-          return;
-        }
-
-        if (compositeKey) {
-          seenComposite.add(compositeKey);
-        }
-      }
-
-      if (source) {
-        sourceNames.add(source);
-      }
-
-      normalizedSlot.__source = source;
-      aggregatedSlots.push(normalizedSlot);
-    };
-
-    const candidateSheets = [
-      { name: SHIFT_SLOTS_SHEET, legacy: false },
-      { name: 'Shift Slots', legacy: true },
-      { name: 'Shift Slot', legacy: true },
-      { name: 'ShiftTemplates', legacy: true },
-      { name: 'Shift Templates', legacy: true },
-      { name: 'Shifts', legacy: true }
-    ];
-
-    candidateSheets.forEach(candidate => {
-      try {
-        const rows = readScheduleSheet(candidate.name) || [];
-        if (!Array.isArray(rows) || !rows.length) {
-          return;
-        }
-
-        console.log(`✅ Loaded ${rows.length} potential shift slots from ${candidate.name}`);
-
-        rows.forEach(row => {
-          if (!row || typeof row !== 'object') {
-            return;
-          }
-          const slot = candidate.legacy ? convertLegacyShiftSlotRecord(row) || row : row;
-          registerSlot(slot, candidate.name);
-        });
-      } catch (sheetError) {
-        console.warn(`Unable to read shift slots from ${candidate.name}:`, sheetError);
-      }
-    });
-
-    if (!aggregatedSlots.length) {
-      console.log('No shift slots found in any schedule sheet, checking main workbook for legacy data');
-      const legacySheets = ['Shift Slots', 'ShiftTemplates', 'Shifts'];
-      legacySheets.forEach(legacyName => {
+    if (!slots.length) {
+      console.warn('No modern shift slots found. Attempting legacy conversion.');
+      const legacySheets = ['Shift Slots', 'Shift Slot', 'ShiftTemplates', 'Shift Template', 'Shifts'];
+      const legacyRecords = [];
+      legacySheets.forEach(sheetName => {
         try {
-          const legacyRows = readSheet(legacyName);
-          if (!Array.isArray(legacyRows) || !legacyRows.length) {
-            return;
+          const rows = readScheduleSheet(sheetName) || [];
+          if (rows.length) {
+            rows
+              .map(convertLegacyShiftSlotRecord)
+              .filter(Boolean)
+              .forEach(slot => legacyRecords.push(slot));
+            sources.add(sheetName);
           }
-
-          console.log(`📄 Found ${legacyRows.length} legacy shift slots in ${legacyName}`);
-          legacyRows
-            .map(convertLegacyShiftSlotRecord)
-            .filter(Boolean)
-            .forEach(slot => registerSlot(slot, legacyName));
-        } catch (legacyError) {
-          console.warn(`Unable to read legacy shift slots from ${legacyName}:`, legacyError);
+        } catch (error) {
+          console.warn(`Unable to read legacy shift slots from ${sheetName}:`, error && error.message ? error.message : error);
         }
       });
+
+      if (legacyRecords.length) {
+        slots = legacyRecords.map(slot => normalizeShiftSlotRecord(convertSlotRecordToRow(slot))).filter(Boolean);
+        writeShiftSlotsNormalized(slots);
+      }
     }
 
-    if (!aggregatedSlots.length) {
-      console.log('No shift slots detected, creating defaults');
-      createDefaultShiftSlots();
-      const defaultSlots = readScheduleSheet(SHIFT_SLOTS_SHEET) || [];
-      defaultSlots.forEach(slot => registerSlot(slot, 'default'));
-    }
-
-    const normalizeBoolean = value => {
-      if (value === true || value === false) return value;
-      if (typeof value === 'number') return value !== 0;
-      if (typeof value === 'string') {
-        const normalized = value.trim().toLowerCase();
-        if (!normalized) return false;
-        return ['true', 'yes', '1', 'y'].includes(normalized);
+    const normalizedSlots = slots.map(slot => {
+      const enriched = Object.assign({}, slot);
+      enriched.ID = slot.SlotId;
+      enriched.Name = slot.SlotName;
+      enriched.Department = slot.Campaign;
+      enriched.DaysOfWeek = slot.DaysCSV;
+      enriched.DaysOfWeekArray = slot.DaysOfWeekArray || convertCsvToDayIndexes(slot.DaysCSV);
+      if (!enriched.GenerationDefaults || typeof enriched.GenerationDefaults !== 'object') {
+        enriched.GenerationDefaults = {};
       }
-      return false;
-    };
-
-    const normalizeNumber = value => {
-      if (value === null || typeof value === 'undefined' || value === '') {
-        return '';
-      }
-      if (typeof value === 'number') return value;
-      if (value instanceof Date) return value;
-      const parsed = Number(value);
-      return Number.isFinite(parsed) ? parsed : value;
-    };
-
-    const normalizeDaysOfWeek = slot => {
-      if (Array.isArray(slot.DaysOfWeekArray) && slot.DaysOfWeekArray.length) {
-        return slot.DaysOfWeekArray;
-      }
-
-      if (Array.isArray(slot.DaysOfWeek) && slot.DaysOfWeek.length) {
-        return slot.DaysOfWeek.map(day => parseInt(String(day).trim(), 10)).filter(day => !isNaN(day));
-      }
-
-      if (typeof slot.Days === 'string') {
-        return slot.Days.split(/[;,]/)
-          .map(day => parseInt(String(day).trim(), 10))
-          .filter(day => !isNaN(day));
-      }
-
-      if (typeof slot.DaysOfWeek === 'string') {
-        return slot.DaysOfWeek.split(/[;,]/)
-          .map(day => parseInt(String(day).trim(), 10))
-          .filter(day => !isNaN(day));
-      }
-
-      return [1, 2, 3, 4, 5];
-    };
-
-    const normalizedSlots = aggregatedSlots.map(slot => {
-      const normalizedSlot = { ...slot };
-
-      normalizedSlot.DaysOfWeekArray = normalizeDaysOfWeek(slot);
-      normalizedSlot.DaysOfWeek = normalizedSlot.DaysOfWeekArray.join(',');
-
-      normalizedSlot.EnableStaggeredBreaks = normalizeBoolean(slot.EnableStaggeredBreaks);
-      normalizedSlot.EnableOvertime = normalizeBoolean(slot.EnableOvertime);
-      normalizedSlot.AllowSwaps = normalizeBoolean(slot.AllowSwaps);
-      normalizedSlot.WeekendPremium = normalizeBoolean(slot.WeekendPremium);
-      normalizedSlot.HolidayPremium = normalizeBoolean(slot.HolidayPremium);
-      normalizedSlot.AutoAssignment = normalizeBoolean(slot.AutoAssignment);
-      const isActive = slot.IsActive === '' ? true : normalizeBoolean(slot.IsActive);
-      normalizedSlot.IsActive = isActive;
-
-      normalizedSlot.MaxCapacity = normalizeNumber(slot.MaxCapacity);
-      normalizedSlot.MinCoverage = normalizeNumber(slot.MinCoverage);
-      normalizedSlot.Priority = normalizeNumber(slot.Priority);
-      normalizedSlot.BreakDuration = normalizeNumber(slot.BreakDuration);
-      normalizedSlot.LunchDuration = normalizeNumber(slot.LunchDuration);
-      normalizedSlot.Break1Duration = normalizeNumber(slot.Break1Duration);
-      normalizedSlot.Break2Duration = normalizeNumber(slot.Break2Duration);
-      normalizedSlot.BreakGroups = normalizeNumber(slot.BreakGroups);
-      normalizedSlot.StaggerInterval = normalizeNumber(slot.StaggerInterval);
-      normalizedSlot.MinCoveragePct = normalizeNumber(slot.MinCoveragePct);
-      normalizedSlot.MaxDailyOT = normalizeNumber(slot.MaxDailyOT);
-      normalizedSlot.MaxWeeklyOT = normalizeNumber(slot.MaxWeeklyOT);
-      normalizedSlot.OTRate = normalizeNumber(slot.OTRate);
-      normalizedSlot.RestPeriod = normalizeNumber(slot.RestPeriod);
-      normalizedSlot.NotificationLead = normalizeNumber(slot.NotificationLead);
-      normalizedSlot.HandoverTime = normalizeNumber(slot.HandoverTime);
-
-      const normalizeDate = (value) => {
-        if (!value) {
-          return value;
-        }
-        if (value instanceof Date) {
-          return value;
-        }
-        const parsed = new Date(value);
-        return isNaN(parsed.getTime()) ? value : parsed;
-      };
-
-      normalizedSlot.CreatedAt = normalizeDate(slot.CreatedAt);
-      normalizedSlot.UpdatedAt = normalizeDate(slot.UpdatedAt);
-
-      if (!normalizedSlot.Name && normalizedSlot.SlotName) {
-        normalizedSlot.Name = normalizedSlot.SlotName;
-      }
-
-      const defaultsFromRecord = parseGenerationDefaults(slot.GenerationDefaults, slot.ID || slot.Name);
-      const derivedDefaults = defaultsFromRecord || buildGenerationDefaultsFromSource(slot);
-      if (derivedDefaults) {
-        normalizedSlot.GenerationDefaults = derivedDefaults;
-      } else if (Object.prototype.hasOwnProperty.call(normalizedSlot, 'GenerationDefaults')) {
-        delete normalizedSlot.GenerationDefaults;
-      }
-
-      if (Object.prototype.hasOwnProperty.call(normalizedSlot, '__source')) {
-        delete normalizedSlot.__source;
-      }
-
-      return normalizedSlot;
+      enriched.MaxCapacity = enriched.GenerationDefaults.maxCapacity;
+      enriched.MinCoverage = enriched.GenerationDefaults.minCoverage;
+      enriched.Priority = enriched.GenerationDefaults.priority;
+      enriched.BreakDuration = enriched.GenerationDefaults.breakDuration;
+      enriched.Break1Duration = enriched.GenerationDefaults.break1Duration;
+      enriched.Break2Duration = enriched.GenerationDefaults.break2Duration;
+      enriched.LunchDuration = enriched.GenerationDefaults.lunchDuration;
+      enriched.EnableStaggeredBreaks = enriched.GenerationDefaults.enableStaggeredBreaks;
+      enriched.BreakGroups = enriched.GenerationDefaults.breakGroups;
+      enriched.StaggerInterval = enriched.GenerationDefaults.staggerInterval;
+      enriched.MinCoveragePct = enriched.GenerationDefaults.minCoveragePct;
+      enriched.EnableOvertime = enriched.GenerationDefaults.enableOvertime;
+      enriched.MaxDailyOT = enriched.GenerationDefaults.maxDailyOT;
+      enriched.MaxWeeklyOT = enriched.GenerationDefaults.maxWeeklyOT;
+      enriched.OTApproval = enriched.GenerationDefaults.otApproval;
+      enriched.OTRate = enriched.GenerationDefaults.otRate;
+      enriched.OTPolicy = enriched.GenerationDefaults.otPolicy;
+      enriched.AllowSwaps = enriched.GenerationDefaults.allowSwaps;
+      enriched.WeekendPremium = enriched.GenerationDefaults.weekendPremium;
+      enriched.HolidayPremium = enriched.GenerationDefaults.holidayPremium;
+      enriched.AutoAssignment = enriched.GenerationDefaults.autoAssignment;
+      enriched.RestPeriod = enriched.GenerationDefaults.restPeriod;
+      enriched.NotificationLead = enriched.GenerationDefaults.notificationLead;
+      enriched.HandoverTime = enriched.GenerationDefaults.handoverTime;
+      enriched.OvertimePolicy = enriched.GenerationDefaults.overtimePolicy;
+      enriched.__sources = Array.from(sources);
+      return enriched;
     });
 
-    const activeCount = normalizedSlots.filter(slot => slot.IsActive !== false).length;
-    const metadata = {
-      totalCount: normalizedSlots.length,
-      activeCount,
-      inactiveCount: normalizedSlots.length - activeCount,
-      sources: Array.from(sourceNames)
-    };
+    console.log(`📦 Loaded ${normalizedSlots.length} shift slots.`);
 
-    console.log(`✅ Returning ${normalizedSlots.length} normalized shift slots`);
     return {
       success: true,
       slots: normalizedSlots,
-      metadata
+      total: normalizedSlots.length,
+      metadata: {
+        sources: Array.from(sources),
+        totalCount: normalizedSlots.length
+      }
     };
 
   } catch (error) {
     console.error('❌ Error getting shift slots:', error);
     safeWriteError('clientGetAllShiftSlots', error);
-
-    try {
-      createDefaultShiftSlots();
-      const fallbackSlots = readScheduleSheet(SHIFT_SLOTS_SHEET) || [];
-      const fallbackActive = fallbackSlots.filter(slot => slot && slot.IsActive !== false).length;
-      return {
-        success: true,
-        slots: fallbackSlots,
-        metadata: {
-          totalCount: fallbackSlots.length,
-          activeCount: fallbackActive,
-          inactiveCount: fallbackSlots.length - fallbackActive,
-          sources: ['default']
-        },
-        message: 'Default shift slots created as fallback.'
-      };
-    } catch (fallbackError) {
-      console.error('❌ Unable to provide default shift slots fallback:', fallbackError);
-      return {
-        success: false,
-        error: error && error.message ? error.message : 'Failed to load shift slots.',
-        slots: [],
-        metadata: { totalCount: 0, activeCount: 0, inactiveCount: 0 }
-      };
-    }
+    return {
+      success: false,
+      error: error.message || 'Failed to load shift slots',
+      slots: [],
+      total: 0,
+      metadata: { sources: [] }
+    };
   }
 }
+
 
 // ────────────────────────────────────────────────────────────────────────────
 // SCHEDULE GENERATION - Enhanced with ScheduleUtilities integration
@@ -1548,362 +1981,447 @@ function determineCapacityLimit(slot, generationOptions) {
  */
 function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlotIds, templateId, generatedBy, options = {}) {
   try {
-    console.log('🚀 Enhanced schedule generation started');
-    console.log('Parameters:', { startDate, endDate, userNames, shiftSlotIds, templateId, generatedBy, options });
+    const normalizedStart = normalizeDateForSheet(startDate, DEFAULT_SCHEDULE_TIME_ZONE);
+    const normalizedEnd = normalizeDateForSheet(endDate, DEFAULT_SCHEDULE_TIME_ZONE);
 
-    // Use ScheduleUtilities validation
-    const validation = validateScheduleParameters(startDate, endDate, userNames);
-    if (!validation.isValid) {
-      throw new Error('Invalid parameters: ' + validation.errors.join('; '));
+    if (!normalizedStart || !normalizedEnd) {
+      return { success: false, error: 'Valid start and end dates are required.' };
     }
 
-    if (!generatedBy) {
-      generatedBy = 'System';
+    if (new Date(normalizedEnd) < new Date(normalizedStart)) {
+      return { success: false, error: 'End date must be on or after the start date.' };
     }
 
-    const start = new Date(startDate);
-    const end = new Date(endDate);
+    const slotList = loadShiftSlotsNormalized();
+    if (!slotList.length) {
+      return { success: false, error: 'No shift slots are available. Please create a slot first.' };
+    }
 
-    // Get users to schedule
-    let usersToSchedule = [];
-    if (userNames && userNames.length > 0) {
-      usersToSchedule = userNames;
-    } else {
-      // If no users specified, get all active users for the requesting user
-      const allUsers = clientGetAttendanceUsers(generatedBy, options.campaignId);
-      if (!allUsers || allUsers.length === 0) {
-        throw new Error('No users found for scheduling. Please check user data.');
+    const requestedSlotIds = Array.isArray(shiftSlotIds) ? shiftSlotIds.filter(Boolean) : [];
+    let selectedSlots = slotList.filter(slot => {
+      if (!requestedSlotIds.length) {
+        return true;
       }
-      usersToSchedule = allUsers;
-    }
-
-    const generationOptions = normalizeGenerationOptions(options || {});
-
-    console.log(`📝 Scheduling for ${usersToSchedule.length} users`);
-    console.log('🧭 Generation options snapshot:', generationOptions.snapshot);
-
-    // Get shift slots - either selected ones or all available
-    const slotLoadResult = clientGetAllShiftSlots();
-    const availableSlots = Array.isArray(slotLoadResult)
-      ? slotLoadResult
-      : (slotLoadResult && Array.isArray(slotLoadResult.slots) ? slotLoadResult.slots : []);
-
-    if (!Array.isArray(slotLoadResult) && slotLoadResult && slotLoadResult.success === false) {
-      throw new Error(slotLoadResult.error || 'Failed to load shift slots.');
-    }
-
-    const slotMetadata = (!Array.isArray(slotLoadResult) && slotLoadResult && slotLoadResult.metadata)
-      ? slotLoadResult.metadata
-      : { totalCount: availableSlots.length };
-
-    let shiftSlots = [];
-    if (shiftSlotIds && shiftSlotIds.length > 0) {
-      console.log(`🎯 Using ${shiftSlotIds.length} selected shift slots:`, shiftSlotIds);
-      shiftSlots = availableSlots.filter(slot => shiftSlotIds.includes(slot.ID));
-
-      if (shiftSlots.length === 0) {
-        throw new Error('None of the selected shift slots were found. Please refresh and try again.');
-      }
-
-      console.log(`✅ Found ${shiftSlots.length} matching shift slots`);
-    } else {
-      shiftSlots = availableSlots;
-      console.log(`📋 Using all available shift slots (${shiftSlots.length} total)`);
-    }
-
-    if (!shiftSlots || shiftSlots.length === 0) {
-      throw new Error('No shift slots available. Please create shift slots first or select specific slots.');
-    }
-
-    if (slotMetadata && typeof slotMetadata.totalCount === 'number') {
-      console.log(`ℹ️ Shift slot metadata:`, slotMetadata);
-    }
-
-    console.log(`⏰ Working with ${shiftSlots.length} shift slot(s)`);
-
-    // Prepare schedule generation tracking
-    const generatedSchedules = [];
-    const conflicts = [];
-    const dstChanges = [];
-    const assignmentsBySlotDate = new Map();
-    const existingAssignments = new Map();
-    const lastShiftEndByUser = new Map();
-
-    // Generate schedules for the entire period
-    const timeZone = Session.getScriptTimeZone();
-    const periodStartStr = Utilities.formatDate(start, timeZone, 'yyyy-MM-dd');
-    const periodEndStr = Utilities.formatDate(end, timeZone, 'yyyy-MM-dd');
-
-    let historicalSchedules = [];
-    try {
-      historicalSchedules = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    } catch (historyError) {
-      console.warn('Unable to load existing schedules for generation context:', historyError);
-    }
-
-    historicalSchedules.forEach(schedule => {
-      const slotKey = buildSlotAssignmentKey(schedule && (schedule.SlotID || schedule.SlotId), schedule && (schedule.PeriodStart || schedule.Date));
-      if (slotKey) {
-        existingAssignments.set(slotKey, (existingAssignments.get(slotKey) || 0) + 1);
-      }
-
-      const scheduleUser = schedule && (schedule.UserName || schedule.UserID);
-      if (!scheduleUser) {
-        return;
-      }
-
-      const scheduleEnd = parseDateTimeForGeneration(schedule.PeriodEnd || schedule.Date || schedule.PeriodStart, schedule.EndTime || schedule.OriginalEndTime || schedule.End || schedule.StartTime);
-      if (!scheduleEnd) {
-        return;
-      }
-
-      const existingHandoverMinutes = Number(schedule.HandoverTimeMinutes || schedule.HandoverTime || 0);
-      const bufferedEnd = new Date(scheduleEnd.getTime() + (Number.isFinite(existingHandoverMinutes) ? Math.max(existingHandoverMinutes, 0) : 0) * 60 * 1000);
-      const currentEnd = lastShiftEndByUser.get(scheduleUser);
-      if (!currentEnd || currentEnd < bufferedEnd) {
-        lastShiftEndByUser.set(scheduleUser, bufferedEnd);
-      }
+      return requestedSlotIds.includes(slot.SlotId) || requestedSlotIds.includes(slot.ID);
     });
 
-    const dstStatusByDate = {};
-    [periodStartStr, periodEndStr].forEach(dateStr => {
-      if (!dateStr || dstStatusByDate[dateStr]) {
-        return;
-      }
-
-      const dstStatus = checkDSTStatus(dateStr);
-      dstStatusByDate[dateStr] = dstStatus;
-
-      if (dstStatus.isDSTChange) {
-        dstChanges.push({
-          date: dateStr,
-          changeType: dstStatus.changeType,
-          adjustment: dstStatus.timeAdjustment
-        });
-      }
-    });
-
-    usersToSchedule.forEach(userName => {
-      try {
-        const activeSlots = shiftSlots.filter(slot => slot && slot.IsActive !== false);
-
-        if (activeSlots.length === 0) {
-          console.log(`⚠️ No active slots available for ${userName} in the requested period`);
-          conflicts.push({
-            user: userName,
-            periodStart: periodStartStr,
-            periodEnd: periodEndStr,
-            error: 'No active shift slots available for this period',
-            type: 'NO_SLOT'
-          });
-          return;
-        }
-
-        const capacityFilteredSlots = activeSlots.filter(slot => {
-          const capacityLimit = determineCapacityLimit(slot, generationOptions);
-          const slotKey = buildSlotAssignmentKey(slot && slot.ID, periodStartStr);
-          if (capacityLimit && capacityLimit > 0 && slotKey) {
-            const usedCount = (existingAssignments.get(slotKey) || 0) + (assignmentsBySlotDate.get(slotKey) || 0);
-            if (usedCount >= capacityLimit) {
-              return false;
-            }
-          }
-          return true;
-        });
-
-        if (capacityFilteredSlots.length === 0) {
-          conflicts.push({
-            user: userName,
-            periodStart: periodStartStr,
-            periodEnd: periodEndStr,
-            error: 'All eligible shift slots have reached capacity for this period',
-            type: 'CAPACITY_LIMIT'
-          });
-          return;
-        }
-
-        const selectedSlot = capacityFilteredSlots.sort((a, b) => {
-          const priorityA = a.Priority || 2;
-          const priorityB = b.Priority || 2;
-          if (priorityA !== priorityB) {
-            return priorityB - priorityA;
-          }
-
-          const capacityA = Number(a.MaxCapacity) || 0;
-          const capacityB = Number(b.MaxCapacity) || 0;
-          return capacityB - capacityA;
-        })[0];
-
-        const appliedSlot = applyGenerationOptionsToSlot(selectedSlot, generationOptions);
-
-        const existingSchedule = checkExistingSchedule(userName, periodStartStr, periodEndStr);
-        if (existingSchedule && !options.overrideExisting) {
-          conflicts.push({
-            user: userName,
-            periodStart: periodStartStr,
-            periodEnd: periodEndStr,
-            existingScheduleId: existingSchedule.ID,
-            error: 'User already has a schedule in this period',
-            type: 'USER_DOUBLE_BOOKING'
-          });
-          return;
-        }
-
-        const restHours = Number(generationOptions.advanced && generationOptions.advanced.restPeriod || 0);
-        const handoverMinutes = Number(generationOptions.advanced && generationOptions.advanced.handoverTime || 0);
-        const restRequirementMs = (restHours * 60 * 60 * 1000) + (handoverMinutes * 60 * 1000);
-
-        const scheduleStartDateTime = parseDateTimeForGeneration(periodStartStr, appliedSlot.StartTime || selectedSlot.StartTime);
-        if (restRequirementMs > 0) {
-          const lastRecordedEnd = lastShiftEndByUser.get(userName);
-          if (lastRecordedEnd && scheduleStartDateTime && (scheduleStartDateTime.getTime() - lastRecordedEnd.getTime()) < restRequirementMs) {
-            const restMessage = handoverMinutes > 0
-              ? `Insufficient rest window before new assignment (requires ${restHours}h ${handoverMinutes}m buffer)`
-              : `Insufficient rest window before new assignment (requires ${restHours}h)`;
-            conflicts.push({
-              user: userName,
-              periodStart: periodStartStr,
-              periodEnd: periodEndStr,
-              error: restMessage,
-              type: 'REST_LIMIT'
-            });
-            return;
-          }
-        }
-
-        const scheduleEndDateTime = parseDateTimeForGeneration(periodEndStr, appliedSlot.EndTime || appliedSlot.StartTime || selectedSlot.EndTime);
-        const notificationLeadHours = Number(generationOptions.advanced && generationOptions.advanced.notificationLead || 0);
-        let notificationTarget = '';
-        if (scheduleStartDateTime && notificationLeadHours > 0) {
-          const notifyAt = new Date(scheduleStartDateTime.getTime() - notificationLeadHours * 60 * 60 * 1000);
-          notificationTarget = Utilities.formatDate(notifyAt, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
-        }
-
-        const toSafeNumber = (value) => {
-          const num = Number(value);
-          return Number.isFinite(num) ? num : '';
-        };
-
-        const schedule = {
-          ID: Utilities.getUuid(),
-          UserID: getUserIdByName(userName),
-          UserName: userName,
-          Date: periodStartStr,
-          PeriodStart: periodStartStr,
-          PeriodEnd: periodEndStr,
-          SlotID: appliedSlot.ID,
-          SlotName: appliedSlot.Name,
-          StartTime: appliedSlot.StartTime,
-          EndTime: appliedSlot.EndTime,
-          OriginalStartTime: appliedSlot.StartTime,
-          OriginalEndTime: appliedSlot.EndTime,
-          BreakStart: calculateBreakStart(appliedSlot),
-          BreakEnd: calculateBreakEnd(appliedSlot),
-          LunchStart: calculateLunchStart(appliedSlot),
-          LunchEnd: calculateLunchEnd(appliedSlot),
-          IsDST: (dstStatusByDate[periodStartStr] && dstStatusByDate[periodStartStr].isDST) || false,
-          Status: 'PENDING',
-          GeneratedBy: generatedBy,
-          ApprovedBy: null,
-          NotificationSent: false,
-          CreatedAt: new Date(),
-          UpdatedAt: new Date(),
-          RecurringScheduleID: null,
-          SwapRequestID: null,
-          Priority: options.priority || 2,
-          Notes: options.notes || `Generated from selected slot: ${appliedSlot.Name}`,
-          Location: appliedSlot.Location || '',
-          Department: appliedSlot.Department || '',
-          MaxCapacity: toSafeNumber(typeof appliedSlot.MaxCapacity === 'number' ? appliedSlot.MaxCapacity : generationOptions.capacity.max),
-          MinCoverage: toSafeNumber(typeof appliedSlot.MinCoverage === 'number' ? appliedSlot.MinCoverage : generationOptions.capacity.min),
-          BreakDuration: toSafeNumber(appliedSlot.BreakDuration !== undefined ? appliedSlot.BreakDuration : appliedSlot.Break1Duration),
-          Break1Duration: toSafeNumber(appliedSlot.Break1Duration),
-          Break2Duration: toSafeNumber(appliedSlot.Break2Duration),
-          LunchDuration: toSafeNumber(appliedSlot.LunchDuration),
-          EnableStaggeredBreaks: typeof appliedSlot.EnableStaggeredBreaks === 'boolean' ? appliedSlot.EnableStaggeredBreaks : '',
-          BreakGroups: toSafeNumber(appliedSlot.BreakGroups),
-          StaggerInterval: toSafeNumber(appliedSlot.StaggerInterval),
-          MinCoveragePct: toSafeNumber(appliedSlot.MinCoveragePct),
-          EnableOvertime: typeof appliedSlot.EnableOvertime === 'boolean' ? appliedSlot.EnableOvertime : '',
-          MaxDailyOT: toSafeNumber(appliedSlot.MaxDailyOT),
-          MaxWeeklyOT: toSafeNumber(appliedSlot.MaxWeeklyOT),
-          OTApproval: appliedSlot.OTApproval || '',
-          OTRate: toSafeNumber(appliedSlot.OTRate),
-          OTPolicy: appliedSlot.OTPolicy || '',
-          AllowSwaps: typeof appliedSlot.AllowSwaps === 'boolean' ? appliedSlot.AllowSwaps : '',
-          WeekendPremium: typeof appliedSlot.WeekendPremium === 'boolean' ? appliedSlot.WeekendPremium : '',
-          HolidayPremium: typeof appliedSlot.HolidayPremium === 'boolean' ? appliedSlot.HolidayPremium : '',
-          AutoAssignment: typeof appliedSlot.AutoAssignment === 'boolean' ? appliedSlot.AutoAssignment : '',
-          RestPeriodHours: restHours,
-          NotificationLeadHours: notificationLeadHours,
-          HandoverTimeMinutes: handoverMinutes,
-          NotificationTarget: notificationTarget,
-          GenerationConfig: JSON.stringify(generationOptions.snapshot)
-        };
-
-        const normalizedSchedule = normalizeSchedulePeriodRecord(schedule, timeZone);
-        generatedSchedules.push(normalizedSchedule);
-        console.log(`✅ Generated schedule for ${userName} from ${periodStartStr} to ${periodEndStr} using slot: ${appliedSlot.Name}`);
-
-        const slotAssignmentKey = buildSlotAssignmentKey(appliedSlot.ID, periodStartStr);
-        if (slotAssignmentKey) {
-          assignmentsBySlotDate.set(slotAssignmentKey, (assignmentsBySlotDate.get(slotAssignmentKey) || 0) + 1);
-        }
-
-        if (scheduleEndDateTime) {
-          const bufferedEnd = new Date(scheduleEndDateTime.getTime() + Math.max(handoverMinutes, 0) * 60 * 1000);
-          lastShiftEndByUser.set(userName, bufferedEnd);
-        } else if (scheduleStartDateTime) {
-          lastShiftEndByUser.set(userName, scheduleStartDateTime);
-        }
-
-      } catch (userError) {
-        conflicts.push({
-          user: userName,
-          periodStart: periodStartStr,
-          periodEnd: periodEndStr,
-          error: userError.message,
-          type: 'GENERATION_ERROR'
-        });
-      }
-    });
-
-    // Save generated schedules using ScheduleUtilities
-    if (generatedSchedules.length > 0) {
-      saveSchedulesToSheet(generatedSchedules);
-      console.log(`💾 Saved ${generatedSchedules.length} schedules`);
+    if (!selectedSlots.length) {
+      return { success: false, error: 'No matching shift slots were found for the selection.' };
     }
 
-    // Return comprehensive result with shift slot information
-    const result = {
-      success: true,
-      generated: generatedSchedules.length,
-      conflicts: conflicts,
-      dstChanges: dstChanges,
-      message: `Successfully generated ${generatedSchedules.length} schedules for period ${periodStartStr} to ${periodEndStr} using ${shiftSlots.length} shift slot(s)`,
-      periodStart: periodStartStr,
-      periodEnd: periodEndStr,
-      schedules: generatedSchedules.slice(0, 10), // Return first 10 for preview
-      userCount: usersToSchedule.length,
-      shiftSlotsUsed: shiftSlots.length,
-      selectedSlots: shiftSlotIds && shiftSlotIds.length > 0 ? shiftSlotIds : null
+    let campaignId = normalizeCampaignIdValue(options.campaignId);
+    if (!campaignId) {
+      const campaignCandidates = selectedSlots
+        .map(slot => normalizeCampaignIdValue(slot.Campaign))
+        .filter(Boolean);
+      if (campaignCandidates.length) {
+        campaignId = campaignCandidates[0];
+      }
+    }
+
+    if (!campaignId) {
+      return { success: false, error: 'A campaign is required to generate schedules. Please select a campaign or ensure slots have a campaign assigned.' };
+    }
+
+    selectedSlots = selectedSlots.filter(slot => normalizeCampaignIdValue(slot.Campaign) === campaignId);
+    if (!selectedSlots.length) {
+      return { success: false, error: 'Selected shift slots do not belong to the requested campaign.' };
+    }
+
+    const slotLookup = buildSlotLookupById(selectedSlots);
+    const targetDefaults = selectedSlots.length ? (selectedSlots[0].GenerationDefaults || {}) : {};
+    const coverageTarget = normalizeCoverageTarget_(options, targetDefaults);
+    const minimumCoverageRequired = computeMinimumCoverageTarget_(coverageTarget);
+
+    const allAssignments = loadShiftAssignmentsNormalized();
+    const existingAssignments = allAssignments.filter(assignment => {
+      if (!assignment || assignment.Status === 'ARCHIVED') {
+        return false;
+      }
+      if (normalizeCampaignIdValue(assignment.Campaign) !== campaignId) {
+        return false;
+      }
+      const assignmentStart = new Date(assignment.StartDate + 'T00:00:00');
+      const assignmentEnd = new Date(assignment.EndDate + 'T23:59:59');
+      const periodStart = new Date(normalizedStart + 'T00:00:00');
+      const periodEnd = new Date(normalizedEnd + 'T23:59:59');
+      return assignmentEnd >= periodStart && assignmentStart <= periodEnd;
+    });
+
+    const generatedByUser = generatedBy || 'system';
+    const scheduleUsers = clientGetScheduleUsers(generatedByUser, campaignId) || [];
+    if (!scheduleUsers.length) {
+      return { success: false, error: 'No eligible users were found for the selected campaign.' };
+    }
+
+    const userNameLookup = new Map();
+    scheduleUsers.forEach(user => {
+      const keys = [user.UserName, user.FullName, user.Email].map(value => normalizeUserKey(value));
+      keys.filter(Boolean).forEach(key => {
+        if (!userNameLookup.has(key)) {
+          userNameLookup.set(key, user);
+        }
+      });
+    });
+
+    const requestedUserKeys = Array.isArray(userNames)
+      ? userNames.map(name => normalizeUserKey(name)).filter(Boolean)
+      : [];
+
+    const includeAllUsers = requestedUserKeys.length === 0 || options.advanced?.autoAssignment === true;
+
+    const eligibleUsers = scheduleUsers.filter(user => {
+      if (!includeAllUsers) {
+        const keyMatches = [user.UserName, user.FullName, user.Email]
+          .map(value => normalizeUserKey(value))
+          .filter(Boolean)
+          .some(key => requestedUserKeys.includes(key));
+        if (!keyMatches) {
+          return false;
+        }
+      }
+
+      if (user.isActive === false) {
+        return false;
+      }
+
+      const hireDate = user.HireDate ? normalizeDateForSheet(user.HireDate, DEFAULT_SCHEDULE_TIME_ZONE) : null;
+      if (hireDate && new Date(hireDate) > new Date(normalizedEnd + 'T23:59:59')) {
+        return false;
+      }
+
+      const terminationDate = user.TerminationDate ? normalizeDateForSheet(user.TerminationDate, DEFAULT_SCHEDULE_TIME_ZONE) : null;
+      if (terminationDate && new Date(terminationDate + 'T23:59:59') < new Date(normalizedStart + 'T00:00:00')) {
+        return false;
+      }
+
+      return true;
+    });
+
+    if (!eligibleUsers.length) {
+      return { success: false, error: 'No eligible users matched the selection or campaign criteria.' };
+    }
+
+    const holidayLookup = buildHolidayLookup_(normalizedStart, normalizedEnd);
+    const attendanceConflicts = collectAttendanceConflicts_(eligibleUsers.map(user => user.UserName || user.FullName || user.Email), normalizedStart, normalizedEnd);
+
+    const restPeriodHours = Number(options.advanced?.restPeriod) || targetDefaults.restPeriod || 0;
+    const allowSwaps = options.advanced?.allowSwaps !== false;
+    const weekendPremiumEnabled = options.advanced?.weekendPremium === true;
+    const holidayPremiumEnabled = options.advanced?.holidayPremium !== false;
+    const includeHolidays = options.includeHolidays !== false;
+
+    const breaksConfig = {
+      breakDuration: Number(options.breaks?.base) || targetDefaults.breakDuration || 15,
+      break1Duration: Number(options.breaks?.first) || targetDefaults.break1Duration || 15,
+      break2Duration: Number(options.breaks?.second) || targetDefaults.break2Duration || 0,
+      lunchDuration: Number(options.breaks?.lunch) || targetDefaults.lunchDuration || 30,
+      enableStaggered: options.breaks?.enableStaggered !== false && (targetDefaults.enableStaggeredBreaks !== false),
+      breakGroups: Number(options.breaks?.groups) || targetDefaults.breakGroups || 3,
+      staggerInterval: Number(options.breaks?.interval) || targetDefaults.staggerInterval || 15,
+      minCoveragePct: Number(options.breaks?.minCoveragePct) || targetDefaults.minCoveragePct || null
     };
 
-    console.log('✅ Enhanced schedule generation completed:', result);
-    return result;
+    const overtimeMinutes = (() => {
+      if (options.overtime?.enabled !== true) {
+        return 0;
+      }
+      const hours = Number(options.overtime?.maxDaily);
+      if (Number.isFinite(hours) && hours > 0) {
+        return Math.round(hours * 60);
+      }
+      return 0;
+    })();
+
+    const notificationLead = Number(options.advanced?.notificationLead) || targetDefaults.notificationLead || 0;
+    const handoverMinutes = Number(options.advanced?.handoverTime) || targetDefaults.handoverTime || 0;
+
+    const existingCoverage = buildAssignmentCoverage_(existingAssignments, slotLookup, normalizedStart, normalizedEnd);
+    const plannedCoverage = new Map();
+    const plannedAssignments = [];
+    const conflicts = [];
+
+    const seedString = options.randomSeed || `${normalizedStart}-${normalizedEnd}-${eligibleUsers.length}`;
+    let seedAccumulator = 0;
+    for (let i = 0; i < seedString.length; i++) {
+      seedAccumulator = (seedAccumulator + seedString.charCodeAt(i)) % 2147483647;
+    }
+
+    const shuffledUsers = eligibleUsers.slice();
+    for (let i = shuffledUsers.length - 1; i > 0; i--) {
+      seedAccumulator = (seedAccumulator * 48271) % 2147483647;
+      const random = seedAccumulator / 2147483647;
+      const j = Math.floor(random * (i + 1));
+      const temp = shuffledUsers[i];
+      shuffledUsers[i] = shuffledUsers[j];
+      shuffledUsers[j] = temp;
+    }
+
+    const groupId = Utilities.getUuid();
+
+    const addCoverage = (slotId, dates) => {
+      dates.forEach(dateStr => {
+        if (!plannedCoverage.has(dateStr)) {
+          plannedCoverage.set(dateStr, new Map());
+        }
+        const slotMap = plannedCoverage.get(dateStr);
+        slotMap.set(slotId, (slotMap.get(slotId) || 0) + 1);
+      });
+    };
+
+    const getCombinedCoverage = (slotId, dateStr) => {
+      const existing = existingCoverage.has(dateStr) ? (existingCoverage.get(dateStr).bySlot.get(slotId) || 0) : 0;
+      const planned = plannedCoverage.has(dateStr) ? (plannedCoverage.get(dateStr).get(slotId) || 0) : 0;
+      return existing + planned;
+    };
+
+    shuffledUsers.forEach(user => {
+      const userId = user.ID;
+      const userName = user.FullName || user.UserName || user.Email;
+      const normalizedUserKey = normalizeUserKey(user.UserName || user.FullName || user.Email);
+      const restConflict = computeRestPeriodViolation_(existingAssignments.concat(plannedAssignments), userId, normalizedStart, restPeriodHours);
+      if (restConflict) {
+        conflicts.push({
+          user: userName,
+          periodStart: normalizedStart,
+          periodEnd: normalizedEnd,
+          type: 'REST_PERIOD',
+          error: `Rest period violation with assignment ${restConflict.AssignmentId}`
+        });
+        return;
+      }
+
+      const slotCandidates = selectedSlots
+        .slice()
+        .sort((a, b) => {
+          const aKey = getCombinedCoverage(a.SlotId, normalizedStart);
+          const bKey = getCombinedCoverage(b.SlotId, normalizedStart);
+          if (aKey !== bKey) {
+            return aKey - bKey;
+          }
+          return (a.Priority || 0) - (b.Priority || 0);
+        });
+
+      let assignedSlot = null;
+      let assignmentCoverageDates = [];
+
+      for (let i = 0; i < slotCandidates.length; i++) {
+        const candidate = slotCandidates[i];
+        if (!candidate) {
+          continue;
+        }
+        const slotCoverageTarget = normalizeCoverageTarget_(options, candidate.GenerationDefaults || {});
+        const capacityLimit = slotCoverageTarget.maxCapacity;
+
+        const tentativeAssignment = {
+          StartDate: normalizedStart,
+          EndDate: normalizedEnd,
+          SlotId: candidate.SlotId
+        };
+
+        const dates = expandAssignmentToDays_(tentativeAssignment, candidate);
+        if (!dates.length) {
+          continue;
+        }
+
+        let capacityExceeded = false;
+        for (let d = 0; d < dates.length; d++) {
+          const dateStr = dates[d];
+          const totalForDate = getCombinedCoverage(candidate.SlotId, dateStr);
+          if (Number.isFinite(capacityLimit) && capacityLimit > 0 && totalForDate >= capacityLimit) {
+            capacityExceeded = true;
+            break;
+          }
+        }
+
+        if (capacityExceeded) {
+          continue;
+        }
+
+        const attendanceRecords = attendanceConflicts.get(normalizedUserKey) || [];
+        if (attendanceRecords.length) {
+          conflicts.push({
+            user: userName,
+            periodStart: normalizedStart,
+            periodEnd: normalizedEnd,
+            type: 'ATTENDANCE',
+            error: `Attendance records conflict with proposed assignment (${attendanceRecords.length} record(s))`
+          });
+          continue;
+        }
+
+        assignedSlot = candidate;
+        assignmentCoverageDates = dates;
+        break;
+      }
+
+      if (!assignedSlot) {
+        conflicts.push({
+          user: userName,
+          periodStart: normalizedStart,
+          periodEnd: normalizedEnd,
+          type: 'CAPACITY',
+          error: 'Unable to place user without exceeding slot capacity or violating policies.'
+        });
+        return;
+      }
+
+      addCoverage(assignedSlot.SlotId, assignmentCoverageDates);
+
+      const premiums = [];
+      if (weekendPremiumEnabled) {
+        const hasWeekend = assignmentCoverageDates.some(date => isWeekendDay_(date));
+        if (hasWeekend) {
+          premiums.push('Weekend');
+        }
+      }
+
+      if (holidayPremiumEnabled) {
+        const hasHoliday = assignmentCoverageDates.some(date => {
+          const holidays = holidayLookup.get(date) || [];
+          return holidays.some(holiday => String(holiday.region || '').toLowerCase() === 'jamaica');
+        });
+        if (hasHoliday) {
+          premiums.push('Holiday');
+        }
+      }
+
+      if (overtimeMinutes > 0) {
+        premiums.push('Overtime');
+      }
+
+      const assignment = {
+        AssignmentId: Utilities.getUuid(),
+        UserId: userId,
+        UserName: userName,
+        Campaign: campaignId,
+        SlotId: assignedSlot.SlotId,
+        StartDate: normalizedStart,
+        EndDate: normalizedEnd,
+        Status: 'PENDING',
+        AllowSwap: allowSwaps,
+        Premiums: premiums,
+        BreaksConfigJSON: {
+          breakDuration: breaksConfig.breakDuration,
+          break1Duration: breaksConfig.break1Duration,
+          break2Duration: breaksConfig.break2Duration,
+          lunchDuration: breaksConfig.lunchDuration,
+          enableStaggered: breaksConfig.enableStaggered,
+          breakGroups: breaksConfig.breakGroups,
+          staggerInterval: breaksConfig.staggerInterval,
+          minCoveragePct: breaksConfig.minCoveragePct
+        },
+        OvertimeMinutes: overtimeMinutes,
+        RestPeriodHours: restPeriodHours,
+        NotificationLeadHours: notificationLead,
+        HandoverMinutes: handoverMinutes,
+        Notes: options.notes || '',
+        CreatedAt: new Date(),
+        CreatedBy: generatedByUser,
+        UpdatedAt: new Date(),
+        UpdatedBy: generatedByUser,
+        RollbackGroupId: groupId,
+        Slot: assignedSlot,
+        UserRecord: user
+      };
+
+      plannedAssignments.push(assignment);
+    });
+
+    const combinedAssignments = existingAssignments.concat(plannedAssignments);
+    const combinedCoverage = buildAssignmentCoverage_(combinedAssignments, slotLookup, normalizedStart, normalizedEnd);
+
+    const coverageSummary = [];
+    const periodStartDate = new Date(normalizedStart + 'T00:00:00');
+    const periodEndDate = new Date(normalizedEnd + 'T00:00:00');
+    const coverageShortfalls = [];
+
+    for (let cursor = new Date(periodStartDate.getTime()); cursor <= periodEndDate; cursor.setDate(cursor.getDate() + 1)) {
+      const dateStr = Utilities.formatDate(cursor, DEFAULT_SCHEDULE_TIME_ZONE, 'yyyy-MM-dd');
+      const coverageEntry = combinedCoverage.get(dateStr);
+      const assignedCount = coverageEntry ? coverageEntry.count : 0;
+      const minRequired = minimumCoverageRequired;
+      const isHoliday = (holidayLookup.get(dateStr) || []).length > 0;
+      const holidayNames = (holidayLookup.get(dateStr) || []).map(entry => entry.name).filter(Boolean);
+      const summaryEntry = {
+        date: dateStr,
+        assigned: assignedCount,
+        required: minRequired,
+        variance: assignedCount - minRequired,
+        isHoliday,
+        holidayNames,
+        isWeekend: isWeekendDay_(dateStr),
+        status: assignedCount < minRequired ? 'SHORTFALL' : 'MET'
+      };
+      if (assignedCount < minRequired) {
+        coverageShortfalls.push(summaryEntry);
+      }
+      coverageSummary.push(summaryEntry);
+    }
+
+    const previewAssignments = plannedAssignments.map(assignment => {
+      const slot = assignment.Slot || slotLookup.get(String(assignment.SlotId));
+      return {
+        assignmentId: assignment.AssignmentId,
+        userName: assignment.UserName,
+        slotName: slot ? slot.SlotName : assignment.SlotId,
+        startDate: assignment.StartDate,
+        endDate: assignment.EndDate,
+        startTime: slot ? slot.StartTime : '',
+        endTime: slot ? slot.EndTime : '',
+        premiums: assignment.Premiums,
+        allowSwap: assignment.AllowSwap,
+        status: assignment.Status
+      };
+    });
+
+    if (options.previewOnly === true) {
+      return {
+        success: true,
+        previewOnly: true,
+        generated: plannedAssignments.length,
+        userCount: eligibleUsers.length,
+        periodStart: normalizedStart,
+        periodEnd: normalizedEnd,
+        assignments: previewAssignments,
+        details: previewAssignments,
+        coverage: coverageSummary,
+        shortfalls: coverageShortfalls,
+        conflicts
+      };
+    }
+
+    if (plannedAssignments.length) {
+      appendShiftAssignments(plannedAssignments);
+      plannedAssignments.forEach(assignment => {
+        logScheduleAudit('CREATE', 'ShiftAssignment', assignment.AssignmentId, null, assignment, 'Auto-generated shift assignment', { campaign: campaignId, slotId: assignment.SlotId });
+      });
+    }
+
+    return {
+      success: true,
+      generated: plannedAssignments.length,
+      userCount: eligibleUsers.length,
+      periodStart: normalizedStart,
+      periodEnd: normalizedEnd,
+      assignments: previewAssignments,
+      details: previewAssignments,
+      coverage: coverageSummary,
+      shortfalls: coverageShortfalls,
+      conflicts,
+      rollbackGroupId: groupId
+    };
 
   } catch (error) {
-    console.error('❌ Enhanced schedule generation failed:', error);
+    console.error('❌ Error generating schedules:', error);
     safeWriteError('clientGenerateSchedulesEnhanced', error);
     return {
       success: false,
-      error: error.message,
-      generated: 0,
-      conflicts: [],
-      dstChanges: []
+      error: error && error.message ? error.message : 'Failed to generate schedules'
     };
   }
 }
+
 
 /**
  * Save schedules to sheet using ScheduleUtilities
@@ -1942,7 +2460,169 @@ function clientGetAllSchedules(filters = {}) {
   try {
     console.log('📋 Getting all schedules with filters:', filters);
 
-    // Use ScheduleUtilities to read schedules
+    const assignments = loadShiftAssignmentsNormalized();
+    if (!assignments.length) {
+      console.warn('No range-based assignments found. Falling back to legacy schedule reader.');
+      return legacyGetAllSchedules_(filters);
+    }
+
+    const slotLookup = buildSlotLookupById(loadShiftSlotsNormalized());
+    const startDateFilter = filters.startDate ? new Date(normalizeDateForSheet(filters.startDate, DEFAULT_SCHEDULE_TIME_ZONE)) : null;
+    const endDateFilter = filters.endDate ? new Date(normalizeDateForSheet(filters.endDate, DEFAULT_SCHEDULE_TIME_ZONE)) : null;
+    const statusFilterRaw = filters.status ? String(filters.status).trim().toUpperCase() : '';
+    const statusFilter = statusFilterRaw && statusFilterRaw !== 'ALL' ? statusFilterRaw : '';
+    const userIdFilter = filters.userId ? String(filters.userId).trim() : '';
+    const userNameFilter = filters.userName ? normalizeUserKey(filters.userName) : '';
+    const campaignFilter = normalizeCampaignIdValue(filters.campaign || filters.campaignId || filters.Department || filters.department);
+    const slotIdFilter = filters.slotId || filters.slot || filters.SlotId || '';
+    const slotNameFilter = filters.slotName ? String(filters.slotName).trim().toLowerCase() : '';
+
+    const filteredAssignments = assignments.filter(assignment => {
+      if (!assignment) {
+        return false;
+      }
+
+      const startDate = assignment.StartDate ? new Date(assignment.StartDate + 'T00:00:00') : null;
+      const endDate = assignment.EndDate ? new Date(assignment.EndDate + 'T23:59:59') : startDate;
+
+      if (startDateFilter && endDate && endDate < startDateFilter) {
+        return false;
+      }
+
+      if (endDateFilter && startDate && startDate > endDateFilter) {
+        return false;
+      }
+
+      if (statusFilter && String(assignment.Status || '').toUpperCase() !== statusFilter) {
+        return false;
+      }
+
+      if (userIdFilter && String(assignment.UserId || '') !== userIdFilter) {
+        return false;
+      }
+
+      if (userNameFilter) {
+        const assignmentNameKey = normalizeUserKey(assignment.UserName || (assignment.UserRecord && (assignment.UserRecord.FullName || assignment.UserRecord.UserName || assignment.UserRecord.Email)));
+        if (assignmentNameKey !== userNameFilter) {
+          return false;
+        }
+      }
+
+      if (campaignFilter && normalizeCampaignIdValue(assignment.Campaign || (assignment.Slot && assignment.Slot.Campaign)) !== campaignFilter) {
+        return false;
+      }
+
+      if (slotIdFilter && String(assignment.SlotId || '') !== String(slotIdFilter)) {
+        return false;
+      }
+
+      if (slotNameFilter) {
+        const slot = assignment.Slot || slotLookup.get(assignment.SlotId) || null;
+        const slotName = slot ? String(slot.SlotName || '').toLowerCase() : String(assignment.SlotName || '').toLowerCase();
+        if (!slotName.includes(slotNameFilter)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    const formatTimeForDisplay = (slot, key, minutesKey) => {
+      if (!slot) {
+        return '';
+      }
+      if (slot[key]) {
+        return slot[key];
+      }
+      const minutes = slot[minutesKey];
+      if (Number.isFinite(minutes)) {
+        return formatMinutesToTime12Hour(minutes);
+      }
+      return '';
+    };
+
+    const formattedAssignments = filteredAssignments.map(assignment => {
+      const slot = assignment.Slot || slotLookup.get(assignment.SlotId) || null;
+      const premiums = Array.isArray(assignment.Premiums)
+        ? assignment.Premiums
+        : parsePremiumCsv_(assignment.Premiums);
+
+      const startTime = formatTimeForDisplay(slot, 'StartTime', 'StartMinutes');
+      const endTime = formatTimeForDisplay(slot, 'EndTime', 'EndMinutes');
+
+      const view = {
+        ID: assignment.AssignmentId,
+        AssignmentId: assignment.AssignmentId,
+        UserId: assignment.UserId,
+        UserName: assignment.UserName || (assignment.UserRecord && (assignment.UserRecord.FullName || assignment.UserRecord.UserName || assignment.UserRecord.Email)) || '',
+        Campaign: assignment.Campaign || (slot && slot.Campaign) || '',
+        SlotId: assignment.SlotId,
+        SlotName: (slot && slot.SlotName) || assignment.SlotName || '',
+        StartDate: assignment.StartDate,
+        EndDate: assignment.EndDate,
+        PeriodStart: assignment.StartDate,
+        PeriodEnd: assignment.EndDate,
+        StartTime: startTime,
+        EndTime: endTime,
+        Status: assignment.Status || 'PENDING',
+        AllowSwap: assignment.AllowSwap === true,
+        Premiums: premiums,
+        BreaksConfigJSON: assignment.BreaksConfigJSON || {},
+        OvertimeMinutes: assignment.OvertimeMinutes || 0,
+        RestPeriodHours: assignment.RestPeriodHours || 0,
+        NotificationLeadHours: assignment.NotificationLeadHours || 0,
+        HandoverMinutes: assignment.HandoverMinutes || 0,
+        Notes: assignment.Notes || '',
+        CreatedAt: assignment.CreatedAt || '',
+        CreatedBy: assignment.CreatedBy || '',
+        UpdatedAt: assignment.UpdatedAt || '',
+        UpdatedBy: assignment.UpdatedBy || '',
+        RollbackGroupId: assignment.RollbackGroupId || '',
+        PremiumFlags: {
+          weekend: premiums.includes('Weekend'),
+          holiday: premiums.includes('Holiday'),
+          overtime: premiums.includes('Overtime')
+        },
+        Source: 'ShiftAssignments'
+      };
+
+      return view;
+    });
+
+    formattedAssignments.sort((a, b) => {
+      const startA = a.StartDate ? new Date(a.StartDate).getTime() : 0;
+      const startB = b.StartDate ? new Date(b.StartDate).getTime() : 0;
+      if (startA !== startB) {
+        return startB - startA;
+      }
+      return String(b.UserName || '').localeCompare(String(a.UserName || ''));
+    });
+
+    return {
+      success: true,
+      schedules: formattedAssignments,
+      total: formattedAssignments.length,
+      filters,
+      metadata: {
+        source: 'ShiftAssignments',
+        fallbackUsed: false
+      }
+    };
+  } catch (error) {
+    console.error('❌ Error getting schedules:', error);
+    safeWriteError('clientGetAllSchedules', error);
+    return {
+      success: false,
+      error: error.message,
+      schedules: [],
+      total: 0,
+      filters
+    };
+  }
+}
+
+function legacyGetAllSchedules_(filters = {}) {
+  try {
     let schedules = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
 
     if (!schedules.length) {
@@ -1958,20 +2638,14 @@ function clientGetAllSchedules(filters = {}) {
 
     const normalizedSchedules = schedules.map(record => normalizeSchedulePeriodRecord(record));
 
-    console.log(`📊 Total schedules in sheet: ${normalizedSchedules.length}`);
-
     let filteredSchedules = normalizedSchedules.slice();
 
-    // Apply filters
     if (filters.startDate) {
       const startDate = new Date(filters.startDate);
       if (!isNaN(startDate.getTime())) {
         filteredSchedules = filteredSchedules.filter(s => {
           const scheduleEnd = resolveSchedulePeriodEndDate(s) || resolveSchedulePeriodStartDate(s);
-          if (!scheduleEnd) {
-            return true;
-          }
-          return scheduleEnd >= startDate;
+          return !scheduleEnd || scheduleEnd >= startDate;
         });
       }
     }
@@ -1981,10 +2655,7 @@ function clientGetAllSchedules(filters = {}) {
       if (!isNaN(endDate.getTime())) {
         filteredSchedules = filteredSchedules.filter(s => {
           const scheduleStart = resolveSchedulePeriodStartDate(s);
-          if (!scheduleStart) {
-            return true;
-          }
-          return scheduleStart <= endDate;
+          return !scheduleStart || scheduleStart <= endDate;
         });
       }
     }
@@ -1998,40 +2669,38 @@ function clientGetAllSchedules(filters = {}) {
     }
 
     if (filters.status) {
-      filteredSchedules = filteredSchedules.filter(s => s.Status === filters.status);
+      filteredSchedules = filteredSchedules.filter(s => String(s.Status || '').toUpperCase() === String(filters.status).toUpperCase());
     }
 
     if (filters.department) {
       filteredSchedules = filteredSchedules.filter(s => s.Department === filters.department);
     }
 
-    // Sort by period start (newest first)
     filteredSchedules.sort((a, b) => getSchedulePeriodSortValue(b) - getSchedulePeriodSortValue(a));
-
-    console.log(`✅ Returning ${filteredSchedules.length} filtered schedules`);
 
     return {
       success: true,
       schedules: filteredSchedules,
       total: filteredSchedules.length,
-      filters: filters
+      filters,
+      metadata: {
+        source: 'LegacyScheduleSheet',
+        fallbackUsed: true
+      }
     };
-
   } catch (error) {
-    console.error('❌ Error getting schedules:', error);
-    safeWriteError('clientGetAllSchedules', error);
+    console.error('❌ Error getting schedules via legacy fallback:', error);
+    safeWriteError('legacyGetAllSchedules_', error);
     return {
       success: false,
       error: error.message,
       schedules: [],
-      total: 0
+      total: 0,
+      filters
     };
   }
 }
 
-/**
- * Core schedule import implementation shared by all callers
- */
 function internalClientImportSchedules(importRequest = {}) {
   try {
     const schedules = Array.isArray(importRequest.schedules) ? importRequest.schedules : [];
@@ -2713,397 +3382,359 @@ function clientGetCountryHolidays(countryCode, year) {
  */
 function clientAddManualShiftSlots(request = {}) {
   try {
-    const timeZone = typeof Session !== 'undefined' ? Session.getScriptTimeZone() : 'UTC';
+    const timeZone = DEFAULT_SCHEDULE_TIME_ZONE;
+    const actor = resolveCurrentActorEmail();
+    const now = new Date();
+    const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
+
     const normalizedStartDate = normalizeDateForSheet(request.startDate || request.date, timeZone);
-    const normalizedEndDate = normalizeDateForSheet(request.endDate || request.startDate || request.date, timeZone);
+    const normalizedEndDate = normalizeDateForSheet(request.endDate || request.startDate || request.date, timeZone) || normalizedStartDate;
 
-    if (!normalizedStartDate) {
+    if (!normalizedStartDate || !normalizedEndDate) {
       return {
         success: false,
-        error: 'A valid start date is required.'
+        error: 'Start date and end date are required.'
       };
     }
 
-    const startDate = new Date(`${normalizedStartDate}T00:00:00Z`);
-    const endDate = normalizedEndDate ? new Date(`${normalizedEndDate}T00:00:00Z`) : new Date(startDate.getTime());
-
-    if (isNaN(startDate.getTime())) {
-      return {
-        success: false,
-        error: 'Start date could not be parsed.'
-      };
-    }
-
-    if (isNaN(endDate.getTime())) {
-      return {
-        success: false,
-        error: 'End date could not be parsed.'
-      };
-    }
-
-    if (endDate < startDate) {
+    if (new Date(normalizedEndDate) < new Date(normalizedStartDate)) {
       return {
         success: false,
         error: 'End date must be on or after the start date.'
       };
     }
 
-    const earliestDate = new Date('2023-01-01T00:00:00Z');
-    if (startDate < earliestDate) {
+    const slotCandidates = [request.slotId, request.slotID, request.SlotId, request.SlotID]
+      .concat(request.slotName ? [request.slotName] : [])
+      .map(value => (value === null || typeof value === 'undefined') ? '' : String(value).trim())
+      .filter(Boolean);
+
+    if (!slotCandidates.length) {
       return {
         success: false,
-        error: 'Assignments can only be created for dates in 2023 or later.'
+        error: 'A shift slot is required for manual assignment.'
       };
     }
 
-    if (endDate < earliestDate) {
+    const allSlots = loadShiftSlotsNormalized();
+    const slotLookup = buildSlotLookupById(allSlots);
+    let selectedSlot = null;
+
+    for (let i = 0; i < slotCandidates.length && !selectedSlot; i++) {
+      const candidate = slotCandidates[i];
+      if (slotLookup.has(candidate)) {
+        selectedSlot = slotLookup.get(candidate);
+        break;
+      }
+      selectedSlot = allSlots.find(slot => {
+        if (!slot) {
+          return false;
+        }
+        const slotIdMatch = [slot.SlotId, slot.ID].some(value => String(value || '') === candidate);
+        if (slotIdMatch) {
+          return true;
+        }
+        return String(slot.SlotName || '').toLowerCase() === candidate.toLowerCase();
+      }) || null;
+    }
+
+    if (!selectedSlot) {
       return {
         success: false,
-        error: 'Assignments can only be created for dates in 2023 or later.'
+        error: 'The selected shift slot could not be found. Please refresh the slot list and try again.'
       };
     }
 
-    const assignmentDates = [];
-    for (let cursor = new Date(startDate.getTime()); cursor.getTime() <= endDate.getTime(); cursor.setUTCDate(cursor.getUTCDate() + 1)) {
-      assignmentDates.push(Utilities.formatDate(cursor, timeZone, 'yyyy-MM-dd'));
-    }
-
-    const normalizeTimeValue = (value) => {
-      if (value === null || typeof value === 'undefined') {
-        return '';
-      }
-
-      const text = value.toString().trim();
-      if (!text) {
-        return '';
-      }
-
-      if (/^\d{1,2}:\d{2}$/.test(text)) {
-        const [hours, minutes] = text.split(':');
-        return `${hours.padStart(2, '0')}:${minutes}`;
-      }
-
-      if (/^\d{1,2}:\d{2}:\d{2}$/.test(text)) {
-        const [hours, minutes] = text.split(':');
-        return `${hours.padStart(2, '0')}:${minutes}`;
-      }
-
-      const parsed = new Date(`1970-01-01T${text}`);
-      if (!isNaN(parsed.getTime())) {
-        const hours = parsed.getHours().toString().padStart(2, '0');
-        const minutes = parsed.getMinutes().toString().padStart(2, '0');
-        return `${hours}:${minutes}`;
-      }
-
-      return text;
-    };
-
-    let startTime = normalizeTimeValue(request.startTime);
-    let endTime = normalizeTimeValue(request.endTime);
-
-    const toMinutes = (value) => {
-      if (!value) {
-        return NaN;
-      }
-      const parts = value.split(':');
-      if (parts.length < 2) {
-        return NaN;
-      }
-      const hours = Number(parts[0]);
-      const minutes = Number(parts[1]);
-      if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
-        return NaN;
-      }
-      return (hours * 60) + minutes;
-    };
-
-    if ((startTime && !endTime) || (!startTime && endTime)) {
+    const campaignId = normalizeCampaignIdValue(request.campaignId || request.campaign || selectedSlot.Campaign);
+    if (!campaignId) {
       return {
         success: false,
-        error: 'Provide both start and end times or leave them blank.'
+        error: 'A campaign is required for manual assignments.'
       };
     }
 
-    if (startTime && endTime) {
-      const startMinutes = toMinutes(startTime);
-      const endMinutes = toMinutes(endTime);
-
-      if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
-        return {
-          success: false,
-          error: 'Start and end times must be valid HH:MM values.'
-        };
-      }
-
-      if (endMinutes <= startMinutes) {
-        return {
-          success: false,
-          error: 'End time must be later than start time.'
-        };
-      }
-    } else {
-      startTime = '';
-      endTime = '';
-    }
-
-    const rawUsers = Array.isArray(request.users) ? request.users : [];
-    if (rawUsers.length === 0) {
+    const requestedUserIds = Array.isArray(request.users) ? request.users.filter(Boolean).map(String) : [];
+    if (!requestedUserIds.length) {
       return {
         success: false,
-        error: 'Select at least one user to receive the shift slot.'
+        error: 'Select at least one user before assigning a shift.'
       };
     }
 
-    const scheduleUsers = clientGetScheduleUsers('system') || [];
-    const usersById = {};
-    const usersByName = {};
+    const usersById = buildUserLookupById_();
+    const userNamesForAttendance = [];
+    const validUsers = [];
 
-    scheduleUsers.forEach(user => {
-      if (!user) {
-        return;
-      }
-      const idKey = normalizeUserIdValue(user.ID);
-      if (idKey) {
-        usersById[idKey] = user;
-      }
-      const nameKey = normalizeUserKey(user.UserName || user.FullName || user.Email || '');
-      if (nameKey) {
-        usersByName[nameKey] = user;
+    requestedUserIds.forEach(userId => {
+      const userRecord = usersById.get(String(userId));
+      if (userRecord) {
+        validUsers.push(userRecord);
+        const attendanceName = userRecord.UserName || userRecord.FullName || userRecord.Email;
+        if (attendanceName) {
+          userNamesForAttendance.push(attendanceName);
+        }
       }
     });
 
-    const existingRecords = readScheduleSheet(SCHEDULE_GENERATION_SHEET) || [];
-    const existingKeySet = new Set();
+    if (!validUsers.length) {
+      return {
+        success: false,
+        error: 'None of the selected users were found in the directory.'
+      };
+    }
 
-    const buildRecordKeys = (record) => {
-      const keys = [];
-      const normalized = normalizeSchedulePeriodRecord(record, timeZone);
-      const start = normalized && normalized.PeriodStart ? normalized.PeriodStart : '';
-      const end = normalized && normalized.PeriodEnd ? normalized.PeriodEnd : start;
+    const attendanceConflicts = collectAttendanceConflicts_(userNamesForAttendance, normalizedStartDate, normalizedEndDate);
+    const existingAssignments = loadShiftAssignmentsNormalized();
+    const holidayLookup = buildHolidayLookup_(normalizedStartDate, normalizedEndDate);
+    const restPeriodHours = Number(selectedSlot.RestPeriod) || Number(selectedSlot.GenerationDefaults?.restPeriod) || 0;
+    const allowSwap = selectedSlot.AllowSwaps === true;
+    const weekendPremiumEnabled = selectedSlot.WeekendPremium === true;
+    const holidayPremiumEnabled = selectedSlot.HolidayPremium === true;
 
-      if (!start) {
-        return keys;
-      }
-
-      const periodKey = `${start}::${end}`;
-
-      const idKey = normalizeUserIdValue(record && record.UserID);
-      if (idKey) {
-        keys.push(`id::${idKey}::${periodKey}`);
-      }
-
-      const nameKey = normalizeUserKey(record && (record.UserName || record.FullName || record.UserID));
-      if (nameKey) {
-        keys.push(`name::${nameKey}::${periodKey}`);
-      }
-
-      return keys;
+    const breaksConfig = {
+      breakDuration: Number(selectedSlot.BreakDuration) || Number(selectedSlot.GenerationDefaults?.breakDuration) || 15,
+      break1Duration: Number(selectedSlot.Break1Duration) || Number(selectedSlot.GenerationDefaults?.break1Duration) || 15,
+      break2Duration: Number(selectedSlot.Break2Duration) || Number(selectedSlot.GenerationDefaults?.break2Duration) || 0,
+      lunchDuration: Number(selectedSlot.LunchDuration) || Number(selectedSlot.GenerationDefaults?.lunchDuration) || 30,
+      enableStaggered: selectedSlot.EnableStaggeredBreaks === true,
+      breakGroups: Number(selectedSlot.BreakGroups) || Number(selectedSlot.GenerationDefaults?.breakGroups) || 0,
+      staggerInterval: Number(selectedSlot.StaggerInterval) || Number(selectedSlot.GenerationDefaults?.staggerInterval) || 0,
+      minCoveragePct: Number(selectedSlot.MinCoveragePct) || Number(selectedSlot.GenerationDefaults?.minCoveragePct) || null
     };
 
-    existingRecords.forEach(record => {
-      buildRecordKeys(record).forEach(key => existingKeySet.add(key));
-    });
+    const resolveOvertimeMinutes = () => {
+      const defaults = selectedSlot.GenerationDefaults || {};
+      if (Number.isFinite(defaults.overtimeMinutes) && defaults.overtimeMinutes > 0) {
+        return defaults.overtimeMinutes;
+      }
+      if (Number.isFinite(defaults.maxDailyOT) && defaults.maxDailyOT > 0) {
+        return Math.round(defaults.maxDailyOT * 60);
+      }
+      return 0;
+    };
+
+    const overtimeMinutes = resolveOvertimeMinutes();
+    const notificationLead = Number(selectedSlot.NotificationLead) || Number(selectedSlot.GenerationDefaults?.notificationLead) || 0;
+    const handoverMinutes = Number(selectedSlot.HandoverTime) || Number(selectedSlot.GenerationDefaults?.handoverTime) || 0;
 
     const replaceExisting = request.replaceExisting === true;
-    const keysToReplace = new Set();
-
-    const monthNumber = Number(request.sourceMonth);
-    const validSourceMonth = Number.isFinite(monthNumber) && monthNumber >= 1 && monthNumber <= 12 ? monthNumber : null;
-    const yearNumber = Number(request.sourceYear);
-    const validSourceYear = Number.isFinite(yearNumber) ? yearNumber : null;
-
-    const sourceParts = [];
-    if (validSourceMonth) {
-      const monthLabel = getMonthNameFromNumber(validSourceMonth) || `Month ${validSourceMonth}`;
-      sourceParts.push(monthLabel);
-    }
-    if (validSourceYear) {
-      sourceParts.push(validSourceYear);
-    }
-    const sourceNote = sourceParts.length ? `Source schedule: ${sourceParts.join(' ')}` : '';
-    const additionalNotes = (request.notes || '').toString().trim();
-    const combinedNotes = [sourceNote, additionalNotes].filter(Boolean).join(' | ');
-
-    const slotLabel = (request.slotName || request.slotLabel || '').toString().trim();
-    const slotName = slotLabel || (startTime && endTime ? `Manual Shift ${startTime}-${endTime}` : 'Manual Shift');
-    const slotId = (request.slotId || '').toString().trim();
-
-    const activeUserEmail = typeof Session !== 'undefined' && Session.getActiveUser
-      ? (Session.getActiveUser().getEmail() || '')
-      : '';
-    const generatedBy = activeUserEmail || 'Manual Shift Slot Entry';
-
-    const now = new Date();
-    const nowIso = Utilities.formatDate(now, timeZone, "yyyy-MM-dd'T'HH:mm:ss");
-
-    const newRecords = [];
+    const archiveIds = new Set();
     const failedUsers = [];
+    const newAssignments = [];
+    const details = [];
+    const groupId = Utilities.getUuid();
 
-    rawUsers.forEach(entry => {
-      const resolvedId = normalizeUserIdValue(entry && (entry.id || entry.ID || entry.userId || entry.UserID));
-      const nameCandidates = [];
+    const notesParts = [];
+    const label = (request.slotLabel || '').trim();
+    const manualNotes = (request.notes || '').trim();
+    const rawSourceMonth = request.sourceMonth;
+    const parsedSourceMonth = rawSourceMonth === null || typeof rawSourceMonth === 'undefined' || rawSourceMonth === ''
+      ? null
+      : Number(rawSourceMonth);
 
-      if (typeof entry === 'string') {
-        nameCandidates.push(entry);
-      } else if (entry && typeof entry === 'object') {
-        ['userName', 'UserName', 'fullName', 'FullName', 'name', 'Name'].forEach(key => {
-          const value = entry[key];
-          if (value) {
-            nameCandidates.push(value);
-          }
-        });
+    if (label) {
+      notesParts.push(`Label: ${label}`);
+    }
+    if (Number.isFinite(parsedSourceMonth)) {
+      notesParts.push(`Source Month: ${parsedSourceMonth}`);
+    }
+    if (manualNotes) {
+      notesParts.push(manualNotes);
+    }
+
+    const combinedNotes = notesParts.join(' | ');
+
+    const normalizeTimeForDisplay = (slot, key, minutesKey) => {
+      if (!slot) {
+        return '';
       }
-
-      const resolvedName = nameCandidates.find(name => name && name.toString().trim()) || '';
-      const normalizedName = normalizeUserKey(resolvedName);
-
-      let matchedUser = null;
-      if (resolvedId && usersById[resolvedId]) {
-        matchedUser = usersById[resolvedId];
-      } else if (normalizedName && usersByName[normalizedName]) {
-        matchedUser = usersByName[normalizedName];
+      const direct = slot[key];
+      if (direct) {
+        return direct;
       }
-
-      if (!matchedUser && normalizedName) {
-        const partialMatch = scheduleUsers.find(user => normalizeUserKey(user.FullName || user.UserName) === normalizedName);
-        if (partialMatch) {
-          matchedUser = partialMatch;
-        }
+      const minutes = slot[minutesKey];
+      if (Number.isFinite(minutes)) {
+        return formatMinutesToTime12Hour(minutes);
       }
+      return '';
+    };
 
-      const userIdForRecord = normalizeUserIdValue(matchedUser ? matchedUser.ID : resolvedId);
-      const nameForRecord = matchedUser
-        ? (matchedUser.UserName || matchedUser.FullName)
-        : (resolvedName || resolvedId || '');
+    const slotStartTime = normalizeTimeForDisplay(selectedSlot, 'StartTime', 'StartMinutes');
+    const slotEndTime = normalizeTimeForDisplay(selectedSlot, 'EndTime', 'EndMinutes');
 
-      if (!nameForRecord) {
-        failedUsers.push({
-          userId: resolvedId || '',
-          userName: resolvedName || '',
-          reason: 'User could not be resolved'
-        });
+    validUsers.forEach(userRecord => {
+      if (!userRecord || !userRecord.ID) {
         return;
       }
 
-      const department = request.department || (matchedUser && matchedUser.campaignName) || '';
-      const location = request.location || '';
-      const priority = Number.isFinite(Number(request.priority)) ? Number(request.priority) : 2;
-      const nameKey = normalizeUserKey(nameForRecord);
+      const userId = String(userRecord.ID);
+      const normalizedCampaign = normalizeCampaignIdValue(selectedSlot.Campaign);
 
-      assignmentDates.forEach(dateValue => {
-        const periodKey = `${dateValue}::${dateValue}`;
-        const recordKeys = [];
+      if (!isUserConsideredActive(userRecord)) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: 'User is not active.' });
+        return;
+      }
 
-        if (userIdForRecord) {
-          recordKeys.push(`id::${userIdForRecord}::${periodKey}`);
+      if (!doesUserBelongToCampaign(userRecord, normalizedCampaign)) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: 'User is not assigned to the selected campaign.' });
+        return;
+      }
+
+      const hireDate = normalizeDateForSheet(userRecord.HireDate || userRecord.hireDate || userRecord.StartDate || userRecord.Hire_Date, timeZone);
+      if (hireDate && new Date(normalizedStartDate) < new Date(hireDate)) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: `Start date precedes hire date (${hireDate}).` });
+        return;
+      }
+
+      const normalizedUserKey = normalizeUserKey(userRecord.UserName || userRecord.FullName || userRecord.Email);
+      const attendanceRecords = normalizedUserKey ? (attendanceConflicts.get(normalizedUserKey) || []) : [];
+      if (attendanceRecords.length) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: 'Attendance records conflict with the requested range.' });
+        return;
+      }
+
+      const overlappingAssignments = existingAssignments.filter(assignment => {
+        if (!assignment || assignment.Status === 'ARCHIVED') {
+          return false;
         }
-
-        if (nameKey) {
-          recordKeys.push(`name::${nameKey}::${periodKey}`);
+        if (String(assignment.UserId) !== userId) {
+          return false;
         }
+        const assignmentStart = new Date((assignment.StartDate || assignment.PeriodStart) + 'T00:00:00');
+        const assignmentEnd = new Date((assignment.EndDate || assignment.PeriodEnd || assignment.StartDate) + 'T23:59:59');
+        const requestedStart = new Date(normalizedStartDate + 'T00:00:00');
+        const requestedEnd = new Date(normalizedEndDate + 'T23:59:59');
+        return assignmentEnd >= requestedStart && assignmentStart <= requestedEnd;
+      });
 
-        const hasExisting = recordKeys.some(key => existingKeySet.has(key));
-        if (hasExisting && !replaceExisting) {
-          failedUsers.push({
-            userId: userIdForRecord || '',
-            userName: nameForRecord,
-            date: dateValue,
-            reason: 'Existing assignment found for this date'
-          });
-          return;
+      if (overlappingAssignments.length && !replaceExisting) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: 'Existing assignment overlaps with the requested range.' });
+        return;
+      }
+
+      overlappingAssignments.forEach(assignment => {
+        if (assignment && assignment.AssignmentId) {
+          archiveIds.add(String(assignment.AssignmentId));
         }
+      });
 
-        recordKeys.forEach(key => {
-          existingKeySet.add(key);
-          if (replaceExisting) {
-            keysToReplace.add(key);
-          }
+      const restConflict = computeRestPeriodViolation_(existingAssignments, userId, normalizedStartDate, restPeriodHours);
+      if (restConflict && !archiveIds.has(String(restConflict.AssignmentId))) {
+        failedUsers.push({ userId, userName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId, reason: 'Rest period policy violation with an existing assignment.' });
+        return;
+      }
+
+      const assignment = {
+        AssignmentId: Utilities.getUuid(),
+        UserId: userId,
+        UserName: userRecord.FullName || userRecord.UserName || userRecord.Email || userId,
+        Campaign: normalizedCampaign,
+        SlotId: selectedSlot.SlotId,
+        SlotName: selectedSlot.SlotName,
+        StartDate: normalizedStartDate,
+        EndDate: normalizedEndDate,
+        Status: 'PENDING',
+        AllowSwap: allowSwap,
+        BreaksConfigJSON: breaksConfig,
+        OvertimeMinutes: overtimeMinutes,
+        RestPeriodHours: restPeriodHours || 0,
+        NotificationLeadHours: notificationLead,
+        HandoverMinutes: handoverMinutes,
+        Notes: combinedNotes,
+        CreatedAt: now,
+        CreatedBy: actor,
+        UpdatedAt: now,
+        UpdatedBy: actor,
+        RollbackGroupId: groupId,
+        Slot: selectedSlot,
+        UserRecord: userRecord
+      };
+
+      const coverageDates = expandAssignmentToDays_(assignment, selectedSlot);
+      const premiums = [];
+
+      if (weekendPremiumEnabled && coverageDates.some(isWeekendDay_)) {
+        premiums.push('Weekend');
+      }
+
+      if (holidayPremiumEnabled) {
+        const hasPremiumHoliday = coverageDates.some(dateStr => {
+          const holidays = holidayLookup.get(dateStr) || [];
+          return holidays.some(holiday => String(holiday.region || '').toLowerCase() === 'jamaica');
         });
+        if (hasPremiumHoliday) {
+          premiums.push('Holiday');
+        }
+      }
 
-        newRecords.push({
-          ID: Utilities.getUuid(),
-          UserID: userIdForRecord || '',
-          UserName: nameForRecord,
-          Date: dateValue,
-          PeriodStart: dateValue,
-          PeriodEnd: dateValue,
-          SlotID: slotId,
-          SlotName: slotName,
-          StartTime: startTime,
-          EndTime: endTime,
-          OriginalStartTime: startTime,
-          OriginalEndTime: endTime,
-          BreakStart: '',
-          BreakEnd: '',
-          LunchStart: '',
-          LunchEnd: '',
-          IsDST: '',
-          Status: 'MANUAL',
-          GeneratedBy: generatedBy,
-          ApprovedBy: '',
-          NotificationSent: '',
-          CreatedAt: nowIso,
-          UpdatedAt: nowIso,
-          RecurringScheduleID: '',
-          SwapRequestID: '',
-          Priority: priority,
-          Notes: combinedNotes,
-          Location: location,
-          Department: department
-        });
+      if (overtimeMinutes > 0) {
+        premiums.push('Overtime');
+      }
+
+      assignment.Premiums = premiums;
+
+      newAssignments.push(assignment);
+      details.push({
+        assignmentId: assignment.AssignmentId,
+        userId: assignment.UserId,
+        userName: assignment.UserName,
+        slotId: assignment.SlotId,
+        slotName: assignment.SlotName,
+        startDate: assignment.StartDate,
+        endDate: assignment.EndDate,
+        startTime: slotStartTime,
+        endTime: slotEndTime
       });
     });
 
-    if (!newRecords.length) {
+    if (!newAssignments.length) {
       return {
         success: false,
-        error: 'No new shift slots were created.',
+        error: 'No assignments were created.',
         failed: failedUsers
       };
     }
 
     let replacedCount = 0;
-
-    if (replaceExisting) {
-      const retainedRecords = existingRecords.filter(existing => {
-        const keys = buildRecordKeys(existing);
-        return !keys.some(key => keysToReplace.has(key));
+    if (archiveIds.size) {
+      const archiveList = Array.from(archiveIds);
+      const archiveResult = updateAssignmentsByIds_(archiveList, (assignment) => {
+        assignment.Status = 'ARCHIVED';
+        assignment.UpdatedAt = now;
+        assignment.UpdatedBy = actor;
+        assignment.RollbackGroupId = groupId;
+        assignment.Notes = assignment.Notes ? `${assignment.Notes} | Replaced by manual assignment ${groupId}` : `Replaced by manual assignment ${groupId}`;
       });
-
-      replacedCount = existingRecords.length - retainedRecords.length;
-
-      const updatedRecords = retainedRecords.concat(newRecords);
-      writeToScheduleSheet(SCHEDULE_GENERATION_SHEET, updatedRecords);
-    } else {
-      saveSchedulesToSheet(newRecords);
+      replacedCount = archiveResult.updated.length;
+      archiveResult.updated.forEach(change => {
+        logScheduleAudit('ARCHIVE', 'ShiftAssignment', change.after.AssignmentId, change.before, change.after, 'Manual assignment replaceExisting', { groupId, replaceExisting: true });
+      });
     }
 
-    const firstDate = assignmentDates[0];
-    const lastDate = assignmentDates[assignmentDates.length - 1];
-    const dateLabel = firstDate === lastDate ? firstDate : `${firstDate} to ${lastDate}`;
+    appendShiftAssignments(newAssignments);
 
-    const uniqueUserCount = new Set(newRecords.map(record => record.UserID || record.UserName || '')).size;
+    newAssignments.forEach(assignment => {
+      logScheduleAudit('CREATE', 'ShiftAssignment', assignment.AssignmentId, null, assignment, 'Manual shift assignment', { groupId, replaceExisting });
+    });
+
+    const uniqueUsers = new Set(newAssignments.map(record => record.UserId));
+    const dateLabel = normalizedStartDate === normalizedEndDate ? normalizedStartDate : `${normalizedStartDate} → ${normalizedEndDate}`;
+    const message = `Added ${newAssignments.length} manual shift assignment${newAssignments.length === 1 ? '' : 's'} for ${selectedSlot.SlotName} (${dateLabel}).`;
 
     return {
       success: true,
-      created: newRecords.length,
+      message,
+      created: newAssignments.length,
       replaced: replacedCount,
       failed: failedUsers,
-      details: newRecords.map(record => ({
-        userId: record.UserID,
-        userName: record.UserName,
-        date: record.Date,
-        startTime: record.StartTime,
-        endTime: record.EndTime,
-        slotName: record.SlotName,
-        slotId: record.SlotID
-      })),
-      slotName,
-      slotId,
-      startDate: firstDate,
-      endDate: lastDate,
-      usersAffected: uniqueUserCount,
-      message: `Added ${newRecords.length} manual shift slot${newRecords.length === 1 ? '' : 's'} covering ${dateLabel}.`
+      details,
+      slotName: selectedSlot.SlotName,
+      slotId: selectedSlot.SlotId,
+      startDate: normalizedStartDate,
+      endDate: normalizedEndDate,
+      usersAffected: uniqueUsers.size,
+      rollbackGroupId: groupId,
+      createdAt: nowIso
     };
   } catch (error) {
     console.error('Error manually adding shift slots:', error);
@@ -3454,102 +4085,112 @@ function clientRunSystemDiagnostics() {
  */
 function clientApproveSchedules(scheduleIds, approvingUserId, notes = '') {
   try {
-    console.log('✅ Approving schedules:', scheduleIds);
-    
-    const sheet = getScheduleSpreadsheet().getSheetByName(SCHEDULE_GENERATION_SHEET);
-    if (!sheet) {
-      throw new Error('Schedules sheet not found');
+    const ids = Array.isArray(scheduleIds) ? scheduleIds.filter(Boolean).map(String) : [];
+    if (!ids.length) {
+      return {
+        success: false,
+        error: 'No schedule identifiers were provided.'
+      };
     }
 
-    const data = sheet.getDataRange().getValues();
-    const headers = data[0];
-    const statusCol = headers.indexOf('Status') + 1;
-    const approvedByCol = headers.indexOf('ApprovedBy') + 1;
-    const updatedAtCol = headers.indexOf('UpdatedAt') + 1;
+    const actor = resolveCurrentActorEmail();
+    const approver = approvingUserId || actor;
+    const noteText = notes ? String(notes).trim() : '';
+    const now = new Date();
 
-    let updated = 0;
-
-    for (let i = 1; i < data.length; i++) {
-      const scheduleId = data[i][0]; // ID is first column
-      if (scheduleIds.includes(scheduleId)) {
-        sheet.getRange(i + 1, statusCol).setValue('APPROVED');
-        sheet.getRange(i + 1, approvedByCol).setValue(approvingUserId || 'System');
-        sheet.getRange(i + 1, updatedAtCol).setValue(new Date());
-        updated++;
+    const { updated } = updateAssignmentsByIds_(ids, (assignment) => {
+      assignment.Status = 'APPROVED';
+      assignment.UpdatedAt = now;
+      assignment.UpdatedBy = approver;
+      if (noteText) {
+        assignment.Notes = assignment.Notes ? `${assignment.Notes} | Approved: ${noteText}` : `Approved: ${noteText}`;
       }
+    });
+
+    if (!updated.length) {
+      return {
+        success: false,
+        error: 'No assignments were approved. They may already be processed or missing.'
+      };
     }
 
-    SpreadsheetApp.flush();
-    invalidateScheduleCaches();
+    updated.forEach(change => {
+      logScheduleAudit('APPROVE', 'ShiftAssignment', change.after.AssignmentId, change.before, change.after, noteText, {
+        action: 'approve',
+        approver
+      });
+    });
 
     return {
       success: true,
-      message: `Approved ${updated} schedules`,
-      approved: updated
+      message: `Approved ${updated.length} assignments`,
+      approved: updated.length,
+      updatedIds: updated.map(change => change.after.AssignmentId)
     };
-
   } catch (error) {
     console.error('Error approving schedules:', error);
     safeWriteError('clientApproveSchedules', error);
     return {
       success: false,
-      error: error.message
+      error: error.message || 'Failed to approve schedules'
     };
   }
 }
 
-/**
- * Reject schedules
- */
 function clientRejectSchedules(scheduleIds, rejectingUserId, reason = '') {
   try {
-    console.log('❌ Rejecting schedules:', scheduleIds);
-    
-    const sheet = getScheduleSpreadsheet().getSheetByName(SCHEDULE_GENERATION_SHEET);
-    if (!sheet) {
-      throw new Error('Schedules sheet not found');
+    const ids = Array.isArray(scheduleIds) ? scheduleIds.filter(Boolean).map(String) : [];
+    if (!ids.length) {
+      return {
+        success: false,
+        error: 'No schedule identifiers were provided.'
+      };
     }
 
-    const data = sheet.getDataRange().getValues();
-    const headers = data[0];
-    const statusCol = headers.indexOf('Status') + 1;
-    const notesCol = headers.indexOf('Notes') + 1;
-    const updatedAtCol = headers.indexOf('UpdatedAt') + 1;
+    const actor = resolveCurrentActorEmail();
+    const rejector = rejectingUserId || actor;
+    const reasonText = reason ? String(reason).trim() : '';
+    const now = new Date();
 
-    let updated = 0;
-
-    for (let i = 1; i < data.length; i++) {
-      const scheduleId = data[i][0]; // ID is first column
-      if (scheduleIds.includes(scheduleId)) {
-        sheet.getRange(i + 1, statusCol).setValue('REJECTED');
-        if (reason) {
-          const existingNotes = data[i][notesCol - 1] || '';
-          const newNotes = existingNotes + (existingNotes ? '; ' : '') + 'Rejected: ' + reason;
-          sheet.getRange(i + 1, notesCol).setValue(newNotes);
-        }
-        sheet.getRange(i + 1, updatedAtCol).setValue(new Date());
-        updated++;
+    const { updated } = updateAssignmentsByIds_(ids, (assignment) => {
+      assignment.Status = 'REJECTED';
+      assignment.UpdatedAt = now;
+      assignment.UpdatedBy = rejector;
+      if (reasonText) {
+        assignment.Notes = assignment.Notes ? `${assignment.Notes} | Rejected: ${reasonText}` : `Rejected: ${reasonText}`;
       }
+    });
+
+    if (!updated.length) {
+      return {
+        success: false,
+        error: 'No assignments were rejected. They may already be processed or missing.'
+      };
     }
 
-    SpreadsheetApp.flush();
-    invalidateScheduleCaches();
+    updated.forEach(change => {
+      logScheduleAudit('REJECT', 'ShiftAssignment', change.after.AssignmentId, change.before, change.after, reasonText, {
+        action: 'reject',
+        rejector
+      });
+    });
 
     return {
       success: true,
-      message: `Rejected ${updated} schedules`,
-      rejected: updated
+      message: `Rejected ${updated.length} assignments`,
+      rejected: updated.length,
+      updatedIds: updated.map(change => change.after.AssignmentId)
     };
-
   } catch (error) {
     console.error('Error rejecting schedules:', error);
     safeWriteError('clientRejectSchedules', error);
     return {
       success: false,
-      error: error.message
+      error: error.message || 'Failed to reject schedules'
     };
   }
 }
+
 
 // ────────────────────────────────────────────────────────────────────────────
 // LEGACY COMPATIBILITY AND UTILITY FUNCTIONS


### PR DESCRIPTION
## Summary
- replace shift slot creation with the normalized range-based schema and serialization helpers
- update manual assignment, schedule listing, and approval/rejection flows to read and write the ShiftAssignments sheet with audit logging
- introduce a legacy fallback reader while exposing new metadata needed by the schedule management UI

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68f8705a1db083269bcc8dea023054d7