### PR TITLE
Add Dynamic form spreadsheet utilities

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2521,6 +2521,12 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
           return renderAccessDenied('You need manager or supervisor privileges to import attendance data.');
         }
 
+      case 'dynamicforms':
+      case 'dynamic-forms':
+      case 'formresponses':
+      case 'form-responses':
+        return serveCampaignPage('DynamicFormResponses', e, baseUrl, user, campaignIdFromCaller);
+
       default:
         // Unknown page - redirect to dashboard
         const defaultCampaignId = user.CampaignID || '';
@@ -3057,6 +3063,10 @@ function handleTemplateSpecificData(tpl, templateName, e, user, campaignId) {
         handleCallReportsData(tpl, e, user, campaignId);
         break;
 
+      case 'DynamicFormResponses':
+        handleDynamicFormResponsesData(tpl, e, user, campaignId);
+        break;
+
       // Campaign-specific QA forms
       case 'IndependenceQAForm':
       case 'CreditSuiteQAForm':
@@ -3290,6 +3300,63 @@ function handleAttendanceReportsData(tpl, e, user, campaignId) {
     tpl.attendanceDataJSON = tpl.attendanceData;
     tpl.userListJSON = JSON.stringify([]);
     tpl.currentUserJSON = JSON.stringify(user || {}).replace(/<\/script>/g, '<\\/script>');
+  }
+}
+
+function handleDynamicFormResponsesData(tpl, e, user, campaignId) {
+  try {
+    var forms = [];
+    if (typeof listDynamicForms === 'function') {
+      var formQuery = null;
+      if (campaignId) {
+        formQuery = { where: { CampaignID: campaignId } };
+      }
+      var formOptions = formQuery ? { query: formQuery } : {};
+      forms = listDynamicForms(formOptions);
+    }
+
+    var selectedFormId = '';
+    if (e && e.parameter && e.parameter.formId) {
+      selectedFormId = String(e.parameter.formId);
+    }
+
+    if (!selectedFormId && forms && forms.length) {
+      selectedFormId = forms[0].ID || forms[0].Id || forms[0].id || '';
+    }
+
+    var responses = [];
+    if (selectedFormId && typeof listDynamicFormResponsesByForm === 'function') {
+      var responseQuery = { orderBy: 'CreatedAt', orderDesc: true };
+      if (campaignId) {
+        responseQuery.where = { CampaignID: campaignId };
+      }
+      responses = listDynamicFormResponsesByForm(selectedFormId, { query: responseQuery });
+    }
+
+    var userDirectory = [];
+    if (typeof getUsers === 'function') {
+      userDirectory = (getUsers() || []).map(function (entry) {
+        return {
+          id: entry.ID || entry.id || '',
+          name: entry.FullName || entry.name || entry.UserName || '',
+          email: entry.Email || entry.email || ''
+        };
+      });
+    }
+
+    tpl.dynamicFormsJSON = JSON.stringify(forms || []).replace(/<\/script>/g, '<\\/script>');
+    tpl.dynamicFormResponsesJSON = JSON.stringify(responses || []).replace(/<\/script>/g, '<\\/script>');
+    tpl.dynamicFormsSelectedId = selectedFormId || '';
+    tpl.dynamicFormUserDirectoryJSON = JSON.stringify(userDirectory || []).replace(/<\/script>/g, '<\\/script>');
+  } catch (error) {
+    console.error('Error handling dynamic form responses data:', error);
+    if (typeof writeError === 'function') {
+      writeError('handleDynamicFormResponsesData', error);
+    }
+    tpl.dynamicFormsJSON = '[]';
+    tpl.dynamicFormResponsesJSON = '[]';
+    tpl.dynamicFormsSelectedId = '';
+    tpl.dynamicFormUserDirectoryJSON = '[]';
   }
 }
 
