### PR TITLE
Align OKR dashboard container with Lumina banner width

### DIFF
--- a/Dashboard.html
+++ b/Dashboard.html
@@ -82,6 +82,13 @@
             padding: 0;
         }
 
+        .dashboard-container {
+            width: 100%;
+            max-width: none;
+            margin: 0;
+            padding: clamp(var(--spacing-lg), calc(3vw + var(--spacing-sm)), var(--spacing-2xl));
+        }
+
         /* Header Styles */
         .dashboard-header {
             background: var(--navy-primary);
@@ -643,7 +650,7 @@
         }
     </style>
 
-    <div class="dashboard-container" style="padding: var(--spacing-lg);">
+    <div class="dashboard-container">
         <!-- Header -->
         <div class="dashboard-header">
             <div class="refresh-indicator" id="refreshIndicator">


### PR DESCRIPTION
## Summary
- override the OKR dashboard container so it stretches to the full main content width like the Lumina banner
- replace the inline padding with responsive clamp-based padding to keep spacing consistent across breakpoints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e57c910f0832698f44e20cb12b242)