### PR TITLE
Improve session tracking and access denied messaging

### DIFF
--- a/AccessDenied.html
+++ b/AccessDenied.html
@@ -7,6 +7,7 @@
     <?!= includeOnce('layoutLoader') ?>
     <?!= includeOnce('layoutAlerts') ?>
     <?!= includeOnce('ResponsiveStyles') ?>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png">
     <style>
         * {
@@ -79,11 +80,51 @@
             letter-spacing: 1px;
         }
 
+    .reason-heading {
+            font-size: 1.2rem;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 0.75rem;
+        }
+
+        .reason-code {
+            display: inline-block;
+            background: rgba(231, 76, 60, 0.12);
+            color: #c0392b;
+            border-radius: 999px;
+            padding: 0.25rem 0.75rem;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 1.25rem;
+        }
+
         .message {
             font-size: 1.1rem;
-            color: #7f8c8d;
-            margin-bottom: 2rem;
+            color: #4f5d75;
+            margin-bottom: 1.5rem;
             line-height: 1.6;
+        }
+
+        .detail-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .detail-list li {
+            position: relative;
+            padding-left: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #5f6c7b;
+        }
+
+        .detail-list li::before {
+            content: '\2022';
+            position: absolute;
+            left: 0.25rem;
+            color: #1d72b8;
+            font-weight: bold;
         }
 
         .actions {
@@ -129,11 +170,15 @@
             transform: translateY(-2px);
         }
 
+        .btn i {
+            font-size: 0.95rem;
+        }
+
         .info-box {
             background: #f8f9fa;
             border-left: 4px solid #3498db;
-            padding: 1rem;
-            margin: 2rem 0;
+            padding: 1.25rem;
+            margin: 1.5rem 0;
             border-radius: 0 8px 8px 0;
             text-align: left;
         }
@@ -148,6 +193,43 @@
             color: #7f8c8d;
             font-size: 0.9rem;
             margin: 0;
