### PR TITLE
Fix duplicate entries in attendance calendar

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1855,15 +1855,22 @@
         select.innerHTML = '<option value="">👥 All Agents</option>';
 
         if (Array.isArray(users) && users.length > 0) {
-          users.forEach(name => {
-            if (!name || typeof name !== 'string') return;
+          const normalizedUsers = Array.from(new Set(
+            users
+              .filter(name => typeof name === 'string')
+              .map(name => name.trim())
+              .filter(Boolean)
+          )).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+          normalizedUsers.forEach(name => {
             const opt = document.createElement('option');
-            opt.value = name.trim();
-            opt.textContent = name.trim();
+            opt.value = name;
+            opt.textContent = name;
             select.appendChild(opt);
           });
-          window.INITIAL_USER_LIST = [...users];
-          console.log('Loaded', users.length, 'users successfully');
+
+          window.INITIAL_USER_LIST = [...normalizedUsers];
+          console.log('Loaded', normalizedUsers.length, 'unique users successfully');
         } else {
           console.warn('No users available');
           const opt = document.createElement('option');
@@ -3443,6 +3450,14 @@
           }
         }
 
+        const normalizedUsers = Array.from(new Set(
+          (Array.isArray(this.userList) ? this.userList : [])
+            .filter(name => typeof name === 'string')
+            .map(name => name.trim())
+            .filter(Boolean)
+        )).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+        this.userList = normalizedUsers;
         this.populateUserSelections();
         console.log('Export manager final user list:', this.userList.length, 'users');
       } catch (error) {

--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -8124,7 +8124,92 @@
                     });
                 });
 
-                return userNames.map(name => {
+                const uniqueEntries = [];
+                const uniqueIndex = new Map();
+
+                const mergeIntoExistingEntry = (existing, incoming) => {
+                    const existingKeys = Array.isArray(existing.recordKeys) ? existing.recordKeys : [];
+                    const incomingKeys = Array.isArray(incoming.recordKeys) ? incoming.recordKeys : [];
+                    const mergedKeys = new Set([...existingKeys, ...incomingKeys].filter(Boolean));
+                    existing.recordKeys = Array.from(mergedKeys);
+
+                    if (!existing.original && incoming.original) {
+                        existing.original = incoming.original;
+                    }
+
+                    const existingDisplay = (existing.displayName || '').toString().trim();
+                    const incomingDisplay = (incoming.displayName || '').toString().trim();
+                    if ((!existingDisplay || existingDisplay === (existing.identifier || '').toString().trim()) && incomingDisplay) {
+                        existing.displayName = incoming.displayName;
+                    }
+
+                    const updateEmploymentBoundary = (currentDate, nextDate, comparator) => {
+                        if (!(currentDate instanceof Date) || Number.isNaN(currentDate.getTime())) {
+                            return nextDate instanceof Date && !Number.isNaN(nextDate.getTime())
+                                ? new Date(nextDate.getTime())
+                                : null;
+                        }
+
+                        if (!(nextDate instanceof Date) || Number.isNaN(nextDate.getTime())) {
+                            return currentDate;
+                        }
+
+                        return comparator(currentDate.getTime(), nextDate.getTime())
+                            ? new Date(nextDate.getTime())
+                            : currentDate;
+                    };
+
+                    const previousStartTime = existing.employmentStart instanceof Date && !Number.isNaN(existing.employmentStart.getTime())
+                        ? existing.employmentStart.getTime()
+                        : null;
+                    existing.employmentStart = updateEmploymentBoundary(
+                        existing.employmentStart,
+                        incoming.employmentStart,
+                        (current, next) => next < current
+                    );
+                    const updatedStartTime = existing.employmentStart instanceof Date && !Number.isNaN(existing.employmentStart.getTime())
+                        ? existing.employmentStart.getTime()
+                        : null;
+                    if (
+                        updatedStartTime !== null
+                        && updatedStartTime !== previousStartTime
+                        && incoming.employmentStart instanceof Date
+                        && !Number.isNaN(incoming.employmentStart.getTime())
+                        && incoming.employmentStart.getTime() === updatedStartTime
+                    ) {
+                        existing.employmentStartIso = incoming.employmentStartIso || existing.employmentStartIso || '';
+                    }
+
+                    const previousEndTime = existing.employmentEnd instanceof Date && !Number.isNaN(existing.employmentEnd.getTime())
+                        ? existing.employmentEnd.getTime()
+                        : null;
+                    existing.employmentEnd = updateEmploymentBoundary(
+                        existing.employmentEnd,
+                        incoming.employmentEnd,
+                        (current, next) => next > current
+                    );
+                    const updatedEndTime = existing.employmentEnd instanceof Date && !Number.isNaN(existing.employmentEnd.getTime())
+                        ? existing.employmentEnd.getTime()
+                        : null;
+                    if (
+                        updatedEndTime !== null
+                        && updatedEndTime !== previousEndTime
+                        && incoming.employmentEnd instanceof Date
+                        && !Number.isNaN(incoming.employmentEnd.getTime())
+                        && incoming.employmentEnd.getTime() === updatedEndTime
+                    ) {
+                        existing.employmentEndIso = incoming.employmentEndIso || existing.employmentEndIso || '';
+                    }
+
+                    if (!existing.employmentStartIso && incoming.employmentStartIso) {
+                        existing.employmentStartIso = incoming.employmentStartIso;
+                    }
+                    if (!existing.employmentEndIso && incoming.employmentEndIso) {
+                        existing.employmentEndIso = incoming.employmentEndIso;
+                    }
+                };
+
+                userNames.forEach(name => {
                     const normalizedName = this.normalizePersonKey(name);
                     const metadata = normalizedName ? metadataIndex.get(normalizedName) : null;
 
@@ -8149,7 +8234,7 @@
                         ? metadata.employment
                         : { startDate: null, endDate: null, startIso: '', endIso: '' };
 
-                    return {
+                    const entry = {
                         identifier,
                         displayName,
                         original: name,
@@ -8159,7 +8244,21 @@
                         employmentStartIso: employment && employment.startIso ? employment.startIso : '',
                         employmentEndIso: employment && employment.endIso ? employment.endIso : ''
                     };
+
+                    const dedupeKey = this.normalizePersonKey(entry.identifier || entry.original || entry.displayName || '');
+
+                    if (dedupeKey && uniqueIndex.has(dedupeKey)) {
+                        mergeIntoExistingEntry(uniqueIndex.get(dedupeKey), entry);
+                        return;
+                    }
+
+                    if (dedupeKey) {
+                        uniqueIndex.set(dedupeKey, entry);
+                    }
+                    uniqueEntries.push(entry);
                 });
+
+                return uniqueEntries;
             }
 
             getEmploymentPeriod(user) {


### PR DESCRIPTION
## Summary
- collapse attendance calendar user entries that resolve to the same identifier so each agent only renders once
- merge record keys, display names, and employment windows when combining duplicate rows to keep context intact

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fd8fa70b348326a5e87cce9e2b7b0c