### PR TITLE
Fix attendance dashboard rendering after unified state load

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -3589,12 +3589,24 @@
                         const year = this.attendanceDashboardPrefetch.year || this.getSelectedAttendanceYear();
                         this.attendanceDashboardYear = year;
                         this.attendanceDashboardRecords = this.attendanceDashboardPrefetch.records.slice();
+                        this.collectAttendanceDashboardRecordUsers(this.attendanceDashboardRecords);
                         const filteredRecords = this.filterAttendanceDashboardRecords(
                             this.attendanceDashboardRecords,
                             this.attendanceDashboardUserFilter
                         );
-                        this.attendanceDashboardData = this.computeAttendanceDashboard(filteredRecords, year);
+                        const computedDashboard = this.computeAttendanceDashboard(filteredRecords, year);
+                        this.attendanceDashboardData = computedDashboard;
+                        const wasInitialized = this.attendanceDashboardInitialized;
                         this.destroyAttendanceDashboardCharts();
+
+                        const attendanceDashboardPane = document.getElementById('attendance-dashboard');
+                        const attendanceDashboardActive = attendanceDashboardPane
+                            && attendanceDashboardPane.classList.contains('show')
+                            && attendanceDashboardPane.classList.contains('active');
+
+                        if (attendanceDashboardActive || wasInitialized) {
+                            this.initializeAttendanceDashboard();
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- refresh attendance dashboard record cache when applying unified state data
- ensure the dashboard reinitializes when unified data destroys existing charts so bi-weekly and recognition sections render

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e93eae51c8326862d3a4c4252f557)