@@ -5942,6 +6009,70 @@ function getQAFormUsers(campaignId, requestingUserId) {
 // ───────────────────────────────────────────────────────────────────────────────
 // FINAL INITIALIZATION LOG
 // ───────────────────────────────────────────────────────────────────────────────
+
+// ───────────────────────────────────────────────────────────────────────────────
+// DYNAMIC FORM SERVICE WRAPPERS
+// ───────────────────────────────────────────────────────────────────────────────
+
+function createDynamicForm(formConfig, options) {
+  var context = options && options.context ? options.context : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.createForm !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.createForm(context, formConfig || {});
+}
+
+function getDynamicForm(formId, options) {
+  var context = options && options.context ? options.context : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.getForm !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.getForm(context, formId);
+}
+
+function listDynamicForms(options) {
+  var context = options && options.context ? options.context : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.listForms !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  var query = options && options.query ? options.query : null;
+  return DynamicFormService.listForms(context, query);
+}
+
+function submitDynamicFormResponse(formId, userId, answers, options) {
+  var context = options && options.context ? options.context : null;
+  var metadata = options && options.metadata ? options.metadata : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.submitFormResponse !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.submitFormResponse(context, formId, userId, answers, metadata);
+}
+
+function listDynamicFormResponsesByUser(userId, options) {
+  var context = options && options.context ? options.context : null;
+  var query = options && options.query ? options.query : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.listResponsesForUser !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.listResponsesForUser(context, userId, query);
+}
+
+function listDynamicFormResponsesByForm(formId, options) {
+  var context = options && options.context ? options.context : null;
+  var query = options && options.query ? options.query : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.listResponsesForForm !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.listResponsesForForm(context, formId, query);
+}
+
+function getDynamicFormDashboardData(options) {
+  var context = options && options.context ? options.context : null;
+  if (typeof DynamicFormService === 'undefined' || !DynamicFormService || typeof DynamicFormService.getDashboardSummary !== 'function') {
+    throw new Error('DynamicFormService is not available.');
+  }
+  return DynamicFormService.getDashboardSummary(context, options || {});
+}
 
 console.log('Enhanced Multi-Campaign Code.gs with Simplified Authentication loaded successfully');
 console.log('Features: Token-based authentication, Campaign-aware routing, Enhanced access control');

--- a/DynamicFormResponses.html
+++ b/DynamicFormResponses.html
@@ -1,0 +1,2009 @@
+<?!= includeOnce('ResponsiveStyles') ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: (typeof currentPage !== 'undefined' && currentPage) ? currentPage : 'dynamic-forms',
+  pageSlug: (typeof pageSlug !== 'undefined' && pageSlug) ? pageSlug : 'dynamic-forms',
+  pageTitle: (typeof pageTitle !== 'undefined' && pageTitle) ? pageTitle : 'Dynamic Form Responses',
+  pageDescription: (typeof pageDescription !== 'undefined' && pageDescription) ? pageDescription : 'Review responses captured through tenant-aware forms and inspect the profile updates applied automatically.'
+}) ?>
+
+<?
+  var __dynamicFormsJSON = (typeof dynamicFormsJSON !== 'undefined' && dynamicFormsJSON) ? dynamicFormsJSON : '[]';
+  var __dynamicFormResponsesJSON = (typeof dynamicFormResponsesJSON !== 'undefined' && dynamicFormResponsesJSON) ? dynamicFormResponsesJSON : '[]';
+  var __dynamicFormUserDirectoryJSON = (typeof dynamicFormUserDirectoryJSON !== 'undefined' && dynamicFormUserDirectoryJSON) ? dynamicFormUserDirectoryJSON : '[]';
+  var __dynamicFormsSelectedId = (typeof dynamicFormsSelectedId !== 'undefined' && dynamicFormsSelectedId) ? String(dynamicFormsSelectedId) : '';
+  var __escapedDynamicFormsSelectedId = __dynamicFormsSelectedId
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'");
+  var __pageRoot = (typeof baseUrl !== 'undefined' && baseUrl)
+    ? baseUrl
+    : ((typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : '');
+?>
+
+<style>
+  :root {
+    --df-primary: #4f46e5;
+    --df-primary-light: #eef2ff;
+    --df-border: #e5e7eb;
+    --df-muted: #6b7280;
+    --df-background: #f9fafb;
+    --df-heading: #111827;
+  }
+
+  .hidden {
+    display: none !important;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .dynamic-forms-page {
+    max-width: 1280px;
+    margin: 0 auto;
+  }
+
+  .page-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .page-heading h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--df-heading);
+  }
+
+  .page-heading p {
+    margin: 0.35rem 0 0;
+    color: var(--df-muted);
+    max-width: 720px;
+  }
+
+  .heading-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  .heading-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+  }
+
+  .create-form-modal .modal-body {
+    background: var(--df-background);
+  }
+
+  .create-form-modal .modal-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+
+  .create-form-modal .modal-title i {
+    color: var(--df-primary);
+  }
+
+  .create-form-modal .alert {
+    margin-bottom: 1rem;
+  }
+
+  .create-form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .create-form-field {
+    position: relative;
+    border: 1px solid var(--df-border);
+    border-radius: 14px;
+    padding: 1rem 1rem 1.25rem;
+    background: #fff;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  }
+
+  .create-form-field__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .create-form-field__title {
+    font-weight: 600;
+    color: var(--df-heading);
+  }
+
+  .create-form-field__type {
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    background: var(--df-primary-light);
+    color: var(--df-primary);
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+
+  .create-form-field__controls {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 0.5rem;
+  }
+
+  .create-form-field__remove {
+    border: none;
+    background: transparent;
+    color: #ef4444;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0.25rem 0.4rem;
+    border-radius: 6px;
+    transition: background 0.2s ease, color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .create-form-field__remove:hover,
+  .create-form-field__remove:focus {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+  }
+
+  .create-form-field__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .create-form-field__options {
+    margin-top: 0.75rem;
+  }
+
+  .create-form-field__options textarea {
+    min-height: 90px;
+  }
+
+  .create-form-field .form-text {
+    color: var(--df-muted);
+  }
+
+  .create-form-modal .modal-footer {
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .create-form-modal .modal-footer .btn-primary {
+    min-width: 160px;
+  }
+
+  .create-form-modal .form-check {
+    margin-top: 0.35rem;
+  }
+
+  .dynamic-forms-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: stretch;
+  }
+
+  .forms-panel,
+  .responses-panel {
+    background: #fff;
+    border: 1px solid var(--df-border);
+    border-radius: 16px;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
+  }
+
+  .forms-panel {
+    padding: 1.25rem 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .forms-panel__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+
+  .forms-panel__title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--df-heading);
+    margin: 0;
+  }
+
+  .forms-panel__count {
+    font-size: 0.85rem;
+    color: var(--df-muted);
+  }
+
+  .forms-panel__helper {
+    margin: 0.5rem 0 0.75rem;
+    color: var(--df-muted);
+    font-size: 0.9rem;
+  }
+
+  .forms-search {
+    margin-bottom: 0.75rem;
+  }
+
+  .forms-search input {
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid var(--df-border);
+    padding: 0.55rem 0.75rem;
+    font-size: 0.95rem;
+    background: var(--df-background);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .forms-search input:focus {
+    border-color: var(--df-primary);
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+    outline: none;
+    background: #fff;
+  }
+
+  .forms-list {
+    margin: 0;
+    padding: 0 0.25rem 0 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    max-height: calc(100vh - 220px);
+    overflow-y: auto;
+  }
+
+  .forms-list::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .forms-list::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.6);
+    border-radius: 999px;
+  }
+
+  .form-list-item {
+    border: 1px solid var(--df-border);
+    background: var(--df-background);
+    border-radius: 12px;
+    padding: 0.75rem 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    text-align: left;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    cursor: pointer;
+  }
+
+  .form-list-item:hover {
+    border-color: var(--df-primary);
+    box-shadow: 0 6px 16px rgba(79, 70, 229, 0.16);
+    transform: translateY(-1px);
+  }
+
+  .form-list-item.is-active {
+    border-color: var(--df-primary);
+    background: var(--df-primary-light);
+    box-shadow: 0 6px 18px rgba(79, 70, 229, 0.2);
+  }
+
+  .form-list-item__name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--df-heading);
+  }
+
+  .form-list-item__meta {
+    font-size: 0.82rem;
+    color: var(--df-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .responses-panel {
+    padding: 1.5rem 1.75rem 2rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .responses-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .responses-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--df-heading);
+  }
+
+  .responses-header p {
+    margin: 0.4rem 0 0;
+    color: var(--df-muted);
+  }
+
+  .responses-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .responses-meta__block {
+    min-width: 110px;
+  }
+
+  .responses-meta__label {
+    display: block;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--df-muted);
+  }
+
+  .responses-meta__value {
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: var(--df-heading);
+  }
+
+  .responses-meta__value--link a {
+    color: var(--df-primary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+
+  .responses-meta__value--link a i {
+    font-size: 0.85rem;
+  }
+
+  .responses-meta__value--link a:hover,
+  .responses-meta__value--link a:focus {
+    text-decoration: underline;
+  }
+
+  .responses-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .responses-toolbar input {
+    width: 280px;
+    max-width: 100%;
+    border-radius: 10px;
+    border: 1px solid var(--df-border);
+    padding: 0.55rem 0.75rem;
+    font-size: 0.95rem;
+    background: var(--df-background);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .responses-toolbar input:focus {
+    border-color: var(--df-primary);
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+    outline: none;
+    background: #fff;
+  }
+
+  .status-banner {
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.92rem;
+    background: #dbeafe;
+    color: #1e40af;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+  }
+
+  .status-banner--loading {
+    background: #e0f2fe;
+    color: #0369a1;
+  }
+
+  .status-banner--error {
+    background: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .status-banner--warning {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  .status-banner--info {
+    background: #d1fae5;
+    color: #047857;
+  }
+
+  .responses-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .response-card {
+    border: 1px solid var(--df-border);
+    border-radius: 14px;
+    padding: 1.1rem 1.25rem 1.25rem;
+    background: #fff;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .response-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .response-card__identity {
+    max-width: 65%;
+  }
+
+  .response-card__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--df-heading);
+  }
+
+  .response-card__submitted-by {
+    font-size: 0.82rem;
+    color: var(--df-muted);
+    margin-top: 0.2rem;
+  }
+
+  .response-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    font-size: 0.82rem;
+    color: var(--df-muted);
+  }
+
+  .response-card__answers {
+    display: grid;
+    grid-template-columns: minmax(140px, 220px) minmax(0, 1fr);
+    gap: 0.5rem 1rem;
+    margin: 0;
+  }
+
+  .response-card__answers dt {
+    font-weight: 600;
+    color: var(--df-heading);
+  }
+
+  .response-card__answers dd {
+    margin: 0;
+    color: #374151;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .response-card__updates {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .response-card__update-pill {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: var(--df-primary-light);
+    color: var(--df-primary);
+    font-size: 0.78rem;
+    font-weight: 500;
+  }
+
+  .empty-state {
+    margin-top: 1rem;
+    padding: 1rem;
+    background: var(--df-background);
+    border-radius: 12px;
+    text-align: center;
+    color: var(--df-muted);
+    font-size: 0.95rem;
+  }
+
+  .responses-empty-inline {
+    margin-top: 0.5rem;
+  }
+
+  @media (max-width: 1024px) {
+    .dynamic-forms-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .response-card__identity {
+      max-width: 100%;
+    }
+
+    .responses-meta {
+      width: 100%;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .responses-toolbar {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .heading-actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+</style>
+<main class='dynamic-forms-page container-fluid py-4 px-4 px-lg-5'>
+  <div class='page-heading'>
+    <div>
+      <h1>Dynamic Form Responses</h1>
+      <p>
+        Monitor every submission captured through campaign-aware forms, inspect the answers that users provided,
+        and review any profile updates that were applied automatically.
+      </p>
+    </div>
+    <div class='heading-actions'>
+      <a id='openResponsesDashboard' class='btn btn-outline-secondary' href='<?= __pageRoot ?>?page=dynamic-form-dashboard'>
+        <i class='fas fa-chart-line'></i>
+        <span>Dashboard</span>
+      </a>
+      <button id='openCreateForm' type='button' class='btn btn-primary'>
+        <i class='fas fa-plus'></i>
+        <span>Create form</span>
+      </button>
+      <button id='refreshResponses' type='button' class='btn btn-outline-primary'>
+        <i class='fas fa-sync-alt'></i>
+        <span>Refresh</span>
+      </button>
+    </div>
+  </div>
+
+  <div class='dynamic-forms-layout'>
+    <section class='forms-panel' aria-labelledby='dynamic-forms-list-label'>
+      <div class='forms-panel__header'>
+        <h2 id='dynamic-forms-list-label' class='forms-panel__title'>Forms</h2>
+        <span id='formsCount' class='forms-panel__count'>0 forms</span>
+      </div>
+      <p class='forms-panel__helper'>Select a form to explore submissions and linked profile updates.</p>
+      <div class='forms-search'>
+        <label class='sr-only' for='formSearch'>Search forms</label>
+        <input type='search' id='formSearch' placeholder='Search forms' autocomplete='off' />
+      </div>
+      <div id='formsList' class='forms-list' role='listbox' aria-label='Available dynamic forms'></div>
+      <div id='formsEmpty' class='empty-state hidden'>No dynamic forms have been created yet.</div>
+    </section>
+
+    <section class='responses-panel' aria-live='polite'>
+      <div class='responses-header'>
+        <div>
+          <h2 id='responsesTitle'>Select a form</h2>
+          <p id='responsesDescription' class='hidden'></p>
+        </div>
+        <div class='responses-meta'>
+          <div class='responses-meta__block'>
+            <span class='responses-meta__label'>Fields</span>
+            <span id='fieldsCount' class='responses-meta__value'>0</span>
+          </div>
+          <div class='responses-meta__block'>
+            <span class='responses-meta__label'>Responses</span>
+            <span id='responsesCount' class='responses-meta__value'>0</span>
+          </div>
+          <div class='responses-meta__block'>
+            <span class='responses-meta__label'>Response sheet</span>
+            <span id='responseSheetLink' class='responses-meta__value responses-meta__value--link'>—</span>
+          </div>
+          <div class='responses-meta__block'>
+            <span class='responses-meta__label'>Last fetched</span>
+            <span id='lastFetched' class='responses-meta__value'>—</span>
+          </div>
+        </div>
+      </div>
+
+      <div class='responses-toolbar'>
+        <label class='sr-only' for='responseSearch'>Search responses</label>
+        <input type='search' id='responseSearch' placeholder='Search responses' autocomplete='off' />
+      </div>
+
+      <div id='responsesStatus' class='status-banner hidden'></div>
+
+      <div id='responsesEmpty' class='empty-state hidden responses-empty-inline'>
+        No responses recorded for this form yet.
+      </div>
+
+      <div id='responsesContainer' class='responses-list' role='list'></div>
+    </section>
+  </div>
+</main>
+
+<div class='modal fade create-form-modal' id='createFormModal' tabindex='-1' aria-labelledby='createFormModalTitle' aria-hidden='true'>
+  <div class='modal-dialog modal-lg modal-dialog-centered'>
+    <div class='modal-content'>
+      <form id='createFormForm' novalidate>
+        <div class='modal-header'>
+          <h5 class='modal-title' id='createFormModalTitle'>
+            <i class='fas fa-plus-circle'></i>
+            <span>Create dynamic form</span>
+          </h5>
+          <button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='Close'></button>
+        </div>
+        <div class='modal-body'>
+          <div id='createFormAlert' class='alert d-none create-form-alert' role='alert'></div>
+          <div class='mb-3'>
+            <label for='createFormName' class='form-label'>Form name</label>
+            <input type='text' id='createFormName' class='form-control' placeholder='e.g. New client intake' required />
+            <div class='form-text'>Give the form a clear title so teams can recognise it when sending campaigns.</div>
+            <div class='invalid-feedback'>Please provide a form name.</div>
+          </div>
+          <div class='mb-3'>
+            <label for='createFormDescription' class='form-label'>Description <span class='text-muted'>(optional)</span></label>
+            <textarea id='createFormDescription' class='form-control' rows='2' placeholder='Explain when or how this form should be used'></textarea>
+            <div class='form-text'>This appears in the responses view to help identify the purpose of the form.</div>
+          </div>
+          <div class='d-flex justify-content-between align-items-center mb-2'>
+            <h6 class='mb-0'>Form fields</h6>
+            <button type='button' class='btn btn-outline-primary btn-sm' id='addFormField'>
+              <i class='fas fa-plus'></i>
+              <span>Add field</span>
+            </button>
+          </div>
+          <div id='createFormFields' class='create-form-fields'></div>
+          <p class='form-text mt-3 mb-0'>Map a field to a user profile value using the binding input. Leave it blank to store the answer without updating the profile.</p>
+          <datalist id='formFieldBindingSuggestions'>
+            <option value='email'>User email</option>
+            <option value='phone'>Phone number</option>
+            <option value='fullname'>Full name</option>
+            <option value='firstname'>First name</option>
+            <option value='lastname'>Last name</option>
+            <option value='insurance.provider'>Insurance provider</option>
+            <option value='insurance.policyNumber'>Insurance policy number</option>
+            <option value='insurance.groupNumber'>Insurance group number</option>
+            <option value='insurance.memberId'>Insurance member ID</option>
+            <option value='insurance.notes'>Insurance notes</option>
+          </datalist>
+        </div>
+        <div class='modal-footer'>
+          <button type='button' class='btn btn-outline-secondary' data-bs-dismiss='modal'>Cancel</button>
+          <button type='submit' id='createFormSubmit' class='btn btn-primary'>
+            <i class='fas fa-save me-2'></i>
+            <span>Create form</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    'use strict';
+
+    const initialForms = <?!= __dynamicFormsJSON ?>;
+    const initialResponses = <?!= __dynamicFormResponsesJSON ?>;
+    const initialUserDirectory = <?!= __dynamicFormUserDirectoryJSON ?>;
+    const initialSelectedFormId = '<?= __escapedDynamicFormsSelectedId ?>';
+
+    const state = {
+      forms: Array.isArray(initialForms) ? initialForms.slice() : [],
+      responsesByForm: {},
+      selectedFormId: initialSelectedFormId || '',
+      formSearch: '',
+      responseSearch: '',
+      lastFetchedByForm: {}
+    };
+
+    const FIELD_TYPES = [
+      { value: 'text', label: 'Short text' },
+      { value: 'textarea', label: 'Paragraph' },
+      { value: 'email', label: 'Email' },
+      { value: 'phone', label: 'Phone number' },
+      { value: 'number', label: 'Number' },
+      { value: 'date', label: 'Date' },
+      { value: 'select', label: 'Dropdown' },
+      { value: 'radio', label: 'Multiple choice' },
+      { value: 'checkbox', label: 'Checkboxes' },
+      { value: 'multiselect', label: 'Multi-select' }
+    ];
+
+    const FIELD_TYPE_LABEL_LOOKUP = FIELD_TYPES.reduce(function (acc, entry) {
+      acc[entry.value] = entry.label;
+      return acc;
+    }, {});
+
+    const OPTION_FIELD_TYPES = ['select', 'radio', 'checkbox', 'multiselect'];
+
+    const userLookup = new Map();
+
+    if (Array.isArray(initialUserDirectory)) {
+      initialUserDirectory.forEach(function (entry) {
+        if (!entry) return;
+        const key = entry.id || entry.ID;
+        if (!key) return;
+        userLookup.set(String(key), {
+          name: entry.name || entry.FullName || entry.fullName || '',
+          email: entry.email || entry.Email || ''
+        });
+      });
+    }
+
+    state.forms = state.forms.map(normalizeForm);
+
+    if (!state.selectedFormId && state.forms.length) {
+      state.selectedFormId = getFormId(state.forms[0]);
+    }
+
+    if (state.selectedFormId && Array.isArray(initialResponses)) {
+      state.responsesByForm[state.selectedFormId] = sortResponses(initialResponses.map(normalizeResponse));
+      state.lastFetchedByForm[state.selectedFormId] = new Date().toISOString();
+    }
+
+    const formsListEl = document.getElementById('formsList');
+    const formsCountEl = document.getElementById('formsCount');
+    const formsEmptyEl = document.getElementById('formsEmpty');
+    const formSearchEl = document.getElementById('formSearch');
+
+    const responsesTitleEl = document.getElementById('responsesTitle');
+    const responsesDescriptionEl = document.getElementById('responsesDescription');
+    const fieldsCountEl = document.getElementById('fieldsCount');
+    const responsesCountEl = document.getElementById('responsesCount');
+    const lastFetchedEl = document.getElementById('lastFetched');
+    const responseSheetLinkEl = document.getElementById('responseSheetLink');
+    const responseSearchEl = document.getElementById('responseSearch');
+    const responsesStatusEl = document.getElementById('responsesStatus');
+    const responsesEmptyEl = document.getElementById('responsesEmpty');
+    const responsesContainerEl = document.getElementById('responsesContainer');
+    const refreshButton = document.getElementById('refreshResponses');
+    const createFormButton = document.getElementById('openCreateForm');
+    const createFormModalEl = document.getElementById('createFormModal');
+    const createFormForm = document.getElementById('createFormForm');
+    const createFormAlertEl = document.getElementById('createFormAlert');
+    const createFormNameEl = document.getElementById('createFormName');
+    const createFormDescriptionEl = document.getElementById('createFormDescription');
+    const createFormFieldsEl = document.getElementById('createFormFields');
+    const addFormFieldButton = document.getElementById('addFormField');
+    const createFormSubmitButton = document.getElementById('createFormSubmit');
+
+    let createFormModalInstance = null;
+    let createFormFieldCounter = 0;
+    let createFormSubmitOriginalHtml = createFormSubmitButton ? createFormSubmitButton.innerHTML : '';
+
+    if (formSearchEl) {
+      formSearchEl.addEventListener('input', function (event) {
+        const value = (event.target && typeof event.target.value !== 'undefined')
+          ? String(event.target.value)
+          : '';
+        state.formSearch = value.trim().toLowerCase();
+        renderFormsList();
+      });
+    }
+
+    if (responseSearchEl) {
+      responseSearchEl.addEventListener('input', function (event) {
+        const value = (event.target && typeof event.target.value !== 'undefined')
+          ? String(event.target.value)
+          : '';
+        state.responseSearch = value.trim().toLowerCase();
+        renderResponses(state.selectedFormId);
+      });
+    }
+
+    if (refreshButton) {
+      refreshButton.addEventListener('click', function () {
+        if (!state.selectedFormId) {
+          setStatus('warning', 'Select a form to refresh responses.');
+          return;
+        }
+        selectForm(state.selectedFormId, { force: true });
+      });
+    }
+
+    if (createFormButton) {
+      if (!canUseGoogleScript()) {
+        createFormButton.classList.add('disabled');
+        createFormButton.setAttribute('disabled', 'disabled');
+        createFormButton.setAttribute('title', 'Form creation is only available inside the Lumina workspace.');
+      } else {
+        createFormButton.addEventListener('click', function () {
+          openCreateFormModal();
+        });
+      }
+    }
+
+    if (createFormModalEl && typeof bootstrap !== 'undefined' && bootstrap && typeof bootstrap.Modal === 'function') {
+      createFormModalEl.addEventListener('hidden.bs.modal', function () {
+        resetCreateFormBuilder();
+      });
+    }
+
+    if (addFormFieldButton) {
+      addFormFieldButton.addEventListener('click', function () {
+        addFormField();
+        refreshBuilderFieldSummaries();
+      });
+    }
+
+    if (createFormForm) {
+      createFormForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        submitCreateForm();
+      });
+    }
+
+    renderFormsList();
+    renderSelectedFormSummary();
+
+    if (state.selectedFormId) {
+      if (state.responsesByForm[state.selectedFormId]) {
+        renderResponses(state.selectedFormId);
+      } else {
+        fetchResponses(state.selectedFormId);
+      }
+    } else {
+      renderResponses('');
+    }
+
+    if (!canUseGoogleScript()) {
+      setStatus('warning', 'google.script.run is not available. Showing cached data only.');
+    }
+
+    function openCreateFormModal() {
+      resetCreateFormBuilder();
+      showCreateFormModal();
+      setTimeout(function () {
+        if (createFormNameEl && typeof createFormNameEl.focus === 'function') {
+          createFormNameEl.focus();
+        }
+      }, 150);
+    }
+
+    function showCreateFormModal() {
+      if (!createFormModalEl) return;
+      if (typeof bootstrap !== 'undefined' && bootstrap && typeof bootstrap.Modal === 'function') {
+        if (!createFormModalInstance) {
+          createFormModalInstance = new bootstrap.Modal(createFormModalEl, { backdrop: 'static' });
+        }
+        createFormModalInstance.show();
+      } else {
+        createFormModalEl.classList.add('show');
+        createFormModalEl.style.display = 'block';
+        createFormModalEl.removeAttribute('aria-hidden');
+      }
+    }
+
+    function hideCreateFormModal() {
+      if (!createFormModalEl) return;
+      if (typeof bootstrap !== 'undefined' && bootstrap && typeof bootstrap.Modal === 'function') {
+        if (createFormModalInstance) {
+          createFormModalInstance.hide();
+        }
+      } else {
+        createFormModalEl.classList.remove('show');
+        createFormModalEl.style.display = 'none';
+        createFormModalEl.setAttribute('aria-hidden', 'true');
+      }
+    }
+
+    function resetCreateFormBuilder() {
+      clearCreateFormAlert();
+      createFormFieldCounter = 0;
+      if (createFormForm && typeof createFormForm.reset === 'function') {
+        createFormForm.reset();
+      }
+      if (createFormFieldsEl) {
+        createFormFieldsEl.innerHTML = '';
+        addFormField();
+        refreshBuilderFieldSummaries();
+      }
+      if (createFormSubmitButton) {
+        createFormSubmitButton.disabled = false;
+        if (createFormSubmitOriginalHtml) {
+          createFormSubmitButton.innerHTML = createFormSubmitOriginalHtml;
+        }
+      }
+      if (addFormFieldButton) {
+        addFormFieldButton.disabled = false;
+      }
+      if (createFormNameEl) {
+        createFormNameEl.classList.remove('is-invalid');
+      }
+    }
+
+    function clearCreateFormAlert() {
+      if (!createFormAlertEl) return;
+      createFormAlertEl.className = 'alert d-none create-form-alert';
+      createFormAlertEl.textContent = '';
+    }
+
+    function showCreateFormAlert(type, message) {
+      if (!createFormAlertEl) return;
+      var className = 'alert create-form-alert';
+      if (type === 'error') {
+        className += ' alert-danger';
+      } else if (type === 'success') {
+        className += ' alert-success';
+      } else {
+        className += ' alert-info';
+      }
+      createFormAlertEl.className = className;
+      createFormAlertEl.textContent = message || '';
+    }
+
+    function addFormField(initialConfig) {
+      if (!createFormFieldsEl) return;
+      var config = initialConfig && typeof initialConfig === 'object' ? initialConfig : {};
+      createFormFieldCounter += 1;
+      var suffix = String(createFormFieldCounter);
+
+      var wrapper = document.createElement('div');
+      wrapper.className = 'create-form-field';
+      wrapper.setAttribute('data-field-id', suffix);
+
+      var header = document.createElement('div');
+      header.className = 'create-form-field__header';
+      wrapper.appendChild(header);
+
+      var title = document.createElement('span');
+      title.className = 'create-form-field__title';
+      title.setAttribute('data-role', 'field-header');
+      header.appendChild(title);
+
+      var typeBadge = document.createElement('span');
+      typeBadge.className = 'create-form-field__type';
+      typeBadge.setAttribute('data-role', 'field-type-badge');
+      header.appendChild(typeBadge);
+
+      var controls = document.createElement('div');
+      controls.className = 'create-form-field__controls';
+      header.appendChild(controls);
+
+      var removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.className = 'create-form-field__remove';
+      removeButton.setAttribute('data-role', 'remove-field');
+      removeButton.setAttribute('aria-label', 'Remove field');
+      removeButton.innerHTML = "<i class='fas fa-trash-alt'></i><span>Remove</span>";
+      controls.appendChild(removeButton);
+
+      var grid = document.createElement('div');
+      grid.className = 'create-form-field__grid';
+      wrapper.appendChild(grid);
+
+      var labelGroup = document.createElement('div');
+      var labelLabel = document.createElement('label');
+      labelLabel.className = 'form-label';
+      labelLabel.setAttribute('for', 'createFormFieldLabel' + suffix);
+      labelLabel.textContent = 'Prompt';
+      labelGroup.appendChild(labelLabel);
+      var labelInput = document.createElement('input');
+      labelInput.type = 'text';
+      labelInput.className = 'form-control';
+      labelInput.id = 'createFormFieldLabel' + suffix;
+      labelInput.placeholder = 'e.g. What is your phone number?';
+      labelInput.setAttribute('data-role', 'field-label');
+      labelGroup.appendChild(labelInput);
+      var labelFeedback = document.createElement('div');
+      labelFeedback.className = 'invalid-feedback';
+      labelFeedback.textContent = 'Please provide a prompt.';
+      labelGroup.appendChild(labelFeedback);
+      grid.appendChild(labelGroup);
+
+      var typeGroup = document.createElement('div');
+      var typeLabel = document.createElement('label');
+      typeLabel.className = 'form-label';
+      typeLabel.setAttribute('for', 'createFormFieldType' + suffix);
+      typeLabel.textContent = 'Answer type';
+      typeGroup.appendChild(typeLabel);
+      var typeSelect = document.createElement('select');
+      typeSelect.className = 'form-select';
+      typeSelect.id = 'createFormFieldType' + suffix;
+      typeSelect.setAttribute('data-role', 'field-type');
+      FIELD_TYPES.forEach(function (option) {
+        var opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label;
+        typeSelect.appendChild(opt);
+      });
+      typeGroup.appendChild(typeSelect);
+      grid.appendChild(typeGroup);
+
+      var bindingGroup = document.createElement('div');
+      var bindingLabel = document.createElement('label');
+      bindingLabel.className = 'form-label';
+      bindingLabel.setAttribute('for', 'createFormFieldBinding' + suffix);
+      bindingLabel.textContent = 'Profile binding (optional)';
+      bindingGroup.appendChild(bindingLabel);
+      var bindingInput = document.createElement('input');
+      bindingInput.type = 'text';
+      bindingInput.className = 'form-control';
+      bindingInput.id = 'createFormFieldBinding' + suffix;
+      bindingInput.placeholder = 'e.g. phone or insurance.provider';
+      bindingInput.setAttribute('list', 'formFieldBindingSuggestions');
+      bindingInput.setAttribute('data-role', 'field-binding');
+      bindingGroup.appendChild(bindingInput);
+      var bindingHelp = document.createElement('div');
+      bindingHelp.className = 'form-text';
+      bindingHelp.textContent = 'Use a binding to update the user profile when this answer is submitted.';
+      bindingGroup.appendChild(bindingHelp);
+      grid.appendChild(bindingGroup);
+
+      var helpGroup = document.createElement('div');
+      helpGroup.className = 'mt-3';
+      var helpLabel = document.createElement('label');
+      helpLabel.className = 'form-label';
+      helpLabel.setAttribute('for', 'createFormFieldHelp' + suffix);
+      helpLabel.textContent = 'Helper text (optional)';
+      helpGroup.appendChild(helpLabel);
+      var helpTextarea = document.createElement('textarea');
+      helpTextarea.className = 'form-control';
+      helpTextarea.rows = 2;
+      helpTextarea.id = 'createFormFieldHelp' + suffix;
+      helpTextarea.placeholder = 'Add additional context shown beneath the prompt';
+      helpTextarea.setAttribute('data-role', 'field-help');
+      helpGroup.appendChild(helpTextarea);
+      wrapper.appendChild(helpGroup);
+
+      var requiredWrapper = document.createElement('div');
+      requiredWrapper.className = 'form-check';
+      var requiredInput = document.createElement('input');
+      requiredInput.className = 'form-check-input';
+      requiredInput.type = 'checkbox';
+      requiredInput.id = 'createFormFieldRequired' + suffix;
+      requiredInput.setAttribute('data-role', 'field-required');
+      requiredWrapper.appendChild(requiredInput);
+      var requiredLabel = document.createElement('label');
+      requiredLabel.className = 'form-check-label';
+      requiredLabel.setAttribute('for', 'createFormFieldRequired' + suffix);
+      requiredLabel.textContent = 'Mark as required';
+      requiredWrapper.appendChild(requiredLabel);
+      wrapper.appendChild(requiredWrapper);
+
+      var optionsWrapper = document.createElement('div');
+      optionsWrapper.className = 'create-form-field__options';
+      optionsWrapper.setAttribute('data-role', 'field-options-container');
+      var optionsLabel = document.createElement('label');
+      optionsLabel.className = 'form-label';
+      optionsLabel.setAttribute('for', 'createFormFieldOptions' + suffix);
+      optionsLabel.textContent = 'Options (one per line)';
+      optionsWrapper.appendChild(optionsLabel);
+      var optionsTextarea = document.createElement('textarea');
+      optionsTextarea.className = 'form-control';
+      optionsTextarea.id = 'createFormFieldOptions' + suffix;
+      optionsTextarea.placeholder = 'Option 1\nOption 2';
+      optionsTextarea.setAttribute('data-role', 'field-options');
+      optionsWrapper.appendChild(optionsTextarea);
+      var optionsHelp = document.createElement('div');
+      optionsHelp.className = 'form-text';
+      optionsHelp.textContent = 'Dropdowns, multiple choice, and checkbox lists need at least one option.';
+      optionsWrapper.appendChild(optionsHelp);
+      wrapper.appendChild(optionsWrapper);
+
+      createFormFieldsEl.appendChild(wrapper);
+
+      var initialLabel = config.label || config.title || '';
+      if (initialLabel && labelInput) {
+        labelInput.value = String(initialLabel);
+      }
+      var initialType = config.type && FIELD_TYPE_LABEL_LOOKUP[config.type]
+        ? String(config.type)
+        : 'text';
+      typeSelect.value = initialType;
+      var initialBinding = '';
+      if (typeof config.binding === 'string') {
+        initialBinding = config.binding;
+      } else if (config.binding && typeof config.binding === 'object') {
+        if (config.binding.type === 'userColumn' && config.binding.column) {
+          initialBinding = config.binding.column.toLowerCase() === 'fullname'
+            ? 'fullname'
+            : config.binding.column.toLowerCase() === 'email'
+              ? 'email'
+              : config.binding.column.toLowerCase() === 'phonenumber'
+                ? 'phone'
+                : '';
+        } else if (config.binding.type === 'namePart' && config.binding.part) {
+          initialBinding = config.binding.part === 'first' ? 'firstname' : config.binding.part === 'last' ? 'lastname' : '';
+        } else if (config.binding.type === 'insurance' && config.binding.key) {
+          initialBinding = 'insurance.' + config.binding.key;
+        }
+      }
+      if (initialBinding && bindingInput) {
+        bindingInput.value = String(initialBinding);
+      }
+      if (config.helpText && helpTextarea) {
+        helpTextarea.value = String(config.helpText);
+      }
+      if (config.required && requiredInput) {
+        requiredInput.checked = true;
+      }
+      if (Array.isArray(config.options) && config.options.length && optionsTextarea) {
+        optionsTextarea.value = config.options.map(function (option) {
+          return option === null || typeof option === 'undefined' ? '' : String(option);
+        }).join('\n');
+      }
+
+      toggleFieldOptions(wrapper, initialType);
+      refreshBuilderFieldSummaries();
+
+      labelInput.addEventListener('input', function () {
+        if (labelInput.value && labelInput.value.trim()) {
+          labelInput.classList.remove('is-invalid');
+        }
+        refreshBuilderFieldSummaries();
+      });
+
+      typeSelect.addEventListener('change', function () {
+        toggleFieldOptions(wrapper, typeSelect.value);
+        refreshBuilderFieldSummaries();
+      });
+
+      removeButton.addEventListener('click', function () {
+        if (!createFormFieldsEl) return;
+        if (createFormFieldsEl.children.length <= 1) {
+          showCreateFormAlert('error', 'At least one field is required.');
+          return;
+        }
+        createFormFieldsEl.removeChild(wrapper);
+        refreshBuilderFieldSummaries();
+      });
+    }
+
+    function toggleFieldOptions(wrapper, typeValue) {
+      if (!wrapper) return;
+      var container = wrapper.querySelector('[data-role="field-options-container"]');
+      if (!container) return;
+      if (needsOptions(typeValue)) {
+        container.classList.remove('hidden');
+      } else {
+        container.classList.add('hidden');
+      }
+    }
+
+    function refreshBuilderFieldSummaries() {
+      if (!createFormFieldsEl) return;
+      var items = Array.prototype.slice.call(createFormFieldsEl.children || []);
+      items.forEach(function (item, index) {
+        if (!item) return;
+        var header = item.querySelector('[data-role="field-header"]');
+        var labelInput = item.querySelector('[data-role="field-label"]');
+        var badge = item.querySelector('[data-role="field-type-badge"]');
+        var typeSelect = item.querySelector('[data-role="field-type"]');
+        var labelValue = labelInput && labelInput.value ? String(labelInput.value).trim() : '';
+        if (header) {
+          header.textContent = labelValue || 'Field ' + (index + 1);
+        }
+        if (badge) {
+          var typeValue = typeSelect ? String(typeSelect.value || '') : '';
+          badge.textContent = getFieldTypeLabel(typeValue);
+        }
+      });
+    }
+
+    function needsOptions(typeValue) {
+      var normalized = (typeValue || '').toLowerCase();
+      return OPTION_FIELD_TYPES.indexOf(normalized) !== -1;
+    }
+
+    function getFieldTypeLabel(typeValue) {
+      if (!typeValue) return 'Field';
+      return FIELD_TYPE_LABEL_LOOKUP[typeValue] || typeValue.charAt(0).toUpperCase() + typeValue.slice(1);
+    }
+
+    function parseFieldOptions(value) {
+      if (!value && value !== 0) return [];
+      return String(value)
+        .split(/\r?\n/)
+        .map(function (part) { return part.trim(); })
+        .filter(function (part) { return part.length > 0; });
+    }
+
+    function collectFormFields() {
+      var result = [];
+      var hasErrors = false;
+      if (!createFormFieldsEl) {
+        return { list: result, hasErrors: true };
+      }
+      var items = Array.prototype.slice.call(createFormFieldsEl.children || []);
+      items.forEach(function (item) {
+        if (!item) return;
+        var labelInput = item.querySelector('[data-role="field-label"]');
+        var typeSelect = item.querySelector('[data-role="field-type"]');
+        var bindingInput = item.querySelector('[data-role="field-binding"]');
+        var helpTextarea = item.querySelector('[data-role="field-help"]');
+        var requiredInput = item.querySelector('[data-role="field-required"]');
+        var optionsTextarea = item.querySelector('[data-role="field-options"]');
+
+        var labelValue = labelInput && typeof labelInput.value !== 'undefined'
+          ? String(labelInput.value).trim()
+          : '';
+        if (!labelValue) {
+          hasErrors = true;
+          if (labelInput) {
+            labelInput.classList.add('is-invalid');
+          }
+          return;
+        }
+        if (labelInput) {
+          labelInput.classList.remove('is-invalid');
+        }
+
+        var typeValue = typeSelect ? String(typeSelect.value || 'text') : 'text';
+        var bindingValue = bindingInput && bindingInput.value ? String(bindingInput.value).trim() : '';
+        var helpValue = helpTextarea && helpTextarea.value ? String(helpTextarea.value).trim() : '';
+        var requiredValue = !!(requiredInput && requiredInput.checked);
+        var optionsList = [];
+        if (needsOptions(typeValue) && optionsTextarea) {
+          optionsList = parseFieldOptions(optionsTextarea.value);
+        }
+
+        var fieldConfig = {
+          label: labelValue,
+          type: typeValue
+        };
+        if (bindingValue) {
+          fieldConfig.binding = bindingValue;
+        }
+        if (helpValue) {
+          fieldConfig.helpText = helpValue;
+        }
+        if (requiredValue) {
+          fieldConfig.required = true;
+        }
+        if (optionsList.length) {
+          fieldConfig.options = optionsList;
+        }
+        result.push(fieldConfig);
+      });
+      return { list: result, hasErrors: hasErrors };
+    }
+
+    function setCreateFormBusy(isBusy) {
+      if (createFormSubmitButton) {
+        if (!createFormSubmitOriginalHtml) {
+          createFormSubmitOriginalHtml = createFormSubmitButton.innerHTML;
+        }
+        if (isBusy) {
+          createFormSubmitButton.disabled = true;
+          createFormSubmitButton.innerHTML = "<span class='spinner-border spinner-border-sm me-2' role='status' aria-hidden='true'></span><span>Creating…</span>";
+        } else {
+          createFormSubmitButton.disabled = false;
+          createFormSubmitButton.innerHTML = createFormSubmitOriginalHtml;
+        }
+      }
+      if (addFormFieldButton) {
+        addFormFieldButton.disabled = !!isBusy;
+      }
+      if (createFormFieldsEl) {
+        var inputs = createFormFieldsEl.querySelectorAll('input, textarea, select, button');
+        inputs.forEach(function (element) {
+          if (!element) return;
+          if (element === createFormSubmitButton) return;
+          if (element === addFormFieldButton) return;
+          element.disabled = !!isBusy;
+        });
+      }
+      if (createFormNameEl) {
+        createFormNameEl.disabled = !!isBusy;
+      }
+      if (createFormDescriptionEl) {
+        createFormDescriptionEl.disabled = !!isBusy;
+      }
+    }
+
+    function submitCreateForm() {
+      if (!canUseGoogleScript()) {
+        showCreateFormAlert('error', 'Form creation is only available when this page is running inside the Lumina workspace.');
+        return;
+      }
+
+      clearCreateFormAlert();
+
+      var nameValue = createFormNameEl && typeof createFormNameEl.value !== 'undefined'
+        ? String(createFormNameEl.value).trim()
+        : '';
+      if (!nameValue && createFormNameEl) {
+        createFormNameEl.classList.add('is-invalid');
+      } else if (createFormNameEl) {
+        createFormNameEl.classList.remove('is-invalid');
+      }
+
+      var descriptionValue = createFormDescriptionEl && typeof createFormDescriptionEl.value !== 'undefined'
+        ? String(createFormDescriptionEl.value).trim()
+        : '';
+
+      var collected = collectFormFields();
+      if (!nameValue) {
+        showCreateFormAlert('error', 'Give the form a name before saving.');
+        if (createFormNameEl && typeof createFormNameEl.focus === 'function') {
+          createFormNameEl.focus();
+        }
+        return;
+      }
+
+      if (collected.hasErrors) {
+        showCreateFormAlert('error', 'Please complete the prompt for each field before saving.');
+        refreshBuilderFieldSummaries();
+        return;
+      }
+
+      if (!collected.list.length) {
+        showCreateFormAlert('error', 'Add at least one field to the form.');
+        return;
+      }
+
+      var payload = {
+        name: nameValue,
+        description: descriptionValue,
+        fields: collected.list
+      };
+
+      setCreateFormBusy(true);
+
+      google.script.run
+        .withSuccessHandler(function (createdForm) {
+          setCreateFormBusy(false);
+          hideCreateFormModal();
+          handleFormCreated(createdForm, payload);
+        })
+        .withFailureHandler(function (error) {
+          setCreateFormBusy(false);
+          var message = error && error.message ? error.message : String(error || 'Unknown error');
+          showCreateFormAlert('error', 'Failed to create form: ' + message);
+        })
+        .createDynamicForm(payload, {});
+    }
+
+    function handleFormCreated(createdForm, payload) {
+      var form = createdForm && typeof createdForm === 'object' ? createdForm : payload;
+      if (!form) return;
+      var normalized = normalizeForm(form);
+      if (!normalized) return;
+      var formId = getFormId(normalized);
+      if (!formId) {
+        setStatus('info', 'Form created. Select it from the list to review responses.');
+        return;
+      }
+
+      var existingIndex = -1;
+      for (var i = 0; i < state.forms.length; i++) {
+        if (getFormId(state.forms[i]) === formId) {
+          existingIndex = i;
+          break;
+        }
+      }
+      if (!normalized.CreatedAt && !normalized.createdAt) {
+        normalized.CreatedAt = new Date().toISOString();
+      }
+
+      if (existingIndex >= 0) {
+        state.forms[existingIndex] = normalized;
+      } else {
+        state.forms.push(normalized);
+      }
+
+      state.formSearch = '';
+      if (formSearchEl) {
+        formSearchEl.value = '';
+      }
+
+      state.responsesByForm[formId] = [];
+      state.lastFetchedByForm[formId] = new Date().toISOString();
+
+      renderFormsList();
+      selectForm(formId);
+
+      var formName = normalized.Name || normalized.name || (payload && payload.name) || 'Form';
+      const sheetName = normalized.ResponseSheetName || normalized.responseSheetName || '';
+      const sheetStatusMessage = sheetName
+        ? ' Responses will also sync to the “' + sheetName + '” sheet.'
+        : ' Responses will also be recorded in the response log.';
+      setStatus('info', 'Form “' + formName + '” created. Share it to start collecting responses.' + sheetStatusMessage);
+    }
+
+    function normalizeForm(form) {
+      if (!form || typeof form !== 'object') return form;
+      if (!Array.isArray(form.Fields) && Array.isArray(form.fields)) {
+        form.Fields = form.fields;
+      }
+      if (typeof form.Name === 'undefined' && typeof form.name !== 'undefined') {
+        form.Name = form.name;
+      }
+      if (typeof form.Description === 'undefined' && typeof form.description !== 'undefined') {
+        form.Description = form.description;
+      }
+      if (typeof form.ResponseSheetName === 'undefined' && typeof form.responseSheetName !== 'undefined') {
+        form.ResponseSheetName = form.responseSheetName;
+      }
+      if (typeof form.ResponseSheetId === 'undefined' && typeof form.responseSheetId !== 'undefined') {
+        form.ResponseSheetId = form.responseSheetId;
+      }
+      if (typeof form.ResponseSheetUrl === 'undefined' && typeof form.responseSheetUrl !== 'undefined') {
+        form.ResponseSheetUrl = form.responseSheetUrl;
+      }
+      return form;
+    }
+
+    function normalizeResponse(response) {
+      if (!response || typeof response !== 'object') return response;
+      if (!Array.isArray(response.Responses) && Array.isArray(response.responses)) {
+        response.Responses = response.responses;
+      }
+      if (!Array.isArray(response.UserUpdates) && Array.isArray(response.userUpdates)) {
+        response.UserUpdates = response.userUpdates;
+      }
+      return response;
+    }
+
+    function getFormId(form) {
+      if (!form || typeof form !== 'object') return '';
+      return String(form.ID || form.Id || form.id || '');
+    }
+
+    function getFormById(id) {
+      const target = String(id || '');
+      if (!target) return null;
+      for (let i = 0; i < state.forms.length; i++) {
+        const form = state.forms[i];
+        if (!form) continue;
+        if (getFormId(form) === target) {
+          return form;
+        }
+      }
+      return null;
+    }
+
+    function getResponsesForForm(id) {
+      const key = String(id || '');
+      if (!key) return [];
+      const list = state.responsesByForm[key];
+      return Array.isArray(list) ? list : [];
+    }
+
+    function getTimestampValue(values) {
+      for (let i = 0; i < values.length; i++) {
+        const raw = values[i];
+        if (!raw) continue;
+        const date = raw instanceof Date ? raw : new Date(raw);
+        if (!isNaN(date.getTime())) {
+          return date;
+        }
+      }
+      return null;
+    }
+
+    function getFormTimestampMs(form) {
+      const updated = getTimestampValue([form.UpdatedAt, form.updatedAt]);
+      const created = getTimestampValue([form.CreatedAt, form.createdAt]);
+      const resolved = updated || created;
+      return resolved ? resolved.getTime() : 0;
+    }
+
+    function sortFormsList(list) {
+      return list.slice().sort(function (a, b) {
+        return getFormTimestampMs(b || {}) - getFormTimestampMs(a || {});
+      });
+    }
+
+    function getResponseTimestampMs(response) {
+      const stamp = getTimestampValue([
+        response && response.UpdatedAt,
+        response && response.updatedAt,
+        response && response.CreatedAt,
+        response && response.createdAt
+      ]);
+      return stamp ? stamp.getTime() : 0;
+    }
+
+    function sortResponses(list) {
+      return list.slice().sort(function (a, b) {
+        return getResponseTimestampMs(b || {}) - getResponseTimestampMs(a || {});
+      });
+    }
+
+    function formatRelativeTimestamp(value) {
+      if (!value) return '';
+      const date = value instanceof Date ? value : new Date(value);
+      if (isNaN(date.getTime())) return '';
+      const diffMs = Date.now() - date.getTime();
+      if (diffMs < 0) return date.toLocaleDateString();
+      const minutes = Math.floor(diffMs / 60000);
+      if (minutes < 1) return 'just now';
+      if (minutes < 60) return minutes + 'm ago';
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return hours + 'h ago';
+      const days = Math.floor(hours / 24);
+      if (days < 7) return days + 'd ago';
+      return date.toLocaleDateString();
+    }
+
+    function formatTimestamp(value) {
+      if (!value) return '—';
+      const date = value instanceof Date ? value : new Date(value);
+      if (isNaN(date.getTime())) return String(value);
+      return date.toLocaleString();
+    }
+
+    function formatAnswerValue(value) {
+      if (value === null || typeof value === 'undefined' || value === '') {
+        return '—';
+      }
+      if (Array.isArray(value)) {
+        const joined = value
+          .map(function (part) {
+            if (part === null || typeof part === 'undefined') return '';
+            return String(part);
+          })
+          .filter(function (part) { return part !== ''; })
+          .join(', ');
+        return joined || '—';
+      }
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value);
+        } catch (err) {
+          return String(value);
+        }
+      }
+      return String(value);
+    }
+
+    function resolveUserSummary(userId) {
+      const key = userId ? String(userId) : '';
+      const stored = key && userLookup.has(key) ? userLookup.get(key) : null;
+      if (stored) {
+        return {
+          name: stored.name || (key ? 'User ' + key : 'Unknown user'),
+          email: stored.email || ''
+        };
+      }
+      return {
+        name: key ? 'User ' + key : 'Unknown user',
+        email: ''
+      };
+    }
+
+    function toDomId(prefix, value) {
+      const safe = String(value || '').replace(/[^a-zA-Z0-9_-]+/g, '-');
+      return prefix + '-' + (safe || 'item');
+    }
+
+    function renderFormsList() {
+      if (!formsListEl) return;
+      const total = state.forms.length;
+      const searchTerm = state.formSearch;
+      const sorted = sortFormsList(state.forms);
+      const filtered = searchTerm
+        ? sorted.filter(function (form) {
+            const name = (form.Name || form.name || '').toLowerCase();
+            const description = (form.Description || form.description || '').toLowerCase();
+            return name.indexOf(searchTerm) !== -1 || description.indexOf(searchTerm) !== -1;
+          })
+        : sorted;
+
+      formsListEl.innerHTML = '';
+      let activeButtonId = '';
+
+      filtered.forEach(function (form) {
+        if (!form) return;
+        const formId = getFormId(form);
+        if (!formId) return;
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'form-list-item';
+        button.setAttribute('role', 'option');
+        button.setAttribute('data-form-id', formId);
+        button.id = toDomId('form-option', formId);
+
+        const isActive = formId === state.selectedFormId;
+        if (isActive) {
+          button.classList.add('is-active');
+          button.setAttribute('aria-selected', 'true');
+          activeButtonId = button.id;
+        } else {
+          button.setAttribute('aria-selected', 'false');
+        }
+
+        const nameEl = document.createElement('div');
+        nameEl.className = 'form-list-item__name';
+        nameEl.textContent = form.Name || form.name || 'Untitled form';
+        button.appendChild(nameEl);
+
+        const metaEl = document.createElement('div');
+        metaEl.className = 'form-list-item__meta';
+
+        const fields = Array.isArray(form.Fields) ? form.Fields : [];
+        const fieldSpan = document.createElement('span');
+        fieldSpan.textContent = fields.length === 1 ? '1 field' : fields.length + ' fields';
+        metaEl.appendChild(fieldSpan);
+
+        const updated = getTimestampValue([form.UpdatedAt, form.updatedAt, form.CreatedAt, form.createdAt]);
+        if (updated) {
+          const updatedSpan = document.createElement('span');
+          const prefix = form.UpdatedAt || form.updatedAt ? 'Updated ' : 'Created ';
+          updatedSpan.textContent = prefix + formatRelativeTimestamp(updated);
+          metaEl.appendChild(updatedSpan);
+        }
+
+        button.appendChild(metaEl);
+
+        button.addEventListener('click', function () {
+          selectForm(formId);
+        });
+
+        formsListEl.appendChild(button);
+      });
+
+      if (formsCountEl) {
+        formsCountEl.textContent = total === 1 ? '1 form' : total + ' forms';
+      }
+
+      if (formsEmptyEl) {
+        if (!total) {
+          formsEmptyEl.textContent = 'No dynamic forms have been created yet.';
+          formsEmptyEl.classList.remove('hidden');
+        } else if (!filtered.length) {
+          formsEmptyEl.textContent = 'No forms match your search.';
+          formsEmptyEl.classList.remove('hidden');
+        } else {
+          formsEmptyEl.classList.add('hidden');
+        }
+      }
+
+      if (formsListEl) {
+        if (activeButtonId) {
+          formsListEl.setAttribute('aria-activedescendant', activeButtonId);
+        } else {
+          formsListEl.removeAttribute('aria-activedescendant');
+        }
+      }
+    }
+
+    function renderResponseSheetLink(form) {
+      if (!responseSheetLinkEl) return;
+      responseSheetLinkEl.innerHTML = '';
+      if (!form) {
+        responseSheetLinkEl.textContent = '—';
+        return;
+      }
+
+      const sheetName = form.ResponseSheetName || form.responseSheetName || '';
+      const sheetUrl = form.ResponseSheetUrl || form.responseSheetUrl || '';
+
+      if (sheetUrl) {
+        const link = document.createElement('a');
+        link.href = sheetUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        if (sheetName) {
+          link.title = sheetName;
+        } else {
+          link.title = 'Open response sheet';
+        }
+        const text = document.createElement('span');
+        text.textContent = 'Open sheet';
+        link.appendChild(text);
+        const icon = document.createElement('i');
+        icon.className = 'fas fa-external-link-alt';
+        link.appendChild(icon);
+        responseSheetLinkEl.appendChild(link);
+      } else if (sheetName) {
+        responseSheetLinkEl.textContent = sheetName;
+      } else {
+        responseSheetLinkEl.textContent = '—';
+      }
+    }
+
+    function renderSelectedFormSummary() {
+      if (!responsesTitleEl || !fieldsCountEl || !responsesCountEl || !lastFetchedEl) return;
+      const form = getFormById(state.selectedFormId);
+      if (!form) {
+        responsesTitleEl.textContent = 'Select a form';
+        if (responsesDescriptionEl) {
+          responsesDescriptionEl.textContent = '';
+          responsesDescriptionEl.classList.add('hidden');
+        }
+        fieldsCountEl.textContent = '0';
+        responsesCountEl.textContent = '0';
+        lastFetchedEl.textContent = '—';
+        renderResponseSheetLink(null);
+        return;
+      }
+
+      const name = form.Name || form.name || 'Untitled form';
+      responsesTitleEl.textContent = name;
+
+      if (responsesDescriptionEl) {
+        const description = form.Description || form.description || '';
+        responsesDescriptionEl.textContent = description;
+        if (description && description.trim()) {
+          responsesDescriptionEl.classList.remove('hidden');
+        } else {
+          responsesDescriptionEl.classList.add('hidden');
+        }
+      }
+
+      const fields = Array.isArray(form.Fields) ? form.Fields : [];
+      fieldsCountEl.textContent = String(fields.length);
+
+      const responses = getResponsesForForm(state.selectedFormId);
+      responsesCountEl.textContent = String(responses.length);
+
+      const fetchedAt = state.lastFetchedByForm[state.selectedFormId];
+      lastFetchedEl.textContent = fetchedAt ? formatTimestamp(fetchedAt) : '—';
+      renderResponseSheetLink(form);
+    }
+
+    function renderResponses(formId) {
+      if (!responsesContainerEl || !responsesEmptyEl || !responsesCountEl || !lastFetchedEl) return;
+      const form = getFormById(formId);
+      if (!form) {
+        responsesContainerEl.innerHTML = '';
+        responsesEmptyEl.textContent = 'Select a form to review responses.';
+        responsesEmptyEl.classList.remove('hidden');
+        responsesCountEl.textContent = '0';
+        lastFetchedEl.textContent = '—';
+        return;
+      }
+
+      const responses = getResponsesForForm(formId);
+      const searchTerm = state.responseSearch;
+      const filtered = !searchTerm
+        ? responses
+        : responses.filter(function (response) {
+            const summary = resolveUserSummary(response && (response.UserID || response.userId || response.userID));
+            let haystack = '';
+            if (summary.name) haystack += ' ' + summary.name;
+            if (summary.email) haystack += ' ' + summary.email;
+            if (response && response.SubmittedBy) haystack += ' ' + response.SubmittedBy;
+            const answers = response && Array.isArray(response.Responses) ? response.Responses : [];
+            answers.forEach(function (answer) {
+              if (!answer) return;
+              if (answer.label) haystack += ' ' + String(answer.label);
+              if (typeof answer.value !== 'undefined' && answer.value !== null) {
+                haystack += ' ' + formatAnswerValue(answer.value);
+              }
+            });
+            return haystack.toLowerCase().indexOf(searchTerm) !== -1;
+          });
+
+      responsesContainerEl.innerHTML = '';
+
+      if (!responses.length) {
+        responsesEmptyEl.textContent = 'No responses recorded for this form yet.';
+        responsesEmptyEl.classList.remove('hidden');
+      } else if (!filtered.length) {
+        responsesEmptyEl.textContent = 'No responses match the current search.';
+        responsesEmptyEl.classList.remove('hidden');
+      } else {
+        responsesEmptyEl.classList.add('hidden');
+      }
+
+      filtered.forEach(function (response) {
+        if (!response) return;
+        const card = document.createElement('article');
+        card.className = 'response-card';
+
+        const header = document.createElement('header');
+        header.className = 'response-card__header';
+        card.appendChild(header);
+
+        const identity = document.createElement('div');
+        identity.className = 'response-card__identity';
+        header.appendChild(identity);
+
+        const summary = resolveUserSummary(response.UserID || response.userId || response.userID);
+
+        const title = document.createElement('div');
+        title.className = 'response-card__title';
+        title.textContent = summary.name;
+        identity.appendChild(title);
+
+        if (summary.email) {
+          const submittedByEl = document.createElement('div');
+          submittedByEl.className = 'response-card__submitted-by';
+          submittedByEl.textContent = summary.email;
+          identity.appendChild(submittedByEl);
+        }
+
+        const meta = document.createElement('div');
+        meta.className = 'response-card__meta';
+        header.appendChild(meta);
+
+        const submittedAt = getTimestampValue([
+          response.UpdatedAt,
+          response.updatedAt,
+          response.CreatedAt,
+          response.createdAt
+        ]);
+        const submittedSpan = document.createElement('span');
+        submittedSpan.textContent = submittedAt
+          ? 'Submitted ' + formatTimestamp(submittedAt)
+          : 'Submission time unavailable';
+        meta.appendChild(submittedSpan);
+
+        if (response.ID || response.id) {
+          const idSpan = document.createElement('span');
+          idSpan.textContent = 'ID ' + String(response.ID || response.id);
+          meta.appendChild(idSpan);
+        }
+
+        if (response.SubmittedBy) {
+          const bySpan = document.createElement('span');
+          bySpan.textContent = 'By ' + String(response.SubmittedBy);
+          meta.appendChild(bySpan);
+        }
+
+        const answersList = document.createElement('dl');
+        answersList.className = 'response-card__answers';
+        const answers = Array.isArray(response.Responses) ? response.Responses : [];
+        answers.forEach(function (answer) {
+          if (!answer) return;
+          const dt = document.createElement('dt');
+          dt.textContent = answer.label || answer.id || 'Field';
+          answersList.appendChild(dt);
+
+          const dd = document.createElement('dd');
+          dd.textContent = formatAnswerValue(answer.value);
+          answersList.appendChild(dd);
+        });
+        card.appendChild(answersList);
+
+        if (Array.isArray(response.UserUpdates) && response.UserUpdates.length) {
+          const updates = document.createElement('div');
+          updates.className = 'response-card__updates';
+          response.UserUpdates.forEach(function (update) {
+            if (!update) return;
+            const pill = document.createElement('span');
+            pill.className = 'response-card__update-pill';
+            const column = update.column || update.field || update.fieldId || 'Field';
+            const value = typeof update.value === 'undefined' || update.value === null
+              ? ''
+              : String(update.value);
+            pill.textContent = column + (value ? ': ' + value : '');
+            updates.appendChild(pill);
+          });
+          card.appendChild(updates);
+        }
+
+        responsesContainerEl.appendChild(card);
+      });
+
+      responsesCountEl.textContent = String(responses.length);
+      const fetchedAt = state.lastFetchedByForm[state.selectedFormId];
+      lastFetchedEl.textContent = fetchedAt ? formatTimestamp(fetchedAt) : '—';
+    }
+
+    function setStatus(type, message) {
+      if (!responsesStatusEl) return;
+      responsesStatusEl.textContent = message || '';
+      responsesStatusEl.className = 'status-banner';
+      if (!message) {
+        responsesStatusEl.classList.add('hidden');
+        return;
+      }
+      responsesStatusEl.classList.remove('hidden');
+      if (type) {
+        responsesStatusEl.classList.add('status-banner--' + type);
+      }
+    }
+
+    function setBusy(isBusy) {
+      if (!responsesContainerEl) return;
+      responsesContainerEl.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    }
+
+    function selectForm(formId, options) {
+      if (!formId) return;
+      const normalizedId = String(formId);
+      const force = options && options.force;
+      const changed = state.selectedFormId !== normalizedId;
+      state.selectedFormId = normalizedId;
+
+      if (changed || force) {
+        state.responseSearch = '';
+        if (responseSearchEl) {
+          responseSearchEl.value = '';
+        }
+      }
+
+      renderFormsList();
+      renderSelectedFormSummary();
+
+      if (!state.responsesByForm[normalizedId] || force) {
+        fetchResponses(normalizedId);
+      } else {
+        renderResponses(normalizedId);
+      }
+    }
+
+    function fetchResponses(formId) {
+      if (!formId) {
+        setStatus('warning', 'Select a form to load responses.');
+        return;
+      }
+      if (!canUseGoogleScript()) {
+        setStatus('warning', 'Unable to reach Apps Script. Showing cached data only.');
+        renderResponses(formId);
+        return;
+      }
+
+      setStatus('loading', 'Loading responses…');
+      setBusy(true);
+
+      google.script.run
+        .withSuccessHandler(function (rows) {
+          const list = Array.isArray(rows) ? rows.map(normalizeResponse) : [];
+          state.responsesByForm[formId] = sortResponses(list);
+          state.lastFetchedByForm[formId] = new Date().toISOString();
+          setBusy(false);
+          setStatus(null, '');
+          if (formId === state.selectedFormId) {
+            renderSelectedFormSummary();
+            renderResponses(formId);
+          }
+        })
+        .withFailureHandler(function (error) {
+          setBusy(false);
+          const message = error && error.message ? error.message : String(error || 'Unknown error');
+          setStatus('error', 'Failed to load responses: ' + message);
+          if (formId === state.selectedFormId) {
+            renderResponses(formId);
+          }
+        })
+        .listDynamicFormResponsesByForm(formId, {
+          query: {
+            orderBy: 'CreatedAt',
+            orderDesc: true
+          }
+        });
+    }
+
+    function canUseGoogleScript() {
+      return typeof google !== 'undefined' && google && google.script && google.script.run;
+    }
+  })();
+</script>

