### PR TITLE
Bind schedule manager date helpers

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2563,6 +2563,10 @@
                 this.resolvedCampaignId = '';
                 this.managedUserIds = [];
                 this.managedUserIdSet = new Set();
+                this.managedRosterSource = '';
+                this.managedRosterUsers = [];
+                this.rosterManagedUserIds = [];
+                this.contextManagedUserIds = [];
                 this.identityResolved = false;
                 this.identitySummary = null;
                 this.contextLoadingPromise = null;
@@ -2586,6 +2590,17 @@
                     yearly: { label: '', entries: [] }
                 };
                 this.attendanceCalendarRecords = [];
+                this.unifiedState = null;
+                this.unifiedStateAppliedAt = null;
+                this.attendanceCalendarPrefetch = null;
+                this.attendanceDashboardPrefetch = null;
+                this.holidayPrefetch = null;
+                this.managedRosterWarnings = [];
+                this.schedulePrefetchRange = null;
+                this.additionalUserSources = {};
+                this.assignmentUserRecords = [];
+                this.attendanceUserRecords = [];
+                this.userSourceSummary = null;
                 this.attendanceContextMenu = null;
                 this.attendanceContextMenuTarget = null;
                 this.attendanceContextMenuOutsideHandler = null;
@@ -2735,6 +2750,48 @@
                         }
                     });
                 });
+
+                const fallbackParseDateValue = (input) => {
+                    if (!input) {
+                        return null;
+                    }
+
+                    if (input instanceof Date) {
+                        return isNaN(input.getTime()) ? null : new Date(input);
+                    }
+
+                    if (typeof input === 'number' && !Number.isNaN(input)) {
+                        const fromNumber = new Date(input);
+                        return isNaN(fromNumber.getTime()) ? null : fromNumber;
+                    }
+
+                    if (typeof input === 'object' && input.iso) {
+                        return fallbackParseDateValue(input.iso);
+                    }
+
+                    if (typeof input === 'string') {
+                        const normalized = input.trim();
+                        if (!normalized) {
+                            return null;
+                        }
+
+                        const fromString = new Date(normalized);
+                        return isNaN(fromString.getTime()) ? null : fromString;
+                    }
+
+                    return null;
+                };
+
+                if (typeof this.parseDateValue === 'function') {
+                    this.parseDateValue = this.parseDateValue.bind(this);
+                } else {
+                    this.parseDateValue = fallbackParseDateValue;
+                }
+
+                if (typeof this.resolveIsoDate === 'function') {
+                    this.resolveIsoDate = this.resolveIsoDate.bind(this);
+                }
+
                 this.updateStatusLegendCard();
                 this.init();
             }
@@ -2966,17 +3023,226 @@
                 updateBreakDuration();
             }
 
