### PR TITLE
Adjust main content margins for responsive layout

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2242,13 +2242,13 @@
         left: 0;
       }
 
-      #maincontent {
+      body #maincontent {
         margin: calc(var(--topbar-height) + 0.25rem)
           clamp(0.25rem, 1.8vw, 0.6rem)
           0.55rem;
       }
 
-      #sidebar.collapsed~#maincontent {
+      body #sidebar.collapsed~#maincontent {
         margin-left: clamp(0.35rem, 2vw, 0.75rem);
       }
 
@@ -2276,7 +2276,7 @@
         padding: 0 1rem;
       }
 
-      #maincontent {
+      body #maincontent {
         margin: calc(var(--topbar-height) + 0.25rem)
           clamp(0.25rem, 3vw, 0.7rem)
           0.55rem;
@@ -2295,7 +2295,7 @@
         padding: 0.75rem clamp(0.75rem, 5vw, 1rem);
       }
 
-      #maincontent {
+      body #maincontent {
         margin: calc(var(--topbar-height) + 0.2rem)
           clamp(0.2rem, 4vw, 0.6rem)
           0.5rem;


### PR DESCRIPTION
## Summary
- update responsive media queries to use higher specificity selectors for the main content container
- ensure the main content margin shrinks when the sidebar is hidden at tablet and mobile breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd43cf268c8326a1e6942ec84946bf