+        }
+
+        .support-note {
+            margin-top: 1.5rem;
+            font-size: 0.9rem;
+            color: #5f6c7b;
+        }
+
+        .support-note a {
+            color: #1d72b8;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .support-note a:hover {
+            text-decoration: underline;
+        }
+
+        .technical-details {
+            margin-top: 1.5rem;
+            text-align: left;
+        }
+
+        .technical-details summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: #344563;
+        }
+
+        .technical-details pre {
+            margin-top: 0.75rem;
+            background: #f1f5f9;
+            border-radius: 8px;
+            padding: 1rem;
+            font-size: 0.85rem;
+            color: #475569;
+            overflow-x: auto;
         }
 
         @media (max-width: 600px) {
@@ -176,32 +258,70 @@
     <div class="error-icon">🚫</div>
     <h1>Access Denied</h1>
     <div class="error-code">Error 403</div>
+    <div class="reason-code"><?= reasonCode || 'ACCESS_DENIED' ?></div>
+    <div class="reason-heading"><?= reasonHeading || 'Access denied' ?></div>
 
     <p class="message"><?= message || 'You do not have permission to view this page.' ?></p>
 
+    <? if (reasons && reasons.length) { ?>
     <div class="info-box">
         <h3>🔐 Why am I seeing this?</h3>
-        <p>This page requires specific permissions that your account doesn't currently have. Contact your administrator if you believe this is an error.</p>
+        <ul class="detail-list">
+            <? for (var i = 0; i < reasons.length; i++) { ?>
+                <li><?= reasons[i] ?></li>
+            <? } ?>
+        </ul>
     </div>
+    <? } ?>
+
+    <? if (suggestions && suggestions.length) { ?>
+    <div class="info-box">
+        <h3>✅ What you can do</h3>
+        <ul class="detail-list">
+            <? for (var j = 0; j < suggestions.length; j++) { ?>
+                <li><?= suggestions[j] ?></li>
+            <? } ?>
+        </ul>
+    </div>
+    <? } ?>
 
     <div class="actions">
-        <a href="<?= baseUrl ?>&page=dashboard" class="btn btn-primary">
-            Go to Dashboard
-        </a>
-        <button onclick="history.back()" class="btn btn-secondary">
-            ← Go Back
-        </button>
+        <? if (actions && actions.length) { ?>
+            <? for (var k = 0; k < actions.length; k++) { var action = actions[k]; ?>
+                <? if (action.type === 'link') { ?>
+                    <a href="<?= action.href || '#' ?>" class="btn <?= action.variant === 'secondary' ? 'btn-secondary' : 'btn-primary' ?>"<? if (action.target) { ?> target="<?= action.target ?>"<? } ?><? if (action.rel) { ?> rel="<?= action.rel ?>"<? } ?>>
+                        <? if (action.icon) { ?><i class="fa <?= action.icon ?>"></i><? } ?><?= action.label ?>
+                    </a>
+                <? } else { ?>
+                    <button class="btn <?= action.variant === 'secondary' ? 'btn-secondary' : 'btn-primary' ?>" onclick="<?= action.onClick || 'history.back()' ?>">
+                        <? if (action.icon) { ?><i class="fa <?= action.icon ?>"></i><? } ?><?= action.label ?>
+                    </button>
+                <? } ?>
+            <? } ?>
+        <? } ?>
     </div>
+
+    <? if (supportEmail) { ?>
+    <p class="support-note">Need help? Email <a href="mailto:<?= supportEmail ?>"><?= supportEmail ?></a>.</p>
+    <? } ?>
+
+    <? if (showTrace && trace && trace.length) { ?>
+    <details class="technical-details">
+        <summary>Technical details</summary>
+        <pre><? for (var t = 0; t < trace.length; t++) { ?><?= trace[t] ?><? if (t < trace.length - 1) { ?>&#10;<? } ?><? } ?></pre>
+    </details>
+    <? } ?>
 </div>
 
 <script>
     // Add some interactive feedback
     document.addEventListener('DOMContentLoaded', function() {
+        const dashboardUrl = <?= JSON.stringify(dashboardUrl || '') ?>;
         // Auto-redirect after 30 seconds if user takes no action
         setTimeout(function() {
             const shouldRedirect = confirm('Would you like to return to the dashboard?');
-            if (shouldRedirect) {
-                window.location.href = '<?= baseUrl ?>&page=dashboard';
+            if (shouldRedirect && dashboardUrl) {
+                window.location.href = dashboardUrl;
             }
         }, 30000);
     });

--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -31,6 +31,11 @@ const OPTIONAL_SESSION_COLUMNS = [
   'ExpiresAt',
   'IdleTimeoutMinutes',
   'RememberMe',
+  'Status',
+  'AuthenticatedAt',
+  'LastSeenAt',
+  'RevokedAt',
+  'RevokedReason',
   'CampaignScope',
   'UserAgent',
   'IpAddress',
@@ -290,6 +295,22 @@ var AuthenticationService = (function () {
       } catch (_) {
         payload.lastActivityAt = '';
       }
+    }
+
+    if (!payload.status) {
+      payload.status = 'active';
+    }
+
+    if (!payload.authenticatedAt) {
+      try {
+        payload.authenticatedAt = new Date().toISOString();
+      } catch (_) {
+        payload.authenticatedAt = payload.lastActivityAt || '';
+      }
+    }
+
+    if (!payload.lastSeenAt) {
+      payload.lastSeenAt = payload.lastActivityAt || '';
     }
 
     try {
@@ -857,9 +878,48 @@ var AuthenticationService = (function () {
     const idleTimeoutMinutes = parseIdleTimeoutMinutes(getRecordValue(record, 'IdleTimeoutMinutes'));
     const lastActivityTime = parseDateValue(getRecordValue(record, 'LastActivityAt'))
       || parseDateValue(getRecordValue(record, 'CreatedAt'));
+    const lastActivityIso = lastActivityTime ? new Date(lastActivityTime).toISOString() : null;
+    const storedStatus = normalizeString(getRecordValue(record, 'Status')).toLowerCase();
+    const lastSeenIso = normalizeString(getRecordValue(record, 'LastSeenAt')) || lastActivityIso;
+
+    if (storedStatus === 'revoked') {
+      return {
+        status: 'revoked',
+        reason: 'REVOKED',
+        entry: entry,
+        tableName: entry.tableName,
+        idleTimeoutMinutes: idleTimeoutMinutes,
+        lastActivityAt: lastActivityIso,
+        expiresAt: getRecordValue(record, 'ExpiresAt') || null,
+        rememberMe: rememberFlag
+      };
+    }
+
+    if (storedStatus === 'expired') {
+      return {
+        status: 'expired',
+        reason: 'EXPIRED',
+        entry: entry,
+        tableName: entry.tableName,
+        idleTimeoutMinutes: idleTimeoutMinutes,
+        lastActivityAt: lastActivityIso,
+        expiresAt: getRecordValue(record, 'ExpiresAt') || null,
+        rememberMe: rememberFlag
+      };
+    }
 
     if (SESSION_EXPIRATION_ENABLED) {
       if (!expiryTime || expiryTime < nowMs) {
+        try {
+          setRecordValue(record, 'Status', 'expired');
+          setRecordValue(record, 'LastSeenAt', new Date(nowMs).toISOString());
+          setRecordValue(record, 'RevokedReason', 'EXPIRED');
+          setRecordValue(record, 'RevokedAt', new Date(nowMs).toISOString());
+          updateSessionRow(entry);
+        } catch (expiryUpdateError) {
+          console.warn('evaluateSessionEntry: unable to mark session expired', expiryUpdateError);
+        }
+
         removeSessionEntry(entry);
         return {
           status: 'expired',
@@ -870,6 +930,16 @@ var AuthenticationService = (function () {
       }
 
       if (lastActivityTime && (nowMs - lastActivityTime) > idleTimeoutMinutes * 60 * 1000) {
+        try {
+          setRecordValue(record, 'Status', 'expired');
+          setRecordValue(record, 'LastSeenAt', new Date(nowMs).toISOString());
+          setRecordValue(record, 'RevokedReason', 'IDLE_TIMEOUT');
+          setRecordValue(record, 'RevokedAt', new Date(nowMs).toISOString());
+          updateSessionRow(entry);
+        } catch (idleUpdateError) {
+          console.warn('evaluateSessionEntry: unable to mark session idle-expired', idleUpdateError);
+        }
+
         removeSessionEntry(entry);
         return {
           status: 'expired',
@@ -881,8 +951,7 @@ var AuthenticationService = (function () {
     }
 
     let expiresAtIso = getRecordValue(record, 'ExpiresAt');
-    let lastActivityIso = getRecordValue(record, 'LastActivityAt')
-      || (lastActivityTime ? new Date(lastActivityTime).toISOString() : null);
+    let effectiveLastActivityIso = getRecordValue(record, 'LastActivityAt') || lastActivityIso;
 
     const touch = options && options.touch;
     const sessionToken = options && options.sessionToken;
@@ -895,6 +964,8 @@ var AuthenticationService = (function () {
       setRecordValue(record, 'LastActivityAt', nowIso);
       setRecordValue(record, 'ExpiresAt', nextExpiryIso);
       setRecordValue(record, 'IdleTimeoutMinutes', String(idleTimeoutMinutes));
+      setRecordValue(record, 'Status', 'active');
+      setRecordValue(record, 'LastSeenAt', nowIso);
 
       if (sessionToken && (entry.matchMethod === 'legacy' || !getRecordValue(record, 'TokenHash') || !getRecordValue(record, 'TokenSalt'))) {
         const salt = generateTokenSalt();
@@ -919,7 +990,17 @@ var AuthenticationService = (function () {
       }
 
       expiresAtIso = nextExpiryIso;
-      lastActivityIso = nowIso;
+      effectiveLastActivityIso = nowIso;
+    } else if (!storedStatus) {
+      try {
+        setRecordValue(record, 'Status', 'active');
+        if (lastSeenIso) {
+          setRecordValue(record, 'LastSeenAt', lastSeenIso);
+        }
+        updateSessionRow(entry);
+      } catch (statusUpdateError) {
+        console.warn('evaluateSessionEntry: unable to backfill session status', statusUpdateError);
+      }
     }
 
     return {
@@ -927,7 +1008,8 @@ var AuthenticationService = (function () {
       entry: entry,
       tableName: entry.tableName,
       idleTimeoutMinutes: idleTimeoutMinutes,
-      lastActivityAt: lastActivityIso,
+      lastActivityAt: effectiveLastActivityIso,
+      lastSeenAt: getRecordValue(record, 'LastSeenAt') || effectiveLastActivityIso,
       expiresAt: expiresAtIso,
       rememberMe: rememberFlag
     };
@@ -1190,6 +1272,38 @@ var AuthenticationService = (function () {
       if (idleTimeoutMinutes) {
         userPayload.sessionIdleTimeoutMinutes = idleTimeoutMinutes;
       }
+
+      const authenticatedIso = getRecordValue(record, 'AuthenticatedAt')
+        || (userPayload.sessionLastActivityAt || null)
+        || (getRecordValue(record, 'CreatedAt') || null);
+      const lastSeenIso = getRecordValue(record, 'LastSeenAt') || lastActivityIso || authenticatedIso;
+      const statusValue = (resolution && resolution.status)
+        ? String(resolution.status).toLowerCase()
+        : normalizeString(getRecordValue(record, 'Status')).toLowerCase() || 'active';
+
+      userPayload.sessionStatus = statusValue || 'active';
+      if (!Object.prototype.hasOwnProperty.call(userPayload, 'sessionRememberMe') && Object.prototype.hasOwnProperty.call(resolution || {}, 'rememberMe')) {
+        userPayload.sessionRememberMe = !!resolution.rememberMe;
+      }
+      if (authenticatedIso) {
+        userPayload.sessionAuthenticatedAt = authenticatedIso;
+        userPayload.authenticatedAt = authenticatedIso;
+      }
+      if (lastSeenIso) {
+        userPayload.sessionLastSeenAt = lastSeenIso;
+      }
+      userPayload.isAuthenticated = userPayload.sessionStatus === 'active';
+
+      userPayload.session = Object.assign({}, userPayload.session || {}, {
+        token: sessionToken,
+        status: userPayload.sessionStatus,
+        authenticatedAt: authenticatedIso || null,
+        lastActivityAt: lastActivityIso || null,
+        lastSeenAt: lastSeenIso || lastActivityIso || authenticatedIso || null,
+        expiresAt: expiresIso || null,
+        rememberMe: Object.prototype.hasOwnProperty.call(resolution || {}, 'rememberMe') ? !!resolution.rememberMe : !!userPayload.sessionRememberMe,
+        idleTimeoutMinutes: idleTimeoutMinutes || null
+      });
 
       userPayload.sessionScope = rawScope || null;
       userPayload.NeedsCampaignAssignment = userPayload.CampaignScope
@@ -4797,6 +4911,9 @@ var AuthenticationService = (function () {
       setRecordValue(canonicalRecord, 'ExpiresAt', expiresAtIso);
       setRecordValue(canonicalRecord, 'IdleTimeoutMinutes', String(idleTimeoutMinutes));
       setRecordValue(canonicalRecord, 'RememberMe', rememberMe ? 'TRUE' : 'FALSE');
+      setRecordValue(canonicalRecord, 'Status', 'active');
+      setRecordValue(canonicalRecord, 'AuthenticatedAt', nowIso);
+      setRecordValue(canonicalRecord, 'LastSeenAt', nowIso);
       setRecordValue(canonicalRecord, 'CampaignScope', serializeCampaignScope(scopeData));
       setRecordValue(canonicalRecord, 'UserAgent', metadata && metadata.userAgent ? metadata.userAgent : 'Google Apps Script');
       setRecordValue(canonicalRecord, 'IpAddress', metadata && metadata.ipAddress ? metadata.ipAddress : 'N/A');
@@ -5149,6 +5266,14 @@ var AuthenticationService = (function () {
       }
 
       const sessionToken = sessionResult.token;
+      const authenticatedAt = getRecordValue(sessionResult.record, 'AuthenticatedAt')
+        || getRecordValue(sessionResult.record, 'CreatedAt')
+        || new Date().toISOString();
+      const sessionLastActivity = getRecordValue(sessionResult.record, 'LastActivityAt')
+        || authenticatedAt;
+      const sessionLastSeen = getRecordValue(sessionResult.record, 'LastSeenAt')
+        || sessionLastActivity;
+      const sessionStatus = 'active';
 
       const warnings = Array.isArray(tenantAccess.warnings) ? tenantAccess.warnings.slice() : [];
       const needsCampaignAssignment = tenantAccess.needsCampaignAssignment === true;
@@ -5182,6 +5307,20 @@ var AuthenticationService = (function () {
           sessionExpiresAt: sessionResult.expiresAt,
           sessionTtlSeconds: sessionResult.ttlSeconds,
           sessionIdleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
+          sessionStatus: sessionStatus,
+          isAuthenticated: true,
+          authenticatedAt: authenticatedAt,
+          session: {
+            token: sessionToken,
+            status: sessionStatus,
+            authenticatedAt: authenticatedAt,
+            lastActivityAt: sessionLastActivity,
+            lastSeenAt: sessionLastSeen,
+            expiresAt: sessionResult.expiresAt,
+            ttlSeconds: sessionResult.ttlSeconds,
+            idleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
+            rememberMe: !!rememberMe
+          },
           tenant: tenantSummary,
           campaignScope: userPayload ? userPayload.CampaignScope : null,
           warnings: warnings,
@@ -5194,7 +5333,11 @@ var AuthenticationService = (function () {
           sessionExpiresAt: sessionResult.expiresAt,
           sessionTtlSeconds: sessionResult.ttlSeconds,
           sessionIdleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
-          rememberMe: !!rememberMe
+          rememberMe: !!rememberMe,
+          status: sessionStatus,
+          authenticatedAt: authenticatedAt,
+          lastSeenAt: sessionLastSeen,
+          lastActivityAt: sessionLastActivity
         }, userPayload);
 
         if (sanitizedMetadata && sanitizedMetadata.requestedReturnUrl) {
@@ -5249,6 +5392,14 @@ var AuthenticationService = (function () {
       }
 
       const userPayload = buildUserPayload(user, tenantAccess.clientPayload);
+      const authenticatedAt = getRecordValue(sessionResult.record, 'AuthenticatedAt')
+        || getRecordValue(sessionResult.record, 'CreatedAt')
+        || new Date().toISOString();
+      const sessionLastActivity = getRecordValue(sessionResult.record, 'LastActivityAt')
+        || authenticatedAt;
+      const sessionLastSeen = getRecordValue(sessionResult.record, 'LastSeenAt')
+        || sessionLastActivity;
+      const sessionStatus = 'active';
 
       if (userPayload && userPayload.CampaignScope) {
         userPayload.CampaignScope.tenantContext = tenantAccess.sessionScope && tenantAccess.sessionScope.tenantContext
@@ -5294,6 +5445,20 @@ var AuthenticationService = (function () {
           sessionExpiresAt: sessionResult.expiresAt,
           sessionTtlSeconds: sessionResult.ttlSeconds,
           sessionIdleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
+          sessionStatus: sessionStatus,
+          isAuthenticated: true,
+          authenticatedAt: authenticatedAt,
+          session: {
+            token: sessionResult.token,
+            status: sessionStatus,
+            authenticatedAt: authenticatedAt,
+            lastActivityAt: sessionLastActivity,
+            lastSeenAt: sessionLastSeen,
+            expiresAt: sessionResult.expiresAt,
+            ttlSeconds: sessionResult.ttlSeconds,
+            idleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
+            rememberMe: !!rememberMe
+          },
           user: userPayload,
           tenant: tenantSummary,
           campaignScope: userPayload ? userPayload.CampaignScope : null,
@@ -5307,7 +5472,11 @@ var AuthenticationService = (function () {
           sessionExpiresAt: sessionResult.expiresAt,
           sessionTtlSeconds: sessionResult.ttlSeconds,
           sessionIdleTimeoutMinutes: sessionResult.idleTimeoutMinutes,
-          rememberMe: !!rememberMe
+          rememberMe: !!rememberMe,
+          status: sessionStatus,
+          authenticatedAt: authenticatedAt,
+          lastSeenAt: sessionLastSeen,
+          lastActivityAt: sessionLastActivity
         }, userPayload);
 
         return response;
@@ -5400,6 +5569,20 @@ var AuthenticationService = (function () {
           console.warn('logout: unable to extract userId for authorization cleanup', registryLookupError);
         }
 
+        try {
+          const nowIso = new Date().toISOString();
+          setRecordValue(entry.record, 'Status', 'revoked');
+          setRecordValue(entry.record, 'LastSeenAt', nowIso);
+          setRecordValue(entry.record, 'RevokedAt', nowIso);
+          setRecordValue(entry.record, 'RevokedReason', 'LOGOUT');
+          setRecordValue(entry.record, 'Token', '');
+          setRecordValue(entry.record, 'TokenHash', '');
+          setRecordValue(entry.record, 'TokenSalt', '');
+          updateSessionRow(entry);
+        } catch (revokeMarkError) {
+          console.warn('logout: unable to mark session as revoked', revokeMarkError);
+        }
+
         removeSessionEntry(entry);
 
         try {
@@ -5467,6 +5650,17 @@ var AuthenticationService = (function () {
         }
       }
 
+      const sessionStatus = (resolution && resolution.status) || (user && user.sessionStatus) || 'active';
+      const authenticatedAt = user.sessionAuthenticatedAt
+        || user.authenticatedAt
+        || (resolution && resolution.entry && resolution.entry.record ? getRecordValue(resolution.entry.record, 'AuthenticatedAt') : null)
+        || null;
+      const lastSeenAt = (resolution && resolution.lastSeenAt)
+        || user.sessionLastSeenAt
+        || user.sessionLastActivityAt
+        || null;
+      const resolvedIdleMinutes = resolution.idleTimeoutMinutes;
+
       const landing = resolveLandingDestination(context.rawUser || context.user, {
         user: context.user,
         userPayload: context.user,
@@ -5486,22 +5680,40 @@ var AuthenticationService = (function () {
           user: user,
           sessionToken: user.sessionToken,
           sessionExpiresAt: user.sessionExpiresAt || user.sessionExpiry || null,
-        sessionTtlSeconds: ttlSeconds,
-        tenant: user.CampaignScope || null,
-        campaignScope: user.CampaignScope || null,
-        warnings: user.CampaignScope && Array.isArray(user.CampaignScope.warnings) ? user.CampaignScope.warnings.slice() : [],
+          sessionTtlSeconds: ttlSeconds,
+          sessionStatus: sessionStatus,
+          isAuthenticated: sessionStatus === 'active',
+          authenticatedAt: authenticatedAt,
+          tenant: user.CampaignScope || null,
+          campaignScope: user.CampaignScope || null,
+          warnings: user.CampaignScope && Array.isArray(user.CampaignScope.warnings) ? user.CampaignScope.warnings.slice() : [],
           needsCampaignAssignment: user.CampaignScope ? !!user.CampaignScope.needsCampaignAssignment : false,
-          idleTimeoutMinutes: resolution.idleTimeoutMinutes,
+          idleTimeoutMinutes: resolvedIdleMinutes,
           lastActivityAt: user.sessionLastActivityAt || null,
           redirectSlug: redirectSlug,
           redirectUrl: redirectUrl
+        };
+
+        response.session = {
+          token: user.sessionToken,
+          status: sessionStatus,
+          authenticatedAt: authenticatedAt,
+          lastActivityAt: user.sessionLastActivityAt || null,
+          lastSeenAt: lastSeenAt,
+          expiresAt: response.sessionExpiresAt || user.sessionExpiresAt || user.sessionExpiry || null,
+          ttlSeconds: ttlSeconds,
+          idleTimeoutMinutes: resolvedIdleMinutes
         };
 
         const persistToken = (user && user.sessionToken) ? user.sessionToken : sessionToken;
         const persistMetadata = {
           sessionExpiresAt: response.sessionExpiresAt || user.sessionExpiresAt || null,
           sessionTtlSeconds: typeof response.sessionTtlSeconds === 'number' ? response.sessionTtlSeconds : ttlSeconds,
-          sessionIdleTimeoutMinutes: response.idleTimeoutMinutes || resolution.idleTimeoutMinutes || null
+          sessionIdleTimeoutMinutes: resolvedIdleMinutes,
+          status: sessionStatus,
+          authenticatedAt: authenticatedAt,
+          lastSeenAt: lastSeenAt,
+          lastActivityAt: user.sessionLastActivityAt || null
         };
 
         if (user) {
@@ -5515,10 +5727,15 @@ var AuthenticationService = (function () {
           }
           if (typeof rememberFlag !== 'undefined') {
             persistMetadata.rememberMe = rememberFlag;
+            response.session.rememberMe = !!rememberFlag;
           }
         }
 
         persistActiveSessionState(persistToken, persistMetadata, user);
+
+        if (typeof persistMetadata.rememberMe !== 'undefined' && typeof response.session.rememberMe === 'undefined') {
+          response.session.rememberMe = !!persistMetadata.rememberMe;
+        }
 
         return response;
     } catch (error) {

--- a/Code.js
+++ b/Code.js
@@ -1437,58 +1437,66 @@ function evaluatePageAccess(user, pageKey, campaignId) {
     const canonicalPage = canonicalizePageKey(page) || page;
     const normalizedPageKey = _normalizePageKey(canonicalPage);
 
+    function allow(code, message) {
+      return { allow: true, reason: message, reasonCode: code, trace: trace.slice() };
+    }
+
+    function deny(code, message) {
+      return { allow: false, reason: message, reasonCode: code, trace: trace.slice() };
+    }
+
     // Basic account checks
-    if (!u || !u.ID) return { allow: false, reason: 'No session', trace };
-    if (!_truthy(u.CanLogin)) return { allow: false, reason: 'Account disabled', trace };
-    if (u.LockoutEnd && _isFuture(u.LockoutEnd)) return { allow: false, reason: 'Account locked', trace };
+    if (!u || !u.ID) return deny('NOT_AUTHENTICATED', 'No session');
+    if (!_truthy(u.CanLogin)) return deny('ACCOUNT_DISABLED', 'Account disabled');
+    if (u.LockoutEnd && _isFuture(u.LockoutEnd)) return deny('ACCOUNT_LOCKED', 'Account locked');
     if (!ACCESS.PUBLIC_PAGES.has(page)) {
-      if (!_truthy(u.EmailConfirmed)) return { allow: false, reason: 'Email not confirmed', trace };
-      if (_truthy(u.ResetRequired)) return { allow: false, reason: 'Password reset required', trace };
+      if (!_truthy(u.EmailConfirmed)) return deny('EMAIL_NOT_CONFIRMED', 'Email not confirmed');
+      if (_truthy(u.ResetRequired)) return deny('PASSWORD_RESET_REQUIRED', 'Password reset required');
     }
 
     // Public pages
     if (ACCESS.PUBLIC_PAGES.has(page)) {
       trace.push('PUBLIC page');
-      return { allow: true, reason: 'public', trace };
+      return allow('ALLOW_PUBLIC', 'public');
     }
 
     // Admin-only pages
     if (ACCESS.ADMIN_ONLY_PAGES.has(page)) {
       if (isSystemAdmin(u)) {
         trace.push('admin-only: allowed');
-        return { allow: true, reason: 'admin', trace };
+        return allow('ALLOW_ADMIN', 'admin');
       }
-      return { allow: false, reason: 'System Admin required', trace };
+      return deny('ADMIN_REQUIRED', 'System Admin required');
     }
 
     // System admin has access to everything
     if (isSystemAdmin(u)) {
       trace.push('System Admin: allow');
-      return { allow: true, reason: 'admin', trace };
+      return allow('ALLOW_ADMIN', 'admin');
     }
 
     // Page managers can bypass assignment checks
     if (_truthy(u.CanManagePages)) {
       trace.push('Manage pages privilege');
-      return { allow: true, reason: 'manage-pages', trace };
+      return allow('ALLOW_MANAGE_PAGES', 'manage-pages');
     }
 
     // For regular users, check if they have campaign access
     if (cid && !hasCampaignAccess(u, cid)) {
-      return { allow: false, reason: 'No campaign access', trace };
+      return deny('CAMPAIGN_FORBIDDEN', 'No campaign access');
     }
 
     // Enforce explicit page assignments
     const assignedPages = _collectUserPageKeys(u);
     if (!assignedPages || assignedPages.size === 0) {
       trace.push('No page assignments');
-      return { allow: false, reason: 'No pages assigned', trace };
+      return deny('NO_PAGES_ASSIGNED', 'No pages assigned');
     }
 
     if (!assignedPages.has('*')) {
       if (!assignedPages.has(normalizedPageKey) && !assignedPages.has(page)) {
         trace.push('Page not assigned: ' + normalizedPageKey);
-        return { allow: false, reason: 'Page not assigned', trace };
+        return deny('PAGE_NOT_ASSIGNED', 'Page not assigned');
       }
       trace.push('Page assignment matched');
     } else {
@@ -1497,12 +1505,12 @@ function evaluatePageAccess(user, pageKey, campaignId) {
 
     // Default allow for authenticated users
     trace.push('Authenticated user access');
-    return { allow: true, reason: 'authenticated', trace };
+    return allow('ALLOW_AUTHENTICATED', 'authenticated');
 
   } catch (e) {
     writeError && writeError('evaluatePageAccess', e);
     trace.push('exception:' + e.message);
-    return { allow: false, reason: 'Evaluator error', trace };
+    return deny('SYSTEM_ERROR', 'Evaluator error');
   }
 }
 
@@ -1520,11 +1528,312 @@ function hasCampaignAccess(user, campaignId) {
   }
 }
 
+function _appendQueryParams(baseUrl, params) {
+  const base = baseUrl ? String(baseUrl) : '';
+  const entries = [];
+  if (params && typeof params === 'object') {
+    Object.keys(params).forEach(function (key) {
+      if (!key) return;
+      const value = params[key];
+      if (value === null || typeof value === 'undefined' || value === '') {
+        return;
+      }
+      entries.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+    });
+  }
+  if (!entries.length) {
+    return base;
+  }
+  if (!base) {
+    return '?' + entries.join('&');
+  }
+  const separator = base.indexOf('?') === -1 ? '?' : (/[?&]$/.test(base) ? '' : '&');
+  return base + separator + entries.join('&');
+}
+
+function _uniqueStrings(list) {
+  const result = [];
+  const seen = Object.create(null);
+  (Array.isArray(list) ? list : []).forEach(function (value) {
+    if (value === null || typeof value === 'undefined') {
+      return;
+    }
+    const text = String(value).trim();
+    if (!text) {
+      return;
+    }
+    if (!Object.prototype.hasOwnProperty.call(seen, text)) {
+      seen[text] = true;
+      result.push(text);
+    }
+  });
+  return result;
+}
+
+function _formatAccessDeniedHeading(code) {
+  if (!code) {
+    return 'Access denied';
+  }
+  return String(code)
+    .toLowerCase()
+    .split('_')
+    .filter(function (part) { return part; })
+    .map(function (part) { return part.charAt(0).toUpperCase() + part.slice(1); })
+    .join(' ') || 'Access denied';
+}
+
+function _sanitizeAccessDeniedActions(actions) {
+  if (!Array.isArray(actions)) {
+    return [];
+  }
+  const deduped = [];
+  const seen = Object.create(null);
+  actions.forEach(function (action) {
+    if (!action || typeof action !== 'object') {
+      return;
+    }
+    const type = action.type === 'button' ? 'button' : 'link';
+    const label = action.label ? String(action.label).trim() : '';
+    const icon = action.icon ? String(action.icon).trim() : '';
+    const variant = action.variant ? String(action.variant).trim() : (type === 'button' ? 'secondary' : 'primary');
+    const target = action.target ? String(action.target).trim() : '_self';
+    const rel = action.rel ? String(action.rel).trim() : '';
+    const href = type === 'link' ? String(action.href || '').trim() : '';
+    const onClick = type === 'button' ? String(action.onClick || action.onclick || 'history.back()').trim() : '';
+    const key = type + '|' + href + '|' + onClick;
+    if (seen[key]) {
+      return;
+    }
+    seen[key] = true;
+    deduped.push({
+      type: type,
+      label: label || (type === 'link' ? 'Open' : 'Go Back'),
+      icon: icon,
+      variant: variant,
+      href: href,
+      onClick: onClick,
+      target: target,
+      rel: rel
+    });
+  });
+  return deduped;
+}
+
+function _buildAccessDeniedActions(reasonCode, baseUrl) {
+  const normalized = String(reasonCode || '').toUpperCase();
+  const actions = [];
+  const loginUrl = _appendQueryParams(baseUrl, { page: 'login' });
+  const dashboardUrl = _appendQueryParams(baseUrl, { page: 'dashboard' });
+
+  if (normalized === 'NOT_AUTHENTICATED') {
+    actions.push({
+      type: 'link',
+      href: loginUrl,
+      label: 'Sign In',
+      variant: 'primary',
+      icon: 'fa-right-to-bracket',
+      target: '_top'
+    });
+  }
+
+  actions.push({
+    type: 'link',
+    href: dashboardUrl,
+    label: 'Go to Dashboard',
+    variant: 'primary',
+    icon: 'fa-gauge-high',
+    target: '_top'
+  });
+
+  actions.push({
+    type: 'button',
+    label: 'Go Back',
+    variant: 'secondary',
+    icon: 'fa-arrow-left',
+    onClick: 'history.back()'
+  });
+
+  return _sanitizeAccessDeniedActions(actions);
+}
+
+function _mapAccessDeniedReason(reasonCode) {
+  const normalized = String(reasonCode || '').toUpperCase() || 'ACCESS_DENIED';
+  const result = {
+    reasonCode: normalized,
+    reasonHeading: '',
+    message: '',
+    reasons: [],
+    suggestions: []
+  };
+
+  switch (normalized) {
+    case 'NOT_AUTHENTICATED':
+      result.reasonHeading = 'Sign in required';
+      result.message = 'Please sign in to continue.';
+      result.reasons.push('You are not currently signed in.');
+      result.suggestions.push('Use the sign-in button below to authenticate and try again.');
+      break;
+    case 'ACCOUNT_DISABLED':
+      result.reasonHeading = 'Account disabled';
+      result.message = 'Your account has been disabled.';
+      result.reasons.push('Your LuminaHQ account is currently disabled.');
+      result.suggestions.push('Contact an administrator to restore your access.');
+      break;
+    case 'ACCOUNT_LOCKED':
+      result.reasonHeading = 'Account locked';
+      result.message = 'Your account is temporarily locked.';
+      result.reasons.push('Too many failed sign-in attempts can trigger a lockout period.');
+      result.suggestions.push('Wait for the lockout period to end or reach out to an administrator.');
+      break;
+    case 'EMAIL_NOT_CONFIRMED':
+      result.reasonHeading = 'Confirm your email';
+      result.message = 'Verify your email address before accessing this page.';
+      result.reasons.push('Your email address has not been confirmed.');
+      result.suggestions.push('Check your inbox for the confirmation link or request a new email from the login page.');
+      break;
+    case 'PASSWORD_RESET_REQUIRED':
+    case 'RESET_REQUIRED':
+      result.reasonHeading = 'Password reset required';
+      result.message = 'You must reset your password before continuing.';
+      result.reasons.push('Your account requires a password reset.');
+      result.suggestions.push('Use the password reset option on the login page.');
+      break;
+    case 'ADMIN_REQUIRED':
+      result.reasonHeading = 'Administrator permission required';
+      result.message = 'Only system administrators can open this page.';
+      result.reasons.push('The requested page is restricted to system administrators.');
+      result.suggestions.push('Ask a system administrator to grant you the appropriate permissions.');
+      break;
+    case 'CAMPAIGN_FORBIDDEN':
+      result.reasonHeading = 'Campaign access required';
+      result.message = 'You are not assigned to the requested campaign.';
+      result.reasons.push('Your account does not have access to this campaign.');
+      result.suggestions.push('Switch to a campaign that you have access to or request access from your administrator.');
+      break;
+    case 'NO_PAGES_ASSIGNED':
+      result.reasonHeading = 'No pages assigned';
+      result.message = 'You do not have any pages assigned to your role yet.';
+      result.reasons.push('Your account has not been assigned to any application pages.');
+      result.suggestions.push('Ask your administrator to assign the pages you need.');
+      break;
+    case 'PAGE_NOT_ASSIGNED':
+      result.reasonHeading = 'Page not assigned';
+      result.message = 'You do not have permission to view this page.';
+      result.reasons.push('Your current role does not include this page.');
+      result.suggestions.push('If you need access, request it from your administrator.');
+      break;
+    case 'SYSTEM_ERROR':
+    case 'ERROR':
+      result.reasonHeading = 'Authentication error';
+      result.message = 'We were unable to verify your permissions due to a system error.';
+      result.suggestions.push('Refresh the page and try again. If the problem persists, contact support.');
+      break;
+    default:
+      result.reasonHeading = 'Access denied';
+      result.message = 'You do not have permission to view this page.';
+      break;
+  }
+
+  result.reasonHeading = result.reasonHeading || _formatAccessDeniedHeading(result.reasonCode);
+  result.message = result.message || 'You do not have permission to view this page.';
+  result.reasons = _uniqueStrings(result.reasons);
+  result.suggestions = _uniqueStrings(result.suggestions);
+  return result;
+}
+
+function buildAccessDeniedView(decision, options) {
+  const baseUrl = getBaseUrl();
+  const mapping = _mapAccessDeniedReason(decision && decision.reasonCode);
+  const extraReasons = [];
+  if (decision && decision.reason) {
+    extraReasons.push(decision.reason);
+  }
+  if (options && Array.isArray(options.additionalReasons)) {
+    Array.prototype.push.apply(extraReasons, options.additionalReasons);
+  }
+
+  const reasons = _uniqueStrings((mapping.reasons || []).concat(extraReasons));
+  const suggestions = _uniqueStrings(mapping.suggestions || []);
+  const actions = _sanitizeAccessDeniedActions((mapping.actions || []).concat(_buildAccessDeniedActions(mapping.reasonCode, baseUrl)));
+  const trace = Array.isArray(decision && decision.trace) ? decision.trace.slice() : [];
+
+  return {
+    baseUrl: baseUrl,
+    message: mapping.message,
+    reasonCode: mapping.reasonCode,
+    reasonHeading: mapping.reasonHeading,
+    reasons: reasons,
+    suggestions: suggestions,
+    actions: actions,
+    trace: trace,
+    showTrace: !!(options && options.showTrace),
+    dashboardUrl: _appendQueryParams(baseUrl, { page: 'dashboard' }),
+    loginUrl: _appendQueryParams(baseUrl, { page: 'login' }),
+    pageKey: options && options.page ? String(options.page) : '',
+    campaignId: options && options.campaignId ? String(options.campaignId) : '',
+    supportEmail: typeof SUPPORT_EMAIL !== 'undefined' ? SUPPORT_EMAIL : ''
+  };
+}
+
+function _normalizeAccessDeniedDetails(details, baseUrl) {
+  const defaultMessage = 'You do not have permission to view this page.';
+  if (!details || typeof details === 'string') {
+    const message = typeof details === 'string' && details ? details : defaultMessage;
+    return {
+      baseUrl: baseUrl,
+      message: message,
+      reasonCode: 'ACCESS_DENIED',
+      reasonHeading: _formatAccessDeniedHeading('ACCESS_DENIED'),
+      reasons: message ? _uniqueStrings([message]) : [],
+      suggestions: [],
+      actions: _buildAccessDeniedActions('ACCESS_DENIED', baseUrl),
+      trace: [],
+      showTrace: false,
+      dashboardUrl: _appendQueryParams(baseUrl, { page: 'dashboard' }),
+      loginUrl: _appendQueryParams(baseUrl, { page: 'login' }),
+      supportEmail: typeof SUPPORT_EMAIL !== 'undefined' ? SUPPORT_EMAIL : ''
+    };
+  }
+
+  const context = Object.assign({}, details);
+  context.baseUrl = baseUrl;
+  context.reasonCode = (context.reasonCode || 'ACCESS_DENIED').toUpperCase();
+  context.reasonHeading = context.reasonHeading || _formatAccessDeniedHeading(context.reasonCode);
+  context.message = context.message || defaultMessage;
+  context.reasons = _uniqueStrings(context.reasons || []);
+  context.suggestions = _uniqueStrings(context.suggestions || []);
+  context.actions = _sanitizeAccessDeniedActions(context.actions || []);
+  if (!context.actions.length) {
+    context.actions = _buildAccessDeniedActions(context.reasonCode, baseUrl);
+  }
+  context.trace = Array.isArray(context.trace) ? context.trace : [];
+  context.showTrace = !!context.showTrace;
+  context.dashboardUrl = context.dashboardUrl || _appendQueryParams(baseUrl, { page: 'dashboard' });
+  context.loginUrl = context.loginUrl || _appendQueryParams(baseUrl, { page: 'login' });
+  context.supportEmail = context.supportEmail || (typeof SUPPORT_EMAIL !== 'undefined' ? SUPPORT_EMAIL : '');
+  context.pageKey = context.pageKey || '';
+  context.campaignId = context.campaignId || '';
+  return context;
+}
+
 function renderAccessDenied(message) {
   const baseUrl = getBaseUrl();
+  const context = _normalizeAccessDeniedDetails(message, baseUrl);
   const tpl = HtmlService.createTemplateFromFile('AccessDenied');
   tpl.baseUrl = baseUrl;
-  tpl.message = message || 'You do not have permission to view this page.';
+  tpl.message = context.message;
+  tpl.reasonCode = context.reasonCode;
+  tpl.reasonHeading = context.reasonHeading;
+  tpl.reasons = context.reasons;
+  tpl.suggestions = context.suggestions;
+  tpl.actions = context.actions;
+  tpl.trace = context.trace;
+  tpl.showTrace = context.showTrace;
+  tpl.dashboardUrl = context.dashboardUrl;
+  tpl.loginUrl = context.loginUrl;
+  tpl.supportEmail = context.supportEmail;
+  tpl.pageKey = context.pageKey;
+  tpl.campaignId = context.campaignId;
   return tpl.evaluate()
     .setTitle('Access Denied')
     .addMetaTag('viewport', 'width=device-width,initial-scale=1')
@@ -1550,7 +1859,11 @@ function requireAuth(e) {
     _debugAccess && _debugAccess('route', decision, user, page, campaignId);
 
     if (!decision || decision.allow !== true) {
-      return renderAccessDenied((decision && decision.reason) || 'You do not have permission to view this page.');
+      const denied = buildAccessDeniedView(decision || { reasonCode: 'ACCESS_DENIED', reason: 'Access denied' }, {
+        page: page,
+        campaignId: campaignId
+      });
+      return renderAccessDenied(denied);
     }
 
     // Hydrate campaign context
@@ -1571,7 +1884,11 @@ function requireAuth(e) {
 
   } catch (error) {
     writeError('requireAuth', error);
-    return renderAccessDenied('Authentication error occurred');
+    return renderAccessDenied(buildAccessDeniedView({
+      reasonCode: 'SYSTEM_ERROR',
+      reason: 'Authentication error occurred',
+      trace: [String(error && error.message ? error.message : '')]
+    }, { showTrace: false }));
   }
 }
 

--- a/Login.html
+++ b/Login.html
@@ -932,7 +932,7 @@
   </style>
 </head>
 
-<body class="bg-light">
+<body class="bg-light" data-public-page="true">
 
   <div class="container-fluid h-100 page-wrapper px-0">
     <div class="row h-100 g-0 align-items-stretch">

--- a/luminaIdentity.js
+++ b/luminaIdentity.js
@@ -356,6 +356,18 @@ var LuminaIdentity = (function () {
       if (metadata.idleTimeoutMinutes || metadata.sessionIdleTimeoutMinutes) {
         payload.idleTimeoutMinutes = metadata.idleTimeoutMinutes || metadata.sessionIdleTimeoutMinutes;
       }
+      if (metadata.status || metadata.sessionStatus) {
+        payload.status = safeString(metadata.status || metadata.sessionStatus);
+      }
+      if (metadata.authenticatedAt || metadata.sessionAuthenticatedAt) {
+        payload.authenticatedAt = safeString(metadata.authenticatedAt || metadata.sessionAuthenticatedAt);
+      }
+      if (metadata.lastSeenAt) {
+        payload.lastSeenAt = safeString(metadata.lastSeenAt);
+      }
+      if (metadata.lastActivityAt) {
+        payload.lastActivityAt = safeString(metadata.lastActivityAt);
+      }
     }
 
     var serialized = null;
@@ -841,9 +853,14 @@ var LuminaIdentity = (function () {
 
     identity.session = {
       token: sessionToken,
+      status: safeString((sessionUser && (sessionUser.sessionStatus || (sessionUser.session && sessionUser.session.status)))) || (sessionToken ? 'active' : ''),
+      authenticatedAt: safeString((sessionUser && (sessionUser.sessionAuthenticatedAt || sessionUser.authenticatedAt || (sessionUser.session && sessionUser.session.authenticatedAt)))),
+      lastSeenAt: safeString((sessionUser && (sessionUser.sessionLastSeenAt || sessionUser.sessionLastActivityAt || (sessionUser.session && sessionUser.session.lastSeenAt)))),
+      lastActivityAt: safeString((sessionUser && (sessionUser.sessionLastActivityAt || (sessionUser.session && sessionUser.session.lastActivityAt)))),
       expiresAt: sessionExpiresAt || '',
       idleTimeoutMinutes: sessionIdleTimeout || '',
-      rememberMe: !!(sessionUser && sessionUser.sessionRememberMe)
+      ttlSeconds: sessionUser && (sessionUser.sessionTtlSeconds || (sessionUser.session && sessionUser.session.ttlSeconds)) || '',
+      rememberMe: !!(sessionUser && (sessionUser.sessionRememberMe || (sessionUser.session && sessionUser.session.rememberMe)))
     };
 
     identity.campaignRoles = identity.campaigns.map(function (campaign) {


### PR DESCRIPTION
## Summary
- enrich authentication session records with explicit status, timestamps, and structured metadata propagated through login, keep-alive, and identity helpers
- persist session state hints to the identity cache so client code can confirm authenticated status reliably
- overhaul the access denied template and helpers to surface reason codes, actionable guidance, and dynamic call-to-action buttons

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2eb067288326931e26a2533d1ea7)