### PR TITLE
Switch landing navigation to white header

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -34,6 +34,8 @@ const ACCESS = {
     'landing',
     'landing-about',
     'landing-capabilities',
+    'landing-story',
+    'landing-capabilities-detail',
     'setpassword',
     'resetpassword',
     'forgotpassword',
@@ -1803,6 +1805,16 @@ function canonicalizePageKey(k) {
     case 'capabilities':
     case 'explore-capabilities':
       return 'landing-capabilities';
+    case 'landing-story':
+    case 'landingstory':
+    case 'stories':
+    case 'customer-stories':
+      return 'landing-story';
+    case 'landing-capabilities-detail':
+    case 'landingcapabilitiesdetail':
+    case 'capabilities-detail':
+    case 'capabilitiesdetail':
+      return 'landing-capabilities-detail';
 
     // Legal & public resources
     case 'terms-of-service':
@@ -2154,6 +2166,13 @@ function doGet(e) {
       'about',
       'landing-capabilities',
       'capabilities',
+      'landing-story',
+      'landingstory',
+      'stories',
+      'customer-stories',
+      'landing-capabilities-detail',
+      'landingcapabilitiesdetail',
+      'capabilities-detail',
       'setpassword',
       'resetpassword',
       'resend-verification',
@@ -2719,6 +2738,32 @@ function handlePublicPage(page, e, baseUrl) {
 
       return capabilitiesTpl.evaluate()
         .setTitle('Explore LuminaHQ Capabilities')
+        .addMetaTag('viewport', 'width=device-width,initial-scale=1')
+        .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+
+    case 'landing-story':
+    case 'stories':
+    case 'customer-stories':
+    case 'landingstory':
+      const storyTpl = HtmlService.createTemplateFromFile('LandingStory');
+      storyTpl.baseUrl = baseUrl;
+      storyTpl.scriptUrl = scriptUrl;
+
+      return storyTpl.evaluate()
+        .setTitle('LuminaHQ Stories')
+        .addMetaTag('viewport', 'width=device-width,initial-scale=1')
+        .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+
+    case 'landing-capabilities-detail':
+    case 'landingcapabilitiesdetail':
+    case 'capabilities-detail':
+    case 'capabilitiesdetail':
+      const capDetailTpl = HtmlService.createTemplateFromFile('LandingCapabilitiesDetail');
+      capDetailTpl.baseUrl = baseUrl;
+      capDetailTpl.scriptUrl = scriptUrl;
+
+      return capDetailTpl.evaluate()
+        .setTitle('LuminaHQ Capability Details')
         .addMetaTag('viewport', 'width=device-width,initial-scale=1')
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 

--- a/Landing.html
+++ b/Landing.html
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LuminaHQ – Grow your operations faster</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
+    <?
+      var __landingBase = scriptUrl || baseUrl || '';
+      var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+      var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+      var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+      var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+      var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+      var landingLogoUrl = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png';
+      var loginUrl = buildLoginPageUrl({});
+    ?>
   </head>
   <body>
     <header class="site-header">
       <nav class="site-nav">
-        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <a class="logo" href="<?!= landingHomeUrl ?>" target="_top">
+          <img src="<?!= landingLogoUrl ?>" alt="LuminaHQ logo" loading="lazy" decoding="async" />
+        </a>
         <ul class="nav-links">
-          <li><a href="LandingCapabilities.html">Capabilities</a></li>
-          <li><a href="LandingAbout.html">About</a></li>
-          <li><a href="LandingStory.html">Stories</a></li>
-          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+          <li><a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities</a></li>
+          <li><a href="<?!= landingAboutUrl ?>" target="_top">About</a></li>
+          <li><a href="<?!= landingStoryUrl ?>" target="_top">Stories</a></li>
+          <li><a class="nav-cta" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Get Started</a></li>
+          <li><a class="nav-cta" href="<?!= loginUrl ?>" target="_top">Login</a></li>
         </ul>
       </nav>
     </header>
@@ -179,10 +192,10 @@
             </p>
           </div>
           <div class="navigation-cta">
-            <a class="btn btn-ghost" href="LandingAbout.html">About LuminaHQ</a>
-            <a class="btn btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
-            <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Dive into details</a>
-            <a class="btn btn-ghost" href="LandingStory.html">Discover our story</a>
+            <a class="btn btn-ghost" href="<?!= landingAboutUrl ?>" target="_top">About LuminaHQ</a>
+            <a class="btn btn-ghost" href="<?!= landingCapabilitiesUrl ?>" target="_top">Explore capabilities</a>
+            <a class="btn btn-ghost" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Dive into details</a>
+            <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">Discover our story</a>
           </div>
         </div>
       </section>
@@ -196,9 +209,9 @@
           leaders.
         </p>
         <div class="footer-links">
-          <a href="LandingAbout.html">Meet the platform</a>
-          <a href="LandingCapabilities.html">Capabilities overview</a>
-          <a href="LandingStory.html">Customer stories</a>
+          <a href="<?!= landingAboutUrl ?>" target="_top">Meet the platform</a>
+          <a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities overview</a>
+          <a href="<?!= landingStoryUrl ?>" target="_top">Customer stories</a>
         </div>
       </div>
     </footer>

--- a/LandingAbout.html
+++ b/LandingAbout.html
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About LuminaHQ</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
+    <?
+      var __landingBase = scriptUrl || baseUrl || '';
+      var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+      var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+      var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+      var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+      var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+      var landingLogoUrl = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png';
+      var loginUrl = buildLoginPageUrl({});
+    ?>
   </head>
   <body>
     <header class="site-header">
       <nav class="site-nav">
-        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <a class="logo" href="<?!= landingHomeUrl ?>" target="_top">
+          <img src="<?!= landingLogoUrl ?>" alt="LuminaHQ logo" loading="lazy" decoding="async" />
+        </a>
         <ul class="nav-links">
-          <li><a href="LandingCapabilities.html">Capabilities</a></li>
-          <li><a href="LandingAbout.html">About</a></li>
-          <li><a href="LandingStory.html">Stories</a></li>
-          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+          <li><a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities</a></li>
+          <li><a href="<?!= landingAboutUrl ?>" target="_top">About</a></li>
+          <li><a href="<?!= landingStoryUrl ?>" target="_top">Stories</a></li>
+          <li><a class="nav-cta" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Get Started</a></li>
+          <li><a class="nav-cta" href="<?!= loginUrl ?>" target="_top">Login</a></li>
         </ul>
       </nav>
     </header>
@@ -31,8 +44,8 @@
               and schedule with intelligence.
             </p>
             <div class="cta-buttons">
-              <a class="btn btn-primary" href="Landing.html">Return to landing</a>
-              <a class="btn btn-ghost" href="LandingStory.html">Read customer stories</a>
+              <a class="btn btn-primary" href="<?!= landingHomeUrl ?>" target="_top">Return to landing</a>
+              <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">Read customer stories</a>
             </div>
             <div class="hero-metrics">
               <div class="metric-card">
@@ -189,8 +202,8 @@
                 every new capability release.
               </p>
               <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
-                <a class="btn btn-ghost" href="LandingCapabilities.html">See capabilities</a>
-                <a class="btn btn-ghost" href="LandingStory.html">Explore customer journey</a>
+                <a class="btn btn-ghost" href="<?!= landingCapabilitiesUrl ?>" target="_top">See capabilities</a>
+                <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">Explore customer journey</a>
               </div>
             </div>
           </div>
@@ -206,9 +219,9 @@
           coaching, and workforce operations.
         </p>
         <div class="footer-links">
-          <a href="LandingCapabilities.html">Capabilities overview</a>
-          <a href="LandingCapabilitiesDetail.html">Detailed modules</a>
-          <a href="LandingStory.html">Customer wins</a>
+          <a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities overview</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Detailed modules</a>
+          <a href="<?!= landingStoryUrl ?>" target="_top">Customer wins</a>
         </div>
       </div>
     </footer>

--- a/LandingCapabilities.html
+++ b/LandingCapabilities.html
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Explore LuminaHQ Capabilities</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
+    <?
+      var __landingBase = scriptUrl || baseUrl || '';
+      var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+      var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+      var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+      var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+      var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+      var landingLogoUrl = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png';
+      var loginUrl = buildLoginPageUrl({});
+    ?>
   </head>
   <body>
     <header class="site-header">
       <nav class="site-nav">
-        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <a class="logo" href="<?!= landingHomeUrl ?>" target="_top">
+          <img src="<?!= landingLogoUrl ?>" alt="LuminaHQ logo" loading="lazy" decoding="async" />
+        </a>
         <ul class="nav-links">
-          <li><a href="LandingCapabilities.html">Capabilities</a></li>
-          <li><a href="LandingAbout.html">About</a></li>
-          <li><a href="LandingStory.html">Stories</a></li>
-          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+          <li><a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities</a></li>
+          <li><a href="<?!= landingAboutUrl ?>" target="_top">About</a></li>
+          <li><a href="<?!= landingStoryUrl ?>" target="_top">Stories</a></li>
+          <li><a class="nav-cta" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Get Started</a></li>
+          <li><a class="nav-cta" href="<?!= loginUrl ?>" target="_top">Login</a></li>
         </ul>
       </nav>
     </header>
@@ -30,8 +43,8 @@
               produce measurable improvements in quality, coaching, and workforce planning.
             </p>
             <div class="cta-buttons">
-              <a class="btn btn-primary" href="LandingCapabilitiesDetail.html">Dive into detail</a>
-              <a class="btn btn-ghost" href="LandingAbout.html">Learn about our team</a>
+              <a class="btn btn-primary" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Dive into detail</a>
+              <a class="btn btn-ghost" href="<?!= landingAboutUrl ?>" target="_top">Learn about our team</a>
             </div>
             <div class="hero-metrics">
               <div class="metric-card">
@@ -181,8 +194,8 @@
                 <li>Granular permissions mapped to your governance policies.</li>
               </ul>
               <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
-                <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Review full module list</a>
-                <a class="btn btn-ghost" href="LandingStory.html">See customer outcomes</a>
+                <a class="btn btn-ghost" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Review full module list</a>
+                <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">See customer outcomes</a>
               </div>
             </div>
             <div class="image-frame">
@@ -234,9 +247,9 @@
         <h3>Take the next step</h3>
         <p>See how LuminaHQ’s capabilities adapt to your programs with a guided walkthrough.</p>
         <div class="footer-links">
-          <a href="LandingCapabilitiesDetail.html">Deep dive modules</a>
-          <a href="LandingStory.html">Success stories</a>
-          <a href="Landing.html">Return home</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Deep dive modules</a>
+          <a href="<?!= landingStoryUrl ?>" target="_top">Success stories</a>
+          <a href="<?!= landingHomeUrl ?>" target="_top">Return home</a>
         </div>
       </div>
     </footer>

--- a/LandingCapabilitiesDetail.html
+++ b/LandingCapabilitiesDetail.html
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dive Into LuminaHQ Capabilities</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
+    <?
+      var __landingBase = scriptUrl || baseUrl || '';
+      var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+      var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+      var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+      var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+      var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+      var landingLogoUrl = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png';
+      var loginUrl = buildLoginPageUrl({});
+    ?>
   </head>
   <body>
     <header class="site-header">
       <nav class="site-nav">
-        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <a class="logo" href="<?!= landingHomeUrl ?>" target="_top">
+          <img src="<?!= landingLogoUrl ?>" alt="LuminaHQ logo" loading="lazy" decoding="async" />
+        </a>
         <ul class="nav-links">
-          <li><a href="LandingCapabilities.html">Capabilities</a></li>
-          <li><a href="LandingAbout.html">About</a></li>
-          <li><a href="LandingStory.html">Stories</a></li>
-          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+          <li><a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities</a></li>
+          <li><a href="<?!= landingAboutUrl ?>" target="_top">About</a></li>
+          <li><a href="<?!= landingStoryUrl ?>" target="_top">Stories</a></li>
+          <li><a class="nav-cta" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Get Started</a></li>
+          <li><a class="nav-cta" href="<?!= loginUrl ?>" target="_top">Login</a></li>
         </ul>
       </nav>
     </header>
@@ -30,8 +43,8 @@
               is built from real-world playbooks contributed by operations experts.
             </p>
             <div class="cta-buttons">
-              <a class="btn btn-primary" href="LandingCapabilities.html">Return to overview</a>
-              <a class="btn btn-ghost" href="LandingStory.html">See it in action</a>
+              <a class="btn btn-primary" href="<?!= landingCapabilitiesUrl ?>" target="_top">Return to overview</a>
+              <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">See it in action</a>
             </div>
             <div class="hero-metrics">
               <div class="metric-card">
@@ -161,8 +174,8 @@
                 <li>Automation audits identify new opportunities for time savings.</li>
               </ul>
               <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
-                <a class="btn btn-ghost" href="LandingStory.html">Read success stories</a>
-                <a class="btn btn-ghost" href="Landing.html">Return to landing</a>
+                <a class="btn btn-ghost" href="<?!= landingStoryUrl ?>" target="_top">Read success stories</a>
+                <a class="btn btn-ghost" href="<?!= landingHomeUrl ?>" target="_top">Return to landing</a>
               </div>
             </div>
             <div class="image-frame">
@@ -184,9 +197,9 @@
           Connect with LuminaHQ specialists for custom demos, integration planning, and transformation playbooks.
         </p>
         <div class="footer-links">
-          <a href="LandingCapabilities.html">Capabilities overview</a>
-          <a href="LandingStory.html">Discover customer wins</a>
-          <a href="LandingAbout.html">Meet the team</a>
+          <a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities overview</a>
+          <a href="<?!= landingStoryUrl ?>" target="_top">Discover customer wins</a>
+          <a href="<?!= landingAboutUrl ?>" target="_top">Meet the team</a>
         </div>
       </div>
     </footer>

--- a/LandingSharedStyles.html
+++ b/LandingSharedStyles.html
@@ -23,13 +23,14 @@
   }
 
   header.site-header {
-    background: linear-gradient(135deg, #0c94d3 0%, #026ba9 100%);
+    background: #ffffff;
     padding: 1rem 2rem;
     position: fixed;
     width: 100%;
     top: 0;
     z-index: 1000;
-    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 20px rgba(15, 23, 42, 0.08);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
   }
 
   .site-nav {
@@ -44,7 +45,7 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    color: #ffffff;
+    color: #0f172a;
     font-size: 1.8rem;
     font-weight: 700;
     letter-spacing: -0.5px;
@@ -62,22 +63,28 @@
   }
 
   .nav-links a {
-    color: #ffffff;
+    color: #0f172a;
     font-weight: 500;
-    transition: opacity 0.3s ease;
+    transition: color 0.3s ease, box-shadow 0.3s ease;
   }
 
   .nav-links a:hover,
   .nav-links a:focus {
-    opacity: 0.8;
+    color: #0284c7;
   }
 
   .nav-cta {
-    background: rgba(255, 255, 255, 0.2);
+    background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+    color: #ffffff !important;
     padding: 0.6rem 1.5rem;
-    border-radius: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    backdrop-filter: blur(10px);
+    border-radius: 999px;
+    border: none;
+    box-shadow: 0 10px 25px rgba(14, 165, 233, 0.2);
+  }
+
+  .nav-cta:hover,
+  .nav-cta:focus {
+    box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
   }
 
   main {

--- a/LandingStory.html
+++ b/LandingStory.html
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Discover the LuminaHQ Story</title>
     <?!= includeOnce('LandingSharedStyles'); ?>
+    <?
+      var __landingBase = scriptUrl || baseUrl || '';
+      var landingHomeUrl = __landingBase ? __landingBase + '?page=landing' : 'Landing.html';
+      var landingAboutUrl = __landingBase ? __landingBase + '?page=landing-about' : 'LandingAbout.html';
+      var landingCapabilitiesUrl = __landingBase ? __landingBase + '?page=landing-capabilities' : 'LandingCapabilities.html';
+      var landingStoryUrl = __landingBase ? __landingBase + '?page=landing-story' : 'LandingStory.html';
+      var landingCapabilitiesDetailUrl = __landingBase ? __landingBase + '?page=landing-capabilities-detail' : 'LandingCapabilitiesDetail.html';
+      var landingLogoUrl = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png';
+      var loginUrl = buildLoginPageUrl({});
+    ?>
   </head>
   <body>
     <header class="site-header">
       <nav class="site-nav">
-        <a class="logo" href="Landing.html">LuminaHQ</a>
+        <a class="logo" href="<?!= landingHomeUrl ?>" target="_top">
+          <img src="<?!= landingLogoUrl ?>" alt="LuminaHQ logo" loading="lazy" decoding="async" />
+        </a>
         <ul class="nav-links">
-          <li><a href="LandingCapabilities.html">Capabilities</a></li>
-          <li><a href="LandingAbout.html">About</a></li>
-          <li><a href="LandingStory.html">Stories</a></li>
-          <li><a class="nav-cta" href="LandingCapabilitiesDetail.html">Get Started</a></li>
+          <li><a href="<?!= landingCapabilitiesUrl ?>" target="_top">Capabilities</a></li>
+          <li><a href="<?!= landingAboutUrl ?>" target="_top">About</a></li>
+          <li><a href="<?!= landingStoryUrl ?>" target="_top">Stories</a></li>
+          <li><a class="nav-cta" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Get Started</a></li>
+          <li><a class="nav-cta" href="<?!= loginUrl ?>" target="_top">Login</a></li>
         </ul>
       </nav>
     </header>
@@ -30,8 +43,8 @@
               customers delighted. Explore the stories behind their results.
             </p>
             <div class="cta-buttons">
-              <a class="btn btn-primary" href="LandingCapabilitiesDetail.html">Review the blueprint</a>
-              <a class="btn btn-ghost" href="LandingAbout.html">Meet our team</a>
+              <a class="btn btn-primary" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Review the blueprint</a>
+              <a class="btn btn-ghost" href="<?!= landingAboutUrl ?>" target="_top">Meet our team</a>
             </div>
             <div class="hero-metrics">
               <div class="metric-card">
@@ -128,8 +141,8 @@
                 </p>
               </div>
               <div class="navigation-cta" style="justify-content: flex-start; margin-top: 2rem">
-                <a class="btn btn-ghost" href="LandingCapabilities.html">Explore capabilities</a>
-                <a class="btn btn-ghost" href="LandingCapabilitiesDetail.html">Dive into workflows</a>
+                <a class="btn btn-ghost" href="<?!= landingCapabilitiesUrl ?>" target="_top">Explore capabilities</a>
+                <a class="btn btn-ghost" href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Dive into workflows</a>
               </div>
             </div>
             <div class="image-frame">
@@ -182,9 +195,9 @@
           programs.
         </p>
         <div class="footer-links">
-          <a href="Landing.html">Return home</a>
-          <a href="LandingCapabilitiesDetail.html">Workflow details</a>
-          <a href="LandingAbout.html">Meet LuminaHQ</a>
+          <a href="<?!= landingHomeUrl ?>" target="_top">Return home</a>
+          <a href="<?!= landingCapabilitiesDetailUrl ?>" target="_top">Workflow details</a>
+          <a href="<?!= landingAboutUrl ?>" target="_top">Meet LuminaHQ</a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- update the shared landing header styling to use a white background with a subtle divider
- adjust navigation link colors and CTA styling to ensure contrast against the lighter header

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc0eaffab48326ad3e272d8ffc1e19