--- a/DynamicFormResponsesDashboard.html
+++ b/DynamicFormResponsesDashboard.html
@@ -1,0 +1,524 @@
+<?!= includeOnce('ResponsiveStyles') ?>
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: (typeof currentPage !== 'undefined' && currentPage) ? currentPage : 'dynamic-form-dashboard',
+  pageSlug: (typeof pageSlug !== 'undefined' && pageSlug) ? pageSlug : 'dynamic-form-dashboard',
+  pageTitle: (typeof pageTitle !== 'undefined' && pageTitle) ? pageTitle : 'Dynamic Form Dashboard',
+  pageDescription: (typeof pageDescription !== 'undefined' && pageDescription) ? pageDescription : 'Monitor form creation trends and response activity across your dynamic forms.'
+}) ?>
+
+<?
+  var __pageRoot = (typeof baseUrl !== 'undefined' && baseUrl)
+    ? baseUrl
+    : ((typeof scriptUrl !== 'undefined' && scriptUrl) ? scriptUrl : '');
+?>
+
+<style>
+  :root {
+    --dfd-primary: #4f46e5;
+    --dfd-primary-dark: #4338ca;
+    --dfd-surface: #f8fafc;
+    --dfd-card: #ffffff;
+    --dfd-border: #e2e8f0;
+    --dfd-muted: #64748b;
+  }
+
+  body {
+    background: var(--dfd-surface);
+  }
+
+  .dynamic-form-dashboard {
+    max-width: 1280px;
+    margin: 0 auto;
+  }
+
+  .dashboard-header {
+    background: linear-gradient(135deg, var(--dfd-primary) 0%, var(--dfd-primary-dark) 100%);
+    color: #fff;
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: 0 20px 45px rgba(79, 70, 229, 0.25);
+    margin-bottom: 2rem;
+  }
+
+  .dashboard-header__content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+
+  .dashboard-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 600;
+  }
+
+  .dashboard-header p {
+    margin: 0.5rem 0 0;
+    max-width: 640px;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .dashboard-header__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .dashboard-header__actions .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.6);
+  }
+
+  .metric-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+  }
+
+  .metric-card {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 16px;
+    padding: 1.25rem;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  .metric-card__label {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .metric-card__value {
+    font-size: 2rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+  }
+
+  .dashboard-section {
+    margin-bottom: 2rem;
+  }
+
+  .dashboard-section__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .dashboard-section__header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .dashboard-section__header p {
+    margin: 0.25rem 0 0;
+    color: var(--dfd-muted);
+  }
+
+  .dashboard-card {
+    background: var(--dfd-card);
+    border-radius: 18px;
+    border: 1px solid var(--dfd-border);
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.07);
+    padding: 1.5rem;
+  }
+
+  table.dashboard-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  table.dashboard-table th,
+  table.dashboard-table td {
+    padding: 0.75rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--dfd-border);
+    font-size: 0.95rem;
+  }
+
+  table.dashboard-table th {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: var(--dfd-muted);
+  }
+
+  table.dashboard-table td:last-child,
+  table.dashboard-table th:last-child {
+    text-align: right;
+  }
+
+  .dashboard-status {
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    margin-bottom: 1.25rem;
+    font-size: 0.95rem;
+    background: #eff6ff;
+    color: #1d4ed8;
+    display: none;
+  }
+
+  .dashboard-status.is-visible {
+    display: block;
+  }
+
+  .dashboard-status--error {
+    background: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .dashboard-status--info {
+    background: #e0f2fe;
+    color: #0369a1;
+  }
+
+  .recent-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .recent-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--dfd-border);
+    padding-bottom: 0.75rem;
+  }
+
+  .recent-item__info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .recent-item__title {
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .recent-item__meta {
+    color: var(--dfd-muted);
+    font-size: 0.9rem;
+  }
+
+  .recent-item__count {
+    font-weight: 600;
+    color: var(--dfd-primary);
+    font-size: 1rem;
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--dfd-muted);
+  }
+
+  @media (max-width: 768px) {
+    .dashboard-header {
+      padding: 1.75rem 1.25rem;
+    }
+  }
+</style>
+
+<main class='dynamic-form-dashboard container-fluid py-4 px-4 px-lg-5'>
+  <div class='dashboard-header'>
+    <div class='dashboard-header__content'>
+      <div>
+        <h1>Dynamic Form Dashboard</h1>
+        <p>Review how teams are using dynamic forms, monitor response velocity, and jump into detailed submissions when you need to investigate.</p>
+      </div>
+      <div class='dashboard-header__actions'>
+        <a class='btn btn-outline-light' href='<?= __pageRoot ?>?page=dynamic-forms'>
+          <i class='fas fa-list'></i>
+          <span>View responses</span>
+        </a>
+      </div>
+    </div>
+    <div id='metricCards' class='metric-cards'></div>
+  </div>
+
+  <div id='dashboardStatus' class='dashboard-status'></div>
+
+  <section class='dashboard-section'>
+    <div class='dashboard-section__header'>
+      <div>
+        <h2>Top forms</h2>
+        <p>Most active forms ranked by total responses.</p>
+      </div>
+    </div>
+    <div class='dashboard-card'>
+      <div class='table-responsive'>
+        <table class='dashboard-table'>
+          <thead>
+            <tr>
+              <th>Form</th>
+              <th>Responses</th>
+              <th>Last submission</th>
+              <th>Response sheet</th>
+            </tr>
+          </thead>
+          <tbody id='topFormsBody'>
+            <tr>
+              <td colspan='4' class='empty-state'>Loading…</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class='dashboard-section'>
+    <div class='dashboard-section__header'>
+      <div>
+        <h2>Recent submissions</h2>
+        <p>Latest activity across all dynamic forms.</p>
+      </div>
+    </div>
+    <div class='dashboard-card'>
+      <div id='recentResponses' class='recent-list'>
+        <div class='empty-state'>Loading…</div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<script>
+  (function () {
+    const metricCardsEl = document.getElementById('metricCards');
+    const statusEl = document.getElementById('dashboardStatus');
+    const topFormsBody = document.getElementById('topFormsBody');
+    const recentListEl = document.getElementById('recentResponses');
+
+    const state = {
+      loading: true,
+      error: '',
+      data: null
+    };
+
+    function canUseGoogleScript() {
+      return typeof google !== 'undefined' && google && google.script && typeof google.script.run !== 'undefined';
+    }
+
+    function formatNumber(value) {
+      if (value === null || typeof value === 'undefined') return '0';
+      const number = Number(value);
+      if (isNaN(number)) return String(value);
+      return number.toLocaleString();
+    }
+
+    function formatAverage(value) {
+      if (value === null || typeof value === 'undefined') return '0.0';
+      const number = Number(value);
+      if (isNaN(number)) return String(value);
+      return (Math.round(number * 10) / 10).toLocaleString();
+    }
+
+    function formatDate(value) {
+      if (!value) return '—';
+      const date = value instanceof Date ? value : new Date(value);
+      if (isNaN(date.getTime())) return '—';
+      return date.toLocaleString();
+    }
+
+    function setStatus(message, type) {
+      if (!statusEl) return;
+      if (!message) {
+        statusEl.classList.remove('is-visible');
+        statusEl.textContent = '';
+        return;
+      }
+      statusEl.textContent = message;
+      statusEl.className = 'dashboard-status is-visible';
+      if (type) {
+        statusEl.classList.add('dashboard-status--' + type);
+      }
+    }
+
+    function renderMetrics(summary) {
+      if (!metricCardsEl) return;
+      metricCardsEl.innerHTML = '';
+      const metrics = [
+        { label: 'Total forms', value: formatNumber(summary.totalForms || 0) },
+        { label: 'Forms with sheets', value: formatNumber(summary.formsWithSheets || 0) },
+        { label: 'Responses captured', value: formatNumber(summary.totalResponses || 0) },
+        { label: 'Avg. per form', value: formatAverage(summary.averageResponsesPerForm || 0) }
+      ];
+      metrics.forEach(function (metric) {
+        const card = document.createElement('div');
+        card.className = 'metric-card';
+
+        const label = document.createElement('div');
+        label.className = 'metric-card__label';
+        label.textContent = metric.label;
+        card.appendChild(label);
+
+        const value = document.createElement('div');
+        value.className = 'metric-card__value';
+        value.textContent = metric.value;
+        card.appendChild(value);
+
+        metricCardsEl.appendChild(card);
+      });
+    }
+
+    function renderTopForms(summary) {
+      if (!topFormsBody) return;
+      topFormsBody.innerHTML = '';
+      const forms = Array.isArray(summary.responsesByForm) ? summary.responsesByForm.slice(0, 5) : [];
+      if (!forms.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.className = 'empty-state';
+        cell.textContent = 'No responses recorded yet.';
+        row.appendChild(cell);
+        topFormsBody.appendChild(row);
+        return;
+      }
+
+      forms.forEach(function (entry) {
+        const row = document.createElement('tr');
+
+        const nameCell = document.createElement('td');
+        nameCell.textContent = entry.formName || 'Untitled form';
+        row.appendChild(nameCell);
+
+        const countCell = document.createElement('td');
+        countCell.textContent = formatNumber(entry.totalResponses || 0);
+        row.appendChild(countCell);
+
+        const lastCell = document.createElement('td');
+        lastCell.textContent = entry.lastSubmissionAt ? formatDate(entry.lastSubmissionAt) : '—';
+        row.appendChild(lastCell);
+
+        const sheetCell = document.createElement('td');
+        if (entry.responseSheetUrl) {
+          const link = document.createElement('a');
+          link.href = entry.responseSheetUrl;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.textContent = entry.responseSheetName ? 'Open sheet' : 'Open sheet';
+          if (entry.responseSheetName) {
+            link.title = entry.responseSheetName;
+          }
+          sheetCell.appendChild(link);
+        } else if (entry.responseSheetName) {
+          sheetCell.textContent = entry.responseSheetName;
+        } else {
+          sheetCell.textContent = '—';
+        }
+        row.appendChild(sheetCell);
+
+        topFormsBody.appendChild(row);
+      });
+    }
+
+    function renderRecentResponses(summary) {
+      if (!recentListEl) return;
+      recentListEl.innerHTML = '';
+      const recent = Array.isArray(summary.recentResponses) ? summary.recentResponses : [];
+      if (!recent.length) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No submissions have been recorded yet.';
+        recentListEl.appendChild(empty);
+        return;
+      }
+
+      recent.forEach(function (entry) {
+        const item = document.createElement('div');
+        item.className = 'recent-item';
+
+        const info = document.createElement('div');
+        info.className = 'recent-item__info';
+
+        const title = document.createElement('div');
+        title.className = 'recent-item__title';
+        title.textContent = entry.formName || 'Untitled form';
+        info.appendChild(title);
+
+        const meta = document.createElement('div');
+        meta.className = 'recent-item__meta';
+        const parts = [];
+        if (entry.userName) parts.push(entry.userName);
+        if (entry.userEmail) parts.push(entry.userEmail);
+        if (entry.submittedBy && entry.submittedBy !== entry.userName) parts.push('via ' + entry.submittedBy);
+        parts.push(formatDate(entry.submittedAt));
+        meta.textContent = parts.join(' · ');
+        info.appendChild(meta);
+
+        item.appendChild(info);
+
+        const count = document.createElement('div');
+        count.className = 'recent-item__count';
+        count.textContent = entry.answerCount === 1 ? '1 answer' : entry.answerCount + ' answers';
+        item.appendChild(count);
+
+        recentListEl.appendChild(item);
+      });
+    }
+
+    function render() {
+      if (state.loading) {
+        setStatus('Loading dashboard data…', 'info');
+        return;
+      }
+
+      if (state.error) {
+        setStatus(state.error, 'error');
+        return;
+      }
+
+      setStatus('');
+      const summary = state.data || {};
+      renderMetrics(summary);
+      renderTopForms(summary);
+      renderRecentResponses(summary);
+    }
+
+    function fetchData() {
+      if (!canUseGoogleScript()) {
+        state.loading = false;
+        state.error = 'This dashboard is only available within the Lumina workspace.';
+        render();
+        return;
+      }
+
+      state.loading = true;
+      render();
+      google.script.run
+        .withSuccessHandler(function (result) {
+          state.loading = false;
+          state.error = '';
+          state.data = result || {};
+          render();
+        })
+        .withFailureHandler(function (err) {
+          state.loading = false;
+          state.error = (err && err.message) ? err.message : 'Failed to load dashboard data.';
+          render();
+        })
+        .getDynamicFormDashboardData({});
+    }
+
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      fetchData();
+    } else {
+      document.addEventListener('DOMContentLoaded', fetchData);
+    }
+  })();
+</script>

