### PR TITLE
Refresh attendance summary UI and align weekly login data

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -111,6 +111,145 @@
       font-size: .875rem;
     }
 
+    /* MODERN DATA TABLES */
+    .modern-data-table {
+      border-collapse: separate;
+      border-spacing: 0;
+      border-radius: var(--border-radius);
+      overflow: hidden;
+      background: #fff;
+    }
+
+    .modern-data-table thead th {
+      background: linear-gradient(135deg, rgba(102, 126, 234, .15) 0%, rgba(118, 75, 162, .15) 100%);
+      border-bottom: none;
+      color: var(--gray-600);
+      font-size: .7rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      padding-top: .9rem;
+      padding-bottom: .9rem;
+    }
+
+    .modern-data-table tbody tr {
+      background: #fff;
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+
+    .modern-data-table tbody tr:hover {
+      transform: translateX(4px);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .modern-data-table tbody td {
+      border-top: 1px solid var(--gray-200);
+      vertical-align: middle;
+    }
+
+    .modern-metric-cell {
+      vertical-align: middle;
+    }
+
+    .metric-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: .4rem;
+      padding: .35rem .75rem;
+      border-radius: var(--border-radius-full);
+      font-weight: 600;
+      font-size: .85rem;
+      background: rgba(241, 245, 249, .9);
+      color: var(--gray-700);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .metric-pill i {
+      font-size: .8rem;
+    }
+
+    .metric-pill-primary {
+      background: rgba(0, 49, 119, .12);
+      color: var(--navy-primary);
+    }
+
+    .metric-pill-warning {
+      background: rgba(255, 184, 0, .15);
+      color: #b45309;
+    }
+
+    .metric-pill-info {
+      background: rgba(0, 191, 255, .15);
+      color: #0369a1;
+    }
+
+    .metric-pill-success {
+      background: rgba(16, 185, 129, .15);
+      color: #0f766e;
+    }
+
+    .metric-pill-neutral {
+      background: rgba(100, 116, 139, .12);
+      color: var(--gray-600);
+    }
+
+    .metric-subtext {
+      font-size: .75rem;
+      color: var(--gray-500);
+      margin-top: .35rem;
+    }
+
+    .attendance-summary-table tbody tr td:first-child {
+      min-width: 200px;
+    }
+
+    /* WEEKLY LOGIN TABLE */
+    .weekly-login-table thead th {
+      text-transform: uppercase;
+      font-size: .68rem;
+      letter-spacing: .08em;
+      border-bottom: none;
+    }
+
+    .weekly-login-table tbody td {
+      border-top: 1px solid var(--gray-200);
+    }
+
+    .weekly-login-cell {
+      display: flex;
+      flex-direction: column;
+      gap: .4rem;
+    }
+
+    @media (min-width: 768px) {
+      .weekly-login-cell {
+        flex-direction: row;
+      }
+    }
+
+    .weekly-login-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: .35rem;
+      padding: .35rem .7rem;
+      border-radius: var(--border-radius-full);
+      font-size: .75rem;
+      font-weight: 600;
+      background: rgba(241, 245, 249, .9);
+      color: var(--gray-700);
+      box-shadow: var(--shadow-sm);
+      white-space: nowrap;
+    }
+
+    .weekly-login-badge.login {
+      background: rgba(16, 185, 129, .15);
+      color: #047857;
+    }
+
+    .weekly-login-badge.logout {
+      background: rgba(255, 184, 0, .18);
+      color: #b45309;
+    }
+
     /* INTELLIGENT INSIGHTS PANEL */
     .intelligent-insights-panel {
       background: linear-gradient(145deg, #ffffff 0%, #f8fafc 100%);
@@ -2794,73 +2933,6 @@
           return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
         };
 
-        const formatDateForDisplay = (dateKey) => {
-          if (typeof dateKey !== 'string' || !dateKey) {
-            return '';
-          }
-
-          if (friendlyDateFormatter) {
-            try {
-              const [year, month, day] = dateKey.split('-').map(part => Number(part));
-              if ([year, month, day].every(num => Number.isFinite(num))) {
-                const date = new Date(Date.UTC(year, month - 1, day));
-                return friendlyDateFormatter.format(date);
-              }
-            } catch (error) {
-              console.warn('Friendly date formatting failed, falling back to raw key:', error);
-            }
-          }
-
-          return dateKey;
-        };
-
-        const getDailyTimingsForUser = (userId) => {
-          if (!userId) {
-            return [];
-          }
-
-          const userDateMap = timingInfoByUser.get(userId);
-          if (!userDateMap) {
-            return [];
-          }
-
-          const entries = Array.from(userDateMap.entries()).map(([dateKey, info]) => {
-            const firstCandidate = Number.isFinite(info.firstAvailable) ? info.firstAvailable : info.earliestEvent;
-            const lastCandidate = Number.isFinite(info.lastEndOfShift) ? info.lastEndOfShift : info.latestEvent;
-
-            const first = Number.isFinite(firstCandidate) ? firstCandidate : null;
-            const last = Number.isFinite(lastCandidate) ? lastCandidate : null;
-
-            if (first === null && last === null) {
-              return null;
-            }
-
-            return {
-              dateKey,
-              first,
-              last
-            };
-          }).filter(Boolean);
-
-          entries.sort((a, b) => a.dateKey.localeCompare(b.dateKey));
-          return entries;
-        };
-
-        const formatDailyTimingsColumn = (dailyTimings, type) => {
-          if (!Array.isArray(dailyTimings) || dailyTimings.length === 0) {
-            return '<span class="text-muted">—</span>';
-          }
-
-          const rows = dailyTimings.slice().reverse().map(timing => {
-            const timeValue = type === 'last' ? timing.last : timing.first;
-            const timeLabel = formatTimestampForDisplay(timeValue);
-            const dateLabel = formatDateForDisplay(timing.dateKey);
-            return `<div class="small"><span class="text-muted d-block">${dateLabel}</span><span class="fw-semibold">${timeLabel}</span></div>`;
-          });
-
-          return `<div class="d-flex flex-column gap-1">${rows.join('')}</div>`;
-        };
-
         const buildWeeklyLoginLogoutTable = () => {
           if (!weeklyTableContainer) {
             return;
@@ -2928,7 +3000,29 @@
             return dates;
           };
 
-          const rawWeekDates = generateWeekDates();
+          const alignWeekToMonday = (dates) => {
+            if (!Array.isArray(dates) || dates.length === 0) {
+              return [];
+            }
+
+            const reference = dates.find(dateObj => dateObj instanceof Date && !Number.isNaN(dateObj.getTime()));
+            if (!reference) {
+              return [];
+            }
+
+            const monday = new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), reference.getUTCDate()));
+            const weekday = monday.getUTCDay();
+            const diffToMonday = weekday === 0 ? -6 : 1 - weekday;
+            monday.setUTCDate(monday.getUTCDate() + diffToMonday);
+
+            return Array.from({ length: 5 }, (_, index) => {
+              const current = new Date(monday.getTime());
+              current.setUTCDate(monday.getUTCDate() + index);
+              return current;
+            });
+          };
+
+          const rawWeekDates = alignWeekToMonday(generateWeekDates());
           if (!Array.isArray(rawWeekDates) || rawWeekDates.length === 0) {
             this.weeklyPagination.totalItems = 0;
             this.weeklyPagination.totalPages = 0;
@@ -2964,7 +3058,7 @@
             if (!startLabel || !endLabel) {
               return '';
             }
-            return `Week range: ${escapeHtml(startLabel)} – ${escapeHtml(endLabel)}`;
+            return `${escapeHtml(startLabel)} – ${escapeHtml(endLabel)}`;
           })();
 
           const timezoneNote = timezoneLabel
