### PR TITLE
Improve mobile topbar spacing

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -2032,7 +2032,8 @@
       top: 0;
       left: var(--sidebar-width);
       right: 0;
-      height: var(--topbar-height);
+      height: auto;
+      min-height: var(--topbar-height);
       background: var(--topbar-bg);
       backdrop-filter: blur(20px);
       border-bottom: 1px solid var(--topbar-border);
@@ -2242,13 +2243,13 @@
         left: 0;
       }
 
-      #maincontent {
+      body #maincontent {
         margin: calc(var(--topbar-height) + 0.25rem)
           clamp(0.25rem, 1.8vw, 0.6rem)
           0.55rem;
       }
 
-      #sidebar.collapsed~#maincontent {
+      body #sidebar.collapsed~#maincontent {
         margin-left: clamp(0.35rem, 2vw, 0.75rem);
       }
 
@@ -2276,7 +2277,7 @@
         padding: 0 1rem;
       }
 
-      #maincontent {
+      body #maincontent {
         margin: calc(var(--topbar-height) + 0.25rem)
           clamp(0.25rem, 3vw, 0.7rem)
           0.55rem;
@@ -2293,10 +2294,12 @@
         flex-wrap: wrap;
         gap: 0.75rem;
         padding: 0.75rem clamp(0.75rem, 5vw, 1rem);
+        align-items: flex-start;
+        row-gap: 0.5rem;
       }
 
-      #maincontent {
-        margin: calc(var(--topbar-height) + 0.2rem)
+      body #maincontent {
+        margin: calc(var(--topbar-height) + 2.75rem)
           clamp(0.2rem, 4vw, 0.6rem)
           0.5rem;
       }


### PR DESCRIPTION
## Summary
- allow the fixed topbar to grow taller when its contents wrap on smaller screens
- increase small-screen main content margin to account for the taller header and keep content from overlapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd43cf268c8326a1e6942ec84946bf