--- a/DynamicFormService.js
+++ b/DynamicFormService.js
@@ -1,0 +1,1093 @@
+/**
+ * DynamicFormService.js
+ *
+ * Provides a lightweight, tenant-aware form builder that lets managers compose
+ * Google Form-style questionnaires and map specific prompts directly to user
+ * profile columns. Form responses always persist, even when no bindings are
+ * supplied, so teams can review every answer submitted by a user alongside the
+ * automatic profile updates.
+ */
+
+var DynamicFormService = (function (global) {
+  var service = {};
+  var USERS_TABLE = (typeof USERS_SHEET === 'string' && USERS_SHEET) ? USERS_SHEET : 'Users';
+  var FORMS_TABLE = 'DynamicForms';
+  var RESPONSES_TABLE = 'DynamicFormResponses';
+  var RESPONSE_SHEET_BASE_HEADERS = (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && Array.isArray(DynamicFormUtilities.RESPONSE_BASE_HEADERS))
+    ? DynamicFormUtilities.RESPONSE_BASE_HEADERS.slice()
+    : ['SubmissionID', 'FormID', 'FormName', 'SubmittedAt', 'UserID', 'UserName', 'SubmittedBy'];
+  var safeConsole = (typeof console !== 'undefined' && console) ? console : {
+    log: function () { },
+    warn: function () { },
+    error: function () { }
+  };
+
+  var activeSpreadsheetCache = {
+    spreadsheet: null,
+    id: '',
+    timestamp: 0
+  };
+
+  var bindingAliases = {
+    email: { type: 'userColumn', column: 'Email' },
+    'user.email': { type: 'userColumn', column: 'Email' },
+    phone: { type: 'userColumn', column: 'PhoneNumber' },
+    phonenumber: { type: 'userColumn', column: 'PhoneNumber' },
+    'user.phone': { type: 'userColumn', column: 'PhoneNumber' },
+    fullname: { type: 'userColumn', column: 'FullName' },
+    'user.fullname': { type: 'userColumn', column: 'FullName' },
+    'user.full-name': { type: 'userColumn', column: 'FullName' },
+    firstname: { type: 'namePart', part: 'first' },
+    lastname: { type: 'namePart', part: 'last' },
+    'user.firstname': { type: 'namePart', part: 'first' },
+    'user.lastname': { type: 'namePart', part: 'last' },
+    'insurance.provider': { type: 'insurance', key: 'provider' },
+    'insurance.policy': { type: 'insurance', key: 'policyNumber' },
+    'insurance.policyNumber': { type: 'insurance', key: 'policyNumber' },
+    'insurance.groupNumber': { type: 'insurance', key: 'groupNumber' },
+    'insurance.memberId': { type: 'insurance', key: 'memberId' },
+    'insurance.notes': { type: 'insurance', key: 'notes' }
+  };
+
+  function ensureTables() {
+    if (typeof DatabaseManager === 'undefined' || !DatabaseManager || typeof DatabaseManager.defineTable !== 'function') {
+      throw new Error('DatabaseManager is required for DynamicFormService.');
+    }
+
+    if (!ensureTables.initialized) {
+      DatabaseManager.defineTable(FORMS_TABLE, {
+        headers: ['ID', 'CampaignID', 'Name', 'Description', 'Fields', 'ResponseSheetId', 'ResponseSheetName', 'CreatedBy', 'CreatedAt', 'UpdatedAt'],
+        idColumn: 'ID',
+        tenantColumn: 'CampaignID',
+        requireTenant: false
+      });
+
+      DatabaseManager.defineTable(RESPONSES_TABLE, {
+        headers: ['ID', 'FormID', 'UserID', 'CampaignID', 'Responses', 'UserUpdates', 'SubmittedBy', 'CreatedAt', 'UpdatedAt'],
+        idColumn: 'ID',
+        tenantColumn: 'CampaignID',
+        requireTenant: false
+      });
+
+      ensureTables.initialized = true;
+    }
+  }
+
+  function copyObject(source, allowedKeys) {
+    var copy = {};
+    for (var i = 0; i < allowedKeys.length; i++) {
+      var key = allowedKeys[i];
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        copy[key] = source[key];
+      }
+    }
+    return copy;
+  }
+
+  function toStringValue(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value);
+  }
+
+  function toDateValue(value) {
+    if (!value && value !== 0) return null;
+    if (value instanceof Date) return value;
+    var asDate = new Date(value);
+    if (isNaN(asDate.getTime())) return null;
+    return asDate;
+  }
+
+  function toIsoString(value) {
+    var date = toDateValue(value);
+    return date ? date.toISOString() : null;
+  }
+
+  function safeJsonParse(value, fallback) {
+    if (!value && value !== 0) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: JSON parse failed', err);
+      }
+      return fallback;
+    }
+  }
+
+  function resolveCampaignId(context, formRecord) {
+    if (formRecord) {
+      if (formRecord.CampaignID) {
+        return formRecord.CampaignID;
+      }
+      if (formRecord.campaignId) {
+        return String(formRecord.campaignId);
+      }
+      if (formRecord.tenantId) {
+        return String(formRecord.tenantId);
+      }
+    }
+    if (!context) return '';
+    if (context.campaignId) return String(context.campaignId);
+    if (context.tenantId) return String(context.tenantId);
+    if (Array.isArray(context.campaignIds) && context.campaignIds.length === 1) {
+      return String(context.campaignIds[0]);
+    }
+    if (Array.isArray(context.tenantIds) && context.tenantIds.length === 1) {
+      return String(context.tenantIds[0]);
+    }
+    return '';
+  }
+
+  function invalidateSpreadsheetCache() {
+    activeSpreadsheetCache.spreadsheet = null;
+    activeSpreadsheetCache.timestamp = 0;
+  }
+
+  function shouldRetrySpreadsheetError(err) {
+    if (!err || !err.message) return false;
+    var message = String(err.message);
+    if (message.indexOf('Service Spreadsheets') !== -1) return true;
+    if (message.indexOf('Document is locked') !== -1) return true;
+    if (message.indexOf('locked') !== -1 && message.indexOf('Spreadsheet') !== -1) return true;
+    return false;
+  }
+
+  function sleepForRetry(attempt) {
+    if (typeof Utilities === 'undefined' || !Utilities || typeof Utilities.sleep !== 'function') {
+      return;
+    }
+    var delay = 200 * Math.max(1, attempt + 1);
+    if (delay > 2000) {
+      delay = 2000;
+    }
+    try {
+      Utilities.sleep(delay);
+    } catch (sleepErr) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: sleep failed during retry', sleepErr);
+      }
+    }
+  }
+
+  function acquireDocumentLock() {
+    if (typeof LockService === 'undefined' || !LockService || typeof LockService.getDocumentLock !== 'function') {
+      return null;
+    }
+    var attempts = 0;
+    var lock = null;
+    while (attempts < 3) {
+      try {
+        lock = LockService.getDocumentLock();
+        if (!lock) {
+          return null;
+        }
+        if (typeof lock.tryLock === 'function') {
+          if (lock.tryLock(5000)) {
+            return lock;
+          }
+        } else if (typeof lock.waitLock === 'function') {
+          lock.waitLock(5000);
+          return lock;
+        }
+      } catch (lockErr) {
+        if (safeConsole && typeof safeConsole.warn === 'function') {
+          safeConsole.warn('DynamicFormService: Failed to acquire document lock', lockErr);
+        }
+      }
+      attempts += 1;
+      sleepForRetry(attempts);
+    }
+    return null;
+  }
+
+  function releaseDocumentLock(lock) {
+    if (!lock) return;
+    try {
+      if (typeof lock.releaseLock === 'function') {
+        lock.releaseLock();
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: Failed to release document lock', err);
+      }
+    }
+  }
+
+  function getActiveSpreadsheet() {
+    if (typeof SpreadsheetApp === 'undefined' || !SpreadsheetApp || typeof SpreadsheetApp.getActiveSpreadsheet !== 'function') {
+      return null;
+    }
+    var now = (typeof Date !== 'undefined' && Date.now) ? Date.now() : new Date().getTime();
+    if (activeSpreadsheetCache.spreadsheet && (now - activeSpreadsheetCache.timestamp) < 60000) {
+      return activeSpreadsheetCache.spreadsheet;
+    }
+    var attempts = 0;
+    var lastError = null;
+    while (attempts < 3) {
+      try {
+        var ss = SpreadsheetApp.getActiveSpreadsheet();
+        if (ss) {
+          activeSpreadsheetCache.spreadsheet = ss;
+          activeSpreadsheetCache.timestamp = now;
+          if (typeof ss.getId === 'function') {
+            activeSpreadsheetCache.id = ss.getId();
+          }
+          return ss;
+        }
+      } catch (err) {
+        lastError = err;
+        invalidateSpreadsheetCache();
+        if (!shouldRetrySpreadsheetError(err)) {
+          break;
+        }
+      }
+      sleepForRetry(attempts);
+      attempts += 1;
+    }
+    if (activeSpreadsheetCache.id && typeof SpreadsheetApp.openById === 'function') {
+      try {
+        var reopened = SpreadsheetApp.openById(activeSpreadsheetCache.id);
+        if (reopened) {
+          activeSpreadsheetCache.spreadsheet = reopened;
+          activeSpreadsheetCache.timestamp = now;
+          return reopened;
+        }
+      } catch (reopenErr) {
+        lastError = reopenErr;
+      }
+    }
+    if (lastError && safeConsole && typeof safeConsole.warn === 'function') {
+      safeConsole.warn('DynamicFormService: Failed to access active spreadsheet', lastError);
+    }
+    return activeSpreadsheetCache.spreadsheet;
+  }
+
+  function sanitizeSheetName(name) {
+    var sanitized = toStringValue(name || '');
+    sanitized = sanitized.replace(/[\[\]\*\/\\\?:]/g, ' ');
+    sanitized = sanitized.replace(/\s+/g, ' ').trim();
+    return sanitized;
+  }
+
+  function ensureUniqueSheetName(ss, desiredName) {
+    if (!ss) return desiredName || 'Dynamic Form Responses';
+    var base = desiredName && desiredName.trim() ? desiredName.trim() : 'Dynamic Form Responses';
+    if (base.length > 99) {
+      base = base.substring(0, 99);
+    }
+    var candidate = base;
+    var attempt = 2;
+    while (ss.getSheetByName(candidate)) {
+      var suffix = ' (' + attempt + ')';
+      var maxLength = 99 - suffix.length;
+      var shortened = base;
+      if (shortened.length > maxLength) {
+        shortened = shortened.substring(0, maxLength);
+      }
+      candidate = shortened + suffix;
+      attempt += 1;
+    }
+    return candidate;
+  }
+
+  function buildResponseSheetHeaders(fields) {
+    if (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && typeof DynamicFormUtilities.buildResponseHeaders === 'function') {
+      return DynamicFormUtilities.buildResponseHeaders(fields);
+    }
+    var headers = RESPONSE_SHEET_BASE_HEADERS.slice();
+    var seen = {};
+    for (var i = 0; i < headers.length; i++) {
+      seen[headers[i]] = true;
+    }
+    if (Array.isArray(fields)) {
+      for (var j = 0; j < fields.length; j++) {
+        var field = fields[j];
+        if (!field) continue;
+        var label = toStringValue(field.label || field.title || field.name || ('Field ' + (j + 1)));
+        if (!label) {
+          label = 'Field ' + (j + 1);
+        }
+        var candidate = label;
+        var counter = 2;
+        while (seen[candidate]) {
+          candidate = label + ' (' + counter + ')';
+          counter += 1;
+        }
+        seen[candidate] = true;
+        headers.push(candidate);
+      }
+    }
+    return headers;
+  }
+
+  function ensureResponseSheetHeaders(sheet, fields) {
+    if (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && typeof DynamicFormUtilities.ensureResponseHeaders === 'function') {
+      DynamicFormUtilities.ensureResponseHeaders(sheet, fields);
+      return;
+    }
+    if (!sheet) return;
+    try {
+      var headers = buildResponseSheetHeaders(fields);
+      var range = sheet.getRange(1, 1, 1, headers.length);
+      var current = range.getValues();
+      var needsUpdate = true;
+      if (current && current.length) {
+        var row = current[0];
+        needsUpdate = row.length !== headers.length;
+        if (!needsUpdate) {
+          needsUpdate = false;
+          for (var i = 0; i < headers.length; i++) {
+            if (toStringValue(row[i]) !== toStringValue(headers[i])) {
+              needsUpdate = true;
+              break;
+            }
+          }
+        }
+      }
+      if (needsUpdate) {
+        range.setValues([headers]);
+      }
+      if (typeof sheet.getFrozenRows === 'function' && sheet.getFrozenRows() < 1 && typeof sheet.setFrozenRows === 'function') {
+        sheet.setFrozenRows(1);
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: Failed to ensure response sheet headers', err);
+      }
+    }
+  }
+
+  function createResponseSheet(formRecord, fields, ssOverride) {
+    if (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && typeof DynamicFormUtilities.createResponseSheet === 'function') {
+      return DynamicFormUtilities.createResponseSheet(formRecord, fields, ssOverride || getActiveSpreadsheet());
+    }
+    var ss = ssOverride || getActiveSpreadsheet();
+    if (!ss || !formRecord) return null;
+    try {
+      var baseName = sanitizeSheetName((formRecord && (formRecord.Name || formRecord.name)) || 'Dynamic Form');
+      if (!baseName) {
+        baseName = 'Dynamic Form';
+      }
+      var suffix = '';
+      if (formRecord.ID || formRecord.id) {
+        var idFragment = String(formRecord.ID || formRecord.id).replace(/[^a-zA-Z0-9]/g, '').substring(0, 6).toUpperCase();
+        if (idFragment) {
+          suffix = ' [' + idFragment + ']';
+        }
+      }
+      var desiredName = sanitizeSheetName(baseName + ' Responses' + suffix);
+      var sheetName = ensureUniqueSheetName(ss, desiredName);
+      var sheet = ss.insertSheet(sheetName);
+      ensureResponseSheetHeaders(sheet, fields);
+      return {
+        id: sheet.getSheetId(),
+        name: sheetName,
+        sheet: sheet
+      };
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.error === 'function') {
+        safeConsole.error('DynamicFormService: Failed to create response sheet for form ' + (formRecord.ID || ''), err);
+      }
+      return null;
+    }
+  }
+
+  function normalizeSheetValue(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    if (value instanceof Date) return value;
+    if (Array.isArray(value)) {
+      var joined = [];
+      for (var i = 0; i < value.length; i++) {
+        if (value[i] === null || typeof value[i] === 'undefined') continue;
+        joined.push(String(value[i]));
+      }
+      return joined.length ? joined.join(', ') : '';
+    }
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value);
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return value;
+  }
+
+  function resolveResponseSheetUrl(formRecord) {
+    if (!formRecord || typeof formRecord !== 'object') return '';
+    var ss = getActiveSpreadsheet();
+    if (!ss || typeof ss.getUrl !== 'function') return '';
+    var baseUrl = ss.getUrl();
+    if (!baseUrl) return '';
+    var sheetIdRaw = formRecord.ResponseSheetId || formRecord.responseSheetId;
+    var sheetName = formRecord.ResponseSheetName || formRecord.responseSheetName;
+    var sheetId = sheetIdRaw;
+    if (!sheetIdRaw && sheetName) {
+      var sheet = ss.getSheetByName(sheetName);
+      if (sheet) {
+        sheetId = sheet.getSheetId();
+        formRecord.ResponseSheetId = String(sheetId);
+      }
+    }
+    if (sheetId && typeof sheetId === 'number') {
+      sheetId = String(sheetId);
+    }
+    if (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && typeof DynamicFormUtilities.getSheetUrl === 'function' && sheet) {
+      return DynamicFormUtilities.getSheetUrl(sheet);
+    }
+    if (sheetId) {
+      return baseUrl + '#gid=' + sheetId;
+    }
+    return '';
+  }
+
+  function persistResponseSheetMetadata(formsTable, formRecord, updates) {
+    if (!formsTable || !formRecord || !formRecord.ID) return;
+    try {
+      formsTable.update(formRecord.ID, updates);
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: Failed to persist response sheet metadata for form ' + formRecord.ID, err);
+      }
+    }
+  }
+
+  function ensureResponseSheetForForm(formRecord, fields, formsTable) {
+    if (!formRecord) return null;
+    var attempts = 0;
+    var lastError = null;
+    while (attempts < 3) {
+      var ss = getActiveSpreadsheet();
+      if (!ss) {
+        return null;
+      }
+      var lock = acquireDocumentLock();
+      try {
+        var sheetName = formRecord.ResponseSheetName || formRecord.responseSheetName || '';
+        var sheetIdRaw = formRecord.ResponseSheetId || formRecord.responseSheetId || '';
+        var sheet = sheetName ? ss.getSheetByName(sheetName) : null;
+        var numericId = sheetIdRaw ? Number(sheetIdRaw) : NaN;
+
+        if (!sheet && sheetIdRaw && !isNaN(numericId)) {
+          var sheets = ss.getSheets();
+          for (var i = 0; i < sheets.length; i++) {
+            if (sheets[i] && typeof sheets[i].getSheetId === 'function' && sheets[i].getSheetId() === numericId) {
+              sheet = sheets[i];
+              break;
+            }
+          }
+          if (sheet && !sheetName) {
+            sheetName = sheet.getName();
+            formRecord.ResponseSheetName = sheetName;
+            persistResponseSheetMetadata(formsTable, formRecord, { ResponseSheetName: sheetName });
+          }
+        }
+
+        if (!sheet) {
+          var created = createResponseSheet(formRecord, fields, ss);
+          if (!created || !created.sheet) {
+            throw new Error('DynamicFormService: Failed to create response sheet.');
+          }
+          sheet = created.sheet;
+          sheetName = created.name;
+          numericId = created.id;
+          formRecord.ResponseSheetName = sheetName;
+          formRecord.ResponseSheetId = String(numericId);
+          persistResponseSheetMetadata(formsTable, formRecord, {
+            ResponseSheetName: sheetName,
+            ResponseSheetId: String(numericId)
+          });
+        } else {
+          ensureResponseSheetHeaders(sheet, fields);
+          if (!sheetName) {
+            sheetName = sheet.getName();
+            formRecord.ResponseSheetName = sheetName;
+            persistResponseSheetMetadata(formsTable, formRecord, { ResponseSheetName: sheetName });
+          }
+          if (!sheetIdRaw || isNaN(numericId)) {
+            numericId = sheet.getSheetId();
+            formRecord.ResponseSheetId = String(numericId);
+            persistResponseSheetMetadata(formsTable, formRecord, { ResponseSheetId: String(numericId) });
+          }
+        }
+
+        ensureResponseSheetHeaders(sheet, fields);
+        formRecord.ResponseSheetUrl = resolveResponseSheetUrl(formRecord);
+        if (typeof DynamicFormUtilities !== 'undefined' && DynamicFormUtilities && typeof DynamicFormUtilities.upsertFormMetadata === 'function') {
+          try {
+            DynamicFormUtilities.upsertFormMetadata(formRecord, fields);
+          } catch (metaErr) {
+            if (safeConsole && typeof safeConsole.warn === 'function') {
+              safeConsole.warn('DynamicFormService: Failed to sync form metadata sheet for form ' + (formRecord.ID || ''), metaErr);
+            }
+          }
+        }
+
+        return {
+          sheet: sheet,
+          name: sheetName,
+          id: sheet.getSheetId()
+        };
+      } catch (err) {
+        lastError = err;
+        invalidateSpreadsheetCache();
+        if (!shouldRetrySpreadsheetError(err)) {
+          if (safeConsole && typeof safeConsole.error === 'function') {
+            safeConsole.error('DynamicFormService: Unable to ensure response sheet for form ' + (formRecord.ID || ''), err);
+          }
+          throw err;
+        }
+      } finally {
+        releaseDocumentLock(lock);
+      }
+      attempts += 1;
+      sleepForRetry(attempts);
+    }
+    if (lastError) {
+      throw lastError;
+    }
+    return null;
+  }
+
+  function appendResponseToSheet(formRecord, responseRecord, normalizedAnswers, existingUser, formsTable, fields) {
+    if (!formRecord || !responseRecord) return;
+    var sheetMeta = ensureResponseSheetForForm(formRecord, fields, formsTable);
+    if (!sheetMeta || !sheetMeta.sheet) return;
+    try {
+      var sheet = sheetMeta.sheet;
+      ensureResponseSheetHeaders(sheet, fields);
+      var submittedAt = toDateValue(responseRecord.CreatedAt || responseRecord.createdAt || responseRecord.UpdatedAt || responseRecord.updatedAt || new Date());
+      if (!submittedAt) {
+        submittedAt = new Date();
+      }
+      var existingName = existingUser && (existingUser.FullName || existingUser.UserName || existingUser.Email || existingUser.fullName || existingUser.userName || existingUser.email);
+      var answersList = normalizedAnswers && Array.isArray(normalizedAnswers.list) ? normalizedAnswers.list : [];
+      var row = [
+        responseRecord.ID || responseRecord.Id || responseRecord.id || '',
+        formRecord.ID || formRecord.Id || formRecord.id || '',
+        formRecord.Name || formRecord.name || 'Untitled form',
+        submittedAt,
+        responseRecord.UserID || responseRecord.userId || responseRecord.userID || '',
+        existingName ? existingName : '',
+        responseRecord.SubmittedBy || responseRecord.submittedBy || ''
+      ];
+      for (var i = 0; i < answersList.length; i++) {
+        var answer = answersList[i];
+        row.push(normalizeSheetValue(answer ? answer.value : ''));
+      }
+      sheet.appendRow(row);
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.error === 'function') {
+        safeConsole.error('DynamicFormService: Failed to append response to sheet for form ' + (formRecord.ID || ''), err);
+      }
+    }
+  }
+
+  function applyResponseSheetMetadata(formRecord) {
+    if (!formRecord || typeof formRecord !== 'object') return formRecord;
+    if (formRecord.ResponseSheetId && typeof formRecord.ResponseSheetId === 'number') {
+      formRecord.ResponseSheetId = String(formRecord.ResponseSheetId);
+    }
+    if (formRecord.responseSheetId && typeof formRecord.responseSheetId === 'number' && !formRecord.ResponseSheetId) {
+      formRecord.ResponseSheetId = String(formRecord.responseSheetId);
+    }
+    if (formRecord.responseSheetName && !formRecord.ResponseSheetName) {
+      formRecord.ResponseSheetName = formRecord.responseSheetName;
+    }
+    var url = resolveResponseSheetUrl(formRecord);
+    if (url) {
+      formRecord.ResponseSheetUrl = url;
+    }
+    return formRecord;
+  }
+
+  function resolveUserDisplay(usersTable, cache, userId) {
+    var key = userId ? String(userId) : '';
+    if (!key) {
+      return { name: '', email: '' };
+    }
+    if (cache && Object.prototype.hasOwnProperty.call(cache, key)) {
+      return cache[key];
+    }
+    var summary = { name: '', email: '' };
+    if (!usersTable || typeof usersTable.findById !== 'function') {
+      if (cache) cache[key] = summary;
+      return summary;
+    }
+    try {
+      var user = usersTable.findById(key);
+      if (user) {
+        summary.name = toStringValue(user.FullName || user.UserName || user.DisplayName || '');
+        summary.email = toStringValue(user.Email || '');
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: Unable to resolve user ' + key, err);
+      }
+    }
+    if (cache) {
+      cache[key] = summary;
+    }
+    return summary;
+  }
+
+  function normalizeField(field, index) {
+    if (!field || typeof field !== 'object') {
+      throw new Error('Field definition at index ' + index + ' must be an object.');
+    }
+
+    var normalized = {};
+    var identifier = field.id || field.name || (field.label ? String(field.label).replace(/\s+/g, '-').toLowerCase() : 'field-' + (index + 1));
+    normalized.id = String(identifier);
+    normalized.label = toStringValue(field.label || field.title || ('Field ' + (index + 1)));
+    normalized.type = field.type ? String(field.type) : 'text';
+    if (field.required) {
+      normalized.required = true;
+    }
+    if (field.helpText) {
+      normalized.helpText = toStringValue(field.helpText);
+    }
+    if (field.options && Array.isArray(field.options)) {
+      normalized.options = field.options.slice();
+    }
+
+    var binding = normalizeBinding(field.binding || field.mapTo);
+    if (binding) {
+      normalized.binding = binding;
+    }
+
+    return normalized;
+  }
+
+  function normalizeBinding(binding) {
+    if (!binding) return null;
+    var bindingObject;
+    if (typeof binding === 'string') {
+      var key = binding.replace(/\s+/g, '').toLowerCase();
+      bindingObject = bindingAliases[key];
+      if (!bindingObject && key.indexOf('insurance:') === 0) {
+        bindingObject = { type: 'insurance', key: key.split(':')[1] };
+      }
+    } else if (binding && typeof binding === 'object') {
+      bindingObject = copyObject(binding, ['type', 'column', 'part', 'key']);
+    }
+
+    if (!bindingObject) {
+      return null;
+    }
+
+    if (bindingObject.type === 'userColumn' && bindingObject.column) {
+      bindingObject.column = String(bindingObject.column);
+      return bindingObject;
+    }
+
+    if (bindingObject.type === 'namePart' && bindingObject.part) {
+      bindingObject.part = bindingObject.part === 'last' ? 'last' : 'first';
+      return bindingObject;
+    }
+
+    if (bindingObject.type === 'insurance' && bindingObject.key) {
+      bindingObject.key = String(bindingObject.key);
+      return bindingObject;
+    }
+
+    return null;
+  }
+
+  function serializeFields(fields) {
+    return JSON.stringify(fields);
+  }
+
+  function parseFields(value) {
+    return safeJsonParse(value, []);
+  }
+
+  function getUsersTable(context) {
+    ensureTables();
+    return DatabaseManager.table(USERS_TABLE, context || null);
+  }
+
+  function getFormsTable(context) {
+    ensureTables();
+    return DatabaseManager.table(FORMS_TABLE, context || null);
+  }
+
+  function getResponsesTable(context) {
+    ensureTables();
+    return DatabaseManager.table(RESPONSES_TABLE, context || null);
+  }
+
+  function normalizeAnswers(fields, answers) {
+    var answerMap = {};
+    if (!answers) {
+      return { map: answerMap, list: [] };
+    }
+
+    if (Array.isArray(answers)) {
+      for (var i = 0; i < answers.length; i++) {
+        var entry = answers[i];
+        if (!entry) continue;
+        if (entry.id || entry.fieldId) {
+          answerMap[entry.id || entry.fieldId] = entry.value;
+        } else if (entry.name) {
+          answerMap[entry.name] = entry.value;
+        }
+      }
+    } else if (typeof answers === 'object') {
+      var keys = Object.keys(answers);
+      for (var j = 0; j < keys.length; j++) {
+        answerMap[keys[j]] = answers[keys[j]];
+      }
+    }
+
+    var ordered = [];
+    for (var k = 0; k < fields.length; k++) {
+      var field = fields[k];
+      var value = answerMap[field.id];
+      ordered.push({ id: field.id, label: field.label, value: value });
+    }
+
+    return { map: answerMap, list: ordered };
+  }
+
+  function getExistingUser(usersTable, userId) {
+    if (!userId) return null;
+    try {
+      return usersTable.findById(userId);
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormService: failed to fetch user ' + userId, err);
+      }
+      return null;
+    }
+  }
+
+  function buildUserUpdates(fields, normalizedAnswers, existingUser) {
+    var map = normalizedAnswers.map;
+    var updates = {};
+    var nameParts = { first: null, last: null };
+    var insurance = {};
+    var appliedBindings = [];
+
+    for (var i = 0; i < fields.length; i++) {
+      var field = fields[i];
+      if (!field.binding) continue;
+      var value = map[field.id];
+      if (value === null || typeof value === 'undefined' || value === '') {
+        continue;
+      }
+
+      if (field.binding.type === 'userColumn' && field.binding.column) {
+        updates[field.binding.column] = value;
+        appliedBindings.push({ fieldId: field.id, column: field.binding.column, value: value });
+        continue;
+      }
+
+      if (field.binding.type === 'namePart') {
+        if (field.binding.part === 'first') {
+          nameParts.first = value;
+        } else if (field.binding.part === 'last') {
+          nameParts.last = value;
+        }
+        appliedBindings.push({ fieldId: field.id, column: field.binding.part === 'last' ? 'FullName.last' : 'FullName.first', value: value });
+        continue;
+      }
+
+      if (field.binding.type === 'insurance' && field.binding.key) {
+        insurance[field.binding.key] = value;
+        appliedBindings.push({ fieldId: field.id, column: 'InsuranceInformation.' + field.binding.key, value: value });
+      }
+    }
+
+    if (nameParts.first || nameParts.last) {
+      var existingFullName = existingUser && existingUser.FullName ? String(existingUser.FullName) : '';
+      var existingTokens = existingFullName ? existingFullName.trim().split(/\s+/) : [];
+      var existingFirst = existingTokens.length ? existingTokens[0] : '';
+      var existingLast = existingTokens.length > 1 ? existingTokens.slice(1).join(' ') : '';
+      var finalFirst = (nameParts.first !== null && nameParts.first !== undefined && nameParts.first !== '') ? nameParts.first : existingFirst;
+      var finalLast = (nameParts.last !== null && nameParts.last !== undefined && nameParts.last !== '') ? nameParts.last : existingLast;
+      var combined = (finalFirst + ' ' + finalLast).trim();
+      if (!combined) {
+        combined = finalFirst || finalLast;
+      }
+      if (combined) {
+        updates.FullName = combined;
+      }
+    }
+
+    if (Object.keys(insurance).length) {
+      var existingInsurance = existingUser && existingUser.InsuranceInformation
+        ? safeJsonParse(existingUser.InsuranceInformation, {})
+        : {};
+      var insuranceKeys = Object.keys(insurance);
+      for (var j = 0; j < insuranceKeys.length; j++) {
+        var key = insuranceKeys[j];
+        existingInsurance[key] = insurance[key];
+      }
+      updates.InsuranceInformation = JSON.stringify(existingInsurance);
+    }
+
+    return { updates: updates, bindings: appliedBindings };
+  }
+
+  service.createForm = function (context, config) {
+    ensureTables();
+    if (!config || typeof config !== 'object') {
+      throw new Error('Form configuration is required.');
+    }
+    if (!config.name && !config.title) {
+      throw new Error('Form name is required.');
+    }
+    if (!Array.isArray(config.fields) || !config.fields.length) {
+      throw new Error('At least one field definition is required.');
+    }
+
+    var fields = [];
+    for (var i = 0; i < config.fields.length; i++) {
+      fields.push(normalizeField(config.fields[i], i));
+    }
+
+    var record = {
+      ID: (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.getUuid === 'function') ? Utilities.getUuid() : String(new Date().getTime()),
+      CampaignID: resolveCampaignId(context, config),
+      Name: toStringValue(config.name || config.title),
+      Description: toStringValue(config.description || ''),
+      Fields: serializeFields(fields),
+      ResponseSheetId: '',
+      ResponseSheetName: '',
+      CreatedBy: config.createdBy || ''
+    };
+
+    var table = getFormsTable(context);
+    var inserted = table.insert(record);
+    inserted.Fields = fields;
+    ensureResponseSheetForForm(inserted, fields, table);
+    applyResponseSheetMetadata(inserted);
+    return inserted;
+  };
+
+  service.getForm = function (context, formId) {
+    ensureTables();
+    if (!formId) {
+      throw new Error('Form ID is required.');
+    }
+    var table = getFormsTable(context);
+    var form = table.findById(formId);
+    if (!form) return null;
+    form.Fields = parseFields(form.Fields);
+    ensureResponseSheetForForm(form, form.Fields, table);
+    applyResponseSheetMetadata(form);
+    return form;
+  };
+
+  service.listForms = function (context, options) {
+    ensureTables();
+    var table = getFormsTable(context);
+    var rows = table.read(options || {});
+    for (var i = 0; i < rows.length; i++) {
+      rows[i].Fields = parseFields(rows[i].Fields);
+      ensureResponseSheetForForm(rows[i], rows[i].Fields, table);
+      applyResponseSheetMetadata(rows[i]);
+    }
+    return rows;
+  };
+
+  service.submitFormResponse = function (context, formId, userId, answers, metadata) {
+    ensureTables();
+    if (!formId) {
+      throw new Error('Form ID is required to submit a response.');
+    }
+    if (!userId) {
+      throw new Error('User ID is required to submit a response.');
+    }
+
+    var formsTable = getFormsTable(context);
+    var form = formsTable.findById(formId);
+    if (!form) {
+      throw new Error('Form not found: ' + formId);
+    }
+
+    var fields = parseFields(form.Fields);
+    var normalizedAnswers = normalizeAnswers(fields, answers);
+    var usersTable = getUsersTable(context);
+    var existingUser = getExistingUser(usersTable, userId);
+    var userUpdatePayload = buildUserUpdates(fields, normalizedAnswers, existingUser);
+
+    if (existingUser && Object.keys(userUpdatePayload.updates).length) {
+      try {
+        usersTable.update(userId, userUpdatePayload.updates);
+      } catch (err) {
+        if (safeConsole && typeof safeConsole.error === 'function') {
+          safeConsole.error('DynamicFormService: failed to update user ' + userId, err);
+        }
+        throw err;
+      }
+    }
+
+    var responseRecord = {
+      ID: (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.getUuid === 'function') ? Utilities.getUuid() : String(new Date().getTime()),
+      FormID: formId,
+      UserID: userId,
+      CampaignID: resolveCampaignId(context, form),
+      Responses: JSON.stringify(normalizedAnswers.list),
+      UserUpdates: JSON.stringify(userUpdatePayload.bindings),
+      SubmittedBy: metadata && metadata.submittedBy ? metadata.submittedBy : ''
+    };
+
+    var responsesTable = getResponsesTable(context);
+    var stored = responsesTable.insert(responseRecord);
+    stored.Responses = normalizedAnswers.list;
+    stored.UserUpdates = userUpdatePayload.bindings;
+
+    appendResponseToSheet(form, stored, normalizedAnswers, existingUser, formsTable, fields);
+    return stored;
+  };
+
+  service.listResponsesForUser = function (context, userId, options) {
+    ensureTables();
+    if (!userId) {
+      throw new Error('User ID is required.');
+    }
+    var table = getResponsesTable(context);
+    var query = options ? Object.assign({}, options) : {};
+    query.where = query.where || {};
+    query.where.UserID = userId;
+    var rows = table.read(query);
+    for (var i = 0; i < rows.length; i++) {
+      rows[i].Responses = safeJsonParse(rows[i].Responses, []);
+      rows[i].UserUpdates = safeJsonParse(rows[i].UserUpdates, []);
+    }
+    return rows;
+  };
+
+  service.listResponsesForForm = function (context, formId, options) {
+    ensureTables();
+    if (!formId) {
+      throw new Error('Form ID is required.');
+    }
+    var table = getResponsesTable(context);
+    var query = options ? Object.assign({}, options) : {};
+    query.where = query.where || {};
+    query.where.FormID = formId;
+    var rows = table.read(query);
+    for (var i = 0; i < rows.length; i++) {
+      rows[i].Responses = safeJsonParse(rows[i].Responses, []);
+      rows[i].UserUpdates = safeJsonParse(rows[i].UserUpdates, []);
+    }
+    return rows;
+  };
+
+  service.getDashboardSummary = function (context, options) {
+    ensureTables();
+    var formsTable = getFormsTable(context);
+    var responsesTable = getResponsesTable(context);
+    var usersTable = getUsersTable(context);
+
+    var forms = formsTable.read(options && options.formsQuery ? options.formsQuery : {});
+    var formsById = {};
+    var formsWithSheets = 0;
+    var formsWithoutSheets = 0;
+    for (var i = 0; i < forms.length; i++) {
+      var form = forms[i];
+      form.Fields = parseFields(form.Fields);
+      ensureResponseSheetForForm(form, form.Fields, formsTable);
+      applyResponseSheetMetadata(form);
+      formsById[String(form.ID)] = form;
+      if (form.ResponseSheetName) {
+        formsWithSheets += 1;
+      } else {
+        formsWithoutSheets += 1;
+      }
+    }
+
+    var responses = responsesTable.read(options && options.responsesQuery ? options.responsesQuery : {});
+    var responsesByFormMap = {};
+    var parsedResponses = [];
+    for (var j = 0; j < responses.length; j++) {
+      var response = responses[j];
+      response.Responses = safeJsonParse(response.Responses, []);
+      response.UserUpdates = safeJsonParse(response.UserUpdates, []);
+      parsedResponses.push(response);
+      var formKey = String(response.FormID || '');
+      if (!responsesByFormMap[formKey]) {
+        responsesByFormMap[formKey] = {
+          formId: formKey,
+          totalResponses: 0,
+          lastSubmissionAt: null
+        };
+      }
+      responsesByFormMap[formKey].totalResponses += 1;
+      var submissionIso = toIsoString(response.CreatedAt || response.createdAt || response.UpdatedAt || response.updatedAt);
+      if (submissionIso && (!responsesByFormMap[formKey].lastSubmissionAt || responsesByFormMap[formKey].lastSubmissionAt < submissionIso)) {
+        responsesByFormMap[formKey].lastSubmissionAt = submissionIso;
+      }
+    }
+
+    var responsesByForm = [];
+    var responseFormKeys = Object.keys(responsesByFormMap);
+    for (var k = 0; k < responseFormKeys.length; k++) {
+      var formId = responseFormKeys[k];
+      var aggregate = responsesByFormMap[formId];
+      var relatedForm = formsById[formId];
+      responsesByForm.push({
+        formId: formId,
+        formName: relatedForm ? (relatedForm.Name || relatedForm.name || 'Untitled form') : 'Untitled form',
+        totalResponses: aggregate.totalResponses,
+        lastSubmissionAt: aggregate.lastSubmissionAt,
+        responseSheetUrl: relatedForm && relatedForm.ResponseSheetUrl ? relatedForm.ResponseSheetUrl : '',
+        responseSheetName: relatedForm && relatedForm.ResponseSheetName ? relatedForm.ResponseSheetName : ''
+      });
+    }
+    responsesByForm.sort(function (a, b) {
+      if (b.totalResponses === a.totalResponses) {
+        var aDate = a.lastSubmissionAt || '';
+        var bDate = b.lastSubmissionAt || '';
+        return bDate < aDate ? -1 : bDate > aDate ? 1 : 0;
+      }
+      return b.totalResponses - a.totalResponses;
+    });
+
+    var recentResponses = [];
+    var sortedResponses = parsedResponses.slice();
+    sortedResponses.sort(function (a, b) {
+      var aDate = toDateValue(a.CreatedAt || a.createdAt || a.UpdatedAt || a.updatedAt || 0);
+      var bDate = toDateValue(b.CreatedAt || b.createdAt || b.UpdatedAt || b.updatedAt || 0);
+      var aTime = aDate ? aDate.getTime() : 0;
+      var bTime = bDate ? bDate.getTime() : 0;
+      return bTime - aTime;
+    });
+
+    var userCache = {};
+    var recentLimit = Math.min(sortedResponses.length, 10);
+    for (var r = 0; r < recentLimit; r++) {
+      var entry = sortedResponses[r];
+      var formEntry = formsById[String(entry.FormID)] || null;
+      var userSummary = resolveUserDisplay(usersTable, userCache, entry.UserID || entry.userId || entry.userID || '');
+      recentResponses.push({
+        submissionId: entry.ID,
+        formId: entry.FormID,
+        formName: formEntry ? (formEntry.Name || formEntry.name || 'Untitled form') : 'Untitled form',
+        userId: entry.UserID || entry.userId || entry.userID || '',
+        userName: userSummary.name,
+        userEmail: userSummary.email,
+        submittedBy: entry.SubmittedBy || entry.submittedBy || '',
+        submittedAt: toIsoString(entry.CreatedAt || entry.createdAt || entry.UpdatedAt || entry.updatedAt),
+        answerCount: Array.isArray(entry.Responses) ? entry.Responses.length : 0
+      });
+    }
+
+    return {
+      generatedAt: new Date().toISOString(),
+      totalForms: forms.length,
+      totalResponses: parsedResponses.length,
+      formsWithSheets: formsWithSheets,
+      formsWithoutSheets: formsWithoutSheets,
+      averageResponsesPerForm: forms.length ? (parsedResponses.length / forms.length) : 0,
+      forms: forms,
+      responsesByForm: responsesByForm,
+      recentResponses: recentResponses
+    };
+  };
+
+  return service;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/DynamicFormUtilities.js
+++ b/DynamicFormUtilities.js
@@ -1,0 +1,399 @@
+/**
+ * DynamicFormUtilities.js
+ *
+ * Helper utilities for working with Dynamic Form spreadsheets. Responsible for
+ * provisioning the metadata sheet that tracks each form and the backing
+ * response sheet where submissions land.
+ */
+var DynamicFormUtilities = (function (global) {
+  var utils = {};
+  var INDEX_SHEET_NAME = 'DynamicFormsIndex';
+  var INDEX_HEADERS = [
+    'FormID',
+    'FormName',
+    'CampaignID',
+    'Description',
+    'ResponseSheetName',
+    'ResponseSheetId',
+    'ResponseSheetUrl',
+    'FieldsJson',
+    'CreatedAt',
+    'UpdatedAt'
+  ];
+  var RESPONSE_BASE_HEADERS = [
+    'SubmissionID',
+    'FormID',
+    'FormName',
+    'SubmittedAt',
+    'UserID',
+    'UserName',
+    'SubmittedBy'
+  ];
+  var safeConsole = (typeof console !== 'undefined' && console) ? console : {
+    log: function () { },
+    warn: function () { },
+    error: function () { }
+  };
+
+  var spreadsheetCache = {
+    id: '',
+    timestamp: 0,
+    spreadsheet: null
+  };
+
+  function toStringValue(value) {
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value);
+  }
+
+  function toDate(value) {
+    if (value instanceof Date) return value;
+    if (!value && value !== 0) return new Date();
+    var asDate = new Date(value);
+    if (isNaN(asDate.getTime())) return new Date();
+    return asDate;
+  }
+
+  function sanitizeSheetName(name) {
+    var sanitized = toStringValue(name);
+    sanitized = sanitized.replace(/[\[\]\*\/\\\?:]/g, ' ');
+    sanitized = sanitized.replace(/\s+/g, ' ').trim();
+    return sanitized || 'Dynamic Form';
+  }
+
+  function ensureUniqueSheetName(ss, desiredName) {
+    if (!ss) return desiredName || 'Dynamic Form';
+    var base = desiredName && desiredName.trim() ? desiredName.trim() : 'Dynamic Form';
+    if (base.length > 99) {
+      base = base.substring(0, 99);
+    }
+    var candidate = base;
+    var attempt = 2;
+    while (ss.getSheetByName(candidate)) {
+      var suffix = ' (' + attempt + ')';
+      var maxLength = 99 - suffix.length;
+      var shortened = base;
+      if (shortened.length > maxLength) {
+        shortened = shortened.substring(0, maxLength);
+      }
+      candidate = shortened + suffix;
+      attempt += 1;
+    }
+    return candidate;
+  }
+
+  function getSpreadsheet() {
+    if (typeof SpreadsheetApp === 'undefined' || !SpreadsheetApp || typeof SpreadsheetApp.getActiveSpreadsheet !== 'function') {
+      return null;
+    }
+    var now = Date.now ? Date.now() : new Date().getTime();
+    if (spreadsheetCache.spreadsheet && (now - spreadsheetCache.timestamp) < 60000) {
+      return spreadsheetCache.spreadsheet;
+    }
+    try {
+      var ss = SpreadsheetApp.getActiveSpreadsheet();
+      if (ss) {
+        spreadsheetCache.spreadsheet = ss;
+        spreadsheetCache.timestamp = now;
+        if (typeof ss.getId === 'function') {
+          spreadsheetCache.id = ss.getId();
+        }
+        return ss;
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormUtilities: Failed to fetch active spreadsheet', err);
+      }
+    }
+    if (spreadsheetCache.id && typeof SpreadsheetApp.openById === 'function') {
+      try {
+        var reopened = SpreadsheetApp.openById(spreadsheetCache.id);
+        if (reopened) {
+          spreadsheetCache.spreadsheet = reopened;
+          spreadsheetCache.timestamp = now;
+          return reopened;
+        }
+      } catch (openErr) {
+        if (safeConsole && typeof safeConsole.warn === 'function') {
+          safeConsole.warn('DynamicFormUtilities: Failed to reopen spreadsheet by id', openErr);
+        }
+      }
+    }
+    return spreadsheetCache.spreadsheet;
+  }
+
+  function ensureIndexSheet(ss) {
+    if (!ss) return null;
+    var sheet = ss.getSheetByName(INDEX_SHEET_NAME);
+    if (!sheet) {
+      sheet = ss.insertSheet(INDEX_SHEET_NAME);
+      sheet.getRange(1, 1, 1, INDEX_HEADERS.length).setValues([INDEX_HEADERS]);
+      if (typeof sheet.setFrozenRows === 'function') {
+        sheet.setFrozenRows(1);
+      }
+    } else {
+      try {
+        var range = sheet.getRange(1, 1, 1, INDEX_HEADERS.length);
+        var existing = range.getValues();
+        var needsUpdate = !existing || !existing.length;
+        if (!needsUpdate) {
+          var row = existing[0];
+          needsUpdate = row.length !== INDEX_HEADERS.length;
+          if (!needsUpdate) {
+            for (var i = 0; i < INDEX_HEADERS.length; i++) {
+              if (toStringValue(row[i]) !== toStringValue(INDEX_HEADERS[i])) {
+                needsUpdate = true;
+                break;
+              }
+            }
+          }
+        }
+        if (needsUpdate) {
+          range.setValues([INDEX_HEADERS]);
+        }
+        if (typeof sheet.getFrozenRows === 'function' && sheet.getFrozenRows() < 1 && typeof sheet.setFrozenRows === 'function') {
+          sheet.setFrozenRows(1);
+        }
+      } catch (err) {
+        if (safeConsole && typeof safeConsole.warn === 'function') {
+          safeConsole.warn('DynamicFormUtilities: Failed to ensure index headers', err);
+        }
+      }
+    }
+    return sheet;
+  }
+
+  function buildResponseHeaders(fields) {
+    var headers = RESPONSE_BASE_HEADERS.slice();
+    var seen = {};
+    for (var i = 0; i < headers.length; i++) {
+      seen[headers[i]] = true;
+    }
+    if (Array.isArray(fields)) {
+      for (var j = 0; j < fields.length; j++) {
+        var field = fields[j];
+        if (!field) continue;
+        var label = toStringValue(field.label || field.title || field.name || ('Field ' + (j + 1)));
+        if (!label) {
+          label = 'Field ' + (j + 1);
+        }
+        var candidate = label;
+        var counter = 2;
+        while (seen[candidate]) {
+          candidate = label + ' (' + counter + ')';
+          counter += 1;
+        }
+        seen[candidate] = true;
+        headers.push(candidate);
+      }
+    }
+    return headers;
+  }
+
+  function ensureResponseHeaders(sheet, fields) {
+    if (!sheet) return;
+    try {
+      var headers = buildResponseHeaders(fields);
+      var range = sheet.getRange(1, 1, 1, headers.length);
+      var existing = range.getValues();
+      var needsUpdate = !existing || !existing.length;
+      if (!needsUpdate) {
+        var row = existing[0];
+        needsUpdate = row.length !== headers.length;
+        if (!needsUpdate) {
+          for (var i = 0; i < headers.length; i++) {
+            if (toStringValue(row[i]) !== toStringValue(headers[i])) {
+              needsUpdate = true;
+              break;
+            }
+          }
+        }
+      }
+      if (needsUpdate) {
+        range.setValues([headers]);
+      }
+      if (typeof sheet.getFrozenRows === 'function' && sheet.getFrozenRows() < 1 && typeof sheet.setFrozenRows === 'function') {
+        sheet.setFrozenRows(1);
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormUtilities: Failed to ensure response headers', err);
+      }
+    }
+  }
+
+  function createResponseSheet(formRecord, fields, ss) {
+    if (!formRecord) return null;
+    var spreadsheet = ss || getSpreadsheet();
+    if (!spreadsheet) return null;
+    try {
+      var baseName = sanitizeSheetName((formRecord && (formRecord.Name || formRecord.name)) || 'Dynamic Form');
+      var suffix = '';
+      if (formRecord.ID || formRecord.id) {
+        var idFragment = String(formRecord.ID || formRecord.id).replace(/[^a-zA-Z0-9]/g, '').substring(0, 6).toUpperCase();
+        if (idFragment) {
+          suffix = ' [' + idFragment + ']';
+        }
+      }
+      var desiredName = sanitizeSheetName(baseName + ' Responses' + suffix);
+      var sheetName = ensureUniqueSheetName(spreadsheet, desiredName);
+      var sheet = spreadsheet.insertSheet(sheetName);
+      ensureResponseHeaders(sheet, fields);
+      return {
+        sheet: sheet,
+        id: sheet.getSheetId(),
+        name: sheetName
+      };
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.error === 'function') {
+        safeConsole.error('DynamicFormUtilities: Failed to create response sheet', err);
+      }
+      return null;
+    }
+  }
+
+  function getSheetUrl(sheet) {
+    if (!sheet) return '';
+    try {
+      var ss = sheet.getParent();
+      if (ss && typeof ss.getUrl === 'function') {
+        var baseUrl = ss.getUrl();
+        if (!baseUrl) return '';
+        if (typeof sheet.getSheetId === 'function') {
+          var id = sheet.getSheetId();
+          return baseUrl + '#gid=' + id;
+        }
+        return baseUrl;
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.warn === 'function') {
+        safeConsole.warn('DynamicFormUtilities: Failed to resolve sheet url', err);
+      }
+    }
+    return '';
+  }
+
+  function upsertFormMetadata(formRecord, fields) {
+    if (!formRecord) return;
+    var ss = getSpreadsheet();
+    if (!ss) return;
+    var sheet = ensureIndexSheet(ss);
+    if (!sheet) return;
+
+    var lock = null;
+    if (typeof LockService !== 'undefined' && LockService && typeof LockService.getDocumentLock === 'function') {
+      try {
+        lock = LockService.getDocumentLock();
+        if (lock && typeof lock.waitLock === 'function') {
+          lock.waitLock(5000);
+        }
+      } catch (err) {
+        if (safeConsole && typeof safeConsole.warn === 'function') {
+          safeConsole.warn('DynamicFormUtilities: Failed to acquire document lock for metadata', err);
+        }
+        lock = null;
+      }
+    }
+
+    try {
+      ensureIndexSheet(ss);
+      var formId = toStringValue(formRecord.ID || formRecord.Id || formRecord.id || '');
+      if (!formId) return;
+      var lastRow = sheet.getLastRow();
+      var targetRow = -1;
+      if (lastRow >= 2) {
+        var idRange = sheet.getRange(2, 1, lastRow - 1, 1);
+        var ids = idRange.getValues();
+        for (var i = 0; i < ids.length; i++) {
+          if (toStringValue(ids[i][0]) === formId) {
+            targetRow = i + 2;
+            break;
+          }
+        }
+      }
+
+      var now = toDate(new Date());
+      var createdAt = now;
+      if (targetRow > -1) {
+        var existingCreated = sheet.getRange(targetRow, 9).getValue();
+        if (existingCreated) {
+          createdAt = existingCreated;
+        }
+      }
+
+      var responseSheetName = toStringValue(formRecord.ResponseSheetName || formRecord.responseSheetName || '');
+      var responseSheetId = toStringValue(formRecord.ResponseSheetId || formRecord.responseSheetId || '');
+      var responseUrl = toStringValue(formRecord.ResponseSheetUrl || formRecord.responseSheetUrl || '');
+      if (!responseUrl && responseSheetName) {
+        var sheetByName = ss.getSheetByName(responseSheetName);
+        if (sheetByName) {
+          responseUrl = getSheetUrl(sheetByName);
+        }
+      }
+
+      var serializedFields = fields;
+      if (!serializedFields && formRecord && formRecord.Fields) {
+        serializedFields = formRecord.Fields;
+      }
+      var fieldsJson;
+      if (typeof serializedFields === 'string') {
+        fieldsJson = serializedFields;
+      } else {
+        try {
+          fieldsJson = JSON.stringify(serializedFields || []);
+        } catch (stringifyErr) {
+          fieldsJson = '[]';
+          if (safeConsole && typeof safeConsole.warn === 'function') {
+            safeConsole.warn('DynamicFormUtilities: Failed to stringify fields for metadata', stringifyErr);
+          }
+        }
+      }
+
+      var payload = [
+        formId,
+        toStringValue(formRecord.Name || formRecord.name || ''),
+        toStringValue(formRecord.CampaignID || formRecord.campaignId || ''),
+        toStringValue(formRecord.Description || formRecord.description || ''),
+        responseSheetName,
+        responseSheetId,
+        responseUrl,
+        fieldsJson || '[]',
+        createdAt,
+        now
+      ];
+
+      if (targetRow > -1) {
+        sheet.getRange(targetRow, 1, 1, payload.length).setValues([payload]);
+      } else {
+        sheet.appendRow(payload);
+      }
+    } catch (err) {
+      if (safeConsole && typeof safeConsole.error === 'function') {
+        safeConsole.error('DynamicFormUtilities: Failed to upsert form metadata', err);
+      }
+    } finally {
+      if (lock && typeof lock.releaseLock === 'function') {
+        try {
+          lock.releaseLock();
+        } catch (releaseErr) {
+          if (safeConsole && typeof safeConsole.warn === 'function') {
+            safeConsole.warn('DynamicFormUtilities: Failed to release lock', releaseErr);
+          }
+        }
+      }
+    }
+  }
+
+  utils.getSpreadsheet = getSpreadsheet;
+  utils.ensureIndexSheet = ensureIndexSheet;
+  utils.buildResponseHeaders = buildResponseHeaders;
+  utils.ensureResponseHeaders = ensureResponseHeaders;
+  utils.createResponseSheet = createResponseSheet;
+  utils.getSheetUrl = getSheetUrl;
+  utils.upsertFormMetadata = upsertFormMetadata;
+  utils.RESPONSE_BASE_HEADERS = RESPONSE_BASE_HEADERS.slice();
+  utils.INDEX_HEADERS = INDEX_HEADERS.slice();
+  utils.INDEX_SHEET_NAME = INDEX_SHEET_NAME;
+
+  return utils;
+})(this);