@@ -2989,7 +3083,13 @@
 
           let html = '';
           html += '<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">';
-          html += `<div class="fw-semibold">${weekRangeLabel}</div>`;
+          html += '<div class="d-flex align-items-center gap-2 flex-wrap">';
+          if (weekRangeLabel) {
+            html += `<span class="metric-pill metric-pill-primary"><i class="fas fa-calendar-week"></i>${weekRangeLabel}</span>`;
+          } else {
+            html += '<span class="text-muted small">Week range unavailable</span>';
+          }
+          html += '</div>';
           html += `<div class="small text-muted">${timezoneNote}</div>`;
           html += '</div>';
           html += '<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mt-3">';
@@ -3005,7 +3105,7 @@
           html += '</div>';
           html += '</div>';
           html += '<div class="table-responsive mt-3">';
-          html += '<table class="table table-sm table-bordered align-middle">';
+          html += '<table class="table table-sm align-middle modern-data-table weekly-login-table">';
           html += '<thead><tr>';
           html += '<th><i class="fas fa-user me-2"></i>Employee</th>';
           formattedWeekDates.forEach(day => {
@@ -3039,9 +3139,19 @@
               const loginDisplay = Number.isFinite(firstCandidate) ? formatTimestampForDisplay(firstCandidate) : '—';
               const logoutDisplay = Number.isFinite(lastCandidate) ? formatTimestampForDisplay(lastCandidate) : '—';
 
-              const cellContent = (loginDisplay === '—' && logoutDisplay === '—')
-                ? '<span class="text-muted">—</span>'
-                : `<div class="small text-muted">Login</div><div class="fw-semibold">${escapeHtml(loginDisplay)}</div><div class="small text-muted mt-1">Logout</div><div class="fw-semibold">${escapeHtml(logoutDisplay)}</div>`;
+              let cellContent;
+              if (loginDisplay === '—' && logoutDisplay === '—') {
+                cellContent = '<span class="text-muted">—</span>';
+              } else {
+                const segments = [];
+                if (loginDisplay !== '—') {
+                  segments.push(`<span class="weekly-login-badge login"><i class="fas fa-sign-in-alt"></i>${escapeHtml(loginDisplay)}</span>`);
+                }
+                if (logoutDisplay !== '—') {
+                  segments.push(`<span class="weekly-login-badge logout"><i class="fas fa-sign-out-alt"></i>${escapeHtml(logoutDisplay)}</span>`);
+                }
+                cellContent = `<div class="weekly-login-cell">${segments.join(' ')}</div>`;
+              }
 
               html += `<td>${cellContent}</td>`;
             });
