### PR TITLE
Normalize attendance range dates using UTC

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9835,10 +9835,14 @@
                     const statusRaw = record?.status || record?.Status || record?.state || record?.State || '';
                     const userName = typeof userNameRaw === 'string' ? userNameRaw.trim() : String(userNameRaw || '').trim();
                     const status = typeof statusRaw === 'string' ? statusRaw.trim() : String(statusRaw || '').trim();
-                    const rawDate = record?.date || record?.Date || record?.timestamp;
+                    const rawDate = record?.date || record?.Date || record?.timestamp || record?.Timestamp;
+                    let isoDate = this.normalizeAttendanceDateValue(rawDate);
 
-                    const date = rawDate instanceof Date ? new Date(rawDate.getTime()) : (rawDate ? new Date(rawDate) : null);
-                    const isoDate = this.toIsoDateString(date);
+                    if (!isoDate && typeof this.parseDateValue === 'function') {
+                        const parsedDate = this.parseDateValue(rawDate);
+                        isoDate = parsedDate instanceof Date ? this.toIsoDateString(parsedDate) : '';
+                    }
+
                     const userKey = this.normalizePersonKey(userName);
 
                     if (!userKey || !isoDate || !status) {
@@ -11287,14 +11291,26 @@
             }
 
             toIsoDateString(date) {
-                if (!(date instanceof Date) || isNaN(date.getTime())) {
+                if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
                     return '';
                 }
 
-                const year = date.getFullYear();
-                const month = String(date.getMonth() + 1).padStart(2, '0');
-                const day = String(date.getDate()).padStart(2, '0');
-                return `${year}-${month}-${day}`;
+                const isLocalMidnight = date.getHours() === 0
+                    && date.getMinutes() === 0
+                    && date.getSeconds() === 0
+                    && date.getMilliseconds() === 0;
+
+                if (isLocalMidnight) {
+                    const localYear = date.getFullYear();
+                    const localMonth = String(date.getMonth() + 1).padStart(2, '0');
+                    const localDay = String(date.getDate()).padStart(2, '0');
+                    return `${localYear}-${localMonth}-${localDay}`;
+                }
+
+                const utcYear = date.getUTCFullYear();
+                const utcMonth = String(date.getUTCMonth() + 1).padStart(2, '0');
+                const utcDay = String(date.getUTCDate()).padStart(2, '0');
+                return `${utcYear}-${utcMonth}-${utcDay}`;
             }
 
             resolveIsoDate(value, fallback = null) {
@@ -12728,9 +12744,29 @@
                         return isNaN(localDate.getTime()) ? null : localDate;
                     }
 
+                    const isoDateTimeMatch = normalized.match(/^([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})(?:[T\s].*)$/);
+                    if (isoDateTimeMatch) {
+                        const [, yearStr, monthStr, dayStr] = isoDateTimeMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
                     const slashDateOnlyMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})$/);
                     if (slashDateOnlyMatch) {
                         const [, monthStr, dayStr, yearStr] = slashDateOnlyMatch;
+                        const year = Number(yearStr);
+                        const month = Number(monthStr) - 1;
+                        const day = Number(dayStr);
+                        const localDate = new Date(year, month, day);
+                        return isNaN(localDate.getTime()) ? null : localDate;
+                    }
+
+                    const slashDateTimeMatch = normalized.match(/^([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})(?:\b.*)$/);
+                    if (slashDateTimeMatch) {
+                        const [, monthStr, dayStr, yearStr] = slashDateTimeMatch;
                         const year = Number(yearStr);
                         const month = Number(monthStr) - 1;
                         const day = Number(dayStr);

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -5643,16 +5643,34 @@ function clientGetAttendanceDataRange(startDate, endDate, campaignId = null) {
 
     const normalizeDate = (value) => {
       if (value instanceof Date) {
-        return new Date(value.getTime());
+        return isNaN(value.getTime()) ? null : new Date(value.getTime());
       }
-      if (typeof value === 'number') {
+
+      if (typeof value === 'number' && Number.isFinite(value)) {
         const parsed = new Date(value);
-        return isNaN(parsed.getTime()) ? null : parsed;
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
       }
-      if (typeof value === 'string' && value.trim().length > 0) {
-        const parsed = new Date(value);
-        return isNaN(parsed.getTime()) ? null : parsed;
+
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return null;
+        }
+
+        const isoDateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (isoDateMatch) {
+          const year = Number(isoDateMatch[1]);
+          const month = Number(isoDateMatch[2]);
+          const day = Number(isoDateMatch[3]);
+          if (Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(day)) {
+            return new Date(Date.UTC(year, month - 1, day));
+          }
+        }
+
+        const parsed = new Date(trimmed);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
       }
+
       return null;
     };
 
@@ -5683,12 +5701,12 @@ function clientGetAttendanceDataRange(startDate, endDate, campaignId = null) {
     });
 
     const toIsoDate = (date) => {
-      if (!(date instanceof Date) || isNaN(date.getTime())) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
         return '';
       }
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
+      const year = date.getUTCFullYear();
+      const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+      const day = String(date.getUTCDate()).padStart(2, '0');
       return `${year}-${month}-${day}`;
     };
 


### PR DESCRIPTION
## Summary
- parse attendance status dates written as ISO strings as UTC-midnight values so filtering uses consistent timestamps
- format attendance records with UTC components when returning them to the client to avoid day shifts at month boundaries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907460b42c88326940270684ef50611