+            async fetchUnifiedState() {
+                const managerId = this.getCurrentUserId();
+                const campaignId = this.getCurrentCampaignId();
+
+                const scheduleStartCandidate = document.getElementById('filterStartDate')?.value
+                    || document.getElementById('scheduleStartDate')?.value
+                    || '';
+                const scheduleEndCandidate = document.getElementById('filterEndDate')?.value
+                    || document.getElementById('scheduleEndDate')?.value
+                    || '';
+
+                const monthInput = document.getElementById('attendanceMonth');
+                const yearInput = document.getElementById('attendanceYear');
+                const monthContext = this.resolveAttendanceMonthContext(
+                    monthInput ? monthInput.value : '',
+                    yearInput ? yearInput.value : ''
+                );
+
+                const payload = {
+                    managerId,
+                    campaignId,
+                    scheduleStart: this.resolveIsoDate(scheduleStartCandidate),
+                    scheduleEnd: this.resolveIsoDate(scheduleEndCandidate),
+                    attendanceMonth: monthContext.month,
+                    attendanceYear: monthContext.year,
+                    attendanceStart: monthContext.startDate,
+                    attendanceEnd: monthContext.endDate
+                };
+
+                return this.callServerFunction('clientGetScheduleUnifiedState', payload);
+            }
+
+            applyUnifiedState(state) {
+                if (!state || state.success !== true) {
+                    throw new Error(state && state.error ? state.error : 'Unified schedule state unavailable');
+                }
+
+                this.unifiedState = Object.assign({}, state);
+                this.unifiedStateAppliedAt = new Date();
+
+                if (state.context && state.context.success) {
+                    this.identityResolved = !!(state.context.authenticated
+                        || (state.context.identity && state.context.identity.authenticated));
+                    this.identitySummary = state.context.identity || null;
+
+                    const resolvedManagerId = this.normalizeUserIdValue(state.context.managerId)
+                        || this.normalizeUserIdValue(state.context.providedManagerId);
+                    if (resolvedManagerId) {
+                        this.resolvedManagerId = resolvedManagerId;
+                    }
+
+                    const resolvedCampaignId = this.normalizeCampaignIdValue(
+                        state.context.campaignId || state.context.providedCampaignId
+                    );
+                    if (resolvedCampaignId) {
+                        this.resolvedCampaignId = resolvedCampaignId;
+                    }
+
+                    if (state.context.user && typeof state.context.user === 'object') {
+                        this.currentUser = Object.assign({}, this.currentUser || {}, state.context.user);
+                    }
+
+                    const managedIdsFromContext = Array.isArray(state.context.managedUserIds)
+                        ? state.context.managedUserIds
+                        : [];
+                    this.managedUserIds = managedIdsFromContext.slice();
+                    this.managedUserIdSet = new Set(
+                        this.managedUserIds.map(id => this.normalizeUserIdValue(id)).filter(Boolean)
+                    );
+                    if (this.resolvedManagerId && this.managedUserIdSet.has(this.resolvedManagerId)) {
+                        this.managedUserIdSet.delete(this.resolvedManagerId);
+                    }
+                }
+
+                const scheduleUsers = state.users && Array.isArray(state.users.schedule)
+                    ? state.users.schedule
+                    : (state.users && Array.isArray(state.users.combined) ? state.users.combined : []);
+                const rosterUsers = state.users && Array.isArray(state.users.roster)
+                    ? state.users.roster
+                    : [];
+
+                const sourceUsers = {};
+                if (state.users && Array.isArray(state.users.assignments) && state.users.assignments.length) {
+                    sourceUsers.assignments = state.users.assignments;
+                }
+                if (state.users && Array.isArray(state.users.attendance) && state.users.attendance.length) {
+                    sourceUsers.attendance = state.users.attendance;
+                }
+
+                this.applyUsersFromSources(scheduleUsers, rosterUsers, {
+                    combinedUsers: state.users && Array.isArray(state.users.combined) ? state.users.combined : null,
+                    rosterSource: state.users?.rosterSource || '',
+                    warnings: state.users?.warnings || [],
+                    managedUserIds: state.users?.managedUserIds || this.managedUserIds,
+                    rosterManagedUserIds: state.users?.rosterManagedUserIds || [],
+                    contextManagedUserIds: state.users?.contextManagedUserIds || [],
+                    sourceUsers,
+                    sourceSummary: state.users?.sources || null
+                });
+
+                if (state.schedule) {
+                    this.schedulePrefetchRange = state.schedule.range || null;
+
+                    if (Array.isArray(state.schedule.shiftSlots)) {
+                        const { slots, metadata } = this.normalizeShiftSlotListResponse(state.schedule.shiftSlots);
+                        this.cachedShiftSlots = slots;
+                        this.updateShiftSlotSelectors(slots);
+                        this.displayShiftSlots(slots);
+                        if (this.manualShiftManager && typeof this.manualShiftManager.setShiftSlots === 'function') {
+                            this.manualShiftManager.setShiftSlots(slots);
+                        }
+                        const totalSlotsElement = document.getElementById('totalSlots');
+                        if (totalSlotsElement && metadata && typeof metadata.totalCount !== 'undefined') {
+                            totalSlotsElement.textContent = metadata.totalCount;
+                        }
+                    }
+
+                    if (state.schedule.assignments) {
+                        const parsedAssignments = this.parseSchedulesResponse(state.schedule.assignments);
+                        const schedules = Array.isArray(parsedAssignments.schedules) ? parsedAssignments.schedules : [];
+                        this.cachedSchedules = schedules;
+                        this.displaySchedules(schedules);
+                        const totalElement = document.getElementById('totalSchedules');
+                        if (totalElement) {
+                            const numericTotal = Number(parsedAssignments.total);
+                            totalElement.textContent = Number.isFinite(numericTotal) && numericTotal >= 0
+                                ? numericTotal
+                                : schedules.length;
+                        }
+                    }
+
+                    if (state.schedule.dashboard) {
+                        this.applyScheduleDashboard(state.schedule.dashboard);
+                    }
+                }
+
+                if (state.attendance) {
+                    this.attendanceCalendarPrefetch = {
+                        range: state.attendance.range ? Object.assign({}, state.attendance.range) : null,
+                        users: state.attendance.users || [],
+                        monthlyRecords: Array.isArray(state.attendance.monthlyRecords)
+                            ? state.attendance.monthlyRecords.slice()
+                            : [],
+                        yearlyRecords: Array.isArray(state.attendance.yearlyRecords)
+                            ? state.attendance.yearlyRecords.slice()
+                            : []
+                    };
+
+                    this.attendanceCalendarRecords = Array.isArray(this.attendanceCalendarPrefetch.monthlyRecords)
+                        ? this.attendanceCalendarPrefetch.monthlyRecords.slice()
+                        : [];
+
+                    this.attendanceDashboardPrefetch = {
+                        year: state.attendance.range ? state.attendance.range.year : null,
+                        records: Array.isArray(state.attendance.yearlyRecords)
+                            ? state.attendance.yearlyRecords.slice()
+                            : [],
+                        dashboard: state.attendance.dashboard || null
+                    };
+
+                    if (this.attendanceDashboardPrefetch.records.length && this.attendanceDashboardPrefetch.year) {
+                        this.mergeAttendanceDashboardRecords(
+                            this.attendanceDashboardPrefetch.records,
+                            this.attendanceDashboardPrefetch.year
+                        );
+                    }
+
+                    if (state.attendance.dashboard && state.attendance.dashboard.success) {
+                        const year = this.attendanceDashboardPrefetch.year || this.getSelectedAttendanceYear();
+                        this.attendanceDashboardYear = year;
+                        this.attendanceDashboardRecords = this.attendanceDashboardPrefetch.records.slice();
+                        const filteredRecords = this.filterAttendanceDashboardRecords(
+                            this.attendanceDashboardRecords,
+                            this.attendanceDashboardUserFilter
+                        );
+                        this.attendanceDashboardData = this.computeAttendanceDashboard(filteredRecords, year);
+                        this.destroyAttendanceDashboardCharts();
+                    }
+                }
+
+                if (state.holidays && state.holidays.success) {
+                    this.holidayPrefetch = state.holidays;
+                }
+            }
+
             async loadInitialData() {
+                let unifiedApplied = false;
+
                 try {
                     this.showToast('Loading system data...', 'info');
+                    const unifiedState = await this.fetchUnifiedState();
+                    if (unifiedState && unifiedState.success) {
+                        this.applyUnifiedState(unifiedState);
+                        unifiedApplied = true;
+                    } else {
+                        throw new Error(unifiedState?.error || 'Unified state unavailable');
+                    }
+                } catch (error) {
+                    console.warn('Unified state bootstrap failed. Falling back to legacy loaders.', error);
+                }
 
-                    // Resolve identity and manager context before loading data
+                if (unifiedApplied) {
+                    const activePane = document.querySelector('#mainTabContent .tab-pane.show.active');
+                    if (activePane?.id === 'attendance') {
+                        await this.loadAttendanceCalendar();
+                    }
+                    if (activePane?.id === 'attendance-dashboard') {
+                        await this.loadAttendanceDashboard(false);
+                    }
+                    await this.refreshHolidays();
+                    this.showToast('System ready! All data loaded successfully.', 'success');
+                    console.log('✅ Unified system state loaded successfully');
+                    return;
+                }
+
+                try {
                     await this.ensureScheduleContext();
 
-                    // Load users first as they're needed everywhere
                     await this.loadUsers();
 
-                    // Load other data concurrently
                     await Promise.allSettled([
                         this.loadCampaigns(),
                         this.loadShiftSlots(),
@@ -2992,8 +3258,10 @@
                         await this.loadAttendanceDashboard(true);
                     }
 
+                    await this.refreshHolidays();
+
                     this.showToast('System ready! All data loaded successfully.', 'success');
-                    console.log('✅ Initial data loaded successfully');
+                    console.log('✅ Initial data loaded successfully (legacy path)');
 
                 } catch (error) {
                     console.error('❌ Error loading initial data:', error);
@@ -3033,6 +3301,321 @@
                 }
             }
 
+            parseManagedRosterResponse(response) {
+                const result = {
+                    users: [],
+                    recognized: false,
+                    error: null
+                };
+
+                if (Array.isArray(response)) {
+                    result.users = response.slice();
+                    result.recognized = true;
+                    return result;
+                }
+
+                if (response && typeof response === 'object') {
+                    if (Array.isArray(response.users)) {
+                        result.users = response.users.slice();
+                        result.recognized = true;
+                        if (response.success === false && response.error) {
+                            result.error = response.error;
+                        }
+                        return result;
+                    }
+
+                    if (Array.isArray(response.managedUsers)) {
+                        result.users = response.managedUsers.slice();
+                        result.recognized = true;
+                        if (response.success === false && response.error) {
+                            result.error = response.error;
+                        }
+                        return result;
+                    }
+
+                    if (response.success === false && response.error) {
+                        result.recognized = true;
+                        result.error = response.error;
+                        return result;
+                    }
+                }
+
+                return result;
+            }
+
+            async fetchManagedRoster(managerId) {
+                if (!managerId) {
+                    console.warn('⚠️ Managed roster request skipped - missing manager identifier');
+                    return { users: [], source: null, error: 'Missing manager ID', managedUserIds: [] };
+                }
+
+                const attempts = [
+                    { functionName: 'clientGetManagedUsersList', label: 'ScheduleService roster endpoint' },
+                    { functionName: 'clientGetManagedUsers', label: 'UserService roster endpoint' }
+                ];
+
+                for (let index = 0; index < attempts.length; index++) {
+                    const attempt = attempts[index];
+                    const isLastAttempt = index === attempts.length - 1;
+
+                    try {
+                        const response = await this.callServerFunction(attempt.functionName, managerId);
+                        const parsed = this.parseManagedRosterResponse(response);
+
+                        if (!parsed.recognized) {
+                            continue;
+                        }
+
+                        if (parsed.error) {
+                            console.warn(`⚠️ ${attempt.label} responded with: ${parsed.error}`);
+                            if (!isLastAttempt && parsed.users.length === 0) {
+                                continue;
+                            }
+                        }
+
+                        return {
+                            users: Array.isArray(parsed.users) ? parsed.users : [],
+                            source: attempt.functionName,
+                            error: parsed.error || null,
+                            managedUserIds: Array.isArray(parsed.users)
+                                ? parsed.users
+                                    .map(user => this.normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId)))
+                                    .filter(Boolean)
+                                : []
+                        };
+                    } catch (error) {
+                        console.warn(`⚠️ ${attempt.label} failed:`, error);
+                        if (isLastAttempt) {
+                            return {
+                                users: [],
+                                source: attempt.functionName,
+                                error: error.message || String(error),
+                                managedUserIds: []
+                            };
+                        }
+                    }
+                }
+
+                return { users: [], source: null, error: null, managedUserIds: [] };
+            }
+
+            applyUsersFromSources(scheduleUsers, rosterUsers, options = {}) {
+                const scheduleList = Array.isArray(scheduleUsers) ? scheduleUsers : [];
+                const rosterList = Array.isArray(rosterUsers) ? rosterUsers : [];
+                const combinedList = Array.isArray(options.combinedUsers) ? options.combinedUsers : [];
+
+                if (Object.prototype.hasOwnProperty.call(options, 'rosterSource')) {
+                    this.managedRosterSource = options.rosterSource || '';
+                }
+
+                if (options && typeof options.sourceSummary === 'object' && options.sourceSummary !== null && !Array.isArray(options.sourceSummary)) {
+                    this.userSourceSummary = Object.assign({}, options.sourceSummary);
+                } else {
+                    this.userSourceSummary = null;
+                }
+
+                this.rosterManagedUserIds = Array.isArray(options.rosterManagedUserIds)
+                    ? options.rosterManagedUserIds.map(id => this.normalizeUserIdValue(id)).filter(Boolean)
+                    : [];
+                this.contextManagedUserIds = Array.isArray(options.contextManagedUserIds)
+                    ? options.contextManagedUserIds.map(id => this.normalizeUserIdValue(id)).filter(Boolean)
+                    : [];
+
+                this.managedRosterUsers = rosterList.slice();
+                this.managedRosterWarnings = Array.isArray(options.warnings) ? options.warnings.slice() : [];
+
+                if (Array.isArray(this.managedRosterWarnings) && this.managedRosterWarnings.length) {
+                    this.managedRosterWarnings.forEach(warning => {
+                        if (warning) {
+                            console.warn('⚠️ Managed roster warning:', warning);
+                        }
+                    });
+                }
+
+                this.additionalUserSources = {};
+                const extraCollections = [];
+                if (options && options.sourceUsers && typeof options.sourceUsers === 'object') {
+                    Object.entries(options.sourceUsers).forEach(([key, collection]) => {
+                        if (!Array.isArray(collection) || !collection.length) {
+                            return;
+                        }
+                        const sanitized = collection
+                            .filter(item => item && typeof item === 'object')
+                            .map(item => Object.assign({}, item));
+                        if (!sanitized.length) {
+                            return;
+                        }
+                        extraCollections.push(sanitized);
+                        this.additionalUserSources[key] = sanitized.slice();
+                    });
+                }
+
+                this.assignmentUserRecords = Array.isArray(this.additionalUserSources.assignments)
+                    ? this.additionalUserSources.assignments.slice()
+                    : [];
+                this.attendanceUserRecords = Array.isArray(this.additionalUserSources.attendance)
+                    ? this.additionalUserSources.attendance.slice()
+                    : [];
+
+                const userMap = new Map();
+                const pushUserRecord = (user) => {
+                    if (!user || typeof user !== 'object') {
+                        return;
+                    }
+
+                    const normalizedId = this.normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+                    const normalizedNameKey = this.normalizePersonKey(
+                        user.UserName || user.username || user.FullName || user.fullName || ''
+                    );
+                    const normalizedEmailKey = this.normalizePersonKey(user.Email || user.email || '');
+
+                    const key = normalizedId
+                        ? `id:${normalizedId}`
+                        : (normalizedNameKey ? `name:${normalizedNameKey}` : (normalizedEmailKey ? `email:${normalizedEmailKey}` : null));
+
+                    if (!key) {
+                        return;
+                    }
+
+                    const existing = userMap.get(key) || {};
+                    const resolvedId = normalizedId
+                        || existing.ID
+                        || (normalizedNameKey ? `name:${normalizedNameKey}` : (normalizedEmailKey ? `email:${normalizedEmailKey}` : key));
+
+                    const normalized = {
+                        ID: resolvedId,
+                        UserName: user.UserName || user.username || existing.UserName || existing.username || resolvedId,
+                        FullName: user.FullName || user.fullName || existing.FullName || existing.fullName || user.UserName || existing.UserName || resolvedId,
+                        Email: user.Email || user.email || existing.Email || '',
+                        CampaignID: user.CampaignID || user.campaignID || user.campaignId || existing.CampaignID || '',
+                        campaignName: user.campaignName || user.CampaignName || existing.campaignName || existing.CampaignName || '',
+                        EmploymentStatus: user.EmploymentStatus || existing.EmploymentStatus || 'Active',
+                        HireDate: user.HireDate || existing.HireDate || '',
+                        TerminationDate: user.TerminationDate || user.terminationDate || existing.TerminationDate || '',
+                        isActive: typeof user.isActive === 'boolean'
+                            ? user.isActive
+                            : (typeof existing.isActive === 'boolean' ? existing.isActive : true),
+                        roleNames: Array.isArray(user.roleNames)
+                            ? user.roleNames.slice()
+                            : (Array.isArray(existing.roleNames) ? existing.roleNames.slice() : []),
+                        syntheticId: normalizedId ? false : (existing.syntheticId === true || !normalizedId)
+                    };
+
+                    userMap.set(key, normalized);
+                };
+
+                const collections = [combinedList, scheduleList, rosterList].concat(extraCollections);
+                collections
+                    .filter(collection => Array.isArray(collection) && collection.length)
+                    .forEach(collection => collection.forEach(pushUserRecord));
+
+                this.availableUsers = Array.from(userMap.values())
+                    .filter(user => user && user.ID && (user.FullName || user.UserName))
+                    .sort((a, b) => {
+                        const nameA = (a.FullName || a.UserName || '').toLowerCase();
+                        const nameB = (b.FullName || b.UserName || '').toLowerCase();
+                        return nameA.localeCompare(nameB);
+                    });
+
+                if (this.attendanceDashboardUserFilter) {
+                    const normalizedFilterId = this.normalizeUserIdValue(this.attendanceDashboardUserFilter);
+                    const normalizedFilterName = this.normalizePersonKey(normalizedFilterId);
+                    const hasUser = this.availableUsers.some(user => {
+                        const userId = this.normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId || user.username);
+                        if (userId && userId === normalizedFilterId) {
+                            return true;
+                        }
+                        const nameKey = this.normalizePersonKey(user.FullName || user.UserName || '');
+                        return normalizedFilterName && nameKey === normalizedFilterName;
+                    });
+
+                    if (!hasUser) {
+                        this.attendanceDashboardUserFilter = '';
+                    }
+                }
+
+                const manualManager = (this.manualShiftManager && typeof this.manualShiftManager.setUsers === 'function')
+                    ? this.manualShiftManager
+                    : (window.manualShiftManager && typeof window.manualShiftManager.setUsers === 'function'
+                        ? window.manualShiftManager
+                        : null);
+                if (manualManager) {
+                    const operationalUsers = this.availableUsers.filter(user => !user.syntheticId);
+                    manualManager.setUsers(operationalUsers);
+                }
+
+                const currentUserId = this.normalizeUserIdValue(this.getCurrentUserId());
+                const managedCandidateIds = Array.isArray(options.managedUserIds)
+                    ? options.managedUserIds
+                    : this.managedUserIds || [];
+
+                const managedSet = new Set(
+                    managedCandidateIds
+                        .map(id => this.normalizeUserIdValue(id))
+                        .filter(Boolean)
+                );
+
+                this.rosterManagedUserIds.forEach(id => {
+                    if (id && id !== currentUserId) {
+                        managedSet.add(id);
+                    }
+                });
+                this.contextManagedUserIds.forEach(id => {
+                    if (id && id !== currentUserId) {
+                        managedSet.add(id);
+                    }
+                });
+
+                const appendManagedFromUser = (user) => {
+                    const managedId = this.normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId));
+                    if (managedId && managedId !== currentUserId) {
+                        managedSet.add(managedId);
+                    }
+                };
+
+                rosterList.forEach(appendManagedFromUser);
+                extraCollections.forEach(collection => collection.forEach(appendManagedFromUser));
+
+                if (currentUserId && managedSet.has(currentUserId)) {
+                    managedSet.delete(currentUserId);
+                }
+
+                this.managedUserIdSet = managedSet;
+                this.managedUserIds = Array.from(managedSet);
+
+                if (managedSet.size) {
+                    const seen = new Set();
+                    this.availableUsers.forEach(user => {
+                        const userId = this.normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId));
+                        if (userId && managedSet.has(userId)) {
+                            seen.add(userId);
+                        }
+                    });
+                    this.visibleManagedCount = seen.size;
+                } else {
+                    this.visibleManagedCount = this.availableUsers.filter(user => {
+                        const userId = this.normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId));
+                        return userId && userId !== currentUserId;
+                    }).length || this.availableUsers.length;
+                }
+
+                this.updateUserDropdowns();
+                this.updateUsersList();
+
+                const totalUsersElement = document.getElementById('totalUsers');
+                if (totalUsersElement) {
+                    totalUsersElement.textContent = this.availableUsers.length;
+                }
+
+                const rosterSourceLabel = this.managedRosterSource
+                    ? ` via ${this.managedRosterSource}`
+                    : '';
+                console.log(`✅ Loaded ${this.availableUsers.length} users (including ${rosterList.length} managed roster entries${rosterSourceLabel})`);
+                if (this.userSourceSummary) {
+                    console.log('ℹ️ User source contribution summary:', this.userSourceSummary);
+                }
+            }
+
             async loadUsers() {
                 try {
                     console.log('👥 Loading users...');
@@ -3043,131 +3626,21 @@
                     console.log('🔐 Resolved manager context:', { managerId: currentUserId, campaignId: campaignId || '(all)' });
 
                     const scheduleUsers = await this.callServerFunction('clientGetScheduleUsers', currentUserId, campaignId || null);
-                    const rosterResponse = await this.callServerFunction('clientGetManagedUsers', currentUserId);
+                    const rosterResult = await this.fetchManagedRoster(currentUserId);
+                    const rosterUsers = Array.isArray(rosterResult.users) ? rosterResult.users : [];
 
-                    const rosterUsers = (() => {
-                        if (!rosterResponse) {
-                            return [];
-                        }
-                        if (Array.isArray(rosterResponse)) {
-                            return rosterResponse;
-                        }
-                        if (typeof rosterResponse === 'object' && rosterResponse.success === false) {
-                            console.warn('⚠️ Unable to load managed roster:', rosterResponse.error);
-                            return [];
-                        }
-                        if (typeof rosterResponse === 'object' && Array.isArray(rosterResponse.users)) {
-                            return rosterResponse.users;
-                        }
-                        return [];
-                    })();
-
-                    const byId = new Map();
-                    const pushUserRecord = (user) => {
-                        if (!user || typeof user !== 'object') {
-                            return;
-                        }
-
-                        const normalizedId = this.normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
-                        if (!normalizedId) {
-                            return;
-                        }
-
-                        const existing = byId.get(normalizedId) || {};
-
-                        const normalized = {
-                            ID: normalizedId,
-                            UserName: user.UserName || user.username || existing.UserName || existing.username || normalizedId,
-                            FullName: user.FullName || user.fullName || existing.FullName || existing.fullName || user.UserName || existing.UserName || normalizedId,
-                            Email: user.Email || user.email || existing.Email || '',
-                            CampaignID: user.CampaignID || user.campaignID || user.campaignId || existing.CampaignID || '',
-                            campaignName: user.campaignName || existing.campaignName || '',
-                            EmploymentStatus: user.EmploymentStatus || existing.EmploymentStatus || 'Active',
-                            HireDate: user.HireDate || existing.HireDate || '',
-                            TerminationDate: user.TerminationDate || user.terminationDate || existing.TerminationDate || '',
-                            isActive: typeof user.isActive === 'boolean' ? user.isActive : (typeof existing.isActive === 'boolean' ? existing.isActive : true),
-                            roleNames: Array.isArray(user.roleNames) ? user.roleNames.slice() : (Array.isArray(existing.roleNames) ? existing.roleNames.slice() : [])
-                        };
-
-                        byId.set(normalizedId, normalized);
-                    };
-
-                    (Array.isArray(scheduleUsers) ? scheduleUsers : []).forEach(pushUserRecord);
-                    rosterUsers.forEach(pushUserRecord);
-
-                    this.availableUsers = Array.from(byId.values())
-                        .filter(user => user && user.ID && (user.FullName || user.UserName))
-                        .sort((a, b) => {
-                            const nameA = (a.FullName || a.UserName || '').toLowerCase();
-                            const nameB = (b.FullName || b.UserName || '').toLowerCase();
-                            return nameA.localeCompare(nameB);
-                        });
-
-                    if (this.attendanceDashboardUserFilter) {
-                        const normalizedFilterId = this.normalizeUserIdValue(this.attendanceDashboardUserFilter);
-                        const normalizedFilterName = this.normalizePersonKey(normalizedFilterId);
-                        const hasUser = this.availableUsers.some(user => {
-                            const userId = this.normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId || user.username);
-                            if (userId && userId === normalizedFilterId) {
-                                return true;
-                            }
-                            const nameKey = this.normalizePersonKey(user.FullName || user.UserName || '');
-                            return normalizedFilterName && nameKey === normalizedFilterName;
-                        });
-
-                        if (!hasUser) {
-                            this.attendanceDashboardUserFilter = '';
-                        }
+                    if (rosterResult.error && rosterUsers.length === 0) {
+                        console.warn('⚠️ Managed roster fallback warning:', rosterResult.error);
                     }
 
-                    const manualManager = (this.manualShiftManager && typeof this.manualShiftManager.setUsers === 'function')
-                        ? this.manualShiftManager
-                        : (window.manualShiftManager && typeof window.manualShiftManager.setUsers === 'function'
-                            ? window.manualShiftManager
-                            : null);
-                    if (manualManager) {
-                        manualManager.setUsers(this.availableUsers);
-                    }
-
-                    if (!(this.managedUserIdSet instanceof Set)) {
-                        this.managedUserIdSet = new Set();
-                    }
-
-                    rosterUsers.forEach(user => {
-                        const managedId = this.normalizeUserIdValue(user && (user.ID || user.UserID));
-                        if (managedId && managedId !== currentUserId) {
-                            this.managedUserIdSet.add(managedId);
-                        }
+                    this.applyUsersFromSources(scheduleUsers, rosterUsers, {
+                        rosterSource: rosterResult.source || '',
+                        warnings: rosterResult.error ? [rosterResult.error] : [],
+                        managedUserIds: Array.isArray(rosterResult.managedUserIds) && rosterResult.managedUserIds.length
+                            ? rosterResult.managedUserIds
+                            : this.managedUserIds,
+                        combinedUsers: null
                     });
-
-                    if (this.resolvedManagerId) {
-                        const managerId = this.normalizeUserIdValue(this.resolvedManagerId);
-                        if (managerId && this.managedUserIdSet.has(managerId)) {
-                            this.managedUserIdSet.delete(managerId);
-                        }
-                    }
-
-                    const managedSet = this.managedUserIdSet instanceof Set ? this.managedUserIdSet : new Set();
-                    if (managedSet.size) {
-                        const seen = new Set();
-                        this.availableUsers.forEach(user => {
-                            const userId = this.normalizeUserIdValue(user && (user.ID || user.UserID));
-                            if (userId && managedSet.has(userId)) {
-                                seen.add(userId);
-                            }
-                        });
-                        this.visibleManagedCount = seen.size;
-                    } else {
-                        this.visibleManagedCount = this.availableUsers.filter(user => {
-                            const userId = this.normalizeUserIdValue(user && (user.ID || user.UserID));
-                            return userId && userId !== currentUserId;
-                        }).length || this.availableUsers.length;
-                    }
-
-                    console.log(`✅ Loaded ${this.availableUsers.length} users (including ${rosterUsers.length} managed roster entries)`);
-
-                    // Update user dropdowns
-                    this.updateUserDropdowns();
 
                     if (this.attendanceDashboardData && Number.isFinite(this.attendanceDashboardYear)) {
                         const filteredRecords = this.filterAttendanceDashboardRecords(this.attendanceDashboardRecords, this.attendanceDashboardUserFilter);
@@ -3176,11 +3649,6 @@
                             this.initializeAttendanceDashboard();
                         }
                     }
-
-                    this.updateUsersList();
-
-                    // Update metrics
-                    document.getElementById('totalUsers').textContent = this.availableUsers.length;
 
                 } catch (error) {
                     console.error('❌ Error loading users:', error);
@@ -3198,7 +3666,8 @@
                     if (!dropdown) return;
 
                     if (dropdownId === 'scheduleUsers') {
-                        dropdown.innerHTML = this.availableUsers.map(user => {
+                        const operationalUsers = this.availableUsers.filter(user => !user.syntheticId);
+                        dropdown.innerHTML = operationalUsers.map(user => {
                             const optionValue = user.UserName || user.FullName || user.ID || '';
                             const labelName = this.escapeHtml(user.FullName || user.UserName || 'Unnamed Agent');
                             const campaignLabel = this.escapeHtml(user.campaignName || 'No Campaign');
@@ -3262,9 +3731,13 @@
                     ? '<span class="badge bg-success">Lumina Identity</span>'
                     : '<span class="badge bg-secondary">Limited Identity</span>';
 
+                const syntheticCount = this.availableUsers.filter(user => user.syntheticId).length;
+                const syntheticBadge = syntheticCount
+                    ? `<span class="badge bg-warning text-dark ms-2">${syntheticCount} unlinked</span>`
+                    : '';
                 const summary = `
                     <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2 small text-muted">
-                        <span>Showing <strong>${this.availableUsers.length}</strong> assigned agents for ${managerName}</span>
+                        <span>Showing <strong>${this.availableUsers.length}</strong> assigned agents ${syntheticBadge} for ${managerName}</span>
                         ${identityBadge}
                     </div>
                 `;
@@ -3276,6 +3749,11 @@
                     const status = this.escapeHtml(user.EmploymentStatus || 'Active');
                     const badgeClass = user.isActive ? 'bg-success' : 'bg-secondary';
                     const badgeLabel = this.escapeHtml(user.isActive ? 'Active' : 'Inactive');
+                    const badges = [`<span class="badge ${badgeClass}">${badgeLabel}</span>`];
+                    if (user.syntheticId) {
+                        badges.push('<span class="badge bg-warning text-dark ms-2">Unlinked</span>');
+                    }
+                    const badgesHtml = badges.join('');
 
                     return `
                         <div class="d-flex justify-content-between align-items-center mb-3 p-3 border rounded interactive-item">
@@ -3285,7 +3763,7 @@
                                     ${email} • ${campaign} • ${status}
                                 </small>
                             </div>
-                            <span class="badge ${badgeClass}">${badgeLabel}</span>
+                            <span class="d-inline-flex align-items-center gap-2">${badgesHtml}</span>
                         </div>
                     `;
                 }).join('');
@@ -3297,13 +3775,14 @@
                 const container = document.getElementById('managerStats');
                 if (!container) return;
 
-                const activeUsers = this.availableUsers.filter(u => u.isActive).length;
-                const managedAgents = this.visibleManagedCount || this.availableUsers.length;
+                const operationalUsers = this.availableUsers.filter(u => !u.syntheticId);
+                const activeUsers = operationalUsers.filter(u => u.isActive).length;
+                const managedAgents = this.visibleManagedCount || operationalUsers.length;
                 const rosterAssignments = (this.managedUserIdSet instanceof Set && this.managedUserIdSet.size)
                     ? this.managedUserIdSet.size
                     : managedAgents;
                 const uniqueCampaigns = new Set(
-                    this.availableUsers
+                    operationalUsers
                         .map(user => (user.campaignName || '').trim())
                         .filter(Boolean)
                 ).size;
@@ -3712,6 +4191,19 @@
                 return parts.join(' ');
             }
 
+            applyScheduleDashboard(dashboard) {
+                if (!dashboard || dashboard.success !== true) {
+                    return false;
+                }
+
+                this.updateScheduleMetrics(dashboard);
+                this.renderCoverageChart(dashboard.coverage);
+                this.renderScheduleInsights(dashboard);
+                this.renderFairnessWatchlist(dashboard.fairness);
+                this.renderComplianceAlerts(dashboard.compliance);
+                return true;
+            }
+
             async refreshDashboard() {
                 try {
                     console.log('📊 Refreshing dashboard...');
@@ -3733,13 +4225,7 @@
 
                     const dashboard = await this.callServerFunction('clientGetScheduleDashboard', managerId, campaignId || null, options);
 
-                    if (dashboard && dashboard.success) {
-                        this.updateScheduleMetrics(dashboard);
-                        this.renderCoverageChart(dashboard.coverage);
-                        this.renderScheduleInsights(dashboard);
-                        this.renderFairnessWatchlist(dashboard.fairness);
-                        this.renderComplianceAlerts(dashboard.compliance);
-                    } else {
+                    if (!this.applyScheduleDashboard(dashboard)) {
                         throw new Error(dashboard && dashboard.error ? dashboard.error : 'Unknown dashboard error');
                     }
 
@@ -5609,6 +6095,19 @@
 
             async fetchAttendanceDashboardData(year) {
                 try {
+                    const prefetch = this.attendanceDashboardPrefetch;
+                    if (prefetch && prefetch.year === year && Array.isArray(prefetch.records)) {
+                        this.attendanceDashboardYear = year;
+                        this.attendanceDashboardRecords = prefetch.records.slice();
+                        const filteredPrefetchRecords = this.filterAttendanceDashboardRecords(
+                            this.attendanceDashboardRecords,
+                            this.attendanceDashboardUserFilter
+                        );
+                        this.attendanceDashboardData = this.computeAttendanceDashboard(filteredPrefetchRecords, year);
+                        this.destroyAttendanceDashboardCharts();
+                        return;
+                    }
+
                     const startDate = `${year}-01-01`;
                     const endDate = `${year}-12-31`;
                     const campaignId = this.getCurrentCampaignId ? this.getCurrentCampaignId() || null : null;
@@ -5619,6 +6118,11 @@
                     }
 
                     const records = Array.isArray(response.records) ? response.records : [];
+                    this.attendanceDashboardPrefetch = {
+                        year,
+                        records: records.slice(),
+                        dashboard: prefetch && prefetch.dashboard ? prefetch.dashboard : null
+                    };
                     this.attendanceDashboardRecords = records;
                     this.attendanceDashboardYear = year;
                     const filteredRecords = this.filterAttendanceDashboardRecords(records, this.attendanceDashboardUserFilter);
@@ -7126,14 +7630,64 @@
                     const managerId = this.getCurrentUserId();
                     const campaignId = this.getCurrentCampaignId() || null;
 
-                    const [attendanceUsersRaw, scheduleUsersRaw] = await Promise.all([
-                        this.callServerFunction('clientGetAttendanceUsers', managerId, campaignId),
-                        Array.isArray(this.availableUsers) && this.availableUsers.length
-                            ? Promise.resolve(this.availableUsers)
-                            : this.callServerFunction('clientGetScheduleUsers', managerId, campaignId)
-                    ]);
+                    let scheduleUsers = Array.isArray(this.availableUsers) ? this.availableUsers.slice() : [];
+                    let attendanceUsersRaw = [];
+                    let attendanceRecords = [];
+                    let attendanceYearRecords = [];
+                    const prefetch = this.attendanceCalendarPrefetch;
+                    if (
+                        prefetch
+                        && prefetch.range
+                        && prefetch.range.startDate === monthContext.startDate
+                        && prefetch.range.endDate === monthContext.endDate
+                    ) {
+                        console.log('📅 Using prefetched attendance data for %s', monthContext.label);
+                        attendanceUsersRaw = Array.isArray(prefetch.users) ? prefetch.users.slice() : [];
+                        attendanceRecords = Array.isArray(prefetch.monthlyRecords) ? prefetch.monthlyRecords.slice() : [];
+                        attendanceYearRecords = Array.isArray(prefetch.yearlyRecords)
+                            ? prefetch.yearlyRecords.slice()
+                            : attendanceRecords.slice();
+                    } else {
+                        const [attendanceUsersResponse, scheduleUsersResponse] = await Promise.all([
+                            this.callServerFunction('clientGetAttendanceUsers', managerId, campaignId),
+                            scheduleUsers.length
+                                ? Promise.resolve(scheduleUsers)
+                                : this.callServerFunction('clientGetScheduleUsers', managerId, campaignId)
+                        ]);
 
-                    const scheduleUsers = Array.isArray(scheduleUsersRaw) ? scheduleUsersRaw : [];
+                        attendanceUsersRaw = Array.isArray(attendanceUsersResponse) ? attendanceUsersResponse : [];
+                        scheduleUsers = Array.isArray(scheduleUsersResponse) ? scheduleUsersResponse : scheduleUsers;
+
+                        let attendanceResponse = null;
+                        try {
+                            attendanceResponse = await this.callServerFunction(
+                                'clientGetAttendanceDataRange',
+                                monthContext.startDate,
+                                monthContext.endDate,
+                                campaignId
+                            );
+                            if (attendanceResponse && attendanceResponse.success) {
+                                attendanceRecords = Array.isArray(attendanceResponse.records)
+                                    ? attendanceResponse.records
+                                    : [];
+                            } else if (attendanceResponse && attendanceResponse.error) {
+                                console.warn('Attendance data range request returned an error:', attendanceResponse.error);
+                            }
+                        } catch (attendanceError) {
+                            console.error('Unable to load attendance statuses for calendar:', attendanceError);
+                        }
+
+                        attendanceYearRecords = attendanceResponse && attendanceResponse.success
+                            ? (Array.isArray(attendanceResponse.records) ? attendanceResponse.records.slice() : [])
+                            : attendanceRecords.slice();
+
+                        this.attendanceCalendarPrefetch = {
+                            range: monthContext,
+                            users: attendanceUsersRaw.slice(),
+                            monthlyRecords: attendanceRecords.slice(),
+                            yearlyRecords: attendanceYearRecords.slice()
+                        };
+                    }
 
                     if (!Array.isArray(this.availableUsers) || !this.availableUsers.length) {
                         this.availableUsers = scheduleUsers.slice();
@@ -7193,25 +7747,11 @@
 
                     const userEntries = this.buildAttendanceUserEntries(combinedUsers, employedScheduleUsers);
 
-                    let attendanceRecords = [];
-                    try {
-                        const attendanceResponse = await this.callServerFunction(
-                            'clientGetAttendanceDataRange',
-                            monthContext.startDate,
-                            monthContext.endDate,
-                            campaignId
-                        );
-                        if (attendanceResponse && attendanceResponse.success) {
-                            attendanceRecords = Array.isArray(attendanceResponse.records) ? attendanceResponse.records : [];
-                        } else {
-                            console.warn('Attendance data range request returned an error:', attendanceResponse?.error);
-                        }
-                    } catch (attendanceError) {
-                        console.error('Unable to load attendance statuses for calendar:', attendanceError);
-                    }
-
                     this.attendanceCalendarRecords = attendanceRecords;
-                    this.mergeAttendanceDashboardRecords(attendanceRecords, monthContext.year);
+                    const mergeSource = attendanceYearRecords.length ? attendanceYearRecords : attendanceRecords;
+                    if (mergeSource.length) {
+                        this.mergeAttendanceDashboardRecords(mergeSource, monthContext.year);
+                    }
                     const attendanceMap = this.buildAttendanceRecordMap(attendanceRecords);
 
                     const calendar = this.generateAttendanceCalendarGrid(
@@ -9001,6 +9541,19 @@
                 return local.toISOString().split('T')[0];
             }
 
+            resolveIsoDate(value, fallback = null) {
+                const parsed = this.parseDateValue(value);
+                if (parsed) {
+                    return this.toIsoDateString(parsed);
+                }
+
+                if (fallback) {
+                    return this.resolveIsoDate(fallback);
+                }
+
+                return '';
+            }
+
             renderImportPreview(schedules, options = {}, summary = {}) {
                 const container = document.getElementById('importPreview');
                 if (!container) return;
@@ -9191,6 +9744,50 @@
                 return months[index] || '';
             }
 
+            buildHolidaySummaryMarkup(response) {
+                const countryNames = {
+                    'JM': 'Jamaica',
+                    'US': 'United States',
+                    'DO': 'Dominican Republic',
+                    'PH': 'Philippines'
+                };
+
+                const holidays = Array.isArray(response?.holidays) ? response.holidays : [];
+                const countryCode = response?.country || response?.countryCode || '';
+                const countryName = countryNames[countryCode] || countryCode || 'Selected Country';
+                const year = response?.year || new Date().getFullYear();
+                const isPrimary = !!response?.isPrimary;
+
+                if (!holidays.length) {
+                    return `
+                        <div class="alert alert-info-modern">
+                            <h6><i class="fas fa-info-circle me-2"></i>No holidays imported yet</h6>
+                            <p class="mb-0">Use the form above to import holidays for ${this.escapeHtml(countryName)} ${this.escapeHtml(String(year))}.</p>
+                        </div>
+                    `;
+                }
+
+                const rows = holidays.map(holiday => `
+                    <div class="col-md-6 mb-1">
+                        <small>
+                            <strong>${this.escapeHtml(holiday.name || holiday.Name || 'Holiday')}</strong> - ${this.formatDate(holiday.date || holiday.Date || '')}
+                        </small>
+                    </div>
+                `).join('');
+
+                return `
+                    <div class="alert ${isPrimary ? 'alert-success' : 'alert-info'}-modern">
+                        <h6>
+                            <i class="fas fa-calendar-day me-2"></i>
+                            ${this.escapeHtml(countryName)} Holidays ${this.escapeHtml(String(year))} ${isPrimary ? '(PRIMARY - Takes Precedence)' : ''}
+                        </h6>
+                        <div class="row">
+                            ${rows}
+                        </div>
+                    </div>
+                `;
+            }
+
             async importHolidays() {
                 try {
                     this.showLoading(true);
@@ -9269,9 +9866,15 @@
                 await this.refreshHolidays();
             }
 
-            async refreshHolidays() {
+            async refreshHolidays(force = false) {
                 const container = document.getElementById('currentHolidays');
                 if (!container) return;
+
+                const usePrefetch = !force && this.holidayPrefetch && this.holidayPrefetch.success;
+                if (usePrefetch) {
+                    container.innerHTML = this.buildHolidaySummaryMarkup(this.holidayPrefetch);
+                    return;
+                }
 
                 container.innerHTML = `
                         <div class="text-center py-4">
@@ -9280,18 +9883,30 @@
                         </div>
                     `;
 
-                // Simulate loading current holidays
-                setTimeout(() => {
+                try {
+                    const countrySelect = document.getElementById('holidayCountry');
+                    const yearSelect = document.getElementById('holidayYear');
+                    const countryCode = countrySelect ? countrySelect.value : (this.holidayPrefetch?.country || 'JM');
+                    const yearValue = yearSelect ? yearSelect.value : (this.holidayPrefetch?.year || new Date().getFullYear());
+
+                    const response = await this.callServerFunction('clientGetCountryHolidays', countryCode, yearValue);
+
+                    if (response && response.success) {
+                        this.holidayPrefetch = response;
+                        container.innerHTML = this.buildHolidaySummaryMarkup(response);
+                        return;
+                    }
+
+                    throw new Error(response?.error || 'Failed to load holidays');
+                } catch (error) {
+                    console.error('Unable to refresh holidays:', error);
                     container.innerHTML = `
-                            <div class="alert alert-info-modern">
-                                <h6><i class="fas fa-info-circle me-2"></i>Holiday System Ready</h6>
-                                <p class="mb-0">
-                                    The holiday system is configured for Jamaica (primary), United States, Dominican Republic, and Philippines. 
-                                    Import holidays using the form above to populate the system.
-                                </p>
-                            </div>
-                        `;
-                }, 1000);
+                        <div class="alert alert-info-modern">
+                            <h6><i class="fas fa-info-circle me-2"></i>Holiday System</h6>
+                            <p class="mb-0">Unable to load holiday data automatically. Use the import form above to configure holidays.</p>
+                        </div>
+                    `;
+                }
             }
 
             onTabChange(target) {

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -612,8 +612,8 @@ function clientGetScheduleUsers(requestingUserId, campaignId = null) {
     const normalizedCampaignId = normalizeCampaignIdValue(campaignId);
     console.log('🔍 Getting schedule users for:', requestingUserId, 'campaign:', normalizedCampaignId || '(not provided)');
 
-    // Use MainUtilities to get all users
-    const allUsers = readSheet(USERS_SHEET) || [];
+    const userLookup = buildScheduleUserLookupIndex();
+    const allUsers = Array.isArray(userLookup.users) ? userLookup.users : [];
     if (allUsers.length === 0) {
       console.warn('No users found in Users sheet');
       return [];
@@ -622,7 +622,7 @@ function clientGetScheduleUsers(requestingUserId, campaignId = null) {
     const normalizedManagerId = normalizeUserIdValue(requestingUserId);
     let requestingUser = null;
     if (normalizedManagerId) {
-      requestingUser = allUsers.find(u => normalizeUserIdValue(u && u.ID) === normalizedManagerId) || null;
+      requestingUser = allUsers.find(u => normalizeUserIdValue(u && (u.ID || u.UserID)) === normalizedManagerId) || null;
     }
 
     let effectiveCampaignId = normalizedCampaignId;
@@ -647,47 +647,55 @@ function clientGetScheduleUsers(requestingUserId, campaignId = null) {
 
     let filteredUsers = allUsers;
 
-    // Filter by campaign if specified - use MainUtilities campaign functions
     if (effectiveCampaignId) {
       filteredUsers = filterUsersByCampaign(allUsers, effectiveCampaignId);
     }
 
-    // Apply manager permissions using MainUtilities functions
     if (normalizedManagerId) {
       if (requestingUser) {
         const isAdmin = scheduleFlagToBool(requestingUser.IsAdmin);
 
         if (!isAdmin) {
           const managedUserIds = buildManagedUserSet(normalizedManagerId);
+          const hasManagedRoster = Array.from(managedUserIds).some(id => id && id !== normalizedManagerId);
 
-          filteredUsers = filteredUsers.filter(user => managedUserIds.has(normalizeUserIdValue(user && user.ID)));
+          let restrictedUsers = [];
+          if (hasManagedRoster) {
+            restrictedUsers = filteredUsers.filter(user => managedUserIds.has(normalizeUserIdValue(user && (user.ID || user.UserID))));
+          }
+
+          if (!restrictedUsers.length) {
+            const fallbackRoster = collectCampaignUsersForManager(normalizedManagerId, { allUsers });
+            const fallbackSet = new Set(
+              (fallbackRoster.users || [])
+                .map(user => normalizeUserIdValue(user && (user.ID || user.UserID)))
+                .filter(Boolean)
+            );
+            const hasFallbackRoster = Array.from(fallbackSet).some(id => id && id !== normalizedManagerId);
+
+            if (hasFallbackRoster) {
+              restrictedUsers = filteredUsers.filter(user => fallbackSet.has(normalizeUserIdValue(user && (user.ID || user.UserID))));
+            }
+          }
+
+          if (restrictedUsers.length) {
+            filteredUsers = restrictedUsers;
+          } else {
+            console.warn('Managed roster empty for manager', normalizedManagerId, '- using campaign roster');
+          }
         }
       } else {
         console.warn('Requesting user not found when applying manager filter:', requestingUserId);
       }
     }
 
-    // Transform to schedule-friendly format
     const scheduleUsers = filteredUsers
-      .filter(user => user && user.ID && (user.UserName || user.FullName))
+      .filter(user => user && (user.ID || user.UserID) && (user.UserName || user.FullName || user.Username))
       .filter(user => !isScheduleNameRestricted(user))
       .filter(user => !isScheduleRoleRestricted(user))
       .filter(user => isUserConsideredActive(user))
-      .map(user => {
-        const campaignName = getCampaignById(user.CampaignID)?.Name || '';
-        return {
-          ID: user.ID,
-          UserName: user.UserName || user.FullName,
-          FullName: user.FullName || user.UserName,
-          Email: user.Email || '',
-          CampaignID: user.CampaignID || '',
-          campaignName: campaignName,
-          EmploymentStatus: user.EmploymentStatus || 'Active',
-          HireDate: user.HireDate || '',
-          TerminationDate: user.TerminationDate || user.terminationDate || '',
-          isActive: isUserConsideredActive(user)
-        };
-      });
+      .map(user => normalizeScheduleUserRecord(user, userLookup))
+      .filter(Boolean);
 
     console.log(`✅ Returning ${scheduleUsers.length} schedule users`);
     return scheduleUsers;
@@ -697,6 +705,63 @@ function clientGetScheduleUsers(requestingUserId, campaignId = null) {
     safeWriteError('clientGetScheduleUsers', error);
     return [];
   }
+}
+
+function normalizeScheduleUserRecord(user, lookup = null) {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+
+  const normalizedId = normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId || user.UserName || user.username);
+  if (!normalizedId) {
+    return null;
+  }
+
+  let baseRecord = user;
+  if (lookup && typeof lookup === 'object' && Array.isArray(lookup.users)) {
+    const lookupRecord = lookup.users.find(entry => normalizeUserIdValue(entry && (entry.ID || entry.UserID)) === normalizedId);
+    if (lookupRecord) {
+      baseRecord = Object.assign({}, lookupRecord, baseRecord);
+    }
+  }
+
+  const campaignId = normalizeCampaignIdValue(
+    baseRecord.CampaignID
+      || baseRecord.campaignID
+      || baseRecord.CampaignId
+      || baseRecord.campaignId
+  );
+
+  let campaignName = baseRecord.campaignName
+    || baseRecord.CampaignName
+    || baseRecord.campaign
+    || baseRecord.Campaign
+    || '';
+
+  if (!campaignName && campaignId && typeof getCampaignById === 'function') {
+    try {
+      const campaignRecord = getCampaignById(campaignId);
+      if (campaignRecord) {
+        campaignName = campaignRecord.Name || campaignRecord.name || campaignName;
+      }
+    } catch (campaignError) {
+      console.warn('Unable to resolve campaign name for user', campaignId, campaignError);
+    }
+  }
+
+  return {
+    ID: normalizedId,
+    UserName: baseRecord.UserName || baseRecord.Username || baseRecord.username || baseRecord.FullName || '',
+    FullName: baseRecord.FullName || baseRecord.fullName || baseRecord.UserName || baseRecord.Username || '',
+    Email: baseRecord.Email || baseRecord.email || '',
+    CampaignID: campaignId || '',
+    campaignName: campaignName || '',
+    EmploymentStatus: baseRecord.EmploymentStatus || baseRecord.employmentStatus || 'Active',
+    HireDate: baseRecord.HireDate || baseRecord.hireDate || '',
+    TerminationDate: baseRecord.TerminationDate || baseRecord.terminationDate || '',
+    isActive: isUserConsideredActive(baseRecord),
+    roleNames: baseRecord.roleNames || baseRecord.RoleNames || []
+  };
 }
 
 /**
@@ -729,27 +794,106 @@ function clientGetAttendanceUsers(requestingUserId, campaignId = null) {
 function clientGetManagedUsersList(managerId) {
   try {
     if (!managerId) return [];
-    
-    // Use MainUtilities function for managed campaigns
-    const managedCampaigns = getUserManagedCampaigns(managerId);
+
+    const normalizedManagerId = normalizeUserIdValue(managerId);
+    const userLookup = buildScheduleUserLookupIndex();
     const managedUsers = [];
-    
-    managedCampaigns.forEach(campaign => {
-      const campaignUsers = getUsersByCampaign(campaign.ID);
-      campaignUsers.forEach(user => {
-        if (String(user.ID) !== String(managerId)) { // Don't include self
-          managedUsers.push({
-            ID: user.ID,
-            UserName: user.UserName,
-            FullName: user.FullName,
-            Email: user.Email,
-            CampaignID: user.CampaignID,
-            campaignName: campaign.Name,
-            EmploymentStatus: user.EmploymentStatus
-          });
+    const seen = new Set();
+
+    const pushUser = (user, campaignInfo = {}) => {
+      if (!user || typeof user !== 'object') {
+        return;
+      }
+
+      const candidateIds = extractUserIdsFromCandidates([user], userLookup);
+      const normalizedId = candidateIds.length
+        ? normalizeUserIdValue(candidateIds[0])
+        : normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+
+      if (!normalizedId || normalizedId === normalizedManagerId || seen.has(normalizedId)) {
+        return;
+      }
+
+      seen.add(normalizedId);
+
+      const campaignId = normalizeCampaignIdValue(
+        campaignInfo.campaignId
+          || user.CampaignID
+          || user.campaignID
+          || user.CampaignId
+          || user.campaignId
+      );
+
+      let campaignName = campaignInfo.campaignName
+        || user.campaignName
+        || user.CampaignName
+        || user.campaign;
+
+      if (!campaignName && campaignId && typeof getCampaignById === 'function') {
+        try {
+          const campaignRecord = getCampaignById(campaignId);
+          if (campaignRecord) {
+            campaignName = campaignRecord.Name || campaignRecord.name || '';
+          }
+        } catch (campaignError) {
+          console.warn('Unable to resolve campaign details for roster entry', campaignId, campaignError);
         }
+      }
+
+      managedUsers.push({
+        ID: normalizedId,
+        UserName: user.UserName || user.Username || user.username || user.FullName || '',
+        FullName: user.FullName || user.fullName || user.UserName || user.Username || '',
+        Email: user.Email || user.email || '',
+        CampaignID: campaignId || '',
+        campaignName: campaignName || '',
+        EmploymentStatus: user.EmploymentStatus || 'Active'
       });
+    };
+
+    let managedCampaigns = [];
+    if (typeof getUserManagedCampaigns === 'function') {
+      try {
+        const rawManaged = getUserManagedCampaigns(normalizedManagerId) || [];
+        managedCampaigns = Array.isArray(rawManaged) ? rawManaged : [];
+      } catch (campaignError) {
+        console.warn('Unable to resolve managed campaigns for roster', normalizedManagerId, campaignError);
+      }
+    }
+
+    managedCampaigns.forEach(campaign => {
+      const campaignId = normalizeCampaignIdValue(
+        campaign && (campaign.ID || campaign.Id || campaign.id || campaign.CampaignID || campaign.CampaignId)
+      );
+
+      if (!campaignId) {
+        return;
+      }
+
+      let campaignUsers = [];
+      if (typeof getUsersByCampaign === 'function') {
+        try {
+          campaignUsers = getUsersByCampaign(campaignId) || [];
+        } catch (campaignError) {
+          console.warn('Unable to read campaign roster for manager', normalizedManagerId, campaignId, campaignError);
+        }
+      }
+
+      if ((!Array.isArray(campaignUsers) || !campaignUsers.length) && userLookup.users.length) {
+        campaignUsers = userLookup.users.filter(user => doesUserBelongToCampaign(user, campaignId));
+      }
+
+      const campaignName = campaign && (campaign.Name || campaign.name || '');
+      campaignUsers.forEach(user => pushUser(user, { campaignId, campaignName }));
     });
+
+    if (!managedUsers.length) {
+      const fallback = collectCampaignUsersForManager(normalizedManagerId, { allUsers: userLookup.users });
+      fallback.users.forEach(user => pushUser(user, {
+        campaignId: fallback.campaignId,
+        campaignName: fallback.campaignName
+      }));
+    }
 
     return managedUsers;
 
@@ -871,6 +1015,271 @@ function clientCreateShiftSlot(slotData) {
   }
 }
 
+function buildScheduleUserLookupIndex() {
+  const lookup = {
+    users: [],
+    byId: new Map(),
+    byEmail: new Map(),
+    byUserName: new Map(),
+    byFullName: new Map()
+  };
+
+  try {
+    const users = readSheet(USERS_SHEET) || [];
+    lookup.users = users;
+
+    users.forEach(user => {
+      if (!user || typeof user !== 'object') {
+        return;
+      }
+
+      const normalizedId = normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+      const normalizedEmail = (user.Email || user.email || '').toString().trim().toLowerCase();
+      const normalizedUserName = (user.UserName || user.Username || user.username || '').toString().trim().toLowerCase();
+      const normalizedFullName = (user.FullName || user.fullName || '').toString().trim().toLowerCase();
+
+      if (normalizedId) {
+        lookup.byId.set(normalizedId, normalizedId);
+      }
+      if (normalizedEmail && !lookup.byEmail.has(normalizedEmail)) {
+        lookup.byEmail.set(normalizedEmail, normalizedId || normalizedEmail);
+      }
+      if (normalizedUserName && !lookup.byUserName.has(normalizedUserName)) {
+        lookup.byUserName.set(normalizedUserName, normalizedId || normalizedUserName);
+      }
+      if (normalizedFullName && !lookup.byFullName.has(normalizedFullName)) {
+        lookup.byFullName.set(normalizedFullName, normalizedId || normalizedFullName);
+      }
+    });
+  } catch (error) {
+    console.warn('Unable to build schedule user lookup index:', error && error.message ? error.message : error);
+  }
+
+  return lookup;
+}
+
+function resolveUserIdViaLookup(candidate, lookup) {
+  if (candidate === null || typeof candidate === 'undefined') {
+    return '';
+  }
+
+  if (Array.isArray(candidate)) {
+    for (let index = 0; index < candidate.length; index++) {
+      const resolved = resolveUserIdViaLookup(candidate[index], lookup);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return '';
+  }
+
+  if (typeof candidate === 'object') {
+    const objectCandidates = [
+      candidate.ID, candidate.Id, candidate.id,
+      candidate.UserID, candidate.UserId, candidate.userId,
+      candidate.ManagedUserID, candidate.ManagedUserId, candidate.managedUserId,
+      candidate.ManagerID, candidate.ManagerId, candidate.managerId,
+      candidate.Email, candidate.email,
+      candidate.UserEmail, candidate.userEmail,
+      candidate.ManagedEmail, candidate.managedEmail,
+      candidate.UserName, candidate.Username, candidate.username,
+      candidate.ManagedUserName, candidate.managedUserName, candidate.ManagedUsername, candidate.managedUsername,
+      candidate.FullName, candidate.fullName,
+      candidate.Name, candidate.name
+    ];
+
+    for (let index = 0; index < objectCandidates.length; index++) {
+      const resolved = resolveUserIdViaLookup(objectCandidates[index], lookup);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return '';
+  }
+
+  const raw = String(candidate).trim();
+  if (!raw) {
+    return '';
+  }
+
+  const normalizedId = normalizeUserIdValue(raw);
+  if (lookup && lookup.byId && lookup.byId.has(normalizedId)) {
+    return lookup.byId.get(normalizedId) || normalizedId;
+  }
+
+  const lower = raw.toLowerCase();
+  if (lookup && lookup.byEmail && lookup.byEmail.has(lower)) {
+    return lookup.byEmail.get(lower) || lower;
+  }
+  if (lookup && lookup.byUserName && lookup.byUserName.has(lower)) {
+    return lookup.byUserName.get(lower) || lower;
+  }
+  if (lookup && lookup.byFullName && lookup.byFullName.has(lower)) {
+    return lookup.byFullName.get(lower) || lower;
+  }
+
+  return normalizedId;
+}
+
+function extractUserIdsFromCandidates(candidates, lookup) {
+  const ids = [];
+
+  const visit = (value) => {
+    if (value === null || typeof value === 'undefined') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+
+    if (typeof value === 'object') {
+      const objectCandidates = [
+        value.ID, value.Id, value.id,
+        value.UserID, value.UserId, value.userId,
+        value.ManagedUserID, value.ManagedUserId, value.managedUserId,
+        value.ManagerID, value.ManagerId, value.managerId,
+        value.Email, value.email,
+        value.UserEmail, value.userEmail,
+        value.ManagedEmail, value.managedEmail,
+        value.UserName, value.Username, value.username,
+        value.ManagedUserName, value.managedUserName, value.ManagedUsername, value.managedUsername,
+        value.FullName, value.fullName,
+        value.Name, value.name
+      ];
+
+      const objectLists = [
+        value.Users, value.users,
+        value.ManagedUsers, value.managedUsers,
+        value.UserIDs, value.UserIds, value.userIds,
+        value.ManagedIds, value.managedIds, value.ManagedIDs, value.managedIDs,
+        value.TeamMembers, value.teamMembers
+      ];
+
+      objectCandidates.forEach(visit);
+      objectLists.forEach(visit);
+      return;
+    }
+
+    const raw = String(value);
+    if (/[;,|]/.test(raw)) {
+      raw.split(/[;,|]/).forEach(part => visit(part));
+      return;
+    }
+
+    const resolved = resolveUserIdViaLookup(raw, lookup);
+    if (resolved) {
+      ids.push(resolved);
+    }
+  };
+
+  (Array.isArray(candidates) ? candidates : [candidates]).forEach(visit);
+
+  return Array.from(new Set(ids.filter(Boolean)));
+}
+
+function collectCampaignUsersForManager(managerId, options = {}) {
+  const normalizedManagerId = normalizeUserIdValue(managerId);
+  const result = {
+    users: [],
+    campaignId: '',
+    campaignName: ''
+  };
+
+  if (!normalizedManagerId) {
+    return result;
+  }
+
+  const providedUsers = Array.isArray(options.allUsers) ? options.allUsers : null;
+  let allUsers = providedUsers || [];
+
+  if (!allUsers.length) {
+    try {
+      allUsers = readSheet(USERS_SHEET) || [];
+    } catch (error) {
+      console.warn('Unable to read users for campaign roster fallback:', error && error.message ? error.message : error);
+      allUsers = [];
+    }
+  }
+
+  let managerRecord = null;
+  if (allUsers.length) {
+    managerRecord = allUsers.find(user => normalizeUserIdValue(user && user.ID) === normalizedManagerId) || null;
+  }
+
+  const candidateCampaignIds = [];
+  if (managerRecord) {
+    candidateCampaignIds.push(
+      managerRecord.CampaignID,
+      managerRecord.campaignID,
+      managerRecord.CampaignId,
+      managerRecord.campaignId,
+      managerRecord.DefaultCampaignID,
+      managerRecord.defaultCampaignId
+    );
+  }
+
+  if (typeof getUserCampaignsSafe === 'function') {
+    try {
+      const joinedCampaigns = getUserCampaignsSafe(normalizedManagerId) || [];
+      joinedCampaigns.forEach(entry => {
+        if (!entry) {
+          return;
+        }
+        candidateCampaignIds.push(
+          entry.campaignId,
+          entry.CampaignId,
+          entry.campaignID,
+          entry.CampaignID,
+          entry.id,
+          entry.Id,
+          entry.ID
+        );
+      });
+    } catch (error) {
+      console.warn('Unable to resolve campaign membership for manager', normalizedManagerId, error);
+    }
+  }
+
+  let resolvedCampaignId = '';
+  for (let index = 0; index < candidateCampaignIds.length; index++) {
+    const normalized = normalizeCampaignIdValue(candidateCampaignIds[index]);
+    if (normalized) {
+      resolvedCampaignId = normalized;
+      break;
+    }
+  }
+
+  if (!resolvedCampaignId) {
+    return result;
+  }
+
+  let campaignUsers = [];
+  if (typeof getUsersByCampaign === 'function') {
+    try {
+      campaignUsers = getUsersByCampaign(resolvedCampaignId) || [];
+    } catch (error) {
+      console.warn('Unable to read campaign users for roster fallback', resolvedCampaignId, error);
+    }
+  }
+
+  if ((!Array.isArray(campaignUsers) || !campaignUsers.length) && allUsers.length) {
+    campaignUsers = allUsers.filter(user => doesUserBelongToCampaign(user, resolvedCampaignId));
+  }
+
+  const campaignRecord = typeof getCampaignById === 'function'
+    ? getCampaignById(resolvedCampaignId)
+    : null;
+
+  result.users = Array.isArray(campaignUsers) ? campaignUsers.filter(Boolean) : [];
+  result.campaignId = resolvedCampaignId;
+  result.campaignName = campaignRecord ? (campaignRecord.Name || campaignRecord.name || '') : '';
+
+  return result;
+}
+
 function getDirectManagedUserIds(managerId) {
   const normalizedManagerId = normalizeUserIdValue(managerId);
   const managedUsers = new Set();
@@ -878,6 +1287,8 @@ function getDirectManagedUserIds(managerId) {
   if (!normalizedManagerId) {
     return managedUsers;
   }
+
+  const userLookup = buildScheduleUserLookupIndex();
 
   const appendFromRows = (rows) => {
     if (!Array.isArray(rows)) {
@@ -889,18 +1300,36 @@ function getDirectManagedUserIds(managerId) {
         return;
       }
 
-      const managerCandidates = [
+      const managerCandidates = extractUserIdsFromCandidates([
         row.ManagerUserID, row.ManagerUserId, row.managerUserId,
         row.ManagerID, row.ManagerId, row.managerId, row.manager_id,
-        row.UserManagerID, row.UserManagerId, row.userManagerId
-      ].map(normalizeUserIdValue).filter(Boolean);
+        row.UserManagerID, row.UserManagerId, row.userManagerId,
+        row.ManagerEmail, row.managerEmail, row.ManagerEmailAddress, row.managerEmailAddress,
+        row.ManagerUserName, row.managerUserName, row.ManagerUsername, row.managerUsername,
+        row.ManagerName, row.managerName,
+        row.Manager, row.manager,
+        row.SupervisorID, row.SupervisorId, row.supervisorId,
+        row.SupervisorEmail, row.supervisorEmail
+      ], userLookup);
 
-      const managedCandidates = [
+      const managedCandidates = extractUserIdsFromCandidates([
         row.UserID, row.UserId, row.userId,
         row.ManagedUserID, row.ManagedUserId, row.managedUserId,
         row.ManagedUserID, row.managed_user_id,
-        row.ManagedID, row.ManagedId
-      ].map(normalizeUserIdValue).filter(Boolean);
+        row.ManagedID, row.ManagedId, row.managedId,
+        row.ManagedUsers, row.managedUsers,
+        row.UserEmail, row.userEmail, row.Email, row.email,
+        row.ManagedEmail, row.managedEmail, row.ManagedEmailAddress, row.managedEmailAddress,
+        row.UserName, row.Username, row.username,
+        row.ManagedUserName, row.managedUserName, row.ManagedUsername, row.managedUsername,
+        row.ManagedName, row.managedName,
+        row.Name, row.name,
+        row.TeamMemberID, row.TeamMemberId, row.teamMemberId,
+        row.TeamMembers, row.teamMembers,
+        row.AgentID, row.AgentId, row.agentId,
+        row.AgentEmail, row.agentEmail,
+        row.AgentName, row.agentName
+      ], userLookup);
 
       const managerMatch = managerCandidates.find(candidate => candidate === normalizedManagerId);
 
@@ -950,6 +1379,23 @@ function getDirectManagedUserIds(managerId) {
     }
   });
 
+  let hasManagedUsers = false;
+  managedUsers.forEach(id => {
+    if (id && id !== normalizedManagerId) {
+      hasManagedUsers = true;
+    }
+  });
+
+  if (!hasManagedUsers) {
+    const fallback = collectCampaignUsersForManager(normalizedManagerId, { allUsers: userLookup.users });
+    const fallbackIds = extractUserIdsFromCandidates(fallback.users, userLookup);
+    fallbackIds.forEach(id => {
+      if (id && id !== normalizedManagerId) {
+        managedUsers.add(id);
+      }
+    });
+  }
+
   return managedUsers;
 }
 
@@ -985,6 +1431,13 @@ function buildManagedUserSet(managerId) {
   } catch (error) {
     console.warn('Unable to expand managed users via campaigns:', error);
   }
+
+  let hasManagedUsers = false;
+  managedUserIds.forEach(id => {
+    if (id && id !== normalizedManagerId) {
+      hasManagedUsers = true;
+    }
+  });
 
   return managedUserIds;
 }
@@ -2410,16 +2863,25 @@ function clientGetCountryHolidays(countryCode, year) {
   try {
     console.log('🎉 Getting holidays for:', countryCode, year);
 
-    if (!SCHEDULE_SETTINGS.SUPPORTED_COUNTRIES.includes(countryCode)) {
+    const scheduleConfig = (typeof SCHEDULE_SETTINGS === 'object' && SCHEDULE_SETTINGS)
+      || (typeof getScheduleConfig === 'function' ? getScheduleConfig() : {});
+    const supportedCountries = Array.isArray(scheduleConfig.SUPPORTED_COUNTRIES) && scheduleConfig.SUPPORTED_COUNTRIES.length
+      ? scheduleConfig.SUPPORTED_COUNTRIES
+      : ['JM', 'US', 'DO', 'PH'];
+    const primaryCountry = typeof scheduleConfig.PRIMARY_COUNTRY === 'string' && scheduleConfig.PRIMARY_COUNTRY.trim()
+      ? scheduleConfig.PRIMARY_COUNTRY.trim()
+      : 'JM';
+
+    if (!supportedCountries.includes(countryCode)) {
       return {
         success: false,
-        error: `Country ${countryCode} not supported. Supported countries: ${SCHEDULE_SETTINGS.SUPPORTED_COUNTRIES.join(', ')}`,
+        error: `Country ${countryCode} not supported. Supported countries: ${supportedCountries.join(', ')}`,
         holidays: []
       };
     }
 
     const holidays = getUpdatedHolidays(countryCode, year);
-    const isPrimary = countryCode === SCHEDULE_SETTINGS.PRIMARY_COUNTRY;
+    const isPrimary = countryCode === primaryCountry;
 
     return {
       success: true,
@@ -4258,6 +4720,515 @@ function clientGetScheduleDashboard(managerIdCandidate, campaignIdCandidate, opt
     return {
       success: false,
       error: error.message
+    };
+  }
+}
+
+function normalizeManagedRosterPayload(payload) {
+  const result = {
+    recognized: false,
+    users: [],
+    error: null
+  };
+
+  if (payload == null) {
+    return result;
+  }
+
+  if (Array.isArray(payload)) {
+    result.recognized = true;
+    result.users = payload.filter(user => user && typeof user === 'object');
+    return result;
+  }
+
+  if (payload && typeof payload === 'object') {
+    if (Array.isArray(payload.users)) {
+      result.recognized = true;
+      result.users = payload.users.filter(user => user && typeof user === 'object');
+      if (payload.success === false && payload.error) {
+        result.error = String(payload.error);
+      }
+      return result;
+    }
+
+    if (Array.isArray(payload.managedUsers)) {
+      result.recognized = true;
+      result.users = payload.managedUsers.filter(user => user && typeof user === 'object');
+      if (payload.success === false && payload.error) {
+        result.error = String(payload.error);
+      }
+      return result;
+    }
+
+    if (payload.success === false && payload.error) {
+      result.recognized = true;
+      result.error = String(payload.error);
+    }
+  }
+
+  return result;
+}
+
+function resolveUnifiedManagedRoster(managerId) {
+  const normalizedManagerId = normalizeUserIdValue(managerId);
+  const response = {
+    users: [],
+    source: '',
+    warnings: [],
+    managedUserIds: []
+  };
+
+  if (!normalizedManagerId) {
+    response.warnings.push('Manager identifier unavailable for roster resolution.');
+    return response;
+  }
+
+  const userLookup = buildScheduleUserLookupIndex();
+
+  const attempts = [
+    { name: 'clientGetManagedUsersList', fn: () => clientGetManagedUsersList(normalizedManagerId) },
+    {
+      name: 'clientGetManagedUsers',
+      fn: () => (typeof clientGetManagedUsers === 'function' ? clientGetManagedUsers(normalizedManagerId) : null)
+    }
+  ];
+
+  for (let index = 0; index < attempts.length; index++) {
+    const attempt = attempts[index];
+    if (typeof attempt.fn !== 'function') {
+      continue;
+    }
+
+    try {
+      const raw = attempt.fn();
+      const parsed = normalizeManagedRosterPayload(raw);
+
+      if (!parsed.recognized) {
+        continue;
+      }
+
+      if (parsed.error) {
+        response.warnings.push(`${attempt.name}: ${parsed.error}`);
+      }
+
+      response.users = parsed.users;
+      response.source = attempt.name;
+      break;
+    } catch (error) {
+      response.warnings.push(`${attempt.name}: ${error && error.message ? error.message : error}`);
+    }
+  }
+
+  const rosterIdSet = new Set(
+    response.users
+      .map(user => normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId)))
+      .filter(Boolean)
+  );
+
+  const managedSet = buildManagedUserSet(normalizedManagerId);
+  managedSet.forEach(id => {
+    if (id) {
+      rosterIdSet.add(id);
+    }
+  });
+
+  const normalizedManagedIds = Array.from(managedSet)
+    .map(id => normalizeUserIdValue(id))
+    .filter(id => id && id !== normalizedManagerId);
+
+  const hasVisibleRoster = Array.from(rosterIdSet).some(id => id && id !== normalizedManagerId);
+
+  if (!hasVisibleRoster) {
+    const fallback = collectCampaignUsersForManager(normalizedManagerId, { allUsers: userLookup.users });
+    if (Array.isArray(fallback.users) && fallback.users.length) {
+      const filteredFallbackUsers = fallback.users.filter(user => {
+        if (!user || typeof user !== 'object') {
+          return false;
+        }
+
+        const id = normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+        if (!id) {
+          return false;
+        }
+
+        if (normalizedManagedIds.length === 0) {
+          return true;
+        }
+
+        return normalizedManagedIds.includes(id);
+      });
+
+      filteredFallbackUsers.forEach(user => {
+        const id = normalizeUserIdValue(user && (user.ID || user.UserID));
+        if (id) {
+          rosterIdSet.add(id);
+        }
+      });
+
+      if (filteredFallbackUsers.length) {
+        response.source = response.source
+          ? `${response.source}+campaignRosterFallback`
+          : 'campaignRosterFallback';
+        response.warnings.push('Managed roster did not return agents; using campaign roster fallback.');
+        response.users = filteredFallbackUsers;
+      }
+    }
+  }
+
+  if (!response.users.length && rosterIdSet.size) {
+    response.users = Array.from(rosterIdSet).map(id => ({ ID: id }));
+  }
+
+  const normalizedRoster = response.users
+    .map(user => normalizeScheduleUserRecord(user, userLookup))
+    .filter(Boolean);
+
+  const dedupedRoster = new Map();
+  normalizedRoster.forEach(user => {
+    const id = normalizeUserIdValue(user && user.ID);
+    if (id && !dedupedRoster.has(id)) {
+      dedupedRoster.set(id, user);
+    }
+  });
+
+  let filteredRoster = Array.from(dedupedRoster.values());
+  if (normalizedManagedIds.length) {
+    filteredRoster = filteredRoster.filter(user => {
+      const id = normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId));
+      return id && id !== normalizedManagerId && normalizedManagedIds.includes(id);
+    });
+  } else {
+    filteredRoster = filteredRoster.filter(user => {
+      const id = normalizeUserIdValue(user && (user.ID || user.UserID || user.id || user.userId));
+      return id && id !== normalizedManagerId;
+    });
+  }
+
+  response.users = filteredRoster;
+
+  const managedIdsSource = normalizedManagedIds.length
+    ? normalizedManagedIds
+    : Array.from(rosterIdSet).map(id => normalizeUserIdValue(id)).filter(id => id && id !== normalizedManagerId);
+  response.managedUserIds = Array.from(new Set(managedIdsSource));
+
+  return response;
+}
+
+function buildUnifiedUserCollection(...collections) {
+  const map = new Map();
+
+  const addUser = (user) => {
+    if (!user || typeof user !== 'object') {
+      return;
+    }
+
+    const normalizedId = normalizeUserIdValue(user.ID || user.UserID || user.id || user.userId);
+    const normalizedUserName = (user.UserName || user.username || '').toString().trim().toLowerCase();
+    const normalizedEmail = (user.Email || user.email || '').toString().trim().toLowerCase();
+
+    const key = normalizedId
+      ? `id:${normalizedId}`
+      : (normalizedUserName ? `username:${normalizedUserName}` : (normalizedEmail ? `email:${normalizedEmail}` : null));
+
+    if (!key) {
+      return;
+    }
+
+    const existing = map.get(key) || {};
+
+    const normalized = Object.assign({}, existing, user, {
+      ID: normalizedId || existing.ID || '',
+      UserName: user.UserName || user.username || existing.UserName || existing.username || '',
+      FullName: user.FullName || user.fullName || existing.FullName || existing.fullName || user.UserName || existing.UserName || '',
+      Email: user.Email || user.email || existing.Email || existing.email || '',
+      CampaignID: user.CampaignID || user.campaignID || existing.CampaignID || existing.campaignID || '',
+      campaignName: user.campaignName || user.CampaignName || existing.campaignName || existing.CampaignName || '',
+      EmploymentStatus: user.EmploymentStatus || existing.EmploymentStatus || 'Active',
+      HireDate: user.HireDate || existing.HireDate || '',
+      TerminationDate: user.TerminationDate || user.terminationDate || existing.TerminationDate || existing.terminationDate || '',
+      isActive: typeof user.isActive === 'boolean'
+        ? user.isActive
+        : (typeof existing.isActive === 'boolean' ? existing.isActive : isUserConsideredActive(user)),
+      roleNames: Array.isArray(user.roleNames)
+        ? user.roleNames.slice()
+        : (Array.isArray(existing.roleNames) ? existing.roleNames.slice() : [])
+    });
+
+    map.set(key, normalized);
+  };
+
+  collections
+    .filter(collection => Array.isArray(collection) && collection.length)
+    .forEach(collection => collection.forEach(addUser));
+
+  const merged = Array.from(map.values());
+  merged.sort((a, b) => {
+    const nameA = (a.FullName || a.UserName || '').toString().toLowerCase();
+    const nameB = (b.FullName || b.UserName || '').toString().toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+
+  return merged;
+}
+
+function resolveUnifiedScheduleRange(request = {}, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const now = new Date();
+  const fallbackStart = normalizeDateForSheet(new Date(now.getFullYear(), now.getMonth(), 1), timeZone);
+  const fallbackEnd = normalizeDateForSheet(new Date(now.getFullYear(), now.getMonth() + 1, 0), timeZone);
+
+  const candidateStart = request.scheduleStart || request.startDate || request.filterStartDate || request.schedulesStart;
+  const candidateEnd = request.scheduleEnd || request.endDate || request.filterEndDate || request.schedulesEnd;
+
+  const startDate = normalizeDateForSheet(candidateStart, timeZone) || fallbackStart;
+  const endDate = normalizeDateForSheet(candidateEnd, timeZone) || fallbackEnd;
+
+  return {
+    startDate,
+    endDate,
+    fallbackStart,
+    fallbackEnd
+  };
+}
+
+function resolveUnifiedAttendanceRange(request = {}, scheduleRange = {}, timeZone = DEFAULT_SCHEDULE_TIME_ZONE) {
+  const monthCandidate = Number(request.attendanceMonth || request.month);
+  const yearCandidate = Number(request.attendanceYear || request.year);
+
+  let resolvedYear = Number.isFinite(yearCandidate) && yearCandidate > 1900 ? yearCandidate : null;
+  let resolvedMonth = Number.isFinite(monthCandidate) && monthCandidate >= 1 && monthCandidate <= 12 ? monthCandidate : null;
+
+  if (!resolvedYear && scheduleRange.startDate) {
+    const parsed = new Date(scheduleRange.startDate);
+    if (!isNaN(parsed.getTime())) {
+      resolvedYear = parsed.getFullYear();
+    }
+  }
+
+  if (!resolvedMonth && scheduleRange.startDate) {
+    const parsed = new Date(scheduleRange.startDate);
+    if (!isNaN(parsed.getTime())) {
+      resolvedMonth = parsed.getMonth() + 1;
+    }
+  }
+
+  if (!resolvedYear) {
+    resolvedYear = new Date().getFullYear();
+  }
+
+  if (!resolvedMonth) {
+    resolvedMonth = new Date().getMonth() + 1;
+  }
+
+  const monthStart = new Date(resolvedYear, resolvedMonth - 1, 1);
+  const monthEnd = new Date(resolvedYear, resolvedMonth, 0);
+
+  const startDate = normalizeDateForSheet(request.attendanceStart || monthStart, timeZone)
+    || normalizeDateForSheet(monthStart, timeZone);
+  const endDate = normalizeDateForSheet(request.attendanceEnd || monthEnd, timeZone)
+    || normalizeDateForSheet(monthEnd, timeZone);
+
+  const yearStart = normalizeDateForSheet(`${resolvedYear}-01-01`, timeZone);
+  const yearEnd = normalizeDateForSheet(`${resolvedYear}-12-31`, timeZone);
+
+  return {
+    startDate,
+    endDate,
+    month: resolvedMonth,
+    year: resolvedYear,
+    yearRange: { start: yearStart, end: yearEnd }
+  };
+}
+
+function clientGetScheduleUnifiedState(request = {}) {
+  try {
+    const options = (request && typeof request === 'object') ? request : {};
+    const candidateManagerId = normalizeUserIdValue(
+      options.managerId || options.userId || options.requestingUserId || options.identityUserId
+    );
+    const candidateCampaignId = normalizeCampaignIdValue(
+      options.campaignId || options.teamId || options.programId || options.identityCampaignId
+    );
+
+    const context = clientGetScheduleContext(candidateManagerId || null, candidateCampaignId || null);
+    if (!context || !context.success) {
+      return {
+        success: false,
+        error: context && context.error ? context.error : 'Unable to resolve schedule context',
+        context
+      };
+    }
+
+    const resolvedManagerId = normalizeUserIdValue(
+      options.managerId
+      || context.managerId
+      || context.providedManagerId
+      || (context.user && (context.user.ID || context.user.UserID))
+      || candidateManagerId
+      || context.identity?.userId
+    );
+
+    const resolvedCampaignId = normalizeCampaignIdValue(
+      options.campaignId
+      || context.campaignId
+      || context.providedCampaignId
+      || candidateCampaignId
+    );
+
+    const scheduleRange = resolveUnifiedScheduleRange(options, DEFAULT_SCHEDULE_TIME_ZONE);
+    const attendanceRange = resolveUnifiedAttendanceRange(options, scheduleRange, DEFAULT_SCHEDULE_TIME_ZONE);
+
+    const scheduleUsers = clientGetScheduleUsers(resolvedManagerId || 'system', resolvedCampaignId || null) || [];
+    const roster = resolveUnifiedManagedRoster(resolvedManagerId || candidateManagerId || context.identity?.userId || '');
+
+    const scheduleFilters = {
+      startDate: scheduleRange.startDate,
+      endDate: scheduleRange.endDate,
+      campaign: resolvedCampaignId || undefined
+    };
+
+    const assignments = options.includeSchedules === false
+      ? { success: true, schedules: [], total: 0, filters: scheduleFilters }
+      : clientGetAllSchedules(scheduleFilters);
+
+    const assignmentUsers = (typeof collectUsersFromScheduleAssignments === 'function')
+      ? collectUsersFromScheduleAssignments(assignments, [scheduleUsers, roster.users])
+      : [];
+
+    const shiftSlots = options.includeShiftSlots === false ? [] : clientGetAllShiftSlots();
+
+    const dashboard = options.includeScheduleDashboard === false
+      ? null
+      : clientGetScheduleDashboard(resolvedManagerId || null, resolvedCampaignId || null, {
+          startDate: scheduleRange.startDate,
+          endDate: scheduleRange.endDate,
+          intervalMinutes: options.intervalMinutes || 30,
+          openingHour: options.openingHour || 8,
+          closingHour: options.closingHour || 21,
+          skipPersistence: options.skipDashboardPersistence === true
+        });
+
+    const attendanceUsers = options.includeAttendanceUsers === false
+      ? []
+      : clientGetAttendanceUsers(resolvedManagerId || null, resolvedCampaignId || null);
+
+    const attendanceUserRecords = (typeof buildUserRecordsFromNames === 'function')
+      ? buildUserRecordsFromNames(attendanceUsers)
+      : attendanceUsers.map(name => ({
+        ID: '',
+        UserID: '',
+        UserName: String(name || ''),
+        FullName: String(name || ''),
+        Email: '',
+        CampaignID: '',
+        campaignName: '',
+        EmploymentStatus: 'Active',
+        isActive: true
+      }));
+
+    const attendanceYearResponse = options.includeAttendance === false
+      ? { success: true, records: [] }
+      : clientGetAttendanceDataRange(attendanceRange.yearRange.start, attendanceRange.yearRange.end, resolvedCampaignId || null);
+
+    const yearlyAttendanceRecords = attendanceYearResponse && attendanceYearResponse.success
+      ? attendanceYearResponse.records || []
+      : [];
+
+    const monthlyAttendanceRecords = yearlyAttendanceRecords.filter(record => {
+      if (!record || !record.date) {
+        return false;
+      }
+      return (!attendanceRange.startDate || record.date >= attendanceRange.startDate)
+        && (!attendanceRange.endDate || record.date <= attendanceRange.endDate);
+    });
+
+    const attendanceDashboard = options.includeAttendanceDashboard === false
+      ? null
+      : clientGetAttendanceDashboard(attendanceRange.yearRange.start, attendanceRange.yearRange.end, resolvedCampaignId || null);
+
+    const holidayCountry = options.holidayCountry || context.identity?.country || SCHEDULE_SETTINGS.PRIMARY_COUNTRY;
+    const holidayYear = options.holidayYear
+      || (scheduleRange.startDate ? Number(String(scheduleRange.startDate).slice(0, 4)) : null)
+      || new Date().getFullYear();
+
+    const holidays = options.includeHolidays === false
+      ? null
+      : clientGetCountryHolidays(holidayCountry, holidayYear);
+
+    const combinedUsers = buildUnifiedUserCollection(
+      scheduleUsers,
+      roster.users,
+      options.combinedUsers,
+      assignmentUsers,
+      attendanceUserRecords
+    );
+
+    const managedUserIdSet = new Set();
+    const appendManagedUserId = (value) => {
+      const normalized = normalizeUserIdValue(value);
+      if (normalized) {
+        managedUserIdSet.add(normalized);
+      }
+    };
+
+    (Array.isArray(roster.managedUserIds) ? roster.managedUserIds : []).forEach(appendManagedUserId);
+    (Array.isArray(context.managedUserIds) ? context.managedUserIds : []).forEach(appendManagedUserId);
+    roster.users.forEach(user => appendManagedUserId(user && (user.ID || user.UserID || user.id || user.userId)));
+    scheduleUsers.forEach(user => appendManagedUserId(user && (user.ID || user.UserID || user.id || user.userId)));
+    assignmentUsers.forEach(user => appendManagedUserId(user && (user.ID || user.UserID || user.id || user.userId)));
+
+    if (resolvedManagerId) {
+      managedUserIdSet.delete(resolvedManagerId);
+    }
+
+    const managedUserIds = Array.from(managedUserIdSet);
+
+    const userSources = {
+      schedule: scheduleUsers.length,
+      roster: roster.users.length,
+      assignments: assignmentUsers.length,
+      attendance: attendanceUserRecords.length
+    };
+
+    return {
+      success: true,
+      generatedAt: new Date().toISOString(),
+      managerId: resolvedManagerId || '',
+      campaignId: resolvedCampaignId || '',
+      context,
+      users: {
+        combined: combinedUsers,
+        schedule: scheduleUsers,
+        roster: roster.users,
+        assignments: assignmentUsers,
+        attendance: attendanceUserRecords,
+        rosterSource: roster.source,
+        managedUserIds,
+        rosterManagedUserIds: Array.isArray(roster.managedUserIds) ? roster.managedUserIds.slice() : [],
+        contextManagedUserIds: Array.isArray(context.managedUserIds) ? context.managedUserIds.slice() : [],
+        warnings: roster.warnings,
+        sources: userSources
+      },
+      schedule: {
+        range: scheduleRange,
+        assignments,
+        shiftSlots,
+        dashboard
+      },
+      attendance: {
+        range: attendanceRange,
+        users: attendanceUsers,
+        monthlyRecords: monthlyAttendanceRecords,
+        yearlyRecords: yearlyAttendanceRecords,
+        dashboard: attendanceDashboard
+      },
+      holidays
+    };
+  } catch (error) {
+    console.error('Error building unified schedule state:', error);
+    safeWriteError && safeWriteError('clientGetScheduleUnifiedState', error);
+    return {
+      success: false,
+      error: error && error.message ? error.message : String(error || 'Unknown error')
     };
   }
 }


### PR DESCRIPTION
## Summary
- bind the schedule manager's date parsing helper during construction so unified state loading always has a callable method
- add a fallback parser implementation and bind the ISO resolver to prevent TypeErrors during initialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f957295dd88326b74c43ec7ed5b1a6