### PR TITLE
Adjust shift generation and assignments for DST

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -312,6 +312,133 @@ function buildDateSeries(startDateStr, endDateStr) {
   return dates;
 }
 
+function getSafeScheduleTimeZone() {
+  if (typeof getScheduleTimeZone === 'function') {
+    try {
+      const tz = getScheduleTimeZone();
+      if (tz) {
+        return tz;
+      }
+    } catch (error) {
+      console.warn('Falling back to default schedule timezone:', error && error.message ? error.message : error);
+    }
+  }
+
+  return DEFAULT_SCHEDULE_TIME_ZONE || 'UTC';
+}
+
+function normalizeSlotDaysArray(slot) {
+  if (!slot) {
+    return [];
+  }
+
+  if (Array.isArray(slot.DaysOfWeekArray) && slot.DaysOfWeekArray.length) {
+    return slot.DaysOfWeekArray.slice();
+  }
+
+  if (slot.DaysOfWeek) {
+    return parseDaysCsv(slot.DaysOfWeek);
+  }
+
+  if (slot.DaysCSV) {
+    return parseDaysCsv(slot.DaysCSV);
+  }
+
+  if (slot.daysOfWeek) {
+    return normalizeDaySelection(slot.daysOfWeek);
+  }
+
+  return [];
+}
+
+function convertDateToScheduleDayIndex(dateStr) {
+  if (!dateStr) {
+    return null;
+  }
+
+  const date = new Date(`${dateStr}T00:00:00Z`);
+  if (isNaN(date.getTime())) {
+    return null;
+  }
+
+  const day = date.getUTCDay();
+  return (day + 6) % 7;
+}
+
+function buildDstAdjustmentsForSlot(slot, dateSeries, timeZone) {
+  if (!slot || !Array.isArray(dateSeries) || !dateSeries.length) {
+    return [];
+  }
+
+  const startMinutes = parseTimeToMinutes(slot.StartTime || slot.startTime || '');
+  const endMinutes = parseTimeToMinutes(slot.EndTime || slot.endTime || '');
+
+  if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
+    return [];
+  }
+
+  const slotDays = normalizeSlotDaysArray(slot);
+  const normalizedStartTime = formatMinutesTo12Hour(startMinutes);
+  const normalizedEndTime = formatMinutesTo12Hour(endMinutes);
+
+  const adjustments = [];
+
+  dateSeries.forEach(dateStr => {
+    const dayIndex = convertDateToScheduleDayIndex(dateStr);
+    if (slotDays.length && (dayIndex === null || !slotDays.includes(dayIndex))) {
+      return;
+    }
+
+    const dstInfo = typeof checkDSTStatus === 'function'
+      ? checkDSTStatus(dateStr, timeZone)
+      : { isDST: false, isDSTChange: false, changeType: null, timeAdjustment: 0 };
+
+    if (!dstInfo.isDST && !dstInfo.isDSTChange) {
+      return;
+    }
+
+    let adjustmentMinutes = 0;
+    let adjustedEndMinutes = endMinutes;
+    let adjustedStartMinutes = startMinutes;
+
+    if (dstInfo.isDSTChange && dstInfo.timeAdjustment) {
+      adjustmentMinutes = -dstInfo.timeAdjustment;
+      adjustedEndMinutes = endMinutes + adjustmentMinutes;
+      if (dstInfo.changeType === 'END') {
+        adjustedStartMinutes = startMinutes + adjustmentMinutes;
+      }
+    }
+
+    adjustments.push({
+      date: dateStr,
+      isDST: !!dstInfo.isDST,
+      isDSTChange: !!dstInfo.isDSTChange,
+      changeType: dstInfo.changeType || '',
+      adjustmentMinutes: adjustmentMinutes,
+      originalStartTime: normalizedStartTime,
+      originalEndTime: normalizedEndTime,
+      adjustedStartTime: formatMinutesTo12Hour(adjustedStartMinutes),
+      adjustedEndTime: formatMinutesTo12Hour(adjustedEndMinutes)
+    });
+  });
+
+  return adjustments;
+}
+
+function summarizeDstAdjustments(adjustments) {
+  if (!Array.isArray(adjustments) || !adjustments.length) {
+    return '';
+  }
+
+  const parts = adjustments.map(entry => {
+    const direction = entry.adjustmentMinutes > 0 ? `+${entry.adjustmentMinutes}` : String(entry.adjustmentMinutes);
+    const change = entry.changeType ? ` (${entry.changeType})` : '';
+    return `${entry.date}${change}: ${direction} mins`;
+  });
+
+  return `DST adjustments applied - ${parts.join('; ')}`;
+}
+
 function loadHolidayMap(startDateStr, endDateStr) {
   const holidays = readScheduleSheet(HOLIDAYS_SHEET) || [];
   const holidayMap = new Map();
@@ -2068,6 +2195,8 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
       };
     }
 