@@ -3065,10 +3175,15 @@
 
         buildWeeklyLoginLogoutTable();
 
+        const summaryTimezoneNote = timezoneLabel
+          ? `Times shown in ${escapeHtml(timezoneLabel)}${timezoneValue ? ` (${escapeHtml(timezoneValue)})` : ''}`
+          : 'Times shown in selected timezone';
+
         let tableHtml = `
-          <div class="d-flex justify-content-between align-items-center mb-3">
-            <div class="text-muted">
-              Showing ${startIndex + 1}-${endIndex} of ${this.pagination.totalItems} employees (company time adjusted)
+          <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-3 gap-3">
+            <div>
+              <div class="text-muted">Showing ${startIndex + 1}-${endIndex} of ${this.pagination.totalItems} employees (company time adjusted)</div>
+              <div class="small text-muted">${summaryTimezoneNote}</div>
             </div>
             <div class="d-flex align-items-center gap-2">
               <label class="form-label mb-0 small">Items per page:</label>
@@ -3081,12 +3196,10 @@
             </div>
           </div>
           <div class="table-responsive mb-4">
-            <table class="table table-hover align-middle">
+            <table class="table table-hover align-middle attendance-summary-table modern-data-table">
               <thead>
                 <tr>
                   <th><i class="fas fa-user me-2"></i>Employee</th>
-                  <th><i class="fas fa-sign-in-alt me-2"></i>Daily First Available <span class="d-block small text-muted">${timezoneLabel}</span></th>
-                  <th><i class="fas fa-sign-out-alt me-2"></i>Daily Last End of Shift <span class="d-block small text-muted">${timezoneLabel}</span></th>
                   <th><i class="fas fa-briefcase me-2"></i>Capped Billable Hours</th>
                   <th><i class="fas fa-coffee me-2"></i>Break Credit Hours</th>
                   <th><i class="fas fa-utensils me-2"></i>Lunch Adjustment Hours</th>
@@ -3109,9 +3222,7 @@
           const weekendAvailabilityDisplay = formatDecimalHours(user.weekendSecs || 0);
           const breakRecordedDisplay = formatDecimalHours(user.breakSecs || 0);
           const lunchRecordedDisplay = formatDecimalHours(user.lunchSecs || 0);
-          const dailyTimings = getDailyTimingsForUser(user.user);
-          const firstAvailableDisplay = formatDailyTimingsColumn(dailyTimings, 'first');
-          const lastEndShiftDisplay = formatDailyTimingsColumn(dailyTimings, 'last');
+          const totalAvailabilityDisplay = formatDecimalHours((user.availableSecsWeekday || 0) + (user.weekendSecs || 0));
 
           tableHtml += `
             <tr>