--- a/MainUtilities.js
+++ b/MainUtilities.js
@@ -1370,6 +1370,13 @@ function getAllPagesFromActualRouting() {
     // UTILITIES
     { key: 'ackform', title: 'Acknowledgment Form', icon: 'fas fa-signature', description: 'Employee acknowledgment and signature forms', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
     { key: 'proxy', title: 'Proxy Service', icon: 'fas fa-exchange-alt', description: 'Proxy service for external content access', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'dynamic-form-dashboard', title: 'Dynamic Form Dashboard', icon: 'fas fa-chart-line', description: 'Track dynamic form creation and response trends', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'dynamicformdashboard', title: 'Dynamic Form Dashboard', icon: 'fas fa-chart-line', description: 'Track dynamic form creation and response trends', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'dynamicformsdashboard', title: 'Dynamic Form Dashboard', icon: 'fas fa-chart-line', description: 'Track dynamic form creation and response trends', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'dynamic-forms', title: 'Dynamic Form Responses', icon: 'fas fa-clipboard-list', description: 'Review dynamic form submissions and applied user profile updates', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'dynamicforms', title: 'Dynamic Form Responses', icon: 'fas fa-clipboard-list', description: 'Review dynamic form submissions and applied user profile updates', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'formresponses', title: 'Dynamic Form Responses', icon: 'fas fa-clipboard-list', description: 'Review dynamic form submissions and applied user profile updates', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
+    { key: 'form-responses', title: 'Dynamic Form Responses', icon: 'fas fa-clipboard-list', description: 'Review dynamic form submissions and applied user profile updates', isSystem: true, requiresAdmin: false, category: 'Forms & Utilities' },
 
     // AUTH
     { key: 'setpassword', title: 'Set Password', icon: 'fas fa-key', description: 'Set new password for user account', isSystem: true, requiresAdmin: false, category: 'Authentication', isPublic: true },

--- a/UserService.js
+++ b/UserService.js
@@ -86,6 +86,7 @@ var USER_SHEET_COLUMN_ORDER = (function resolveUserSheetColumnOrder_() {
     'InsuranceQualified',
     'InsuranceEnrolled',
     'InsuranceCardReceivedDate',
+    'InsuranceInformation',
     'ProbationEndDate',
     'InsuranceQualifiedDate',
     'InsuranceEligible',

--- a/layout.html
+++ b/layout.html
@@ -85,6 +85,7 @@
       'creditsuiteqa': 'Evaluate Credit Suite cases with standardized QA scoring and compliance checks.',
       'dashboard': 'View OKR performance, goal progress, and campaign-level analytics.',
       'dashboard-detail': 'Inspect a single campaign\'s OKR metrics, agent roster, and alerts.',
+      'dynamic-forms': 'Review dynamic form submissions and the profile updates they triggered.',
       'eodreport': 'Compile end-of-day summaries, escalations, and operational highlights.',
       'escalations': 'Manage customer escalations, ownership, and resolution progress.',
       'goalsetting': 'Set, track, and update operational goals with transparent accountability.',


### PR DESCRIPTION
## Summary
- add DynamicFormUtilities to provision the dynamic form index sheet and shared helpers for response sheets
- update DynamicFormService to use the new helpers and sync each form's metadata into the spreadsheet while keeping response rows intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe5e41fdf88326944ff8a962462eea