### PR TITLE
Remove default seeded shift slots from schedule utilities

### DIFF
--- a/ScheduleUtilities.js
+++ b/ScheduleUtilities.js
@@ -1488,103 +1488,21 @@ function completeScheduleSetup() {
  */
 function createDefaultShiftSlots() {
   try {
+    ensureScheduleSheetWithHeaders(SHIFT_SLOTS_SHEET, SHIFT_SLOTS_HEADERS);
     const slots = readScheduleSheet(SHIFT_SLOTS_SHEET) || [];
-    if (slots.length > 0) {
-      console.log('Shift slots already exist, skipping default creation');
-      return;
+
+    if (!slots.length) {
+      console.log('Shift slot sheet ensured with no seeded data.');
+    } else {
+      console.log('Shift slots already exist; no default data created.');
     }
 
-    const now = new Date();
-    const defaultSlots = [
-      {
-        ID: Utilities.getUuid(),
-        Name: 'Morning Shift',
-        Department: 'General',
-        Location: 'Office',
-        StartTime: '08:00 AM',
-        EndTime: '04:00 PM',
-        DaysOfWeek: 'Mon,Tue,Wed,Thu,Fri',
-        Description: 'Standard morning shift (8 AM - 4 PM)',
-        CreatedBy: 'System',
-        Notes: '',
-        Status: 'Active',
-        CreatedAt: now,
-        UpdatedAt: now,
-        UpdatedBy: 'System',
-        // Compatibility fields for legacy readers
-        SlotId: '',
-        SlotName: 'Morning Shift',
-        Campaign: 'General',
-        DaysCSV: 'Mon,Tue,Wed,Thu,Fri'
-      },
-      {
-        ID: Utilities.getUuid(),
-        Name: 'Evening Shift',
-        Department: 'General',
-        Location: 'Hybrid',
-        StartTime: '04:00 PM',
-        EndTime: '12:00 AM',
-        DaysOfWeek: 'Mon,Tue,Wed,Thu,Fri',
-        Description: 'Evening coverage for escalations (4 PM - 12 AM)',
-        CreatedBy: 'System',
-        Notes: '',
-        Status: 'Active',
-        CreatedAt: now,
-        UpdatedAt: now,
-        UpdatedBy: 'System',
-        SlotId: '',
-        SlotName: 'Evening Shift',
-        Campaign: 'General',
-        DaysCSV: 'Mon,Tue,Wed,Thu,Fri'
-      },
-      {
-        ID: Utilities.getUuid(),
-        Name: 'Weekend Support',
-        Department: 'General',
-        Location: 'Remote',
-        StartTime: '09:00 AM',
-        EndTime: '05:00 PM',
-        DaysOfWeek: 'Sat,Sun',
-        Description: 'Weekend staffing block (9 AM - 5 PM)',
-        CreatedBy: 'System',
-        Notes: '',
-        Status: 'Active',
-        CreatedAt: now,
-        UpdatedAt: now,
-        UpdatedBy: 'System',
-        SlotId: '',
-        SlotName: 'Weekend Support',
-        Campaign: 'General',
-        DaysCSV: 'Sat,Sun'
-      }
-    ].map(slot => ({
-      SlotId: slot.SlotId || slot.ID,
-      SlotName: slot.SlotName || slot.Name,
-      Campaign: slot.Campaign || slot.Department,
-      DaysCSV: slot.DaysCSV || slot.DaysOfWeek,
-      ...slot,
-      ID: slot.ID || slot.SlotId,
-      Name: slot.Name || slot.SlotName,
-      Department: slot.Department || slot.Campaign,
-      DaysOfWeek: slot.DaysOfWeek || slot.DaysCSV
-    }));
-
-    const sheet = ensureScheduleSheetWithHeaders(SHIFT_SLOTS_SHEET, SHIFT_SLOTS_HEADERS);
-    defaultSlots.forEach(slot => {
-      const rowData = SHIFT_SLOTS_HEADERS.map(header =>
-        Object.prototype.hasOwnProperty.call(slot, header) ? slot[header] : ''
-      );
-      sheet.appendRow(rowData);
-    });
-
-    // Invalidate cache
+    // Invalidate cache so external updates are detected.
     const cacheKey = `schedule_${SHIFT_SLOTS_SHEET}`;
     removeFromCache(cacheKey);
 
-    console.log('Created default shift slots');
-
   } catch (error) {
-    console.error('Error creating default shift slots:', error);
+    console.error('Error ensuring shift slot sheet:', error);
     safeWriteError('createDefaultShiftSlots', error);
   }
 }


### PR DESCRIPTION
## Summary
- ensure the shift slot sheet is created without inserting placeholder records
- remove the hard-coded default shift slots so no dummy data is seeded automatically
- update logging to reflect the absence of seeded shift slots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd876a818c8326896d54d871d5fd80