+    const scheduleTimeZone = getSafeScheduleTimeZone();
+
     const startDateObj = new Date(normalizedStart);
     const endDateObj = new Date(normalizedEnd);
     if (startDateObj > endDateObj) {
@@ -2197,6 +2326,8 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
       };
     }
 
+    const dateSeries = buildDateSeries(normalizedStart, normalizedEnd);
+
     const seed = options.seed || `${campaignId || 'ALL'}-${normalizedStart}-${normalizedEnd}-${(shiftSlotIds || []).join('|')}`;
     const orderedUsers = shuffleWithSeed(filteredUsers, seed);
     const slotCounts = new Map();
@@ -2228,6 +2359,25 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
 
       slotCounts.set(assignedSlot.SlotId, (slotCounts.get(assignedSlot.SlotId) || 0) + 1);
 
+      const dstAdjustments = buildDstAdjustmentsForSlot(assignedSlot, dateSeries, scheduleTimeZone);
+      const breakConfig = {
+        break1: breaksOptions.first || 15,
+        break2: breaksOptions.second || 0,
+        lunch: breaksOptions.lunch || 30,
+        enableStaggered: scheduleFlagToBool(breaksOptions.enableStaggered, false),
+        groups: breaksOptions.groups || '',
+        interval: breaksOptions.interval || '',
+        minCoveragePct: breaksOptions.minCoveragePct || '',
+        unproductive: (breaksOptions.first || 0) + (breaksOptions.second || 0) + (breaksOptions.lunch || 0)
+      };
+
+      if (dstAdjustments.length) {
+        breakConfig.dstAdjustments = dstAdjustments;
+      }
+
+      const dstNotes = summarizeDstAdjustments(dstAdjustments);
+      const assignmentNotes = [options.notes || '', dstNotes].filter(Boolean).join(' | ');
+
       assignments.push({
         AssignmentId: Utilities.getUuid(),
         UserId: user.ID,
@@ -2240,21 +2390,12 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
         Status: 'PENDING',
         AllowSwap: allowSwaps,
         Premiums: '',
-        BreaksConfigJSON: JSON.stringify({
-          break1: breaksOptions.first || 15,
-          break2: breaksOptions.second || 0,
-          lunch: breaksOptions.lunch || 30,
-          enableStaggered: scheduleFlagToBool(breaksOptions.enableStaggered, false),
-          groups: breaksOptions.groups || '',
-          interval: breaksOptions.interval || '',
-          minCoveragePct: breaksOptions.minCoveragePct || '',
-          unproductive: (breaksOptions.first || 0) + (breaksOptions.second || 0) + (breaksOptions.lunch || 0)
-        }),
+        BreaksConfigJSON: JSON.stringify(breakConfig),
         OvertimeMinutes: overtimeMinutes || '',
         RestPeriodHours: restHours || '',
         NotificationLeadHours: notificationLead || '',
         HandoverMinutes: handoverMinutes || '',
-        Notes: options.notes || '',
+        Notes: assignmentNotes,
         CreatedAt: now,
         CreatedBy: actor,
         UpdatedAt: now,
@@ -2262,7 +2403,6 @@ function clientGenerateSchedulesEnhanced(startDate, endDate, userNames, shiftSlo
       });
     });
 
