### PR TITLE
Fix collaboration hub initialization error

### DIFF
--- a/CollaborationReporting.html
+++ b/CollaborationReporting.html
@@ -1219,10 +1219,6 @@
         userName: 'Team member',
         campaignsText: 'No campaigns connected',
         lastUpdatedText: 'Updated —',
-        insights: []
-      },
-      ai: { summary: '', report: [], suggestions: [], notes: [] },
-        lastUpdatedText: 'Updated —',
         insights: [
           { key: 'quality', label: 'Quality pulse', value: '—', hint: 'QA average this cycle', icon: 'fa-solid fa-sparkles' },
           { key: 'attendance', label: 'Attendance', value: '—', hint: 'Attendance this cycle', icon: 'fa-solid fa-user-check' },


### PR DESCRIPTION
## Summary
- remove duplicate banner state fields that broke the Collaboration Hub script initialization
- ensure default insight values are defined within the banner state so data loading can execute

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68fd89f6595c8326bd0c167f2984d034