### PR TITLE
Normalize shift slot deletion handling

### DIFF
--- a/SlotManagementInterface.html
+++ b/SlotManagementInterface.html
@@ -708,7 +708,10 @@
                 }
 
                 this.slots.forEach(slot => {
+                    const slotId = this.getSlotIdentifier(slot);
+                    const normalizedSlotId = this.normalizeSlotId(slotId);
                     const row = document.createElement('tr');
+                    row.dataset.slotId = normalizedSlotId;
                     row.innerHTML = `
                         <td>
                             <div class="slot-name-display">${slot.Name || 'Unnamed Slot'}</div>
@@ -745,17 +748,83 @@
                         </td>
                         <td>
                             <div class="btn-group btn-group-sm">
-                                <button class="btn btn-outline-primary" onclick="slotManager.editSlot('${slot.ID}')" title="Edit">
+                                <button class="btn btn-outline-primary btn-edit-slot" title="Edit" ${normalizedSlotId ? '' : 'disabled'}>
                                     <i class="fas fa-edit"></i>
                                 </button>
-                                <button class="btn btn-outline-danger" onclick="slotManager.deleteSlot('${slot.ID}')" title="Delete">
+                                <button class="btn btn-outline-danger btn-delete-slot" title="Delete" ${normalizedSlotId ? '' : 'disabled'}>
                                     <i class="fas fa-trash"></i>
                                 </button>
                             </div>
                         </td>
                     `;
                     tbody.appendChild(row);
+
+                    const editButton = row.querySelector('.btn-edit-slot');
+                    if (editButton) {
+                        editButton.addEventListener('click', () => {
+                            if (!normalizedSlotId) {
+                                this.showNotification('Unable to edit slot: missing identifier', 'error');
+                                return;
+                            }
+                            this.editSlot(normalizedSlotId);
+                        });
+                    }
+
+                    const deleteButton = row.querySelector('.btn-delete-slot');
+                    if (deleteButton) {
+                        deleteButton.addEventListener('click', () => {
+                            if (!normalizedSlotId) {
+                                this.showNotification('Unable to delete slot: missing identifier', 'error');
+                                return;
+                            }
+                            this.deleteSlot(normalizedSlotId);
+                        });
+                    }
                 });
+            }
+
+            getSlotIdentifier(slot) {
+                if (!slot || typeof slot !== 'object') {
+                    return '';
+                }
+
+                const identifierKeys = [
+                    'ID',
+                    'Id',
+                    'id',
+                    'SlotID',
+                    'SlotId',
+                    'slotId',
+                    'Identifier',
+                    'identifier',
+                    'SlotIdentifier'
+                ];
+
+                for (const key of identifierKeys) {
+                    if (slot[key] !== undefined && slot[key] !== null) {
+                        return slot[key];
+                    }
+                }
+
+                return '';
+            }
+
+            normalizeSlotId(slotId) {
+                if (slotId === null || slotId === undefined) {
+                    return '';
+                }
+
+                const normalized = String(slotId).trim();
+                if (!normalized) {
+                    return '';
+                }
+
+                const lower = normalized.toLowerCase();
+                if (lower === 'undefined' || lower === 'null') {
+                    return '';
+                }
+
+                return normalized;
             }
 
             formatDaysOfWeek(daysString) {
@@ -810,11 +879,17 @@
             }
 
             async editSlot(slotId) {
+                const normalizedSlotId = this.normalizeSlotId(slotId);
+                if (!normalizedSlotId) {
+                    this.showNotification('Unable to edit slot: missing identifier', 'error');
+                    return;
+                }
+
                 try {
                     this.showLoading(true);
-                    this.log('Editing slot:', slotId);
-                    
-                    const result = await this.callServerFunction('clientGetShiftSlotById', slotId);
+                    this.log('Editing slot:', normalizedSlotId);
+
+                    const result = await this.callServerFunction('clientGetShiftSlotById', normalizedSlotId);
                     
                     if (result && result.success && result.slot) {
                         this.currentSlot = result.slot;
@@ -835,10 +910,10 @@
             }
 
             populateSlotForm(slot) {
-                document.getElementById('slotId').value = slot.ID;
+                document.getElementById('slotId').value = this.normalizeSlotId(this.getSlotIdentifier(slot));
                 const identifierField = document.getElementById('slotIdentifier');
                 if (identifierField) {
-                    identifierField.value = slot.ID || slot.SlotID || slot.SlotId || 'Unavailable';
+                    identifierField.value = slot.Identifier || slot.ID || slot.SlotID || slot.SlotId || 'Unavailable';
                 }
                 document.getElementById('slotName').value = slot.Name || '';
                 document.getElementById('slotDepartment').value = slot.Department || '';
@@ -1010,15 +1085,21 @@
             }
 
             async deleteSlot(slotId) {
+                const normalizedSlotId = this.normalizeSlotId(slotId);
+                if (!normalizedSlotId) {
+                    this.showNotification('Unable to delete slot: missing identifier', 'error');
+                    return;
+                }
+
                 if (!confirm('Are you sure you want to delete this shift slot? This action cannot be undone.')) {
                     return;
                 }
 
                 try {
                     this.showLoading(true);
-                    this.log('Deleting slot:', slotId);
-                    
-                    const result = await this.callServerFunction('clientDeleteShiftSlot', slotId);
+                    this.log('Deleting slot:', normalizedSlotId);
+
+                    const result = await this.callServerFunction('clientDeleteShiftSlot', normalizedSlotId);
 
                     if (result && result.success) {
                         this.showNotification('Slot deleted successfully!', 'success');


### PR DESCRIPTION
## Summary
- normalize and reuse shift slot identifiers when rendering the management table
- wire edit/delete buttons with explicit event handlers that validate slot identifiers before use
- guard edit and delete flows against missing identifiers to avoid accidental failures

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fb9ccf229c8326b661e77685b7628a