### PR TITLE
Handle local-midnight attendance dates without shifting

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9835,10 +9835,14 @@
                     const statusRaw = record?.status || record?.Status || record?.state || record?.State || '';
                     const userName = typeof userNameRaw === 'string' ? userNameRaw.trim() : String(userNameRaw || '').trim();
                     const status = typeof statusRaw === 'string' ? statusRaw.trim() : String(statusRaw || '').trim();
-                    const rawDate = record?.date || record?.Date || record?.timestamp;
+                    const rawDate = record?.date || record?.Date || record?.timestamp || record?.Timestamp;
+                    let isoDate = this.normalizeAttendanceDateValue(rawDate);
 
-                    const date = rawDate instanceof Date ? new Date(rawDate.getTime()) : (rawDate ? new Date(rawDate) : null);
-                    const isoDate = this.toIsoDateString(date);
+                    if (!isoDate && typeof this.parseDateValue === 'function') {
+                        const parsedDate = this.parseDateValue(rawDate);
+                        isoDate = parsedDate instanceof Date ? this.toIsoDateString(parsedDate) : '';
+                    }
+
                     const userKey = this.normalizePersonKey(userName);
 
                     if (!userKey || !isoDate || !status) {
@@ -11287,14 +11291,26 @@
             }
 
             toIsoDateString(date) {
-                if (!(date instanceof Date) || isNaN(date.getTime())) {
+                if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
                     return '';
                 }
 
-                const year = date.getFullYear();
-                const month = String(date.getMonth() + 1).padStart(2, '0');
-                const day = String(date.getDate()).padStart(2, '0');
-                return `${year}-${month}-${day}`;
+                const isLocalMidnight = date.getHours() === 0
+                    && date.getMinutes() === 0
+                    && date.getSeconds() === 0
+                    && date.getMilliseconds() === 0;
+
+                if (isLocalMidnight) {
+                    const localYear = date.getFullYear();
+                    const localMonth = String(date.getMonth() + 1).padStart(2, '0');
+                    const localDay = String(date.getDate()).padStart(2, '0');
+                    return `${localYear}-${localMonth}-${localDay}`;
+                }
+
+                const utcYear = date.getUTCFullYear();
+                const utcMonth = String(date.getUTCMonth() + 1).padStart(2, '0');
+                const utcDay = String(date.getUTCDate()).padStart(2, '0');
+                return `${utcYear}-${utcMonth}-${utcDay}`;
             }
 
             resolveIsoDate(value, fallback = null) {
@@ -12728,9 +12744,29 @@
                         return isNaN(localDate.getTime()) ? null : localDate;
                     }
 
+                    const isoDateTimeMatch = normalized.match(/^([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})(?:[T\s].*)$/);
+                    if (isoDateTimeMatch) {
+                        const [, yearStr, monthStr, dayStr] = isoDateTimeMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
                     const slashDateOnlyMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})$/);
                     if (slashDateOnlyMatch) {
                         const [, monthStr, dayStr, yearStr] = slashDateOnlyMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
+                    const slashDateTimeMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})(?:\b.*)$/);
+                    if (slashDateTimeMatch) {
+                        const [, monthStr, dayStr, yearStr] = slashDateTimeMatch;
                         const year = Number(yearStr);
                         const month = Number(monthStr) - 1;
                         const day = Number(dayStr);


### PR DESCRIPTION
## Summary
- ensure ISO date formatting preserves local calendar days when schedule data uses midnight-local Date objects
- fall back to UTC components only when the Date includes a non-midnight time component

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907460b42c88326940270684ef50611