### PR TITLE
Fix attendance recognition fallback when roles metadata is missing

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -6899,9 +6899,13 @@
                         }
                     });
 
+                    const inferredAgentRole = !hasAgentRole && !hasRestrictedRole && tokens.length === 0;
+                    const resolvedAgentRole = hasAgentRole || inferredAgentRole;
+                    const eligible = resolvedAgentRole && !hasRestrictedRole;
+
                     return {
-                        eligible: hasAgentRole && !hasRestrictedRole,
-                        hasAgentRole,
+                        eligible,
+                        hasAgentRole: resolvedAgentRole,
                         hasRestrictedRole
                     };
                 };


### PR DESCRIPTION
## Summary
- infer agent eligibility for attendance recognition when no role metadata is present
- ensure punctuality recognition highlights render for users without explicit agent role flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909b25cecf88326871ed96d9e75b99d