### PR TITLE
Ensure attendance exports cover custom ranges and download Google Sheets files

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4571,35 +4571,50 @@
         this.updateExportProgress(75, 'Finalizing export...');
 
         if (result && result.success !== false) {
-          this.updateExportProgress(100, 'Export completed successfully!');
+          const isGoogleSheetExport = (result.fileType === 'google_sheet')
+            || (typeof result.filename === 'string' && result.filename.toLowerCase().endsWith('.gsheet'));
 
-          if (result.spreadsheetUrl) {
+          let handled = false;
+
+          if (isGoogleSheetExport) {
+            this.updateExportProgress(90, 'Packaging Google Sheets download...');
+            this.downloadGoogleSheet(result);
+            handled = true;
+          } else if (result.spreadsheetUrl) {
             this.openSpreadsheet(result.spreadsheetUrl);
-          } else if (result.fileData) {
+            handled = true;
+          }
+
+          if (!handled && result.fileData) {
             this.downloadFile(
               result.fileData,
               result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.xlsx`,
               result.mimeType || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
               (result.encoding || '').toLowerCase() === 'base64'
             );
-          } else if (result.csvData) {
+            handled = true;
+          } else if (!handled && result.csvData) {
             this.downloadFile(
               result.csvData,
               result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
               result.mimeType || 'text/csv;charset=utf-8;',
               false
             );
-          } else if (typeof result === 'string') {
+            handled = true;
+          } else if (!handled && typeof result === 'string') {
             this.downloadFile(
               result,
               `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
               'text/csv;charset=utf-8;',
               false
             );
+            handled = true;
           }
 
-          const successMessage = result.fileType === 'google_sheet'
-            ? 'Daily pivot matrix opened in Google Sheets.'
+          this.updateExportProgress(100, 'Export completed successfully!');
+
+          const successMessage = isGoogleSheetExport
+            ? 'Daily pivot matrix downloaded as a Google Sheets file.'
             : 'Export completed successfully!';
 
           setTimeout(() => {
@@ -4668,8 +4683,8 @@
           alert('Please select both start and end dates for custom range.');
           return false;
         }
-        if (new Date(params.period.start) >= new Date(params.period.end)) {
-          alert('Start date must be before end date.');
+        if (new Date(params.period.start) > new Date(params.period.end)) {
+          alert('Start date must be on or before the end date.');
           return false;
         }
       } else {
@@ -4725,6 +4740,61 @@
       a.click();
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
+    }
+
+    downloadGoogleSheet(result) {
+      const url = result?.spreadsheetUrl || result?.url;
+      if (!url) {
+        this.showErrorMessage('Google Sheets link unavailable for this export.');
+        return;
+      }
+
+      const providedName = (typeof result?.filename === 'string' && result.filename.trim())
+        ? result.filename.trim()
+        : '';
+      let finalName = providedName || `attendance_matrix_${new Date().toISOString().split('T')[0]}.gsheet`;
+
+      if (!/\.gsheet$/i.test(finalName)) {
+        const baseName = finalName.replace(/\.(csv|xlsx)$/ig, '').trim() || `attendance_matrix_${new Date().toISOString().split('T')[0]}`;
+        finalName = `${baseName}.gsheet`;
+      }
+
+      const descriptor = {
+        url,
+        mimeType: 'application/vnd.google-apps.spreadsheet'
+      };
+
+      if (typeof result?.spreadsheetName === 'string' && result.spreadsheetName.trim()) {
+        descriptor.name = result.spreadsheetName.trim();
+      } else if (typeof result?.sheetTitle === 'string' && result.sheetTitle.trim()) {
+        descriptor.name = result.sheetTitle.trim();
+      } else {
+        descriptor.name = finalName.replace(/\.gsheet$/i, '');
+      }
+
+      if (typeof result?.fileId === 'string' && result.fileId.trim()) {
+        descriptor.documentId = result.fileId.trim();
+      }
+
+      if (typeof result?.periodLabel === 'string' && result.periodLabel.trim()) {
+        descriptor.periodLabel = result.periodLabel.trim();
+      }
+
+      if (result?.customRange && typeof result.customRange === 'object') {
+        const rangeStart = typeof result.customRange.startIso === 'string' ? result.customRange.startIso : '';
+        const rangeEnd = typeof result.customRange.endIso === 'string' ? result.customRange.endIso : '';
+        if (rangeStart || rangeEnd) {
+          descriptor.rangeStart = rangeStart;
+          descriptor.rangeEnd = rangeEnd;
+          const label = typeof result.customRange.displayLabel === 'string' ? result.customRange.displayLabel : '';
+          if (label) {
+            descriptor.rangeLabel = label;
+          }
+        }
+      }
+
+      const jsonDescriptor = JSON.stringify(descriptor, null, 2);
+      this.downloadFile(jsonDescriptor, finalName, 'application/json', false);
     }
 
     openSpreadsheet(url) {

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -162,6 +162,34 @@ function normalizeDateValue(value) {
   return null;
 }
 
+function formatDateIdentifier(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return '';
+  }
+
+  if (typeof Utilities !== 'undefined' && Utilities.formatDate) {
+    return Utilities.formatDate(date, ATTENDANCE_TIMEZONE, 'yyyy-MM-dd');
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatDisplayDate(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return '';
+  }
+
+  if (typeof Utilities !== 'undefined' && Utilities.formatDate) {
+    return Utilities.formatDate(date, ATTENDANCE_TIMEZONE, 'MMM d, yyyy');
+  }
+
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+}
+
 function toIsoDateString(date) {
   if (!(date instanceof Date) || isNaN(date.getTime())) {
     return '';
@@ -1884,15 +1912,22 @@ function generateEnhancedDailyPivotMatrix(params) {
   try {
     const { period, users, userSelection, dailyPivotOptions } = params;
     const hourPolicyOptions = params.hourPolicy || (dailyPivotOptions && dailyPivotOptions.hourPolicy) || {};
-    let granularity, periodValue;
+    let granularity = period.type || 'Week';
+    let periodValue = period.value;
+    let periodLabel = periodValue ? `${granularity} ${periodValue}` : granularity;
+    let customRangeInfo = null;
 
     // Determine period
     if (period.type === 'custom') {
-      granularity = 'Week';
-      periodValue = weekStringFromDate(new Date(period.start));
-    } else {
-      granularity = period.type;
-      periodValue = period.value;
+      const normalizedRange = normalizeCustomRangeBounds(period.start, period.end);
+      customRangeInfo = {
+        startIso: normalizedRange.startIso,
+        endIso: normalizedRange.endIso,
+        displayLabel: normalizedRange.displayLabel
+      };
+      granularity = 'CustomRange';
+      periodValue = `${customRangeInfo.startIso}::${customRangeInfo.endIso}`;
+      periodLabel = customRangeInfo.displayLabel;
     }
 
     // Get analytics data
@@ -1918,18 +1953,30 @@ function generateEnhancedDailyPivotMatrix(params) {
     // Generate enhanced export file (XLSX when possible, CSV fallback otherwise)
     const exportFile = generateEnhancedDailyPivotExport(pivotMatrix, params, {
       granularity,
-      periodValue
+      periodValue,
+      periodLabel,
+      customRange: customRangeInfo
     });
 
-    return {
+    const response = {
       success: true,
       type: 'daily_pivot_matrix',
       users: pivotMatrix.users.length,
       days: pivotMatrix.dateRange.length,
       dateRange: pivotMatrix.dateRange.length > 0 ?
         `${pivotMatrix.dateRange[0].date} to ${pivotMatrix.dateRange[pivotMatrix.dateRange.length - 1].date}` : 'No data',
+      periodValue,
+      periodLabel,
       ...exportFile
     };
+
+    if (customRangeInfo) {
+      response.rangeStart = customRangeInfo.startIso;
+      response.rangeEnd = customRangeInfo.endIso;
+      response.customRange = customRangeInfo;
+    }
+
+    return response;
 
   } catch (error) {
     console.error('Enhanced daily pivot matrix generation failed:', error);
@@ -2289,8 +2336,14 @@ function generateEnhancedDailyPivotExport(pivotMatrix, params, context) {
       .setFontSize(11);
 
     currentRow += 1;
-    const periodDescription = `${context.granularity || 'Period'} ${context.periodValue || 'Custom Range'}`;
-    sheet.getRange(currentRow, 1).setValue(`Period: ${periodDescription}`);
+    const friendlyGranularity = context.granularity === 'CustomRange'
+      ? 'Custom Range'
+      : (context.granularity || 'Period');
+    const periodDetails = (context.customRange && context.customRange.displayLabel)
+      || context.periodLabel
+      || context.periodValue
+      || 'Custom Range';
+    sheet.getRange(currentRow, 1).setValue(`Period: ${friendlyGranularity} – ${periodDetails}`);
     sheet.getRange(currentRow, 1, 1, exportWidth).merge()
       .setFontColor('#475569')
       .setFontSize(11);
@@ -2685,7 +2738,11 @@ function generateEnhancedDailyPivotExport(pivotMatrix, params, context) {
       spreadsheetUrl,
       mimeType: 'application/vnd.google-apps.spreadsheet',
       filename: `${spreadsheetName}.gsheet`,
-      fileType: 'google_sheet'
+      fileType: 'google_sheet',
+      spreadsheetName,
+      sheetTitle: sheet.getName(),
+      periodLabel: context.periodLabel,
+      customRange: context.customRange
     };
   } catch (error) {
     try {
@@ -3548,6 +3605,53 @@ function createEmptyAnalytics() {
 // PERIOD CALCULATION UTILITIES
 // ────────────────────────────────────────────────────────────────────────────
 
+function normalizeCustomRangeBounds(startInput, endInput) {
+  const startDate = normalizeDateValue(startInput);
+  const endDate = normalizeDateValue(endInput);
+
+  if (!(startDate instanceof Date) || isNaN(startDate.getTime())) {
+    throw new Error('Invalid custom range start date');
+  }
+  if (!(endDate instanceof Date) || isNaN(endDate.getTime())) {
+    throw new Error('Invalid custom range end date');
+  }
+
+  const start = createDateInLocalTime(
+    startDate.getFullYear(),
+    startDate.getMonth() + 1,
+    startDate.getDate(),
+    0,
+    0,
+    0
+  ) || new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate(), 0, 0, 0, 0);
+
+  const end = createDateInLocalTime(
+    endDate.getFullYear(),
+    endDate.getMonth() + 1,
+    endDate.getDate(),
+    23,
+    59,
+    59
+  ) || new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate(), 23, 59, 59, 999);
+
+  end.setMilliseconds(999);
+
+  if (end.getTime() < start.getTime()) {
+    throw new Error('Custom range end date must be on or after the start date');
+  }
+
+  const startIso = formatDateIdentifier(start);
+  const endIso = formatDateIdentifier(end);
+
+  return {
+    start,
+    end,
+    startIso,
+    endIso,
+    displayLabel: `${formatDisplayDate(start)} to ${formatDisplayDate(end)}`
+  };
+}
+
 function derivePeriodBounds(granularity, id) {
   function weekStartLocal(d) {
     const day = d.getDay();
@@ -3607,6 +3711,16 @@ function derivePeriodBounds(granularity, id) {
     return [new Date(y, 0, 1, 0, 0, 0, 0), new Date(y, 11, 31, 23, 59, 59, 999)];
   }
 
+  if (granularity === 'CustomRange') {
+    if (!id || typeof id !== 'string' || id.indexOf('::') === -1) {
+      throw new Error(`Invalid custom range identifier: ${id}`);
+    }
+
+    const [startToken, endToken] = id.split('::');
+    const { start, end } = normalizeCustomRangeBounds(startToken, endToken);
+    return [start, end];
+  }
+
   throw new Error(`Unknown granularity: ${granularity}`);
 }
 
@@ -3641,6 +3755,12 @@ function validateEnhancedExportParams(params) {
   if (params.period && params.period.type === 'custom') {
     if (!params.period.start || !params.period.end) {
       errors.push('Start and end dates are required for custom period');
+    } else {
+      try {
+        normalizeCustomRangeBounds(params.period.start, params.period.end);
+      } catch (rangeError) {
+        errors.push(rangeError.message);
+      }
     }
   }
   


### PR DESCRIPTION
## Summary
- normalize custom ranges for the attendance daily pivot export so monthly, quarterly, and custom periods include every day in the selected span
- surface friendly period labels and custom range metadata from the Apps Script export to the client
- download the enhanced export as a Google Sheets (.gsheet) descriptor instead of only opening the spreadsheet link

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec2f048b083269b4a1a94394a4c2c)