### PR TITLE
Fix GLOBAL_SCOPE redeclaration in ScheduleService

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -335,15 +335,17 @@ function formatMinutesToTime12Hour(minutes) {
   return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')} ${period}`;
 }
 
-const GLOBAL_SCOPE = (typeof globalThis !== 'undefined')
-  ? globalThis
-  : (typeof self !== 'undefined')
-    ? self
-    : (typeof window !== 'undefined')
-      ? window
-      : (typeof global !== 'undefined')
-        ? global
-        : this;
+var GLOBAL_SCOPE = (typeof GLOBAL_SCOPE !== 'undefined')
+  ? GLOBAL_SCOPE
+  : (typeof globalThis !== 'undefined')
+    ? globalThis
+    : (typeof self !== 'undefined')
+      ? self
+      : (typeof window !== 'undefined')
+        ? window
+        : (typeof global !== 'undefined')
+          ? global
+          : this;
 
 if (GLOBAL_SCOPE) {
   if (typeof GLOBAL_SCOPE.convertCsvToDayIndexes !== 'function') {


### PR DESCRIPTION
## Summary
- update the ScheduleService global scope initializer to reuse an existing definition when present
- ensure the global reference gracefully falls back to globalThis, self, window, global, or this

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8977b53bc8326932d180c0d9f6653