### PR TITLE
Fix attendance calendar date parsing for timezone-stamped entries

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9835,9 +9835,16 @@
                     const statusRaw = record?.status || record?.Status || record?.state || record?.State || '';
                     const userName = typeof userNameRaw === 'string' ? userNameRaw.trim() : String(userNameRaw || '').trim();
                     const status = typeof statusRaw === 'string' ? statusRaw.trim() : String(statusRaw || '').trim();
-                    const rawDate = record?.date || record?.Date || record?.timestamp;
+                    const rawDate = record?.date || record?.Date || record?.timestamp || record?.Timestamp;
 
-                    const date = rawDate instanceof Date ? new Date(rawDate.getTime()) : (rawDate ? new Date(rawDate) : null);
+                    const date = typeof this.parseDateValue === 'function'
+                        ? (this.parseDateValue(rawDate)
+                            || (rawDate instanceof Date
+                                ? new Date(rawDate.getTime())
+                                : (rawDate ? new Date(rawDate) : null)))
+                        : rawDate instanceof Date
+                            ? new Date(rawDate.getTime())
+                            : (rawDate ? new Date(rawDate) : null);
                     const isoDate = this.toIsoDateString(date);
                     const userKey = this.normalizePersonKey(userName);
 
@@ -12728,9 +12735,29 @@
                         return isNaN(localDate.getTime()) ? null : localDate;
                     }
 
+                    const isoDateTimeMatch = normalized.match(/^([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})(?:[T\s].*)$/);
+                    if (isoDateTimeMatch) {
+                        const [, yearStr, monthStr, dayStr] = isoDateTimeMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
                     const slashDateOnlyMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})$/);
                     if (slashDateOnlyMatch) {
                         const [, monthStr, dayStr, yearStr] = slashDateOnlyMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
+                    const slashDateTimeMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})(?:\b.*)$/);
+                    if (slashDateTimeMatch) {
+                        const [, monthStr, dayStr, yearStr] = slashDateTimeMatch;
                         const year = Number(yearStr);
                         const month = Number(monthStr) - 1;
                         const day = Number(dayStr);


### PR DESCRIPTION
## Summary
- treat timezone-stamped attendance dates as local calendar days during parsing to keep bulk selections anchored after reloads
- include timestamp variants when normalizing attendance records so day lookups remain consistent

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907460b42c88326940270684ef50611