### PR TITLE
Fix punctuality recognition metrics

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -8516,17 +8516,57 @@
                     return 'th';
                 };
 
+                const parseNumericValue = (value) => {
+                    if (typeof value === 'number' && Number.isFinite(value)) {
+                        return value;
+                    }
+
+                    if (typeof value === 'string') {
+                        const trimmed = value.trim();
+                        if (!trimmed) {
+                            return NaN;
+                        }
+
+                        const normalized = trimmed.replace(/[^0-9.\-]+/g, '');
+                        if (!normalized) {
+                            return NaN;
+                        }
+
+                        const parsed = Number(normalized);
+                        return Number.isFinite(parsed) ? parsed : NaN;
+                    }
+
+                    return NaN;
+                };
+
                 const html = safeEntries.slice(0, 3).map((entry, index) => {
                     const rank = index + 1;
                     const suffix = ordinalSuffix(rank);
                     const rankHtml = `${rank}<sup>${suffix}</sup>`;
                     const safeName = this.escapeHtml(entry.displayName || entry.name || entry.identifier || 'Team Member');
-                    const present = Number(entry.present) || 0;
-                    const total = Number(entry.total) || 0;
-                    const punctualRate = Number.isFinite(entry.punctualRate)
-                        ? entry.punctualRate.toFixed(2)
-                        : '0.00';
-                    const meta = this.escapeHtml(`On time for ${present} of ${total} tracked shifts (${punctualRate}%)`);
+                    const presentValue = parseNumericValue(entry.present);
+                    const totalValue = parseNumericValue(entry.total);
+                    const safePresent = Number.isFinite(presentValue) ? presentValue : 0;
+                    const safeTotal = Number.isFinite(totalValue) ? totalValue : 0;
+
+                    const punctualRateValue = (() => {
+                        const directRate = parseNumericValue(entry.punctualRate);
+                        if (Number.isFinite(directRate)) {
+                            return directRate;
+                        }
+
+                        if (safeTotal > 0) {
+                            return (safePresent / safeTotal) * 100;
+                        }
+
+                        return 0;
+                    })();
+
+                    const punctualRate = Number.isFinite(punctualRateValue)
+                        ? Math.min(Math.max(punctualRateValue, 0), 100)
+                        : 0;
+
+                    const meta = this.escapeHtml(`On time for ${safePresent} of ${safeTotal} tracked shifts (${punctualRate.toFixed(2)}%)`);
                     const tierClass = ['first', 'second', 'third'][index] || 'other';
 
                     return `


### PR DESCRIPTION
## Summary
- ensure punctuality recognition entries tolerate string-based metrics
- compute fallback punctuality rate from present vs total counts and clamp the value

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_6909623974f4832683a58656d3d10af0