### PR TITLE
Add fallback session resume when login failures occur

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2157,6 +2157,7 @@
 
     function clearAuthCookie() {
       stopKeepAliveHeartbeat();
+      state.authToken = '';
       try {
         if (window.CookieHandler && typeof CookieHandler.clearAuthToken === 'function') {
           CookieHandler.clearAuthToken();
@@ -2286,6 +2287,56 @@
       restartSessionHeartbeat();
     }
 
+    function getStoredSessionToken(options = {}) {
+      const { includeFallback = true } = options || {};
+
+      if (state.authToken) {
+        return state.authToken;
+      }
+
+      let token = '';
+
+      try {
+        token = readAuthCookie();
+      } catch (err) {
+        console.warn('getStoredSessionToken: unable to read auth cookie', err);
+      }
+
+      if (token || !includeFallback) {
+        return token || '';
+      }
+
+      const storageKeys = ['lumina.session.token', 'lumina.auth.sessionToken', 'lumina.auth.fallbackToken'];
+
+      try {
+        if (window.localStorage) {
+          for (let i = 0; i < storageKeys.length; i += 1) {
+            const value = window.localStorage.getItem(storageKeys[i]) || '';
+            if (value) {
+              return value;
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('getStoredSessionToken: unable to read localStorage token', err);
+      }
+
+      try {
+        if (window.sessionStorage) {
+          for (let i = 0; i < storageKeys.length; i += 1) {
+            const value = window.sessionStorage.getItem(storageKeys[i]) || '';
+            if (value) {
+              return value;
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('getStoredSessionToken: unable to read sessionStorage token', err);
+      }
+
+      return '';
+    }
+
     function stopKeepAliveHeartbeat() {
       if (state.keepAliveTimer) {
         clearTimeout(state.keepAliveTimer);
@@ -2388,15 +2439,30 @@
       }
     }
 
-    function attemptSessionResume() {
-      if (state.hasAttemptedResume) {
+    function attemptSessionResume(options = {}) {
+      const force = options && options.force === true;
+      const silent = options && options.silent === true;
+      const overrideToken = options && typeof options.token === 'string' ? options.token.trim() : '';
+      const onSuccess = options && typeof options.onSuccess === 'function' ? options.onSuccess : null;
+      const onFailure = options && typeof options.onFailure === 'function' ? options.onFailure : null;
+
+      if (state.hasAttemptedResume && !force) {
         return false;
       }
 
+      if (force) {
+        cancelSessionResumeLoader();
+      }
+
       state.hasAttemptedResume = true;
-      const cookieToken = readAuthCookie();
+      const cookieToken = overrideToken || getStoredSessionToken();
 
       if (!cookieToken) {
+        if (typeof onFailure === 'function') {
+          try { onFailure(); } catch (callbackError) {
+            console.warn('attemptSessionResume.onFailure callback failed', callbackError);
+          }
+        }
         return false;
       }
 
@@ -2414,7 +2480,14 @@
           if (!result || !result.success) {
             if (result && result.expired) {
               clearAuthCookie();
-              showAlert('info', 'Your previous session has expired. Please sign in again.');
+              if (!silent) {
+                showAlert('info', 'Your previous session has expired. Please sign in again.');
+              }
+            }
+            if (typeof onFailure === 'function') {
+              try { onFailure(result); } catch (callbackError) {
+                console.warn('attemptSessionResume.onFailure callback failed', callbackError);
+              }
             }
             return;
           }
@@ -2476,14 +2549,43 @@
           } else {
             showAlert('info', 'Welcome back! Click Log in to continue.');
           }
+
+          if (typeof onSuccess === 'function') {
+            try { onSuccess(result); } catch (callbackError) {
+              console.warn('attemptSessionResume.onSuccess callback failed', callbackError);
+            }
+          }
         })
         .withFailureHandler(error => {
           finalizeResumeAttempt();
           console.error('Session resume validation failed:', error);
+          if (typeof onFailure === 'function') {
+            try { onFailure(error); } catch (callbackError) {
+              console.warn('attemptSessionResume.onFailure callback failed', callbackError);
+            }
+          }
         })
         .keepAlive(cookieToken);
 
       return true;
+    }
+
+    function tryResumeAfterLoginFailure(contextLabel) {
+      const token = getStoredSessionToken();
+      if (!token) {
+        return false;
+      }
+
+      console.log('Detected stored session token after login failure – attempting resume.', contextLabel || '');
+      return attemptSessionResume({
+        force: true,
+        silent: true,
+        token,
+        onSuccess: () => {
+          hideAllAlerts();
+          hideNextSteps();
+        }
+      });
     }
 
     function collectClientMetadata() {
@@ -2814,6 +2916,8 @@
       const errorCode = response && response.errorCode
         ? String(response.errorCode).toUpperCase()
         : '';
+
+      tryResumeAfterLoginFailure('response-clear');
 
       switch (errorCode) {
         case 'PASSWORD_RESET_REQUIRED': {
@@ -3325,6 +3429,8 @@
         ? String(response.errorCode).toUpperCase()
         : '';
 
+      tryResumeAfterLoginFailure('response');
+
       switch (errorCode) {
         case 'PASSWORD_RESET_REQUIRED': {
           showAlert('warning', errorMessage);
@@ -3802,6 +3908,8 @@
               }
             ]
           });
+
+          tryResumeAfterLoginFailure('transport');
         })
         .loginUser(email, password, rememberMe, clientMetadata);
     }


### PR DESCRIPTION
## Summary
- add a helper to reuse any stored session token and retry session resume when the login response reports an error
- allow the login resume logic to run in a forced mode with optional callbacks so we can hide stale alerts after recovering
- attempt an automatic session resume after transport errors or server-side login denials to avoid false failure messages

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_690952ac1e988326bb343ecc8b73c301