### PR TITLE
Fix attendance calendar date normalization

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -11291,8 +11291,10 @@
                     return '';
                 }
 
-                const local = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-                return local.toISOString().split('T')[0];
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
             }
 
             resolveIsoDate(value, fallback = null) {


### PR DESCRIPTION
## Summary
- update the attendance calendar ISO date conversion to build the string from local date parts
- prevent the calendar from shifting entries backward when the page reloads

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690451b355788326b7a51ced2051b051