### PR TITLE
Refresh landing page marketing copy

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -37,10 +37,11 @@
         <div class="hero-content">
           <div class="hero-text">
             <span class="hero-badge">LuminaHQ Platform</span>
-            <h1>We help your operations grow faster</h1>
+            <h1>Your operations, orchestrated in one hub</h1>
             <p>
-              LuminaHQ centralizes quality, coaching, and workforce intelligence into one modern command center. Align
-              leaders and agents with AI-assisted workflows that accelerate insights into action.
+              LuminaHQ fuses quality programs, coaching journeys, workforce planning, and governance into a connected
+              workspace. Teams can surface insights, launch follow-ups, and measure progress without hopping between
+              tools or spreadsheets.
             </p>
             <div class="cta-buttons">
               <a class="btn btn-primary" href="#capabilities">Explore capabilities</a>
@@ -49,15 +50,15 @@
             <div class="hero-metrics">
               <div class="metric-card">
                 <strong>20 days</strong>
-                <span>to deploy and see measurable ROI</span>
+                <span>average time to deploy with production-ready playbooks</span>
               </div>
               <div class="metric-card">
                 <strong>30%</strong>
-                <span>coaching completion lift across teams</span>
+                <span>lift in coaching completion across distributed teams</span>
               </div>
               <div class="metric-card">
                 <strong>12+</strong>
-                <span>modules covering QA, coaching, and staffing</span>
+                <span>integrated modules covering QA, staffing, and compliance</span>
               </div>
             </div>
           </div>
@@ -87,10 +88,10 @@
       <section class="section" id="capabilities">
         <div class="section-content">
           <div class="section-headline">
-            <h2>Measure impressions, reach, and performance with clarity</h2>
+            <h2>Operate with clarity from evaluation to execution</h2>
             <p>
-              Bring together the insights your analysts, coaches, and workforce leaders rely on. LuminaHQ overlays data
-              visualization with contextual playbooks so every decision is grounded in operational reality.
+              LuminaHQ aggregates cross-team data, automates assignments, and guides action plans. Analysts, supervisors,
+              and support leaders rally around a shared source of truth that keeps every initiative measurable.
             </p>
           </div>
           <div class="highlight-rows">
@@ -98,21 +99,22 @@
               <article class="card">
                 <h3>Quality intelligence</h3>
                 <p>
-                  Stream QA evaluations into dynamic dashboards that reveal trends, highlight skill gaps, and trigger
-                  targeted calibrations.
+                  Bring QA forms, calibrations, appeals, and reporting together to spotlight emerging trends and surface
+                  skill opportunities instantly.
                 </p>
               </article>
               <article class="card">
                 <h3>Coaching activations</h3>
                 <p>
-                  Launch structured coaching plans with acknowledgments, next steps, and automated reminders embedded
-                  inside every conversation.
+                  Launch structured coaching plans with acknowledgments, follow-up tasks, and nudges embedded directly in
+                  every conversation thread.
                 </p>
               </article>
               <article class="card">
                 <h3>Workforce precision</h3>
                 <p>
-                  Model schedules, track adherence, and manage attendance in a shared space designed for hybrid teams.
+                  Model schedules, manage attendance, and coordinate shift swaps in a shared space built for hybrid
+                  teams.
                 </p>
               </article>
             </div>
@@ -120,20 +122,22 @@
               <article class="card">
                 <h3>Analytics storytelling</h3>
                 <p>
-                  Present leaders with living stories that translate metrics into actions and celebrate operational wins.
+                  Present leaders with guided narratives that translate dashboards into decisions, with context-rich
+                  callouts for each milestone.
                 </p>
               </article>
               <article class="card">
                 <h3>Automation ready</h3>
                 <p>
-                  Pair AI-driven suggestions with manual expertise to unlock efficiencies without losing the human touch.
+                  Pair AI-driven evaluations, auto-scheduling, and personalized recommendations with expert oversight to
+                  unlock efficiencies.
                 </p>
               </article>
               <article class="card">
                 <h3>Secure collaboration</h3>
                 <p>
-                  Role-based spaces ensure partners, clients, and internal teams have the right context at the right
-                  time.
+                  Role-based spaces and audit-ready histories ensure partners, clients, and internal teams stay aligned
+                  with the right context at the right time.
                 </p>
               </article>
             </div>
@@ -170,13 +174,13 @@
           <div class="phone-copy">
             <h3>Designed for every screen size</h3>
             <p>
-              Stay connected to your metrics wherever work happens. LuminaHQ delivers responsive dashboards, guided
-              tasks, and coaching workflows on desktop, tablet, and mobile.
+              Stay connected to operational health wherever work happens. LuminaHQ delivers responsive dashboards,
+              dynamic forms, and coaching workflows on desktop, tablet, and mobile.
             </p>
             <ul>
-              <li>Instantly review QA results and acknowledge coaching actions on the go.</li>
-              <li>Push alerts keep leaders on top of attendance trends and escalation activity.</li>
-              <li>Secure authentication keeps sensitive client data protected across devices.</li>
+              <li>Instantly review QA results, submit follow-ups, and acknowledge coaching actions on the go.</li>
+              <li>Push alerts keep leaders ahead of attendance trends, escalation activity, and task assignments.</li>
+              <li>Enterprise-grade authentication and governance keep sensitive client data protected across devices.</li>
             </ul>
           </div>
         </div>
@@ -187,8 +191,9 @@
           <div class="section-headline">
             <h2>Ready to dive deeper?</h2>
             <p>
-              Explore how LuminaHQ aligns teams from onboarding through continuous optimization. Every page in our suite
-              expands on the modules, stories, and playbooks available to your operation.
+              Discover how LuminaHQ supports every stage of the customer journey—from onboarding and QA to compliance and
+              workforce optimization. Each section of the platform reveals curated playbooks, templates, and insights
+              tailored to your operation.
             </p>
           </div>
           <div class="navigation-cta">
@@ -205,8 +210,8 @@
       <div class="footer-card">
         <h3>Experience LuminaHQ today</h3>
         <p>
-          Connect with our team to see how LuminaHQ can amplify the impact of your quality, coaching, and workforce
-          leaders.
+          Connect with our team to see how LuminaHQ amplifies the impact of your quality, coaching, workforce, and
+          compliance leaders with one unified command center.
         </p>
         <div class="footer-links">
           <a href="<?!= landingAboutUrl ?>" target="_top">Meet the platform</a>


### PR DESCRIPTION
## Summary
- update the landing page hero and capability descriptions with refreshed messaging
- highlight integrated modules, automation, and governance improvements across the page
- expand footer and section copy to better describe LuminaHQ's value for operations teams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690952f2c5e48326b74280814588914a