### PR TITLE
Display daily login and logout times in attendance table

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -2588,6 +2588,251 @@
         const timezoneLabel = window.COMPANY_TIMEZONE_LABEL || COMPANY_TIMEZONE_LABEL || 'company timezone';
         const timezoneValue = window.COMPANY_TIMEZONE || COMPANY_TIMEZONE;
 
+        const filteredRows = Array.isArray(this.currentData.filteredRows)
+          ? this.currentData.filteredRows
+          : [];
+        const loginStates = new Set([
+          'available',
+          'start of shift',
+          'start shift',
+          'clocked in',
+          'clock in',
+          'logged in',
+          'log in',
+          'signed in'
+        ]);
+        const logoutStates = new Set([
+          'end of shift',
+          'end-of-shift',
+          'end shift',
+          'logged out',
+          'log out',
+          'clocked out',
+          'clock out',
+          'signed out'
+        ]);
+        const isoDateFormatter = (() => {
+          try {
+            return new Intl.DateTimeFormat('en-CA', {
+              timeZone: timezoneValue || 'UTC'
+            });
+          } catch (error) {
+            console.warn('Failed to create ISO date formatter for attendance table:', error);
+            return null;
+          }
+        })();
+
+        const friendlyDateFormatter = (() => {
+          try {
+            return new Intl.DateTimeFormat('en-US', {
+              weekday: 'short',
+              month: 'short',
+              day: 'numeric',
+              timeZone: timezoneValue || 'UTC'
+            });
+          } catch (error) {
+            console.warn('Failed to create friendly date formatter for attendance table:', error);
+            return null;
+          }
+        })();
+
+        const ensureDateKey = (timestamp, dateString) => {
+          if (typeof dateString === 'string') {
+            const trimmed = dateString.trim();
+            if (trimmed) {
+              return trimmed;
+            }
+          }
+
+          if (!Number.isFinite(timestamp)) {
+            return null;
+          }
+
+          const date = new Date(timestamp);
+          if (Number.isNaN(date.getTime())) {
+            return null;
+          }
+
+          if (isoDateFormatter) {
+            try {
+              return isoDateFormatter.format(date);
+            } catch (err) {
+              console.warn('ISO date formatting failed, falling back to UTC string:', err);
+            }
+          }
+
+          try {
+            return date.toISOString().slice(0, 10);
+          } catch (error) {
+            console.warn('Failed to derive ISO date key for attendance table:', error);
+            return null;
+          }
+        };
+
+        const timingInfoByUser = new Map();
+
+        filteredRows.forEach(row => {
+          if (!row || !row.user) {
+            return;
+          }
+
+          const timestamp = typeof row.timestampMs === 'number'
+            ? row.timestampMs
+            : Number(row.timestamp);
+          if (!Number.isFinite(timestamp)) {
+            return;
+          }
+
+          const rawState = typeof row.state === 'string' ? row.state.trim() : '';
+          const normalizedState = rawState.toLowerCase();
+          const dateKey = ensureDateKey(timestamp, row.dateString);
+
+          if (!dateKey) {
+            return;
+          }
+
+          if (!timingInfoByUser.has(row.user)) {
+            timingInfoByUser.set(row.user, new Map());
+          }
+
+          const userDateMap = timingInfoByUser.get(row.user);
+          if (!userDateMap) {
+            return;
+          }
+
+          if (!userDateMap.has(dateKey)) {
+            userDateMap.set(dateKey, {
+              firstAvailable: null,
+              lastEndOfShift: null,
+              earliestEvent: null,
+              latestEvent: null
+            });
+          }
+
+          const info = userDateMap.get(dateKey);
+          if (!info) {
+            return;
+          }
+
+          if (info.earliestEvent === null || timestamp < info.earliestEvent) {
+            info.earliestEvent = timestamp;
+          }
+          if (info.latestEvent === null || timestamp > info.latestEvent) {
+            info.latestEvent = timestamp;
+          }
+
+          if (loginStates.has(normalizedState)) {
+            if (info.firstAvailable === null || timestamp < info.firstAvailable) {
+              info.firstAvailable = timestamp;
+            }
+          }
+
+          if (logoutStates.has(normalizedState)) {
+            if (info.lastEndOfShift === null || timestamp > info.lastEndOfShift) {
+              info.lastEndOfShift = timestamp;
+            }
+          }
+        });
+
+        const timeFormatter = (() => {
+          try {
+            return new Intl.DateTimeFormat('en-US', {
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: true,
+              timeZone: timezoneValue || 'UTC'
+            });
+          } catch (error) {
+            console.warn('Failed to create Intl.DateTimeFormat for attendance table:', error);
+            return null;
+          }
+        })();
+
+        const formatTimestampForDisplay = (timestamp) => {
+          if (!Number.isFinite(timestamp)) {
+            return '—';
+          }
+          const date = new Date(timestamp);
+          if (Number.isNaN(date.getTime())) {
+            return '—';
+          }
+          if (timeFormatter) {
+            try {
+              return timeFormatter.format(date);
+            } catch (err) {
+              console.warn('Time formatting failed, falling back to locale string:', err);
+            }
+          }
+          return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        };
+
+        const formatDateForDisplay = (dateKey) => {
+          if (typeof dateKey !== 'string' || !dateKey) {
+            return '';
+          }
+
+          if (friendlyDateFormatter) {
+            try {
+              const [year, month, day] = dateKey.split('-').map(part => Number(part));
+              if ([year, month, day].every(num => Number.isFinite(num))) {
+                const date = new Date(Date.UTC(year, month - 1, day));
+                return friendlyDateFormatter.format(date);
+              }
+            } catch (error) {
+              console.warn('Friendly date formatting failed, falling back to raw key:', error);
+            }
+          }
+
+          return dateKey;
+        };
+
+        const getDailyTimingsForUser = (userId) => {
+          if (!userId) {
+            return [];
+          }
+
+          const userDateMap = timingInfoByUser.get(userId);
+          if (!userDateMap) {
+            return [];
+          }
+
+          const entries = Array.from(userDateMap.entries()).map(([dateKey, info]) => {
+            const firstCandidate = Number.isFinite(info.firstAvailable) ? info.firstAvailable : info.earliestEvent;
+            const lastCandidate = Number.isFinite(info.lastEndOfShift) ? info.lastEndOfShift : info.latestEvent;
+
+            const first = Number.isFinite(firstCandidate) ? firstCandidate : null;
+            const last = Number.isFinite(lastCandidate) ? lastCandidate : null;
+
+            if (first === null && last === null) {
+              return null;
+            }
+
+            return {
+              dateKey,
+              first,
+              last
+            };
+          }).filter(Boolean);
+
+          entries.sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+          return entries;
+        };
+
+        const formatDailyTimingsColumn = (dailyTimings, type) => {
+          if (!Array.isArray(dailyTimings) || dailyTimings.length === 0) {
+            return '<span class="text-muted">—</span>';
+          }
+
+          const rows = dailyTimings.slice().reverse().map(timing => {
+            const timeValue = type === 'last' ? timing.last : timing.first;
+            const timeLabel = formatTimestampForDisplay(timeValue);
+            const dateLabel = formatDateForDisplay(timing.dateKey);
+            return `<div class="small"><span class="text-muted d-block">${dateLabel}</span><span class="fw-semibold">${timeLabel}</span></div>`;
+          });
+
+          return `<div class="d-flex flex-column gap-1">${rows.join('')}</div>`;
+        };
+
         let tableHtml = `
           <div class="d-flex justify-content-between align-items-center mb-3">
             <div class="text-muted">
@@ -2608,6 +2853,8 @@
               <thead>
                 <tr>
                   <th><i class="fas fa-user me-2"></i>Employee</th>
+                  <th><i class="fas fa-sign-in-alt me-2"></i>Daily First Available <span class="d-block small text-muted">${timezoneLabel}</span></th>
+                  <th><i class="fas fa-sign-out-alt me-2"></i>Daily Last End of Shift <span class="d-block small text-muted">${timezoneLabel}</span></th>
                   <th><i class="fas fa-briefcase me-2"></i>Capped Billable Hours</th>
                   <th><i class="fas fa-coffee me-2"></i>Break Credit Hours</th>
                   <th><i class="fas fa-utensils me-2"></i>Lunch Adjustment Hours</th>
@@ -2630,6 +2877,9 @@
           const weekendAvailabilityDisplay = formatDecimalHours(user.weekendSecs || 0);
           const breakRecordedDisplay = formatDecimalHours(user.breakSecs || 0);
           const lunchRecordedDisplay = formatDecimalHours(user.lunchSecs || 0);
+          const dailyTimings = getDailyTimingsForUser(user.user);
+          const firstAvailableDisplay = formatDailyTimingsColumn(dailyTimings, 'first');
+          const lastEndShiftDisplay = formatDailyTimingsColumn(dailyTimings, 'last');
 
           tableHtml += `
             <tr>
@@ -2640,6 +2890,12 @@
                   </div>
                   <strong>${user.user || 'Unknown'}</strong>
                 </div>
+              </td>
+              <td>
+                ${firstAvailableDisplay}
+              </td>
+              <td>
+                ${lastEndShiftDisplay}
               </td>
               <td>
                 <span class="badge bg-primary">${baseHoursDisplay}</span>


### PR DESCRIPTION
## Summary
- derive per-agent, per-day login and logout timestamps from filtered attendance rows using timezone-aware formatting
- render each agent's daily first-available and end-of-shift entries within the attendance table with friendly date labels

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908eb0afda883269e2b590521c5e5e1