### PR TITLE
Fix attendance calendar bulk selection date shifting

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9837,7 +9837,14 @@
                     const status = typeof statusRaw === 'string' ? statusRaw.trim() : String(statusRaw || '').trim();
                     const rawDate = record?.date || record?.Date || record?.timestamp;
 
-                    const date = rawDate instanceof Date ? new Date(rawDate.getTime()) : (rawDate ? new Date(rawDate) : null);
+                    const date = typeof this.parseDateValue === 'function'
+                        ? (this.parseDateValue(rawDate)
+                            || (rawDate instanceof Date
+                                ? new Date(rawDate.getTime())
+                                : (rawDate ? new Date(rawDate) : null)))
+                        : rawDate instanceof Date
+                            ? new Date(rawDate.getTime())
+                            : (rawDate ? new Date(rawDate) : null);
                     const isoDate = this.toIsoDateString(date);
                     const userKey = this.normalizePersonKey(userName);
 


### PR DESCRIPTION
## Summary
- parse attendance record dates using the existing helper to preserve local calendar days and avoid weekend shifting after reloads

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907460b42c88326940270684ef50611