-    const dateSeries = buildDateSeries(normalizedStart, normalizedEnd);
     const holidayMap = includeHolidays ? loadHolidayMap(normalizedStart, normalizedEnd) : new Map();
 
     const existingAssignments = readShiftAssignments()
@@ -3272,6 +3412,7 @@ function clientGetCountryHolidays(countryCode, year) {
     const campaignId = normalizeCampaignIdValue(request.campaignId || slot.Campaign || '');
     const actor = request.createdBy || (typeof getCurrentUser === 'function' ? (getCurrentUser()?.Email || 'System') : 'System');
 
+    const scheduleTimeZone = getSafeScheduleTimeZone();
     const scheduleUsers = clientGetScheduleUsers(actor, campaignId || null);
     const userKeyMap = new Map();
     const userIdMap = new Map();
@@ -3290,6 +3431,7 @@ function clientGetCountryHolidays(countryCode, year) {
     const failedUsers = [];
     const archivedAssignments = [];
     const now = new Date();
+    const dateSeries = buildDateSeries(normalizedStart, normalizedEnd);
 
     userEntries.forEach(entry => {
       if (!entry) {
@@ -3344,6 +3486,24 @@ function clientGetCountryHolidays(countryCode, year) {
         });
       }
 
+      const dstAdjustments = buildDstAdjustmentsForSlot(slot, dateSeries, scheduleTimeZone);
+      const baseBreakConfig = {
+        break1: 15,
+        break2: 15,
+        lunch: 30,
+        enableStaggered: false,
+        groups: '',
+        interval: '',
+        unproductive: 60
+      };
+
+      if (dstAdjustments.length) {
+        baseBreakConfig.dstAdjustments = dstAdjustments;
+      }
+
+      const dstNotes = summarizeDstAdjustments(dstAdjustments);
+      const assignmentNotes = [request.notes || '', dstNotes].filter(Boolean).join(' | ');
+
       createdAssignments.push({
         AssignmentId: Utilities.getUuid(),
         UserId: user.ID,
@@ -3356,20 +3516,12 @@ function clientGetCountryHolidays(countryCode, year) {
         Status: 'PENDING',
         AllowSwap: scheduleFlagToBool(request.allowSwaps, true),
         Premiums: '',
-        BreaksConfigJSON: JSON.stringify({
-          break1: 15,
-          break2: 15,
-          lunch: 30,
-          enableStaggered: false,
-          groups: '',
-          interval: '',
-          unproductive: 60
-        }),
+        BreaksConfigJSON: JSON.stringify(baseBreakConfig),
         OvertimeMinutes: '',
         RestPeriodHours: '',
         NotificationLeadHours: '',
         HandoverMinutes: '',
-        Notes: request.notes || '',
+        Notes: assignmentNotes,
         CreatedAt: now,
         CreatedBy: actor,
         UpdatedAt: now,

--- a/ScheduleUtilities.js
+++ b/ScheduleUtilities.js
@@ -1827,24 +1827,86 @@ function checkIfHoliday(dateStr) {
 /**
  * Basic DST status check
  */
-function checkDSTStatus(dateStr) {
+function checkDSTStatus(dateStr, timeZone) {
+  const safeTimeZone = timeZone || (typeof getScheduleTimeZone === 'function'
+    ? getScheduleTimeZone()
+    : (typeof DEFAULT_SCHEDULE_TIME_ZONE !== 'undefined' ? DEFAULT_SCHEDULE_TIME_ZONE : 'UTC'));
+
+  const parseOffsetToMinutes = (offsetString) => {
+    if (!offsetString || typeof offsetString !== 'string') {
+      return 0;
+    }
+
+    const sign = offsetString.startsWith('-') ? -1 : 1;
+    const hours = Number(offsetString.slice(1, 3));
+    const minutes = Number(offsetString.slice(3, 5));
+
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+      return 0;
+    }
+
+    return sign * (hours * 60 + minutes);
+  };
+
+  const resolveOffsetMinutes = (date) => {
+    try {
+      const offset = Utilities.formatDate(date, safeTimeZone, 'Z');
+      return parseOffsetToMinutes(offset);
+    } catch (error) {
+      return 0;
+    }
+  };
+
   try {
-    const date = new Date(dateStr);
-    const year = date.getFullYear();
+    if (!dateStr) {
+      throw new Error('Date string required for DST check');
+    }
 
-    // Simple US DST check (second Sunday in March to first Sunday in November)
-    const dstStart = new Date(year, 2, 8 + (7 - new Date(year, 2, 8).getDay()) % 7);
-    const dstEnd = new Date(year, 10, 1 + (7 - new Date(year, 10, 1).getDay()) % 7);
+    const midnight = new Date(`${dateStr}T00:00:00Z`);
+    if (isNaN(midnight.getTime())) {
+      throw new Error('Invalid date provided for DST check');
+    }
 
-    const isDST = date >= dstStart && date < dstEnd;
+    const midday = new Date(midnight.getTime() + 12 * 60 * 60 * 1000);
+    const previousMidnight = new Date(midnight.getTime() - 24 * 60 * 60 * 1000);
+    const nextMidnight = new Date(midnight.getTime() + 24 * 60 * 60 * 1000);
+
+    const offsetAtMidnight = resolveOffsetMinutes(midnight);
+    const offsetAtMidday = resolveOffsetMinutes(midday);
+    const offsetPreviousMidnight = resolveOffsetMinutes(previousMidnight);
+    const offsetNextMidnight = resolveOffsetMinutes(nextMidnight);
+
+    const year = midnight.getUTCFullYear();
+    const januaryBaseline = new Date(Date.UTC(year, 0, 1, 12, 0, 0));
+    const julyBaseline = new Date(Date.UTC(year, 6, 1, 12, 0, 0));
+    const januaryOffset = resolveOffsetMinutes(januaryBaseline);
+    const julyOffset = resolveOffsetMinutes(julyBaseline);
+    const standardOffset = Math.min(januaryOffset, julyOffset);
+
+    const isDST = offsetAtMidday !== standardOffset;
+
+    let isDSTChange = false;
+    let changeType = null;
+    let timeAdjustment = 0;
+
+    if (offsetAtMidnight !== offsetNextMidnight) {
+      isDSTChange = true;
+      timeAdjustment = offsetAtMidnight - offsetNextMidnight;
+      changeType = timeAdjustment > 0 ? 'END' : 'START';
+    } else if (offsetPreviousMidnight !== offsetAtMidnight) {
+      isDSTChange = true;
+      timeAdjustment = offsetPreviousMidnight - offsetAtMidnight;
+      changeType = timeAdjustment > 0 ? 'START' : 'END';
+    }
 
     return {
       isDST: isDST,
-      isDSTChange: false,
-      changeType: null,
-      timeAdjustment: 0
+      isDSTChange: isDSTChange,
+      changeType: changeType,
+      timeAdjustment: timeAdjustment
     };
   } catch (error) {
+    console.warn('DST status check failed:', error && error.message ? error.message : error);
     return {
       isDST: false,
       isDSTChange: false,


### PR DESCRIPTION
## Summary
- enhance daylight saving time detection to use timezone-aware offsets and report change metadata
- add utilities that calculate DST adjustments for shift slots and append them to break configurations and notes during generation
- update manual assignment creation to embed DST adjustments so shift coverage stays accurate on transition days

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fdc422f1b483269e2c462973a64ef0