### PR TITLE
Fix login metadata serialization fallback

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1650,7 +1650,21 @@ function renderLoginPage(e) {
   const tpl = HtmlService.createTemplateFromFile('Login');
   tpl.baseUrl = getBaseUrl();
   tpl.scriptUrl = SCRIPT_URL;
-  tpl.serverMetadataJson = JSON.stringify(serverMetadata || null);
+
+  let serializedServerMetadata = 'null';
+  try {
+    const metadataPayload = (typeof serverMetadata === 'undefined' || serverMetadata === null)
+      ? null
+      : serverMetadata;
+    const json = JSON.stringify(metadataPayload);
+    if (typeof json === 'string' && json.length) {
+      serializedServerMetadata = json;
+    }
+  } catch (serializeError) {
+    console.warn('renderLoginPage: unable to serialize server metadata', serializeError);
+  }
+
+  tpl.serverMetadataJson = serializedServerMetadata;
   tpl.initialReturnUrl = initialReturnUrl || '';
   return tpl.evaluate()
     .setTitle('Login - VLBPO LuminaHQ')

--- a/Login.html
+++ b/Login.html
@@ -1124,7 +1124,7 @@
       return fallback;
     }
 
-    const SERVER_OBSERVED_METADATA = <?!= serverMetadataJson ?>;
+    const SERVER_OBSERVED_METADATA = <?!= serverMetadataJson || 'null' ?>;
     const INITIAL_RETURN_URL = <?!= JSON.stringify(initialReturnUrl || '') ?>;
     // ───────────────────────────────────────────────────────────────────────────────
     // SIMPLIFIED AUTHENTICATION CONFIGURATION


### PR DESCRIPTION
## Summary
- guard login metadata serialization so templating always receives valid JSON
- default the client-side metadata constant to `null` when the server provides no payload

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fd8269ae2483268afebe83ea9d2784