@@ -3123,37 +3234,31 @@
                   <strong>${user.user || 'Unknown'}</strong>
                 </div>
               </td>
-              <td>
-                ${firstAvailableDisplay}
+              <td class="modern-metric-cell">
+                <span class="metric-pill metric-pill-primary"><i class="fas fa-briefcase"></i>${baseHoursDisplay}</span>
+                <div class="metric-subtext">Weekday ${weekdayAvailabilityDisplay} • Weekend ${weekendAvailabilityDisplay}</div>
               </td>
-              <td>
-                ${lastEndShiftDisplay}
+              <td class="modern-metric-cell">
+                <span class="metric-pill metric-pill-warning"><i class="fas fa-coffee"></i>${breakCreditDisplay}</span>
+                <div class="metric-subtext">${breakRecordedDisplay} recorded</div>
               </td>
-              <td>
-                <span class="badge bg-primary">${baseHoursDisplay}</span>
-                <small class="text-muted d-block">Weekday ${weekdayAvailabilityDisplay} • Weekend ${weekendAvailabilityDisplay}</small>
+              <td class="modern-metric-cell">
+                <span class="metric-pill metric-pill-info"><i class="fas fa-utensils"></i>${lunchAdjustmentDisplay}</span>
+                <div class="metric-subtext">${lunchRecordedDisplay} recorded</div>
               </td>
-              <td>
-                <span class="badge bg-warning text-dark">${breakCreditDisplay}</span>
-                <small class="text-muted d-block">${breakRecordedDisplay} recorded</small>
+              <td class="modern-metric-cell">
+                <span class="metric-pill metric-pill-success"><i class="fas fa-clock"></i>${adjustedHoursDisplay}</span>
+                <div class="metric-subtext">Total availability ${totalAvailabilityDisplay}</div>
               </td>
-              <td>
-                <span class="badge bg-info text-dark">${lunchAdjustmentDisplay}</span>
-                <small class="text-muted d-block">${lunchRecordedDisplay} recorded</small>
-              </td>
-              <td>
-                <span class="badge bg-success">${adjustedHoursDisplay}</span>
-                <small class="text-muted d-block">Total availability ${formatDecimalHours((user.availableSecsWeekday || 0) + (user.weekendSecs || 0))}</small>
-              </td>
-              <td>
-                <div class="d-flex align-items-center">
-                  <div class="progress" style="width:60px;height:8px;">
+              <td class="modern-metric-cell">
+                <div class="d-flex align-items-center gap-3 flex-wrap">
+                  <div class="progress flex-grow-1" style="height:8px; max-width:140px;">
                     <div class="progress-bar bg-${complianceScore >= 80 ? 'success' : complianceScore >= 60 ? 'warning' : 'danger'}" style="width:${complianceScore}%"></div>
                   </div>
-                  <small class="ms-2">${complianceScore}%</small>
+                  <span class="metric-pill metric-pill-neutral"><i class="fas fa-star"></i>${complianceScore}%</span>
                 </div>
               </td>
-              <td>${statusBadge}</td>
+              <td class="modern-metric-cell">${statusBadge}</td>
             </tr>`;
         });
 


### PR DESCRIPTION
## Summary
- remove the first available and last end-of-shift columns from the employee attendance summary while modernizing the metric styling
- refresh the weekly login/logout table with pill badges and ensure the rendered week always begins on Monday
- surface the active timezone context alongside the employee summary controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690945f64d288326be9f9d2d6088022a