### PR TITLE
Fix login page auth guard redirect loop

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -932,7 +932,7 @@
   </style>
 </head>
 
-<body class="bg-light">
+<body class="bg-light" data-public-page="true">
 
   <div class="container-fluid h-100 page-wrapper px-0">
     <div class="row h-100 g-0 align-items-stretch">


### PR DESCRIPTION
## Summary
- mark the login page as a public view so the client-side auth guard does not force a logout redirect

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2eb067288326931e26a2533d1ea7)