### PR TITLE
Store attendance exports in shared folder and add saved exports viewer

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -723,6 +723,152 @@
       padding: 1.5rem 2rem;
     }
 
+    #exportHistoryModal .modal-dialog {
+      max-width: 860px;
+    }
+
+    .export-history-modal-content {
+      border-radius: 24px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+      background: linear-gradient(180deg, rgba(248, 250, 252, 0.96) 0%, #ffffff 100%);
+      overflow: hidden;
+    }
+
+    .export-history-modal-header {
+      border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      background: linear-gradient(135deg, rgba(30, 64, 175, 0.12) 0%, rgba(37, 99, 235, 0.08) 100%);
+      padding: 1.5rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .export-history-modal-header .modal-title {
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      color: var(--gray-800);
+    }
+
+    .export-history-modal-header .modal-title i {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 14px;
+      background: linear-gradient(135deg, rgba(30, 64, 175, 0.9) 0%, rgba(59, 130, 246, 0.9) 100%);
+      color: #fff;
+      font-size: 1rem;
+      box-shadow: 0 12px 24px rgba(30, 64, 175, 0.25);
+    }
+
+    .export-history-modal-body {
+      padding: 2rem;
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0.85) 0%, #ffffff 100%);
+    }
+
+    .export-history-modal-footer {
+      border-top: 1px solid rgba(148, 163, 184, 0.18);
+      padding: 1.25rem 2rem;
+      display: flex;
+      gap: 0.75rem;
+      justify-content: flex-end;
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0.92) 0%, #ffffff 100%);
+    }
+
+    .export-history-content {
+      min-height: 240px;
+    }
+
+    .export-history-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2.5rem 1rem;
+      color: var(--gray-500);
+    }
+
+    .export-history-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+    }
+
+    .export-history-item {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem 1.25rem;
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: var(--shadow-sm);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+
+    .export-history-item:hover {
+      transform: translateY(-2px);
+      border-color: rgba(37, 99, 235, 0.35);
+      box-shadow: var(--shadow-md);
+    }
+
+    .export-history-icon {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: linear-gradient(135deg, rgba(14, 165, 233, 0.18) 0%, rgba(14, 165, 233, 0.06) 100%);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: #0ea5e9;
+      font-size: 1.1rem;
+    }
+
+    .export-history-details {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .export-history-details h6 {
+      margin: 0;
+      font-weight: 600;
+      color: var(--gray-800);
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .export-history-meta {
+      margin-top: 0.35rem;
+      font-size: 0.8rem;
+      color: var(--gray-500);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .export-history-empty {
+      text-align: center;
+      padding: 2.5rem 1rem;
+      color: var(--gray-500);
+      border: 1px dashed rgba(148, 163, 184, 0.35);
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .export-history-error {
+      padding: 1rem 1.25rem;
+      border-radius: 16px;
+      background: rgba(248, 113, 113, 0.12);
+      border: 1px solid rgba(220, 38, 38, 0.3);
+      color: #b91c1c;
+    }
+
+
     #exportModal .form-label {
       font-weight: 600;
       letter-spacing: 0.02em;
@@ -1056,6 +1202,9 @@
   <div class="d-flex gap-3 mb-4 flex-wrap">
     <button id="exportBtn" class="btn btn-light" onclick="showEnhancedExportModal()">
       <i class="fas fa-table me-2"></i>Export Matrix
+    </button>
+    <button id="viewExportsBtn" class="btn btn-outline-primary" onclick="window.exportHistoryManager?.show()">
+      <i class="fas fa-folder-open me-2"></i>Saved Exports
     </button>
     <button id="aiInsightsBtn" class="btn btn-ai" onclick="refreshAIInsights()">
       <i class="fas fa-magic me-2"></i>View Analytics
@@ -1553,6 +1702,38 @@
         <button type="button" class="btn btn-success" id="executeExport">
           <i class="fas fa-download me-2"></i>Export Matrix
         </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Export History Modal -->
+<div class="modal fade" id="exportHistoryModal" tabindex="-1" aria-labelledby="exportHistoryLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content export-history-modal-content">
+      <div class="modal-header export-history-modal-header">
+        <h5 class="modal-title" id="exportHistoryLabel">
+          <i class="fas fa-folder-open"></i>
+          Saved Attendance Exports
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body export-history-modal-body">
+        <div id="exportHistoryContent" class="export-history-content">
+          <div class="export-history-loading">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="text-muted mt-3 mb-0">Loading saved exports...</p>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer export-history-modal-footer">
+        <a id="exportHistoryFolderLink" class="btn btn-outline-primary" href="#" target="_blank" rel="noopener" style="display: none;">
+          <i class="fas fa-external-link-alt me-2"></i>Open Folder in Drive
+        </a>
+        <button type="button" class="btn btn-light" onclick="window.exportHistoryManager?.refresh(true)">
+          <i class="fas fa-sync me-2"></i>Refresh
+        </button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>
   </div>
@@ -4571,40 +4752,65 @@
         this.updateExportProgress(75, 'Finalizing export...');
 
         if (result && result.success !== false) {
-          this.updateExportProgress(100, 'Export completed successfully!');
+          const isGoogleSheetExport = (result.fileType === 'google_sheet')
+            || (typeof result.filename === 'string' && result.filename.toLowerCase().endsWith('.gsheet'));
 
-          if (result.spreadsheetUrl) {
+          let handled = false;
+
+          if (isGoogleSheetExport) {
+            this.updateExportProgress(90, 'Opening Google Sheets export...');
+            const targetUrl = result.spreadsheetUrl || result.url;
+            if (targetUrl) {
+              this.openSpreadsheet(targetUrl);
+              handled = true;
+            } else {
+              this.showErrorMessage('Google Sheets link unavailable for this export.');
+            }
+          } else if (result.spreadsheetUrl) {
             this.openSpreadsheet(result.spreadsheetUrl);
-          } else if (result.fileData) {
+            handled = true;
+          }
+
+          if (!handled && result.fileData) {
             this.downloadFile(
               result.fileData,
               result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.xlsx`,
               result.mimeType || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
               (result.encoding || '').toLowerCase() === 'base64'
             );
-          } else if (result.csvData) {
+            handled = true;
+          } else if (!handled && result.csvData) {
             this.downloadFile(
               result.csvData,
               result.filename || `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
               result.mimeType || 'text/csv;charset=utf-8;',
               false
             );
-          } else if (typeof result === 'string') {
+            handled = true;
+          } else if (!handled && typeof result === 'string') {
             this.downloadFile(
               result,
               `attendance_export_${new Date().toISOString().split('T')[0]}.csv`,
               'text/csv;charset=utf-8;',
               false
             );
+            handled = true;
           }
 
-          const successMessage = result.fileType === 'google_sheet'
-            ? 'Daily pivot matrix opened in Google Sheets.'
+          this.updateExportProgress(100, 'Export completed successfully!');
+
+          const successMessage = isGoogleSheetExport
+            ? (result.folderName
+              ? `Daily pivot matrix saved to "${result.folderName}" and opened in Google Sheets.`
+              : 'Daily pivot matrix opened in Google Sheets.')
             : 'Export completed successfully!';
 
           setTimeout(() => {
             if (progressModal) progressModal.hide();
             this.showSuccessMessage(successMessage);
+            if (window.exportHistoryManager && typeof window.exportHistoryManager.handleExportSuccess === 'function') {
+              window.exportHistoryManager.handleExportSuccess(result);
+            }
           }, 1000);
 
         } else {
@@ -4668,8 +4874,8 @@
           alert('Please select both start and end dates for custom range.');
           return false;
         }
-        if (new Date(params.period.start) >= new Date(params.period.end)) {
-          alert('Start date must be before end date.');
+        if (new Date(params.period.start) > new Date(params.period.end)) {
+          alert('Start date must be on or before the end date.');
           return false;
         }
       } else {
@@ -4764,6 +4970,206 @@
   let dashboard;
   let analyticsModalInstance;
   let employeeTrendsModalInstance;
+  class AttendanceExportHistoryManager {
+    constructor() {
+      this.modalElement = document.getElementById('exportHistoryModal');
+      this.contentElement = document.getElementById('exportHistoryContent');
+      this.folderLinkElement = document.getElementById('exportHistoryFolderLink');
+      this.modalInstance = this.modalElement ? new bootstrap.Modal(this.modalElement) : null;
+      this.cache = null;
+      this.lastLoaded = 0;
+      this.isRefreshing = false;
+    }
+
+    async show(forceRefresh = false) {
+      if (!this.modalInstance) {
+        return;
+      }
+      this.renderLoading('Loading saved exports...');
+      this.modalInstance.show();
+      await this.refresh(forceRefresh);
+    }
+
+    async refresh(forceRefresh = false) {
+      if (!this.contentElement || this.isRefreshing) {
+        return;
+      }
+
+      const shouldUseCache = this.cache && !forceRefresh && (Date.now() - this.lastLoaded < 60000);
+      if (shouldUseCache) {
+        this.render(this.cache);
+        return;
+      }
+
+      this.isRefreshing = true;
+      this.renderLoading('Loading saved exports...');
+
+      try {
+        const result = await safeServerCall('listAttendanceExportFiles', [], { timeoutMs: 20000 });
+        if (result?.success) {
+          this.cache = result;
+          this.lastLoaded = Date.now();
+          this.render(result);
+        } else {
+          const errorMessage = typeof result?.error === 'string' && result.error.trim()
+            ? result.error.trim()
+            : 'Unable to load attendance export history.';
+          this.renderError(errorMessage);
+        }
+      } catch (error) {
+        console.error('Failed to load attendance export history:', error);
+        this.renderError('Failed to load attendance export history.');
+      } finally {
+        this.isRefreshing = false;
+      }
+    }
+
+    invalidate() {
+      this.cache = null;
+      this.lastLoaded = 0;
+    }
+
+    handleExportSuccess(result) {
+      this.invalidate();
+      if (this.isModalVisible()) {
+        this.refresh(true);
+      } else if (result && typeof result === 'object') {
+        const file = {
+          id: result.fileId || '',
+          name: result.spreadsheetName || result.periodLabel || 'Daily Pivot Matrix',
+          url: result.spreadsheetUrl || result.url || '',
+          description: result.periodLabel || '',
+          createdAtDisplay: result.createdAtIso ? this.formatDisplayDate(result.createdAtIso) : '',
+          updatedAtDisplay: result.updatedAtIso ? this.formatDisplayDate(result.updatedAtIso) : '',
+          createdAtIso: result.createdAtIso || '',
+          updatedAtIso: result.updatedAtIso || ''
+        };
+
+        if (file.url) {
+          this.cache = this.cache || { success: true, files: [], folderId: result.folderId, folderName: result.folderName, folderUrl: result.folderUrl };
+          this.cache.files = [file, ...(Array.isArray(this.cache.files) ? this.cache.files : [])];
+          this.lastLoaded = Date.now();
+        }
+      }
+    }
+
+    isModalVisible() {
+      return !!(this.modalElement && this.modalElement.classList.contains('show'));
+    }
+
+    renderLoading(message) {
+      if (!this.contentElement) {
+        return;
+      }
+      this.contentElement.innerHTML = `
+        <div class="export-history-loading">
+          <div class="spinner-border text-primary" role="status"></div>
+          <p class="text-muted mt-3 mb-0">${escapeHtml(message || 'Loading...')}</p>
+        </div>
+      `;
+      if (this.folderLinkElement) {
+        this.folderLinkElement.style.display = 'none';
+        this.folderLinkElement.href = '#';
+      }
+    }
+
+    renderError(message) {
+      if (!this.contentElement) {
+        return;
+      }
+      this.contentElement.innerHTML = `
+        <div class="export-history-error">
+          <i class="fas fa-exclamation-triangle me-2"></i>${escapeHtml(message || 'An unexpected error occurred.')}
+        </div>
+      `;
+      if (this.folderLinkElement) {
+        this.folderLinkElement.style.display = 'none';
+        this.folderLinkElement.href = '#';
+      }
+    }
+
+    render(data) {
+      if (!this.contentElement) {
+        return;
+      }
+
+      if (!data || !Array.isArray(data.files) || data.files.length === 0) {
+        this.contentElement.innerHTML = `
+          <div class="export-history-empty">
+            <i class="fas fa-info-circle mb-2"></i>
+            <p class="mb-0">No attendance exports have been saved yet.</p>
+          </div>
+        `;
+      } else {
+        const itemsHtml = data.files.map(file => this.renderItemHtml(file)).join('');
+        this.contentElement.innerHTML = `<div class="export-history-list">${itemsHtml}</div>`;
+      }
+
+      if (this.folderLinkElement) {
+        if (data && typeof data.folderUrl === 'string' && data.folderUrl) {
+          this.folderLinkElement.href = data.folderUrl;
+          this.folderLinkElement.style.display = 'inline-flex';
+        } else {
+          this.folderLinkElement.style.display = 'none';
+          this.folderLinkElement.href = '#';
+        }
+      }
+    }
+
+    renderItemHtml(file) {
+      const name = escapeHtml(file?.name || 'Attendance Matrix');
+      const urlValue = typeof file?.url === 'string' ? file.url : '';
+      const url = /^https?:/i.test(urlValue) ? urlValue : '#';
+      const updated = escapeHtml(file?.updatedAtDisplay || file?.createdAtDisplay || '');
+      const description = escapeHtml(file?.description || '');
+
+      const metaSegments = [];
+      if (updated) {
+        metaSegments.push(`<span><i class="fas fa-clock me-1"></i>${updated}</span>`);
+      }
+      if (description) {
+        metaSegments.push(`<span><i class="fas fa-calendar-alt me-1"></i>${description}</span>`);
+      }
+
+      return `
+        <div class="export-history-item">
+          <div class="export-history-icon">
+            <i class="fas fa-file-spreadsheet"></i>
+          </div>
+          <div class="export-history-details">
+            <h6>${name}</h6>
+            ${metaSegments.length > 0 ? `<div class="export-history-meta">${metaSegments.join('')}</div>` : ''}
+          </div>
+          <a class="btn btn-sm btn-primary" href="${url}" target="_blank" rel="noopener">
+            <i class="fas fa-external-link-alt me-1"></i>Open
+          </a>
+        </div>
+      `;
+    }
+
+    formatDisplayDate(isoString) {
+      if (typeof isoString !== 'string' || !isoString) {
+        return '';
+      }
+      try {
+        const date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) {
+          return '';
+        }
+        return date.toLocaleString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit'
+        });
+      } catch (error) {
+        console.warn('Unable to format export history date:', error);
+        return '';
+      }
+    }
+  }
+
 
   function showEnhancedExportModal() {
     const modal = new bootstrap.Modal(document.getElementById('exportModal'));
@@ -4840,6 +5246,7 @@
     initializeTimezoneLabels();
     dashboard = new AttendanceDashboard();
     window.dashboard = dashboard;
+    window.exportHistoryManager = new AttendanceExportHistoryManager();
 
     // Initialize export manager when modal is shown
     document.getElementById('exportModal')?.addEventListener('shown.bs.modal', function () {

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -59,6 +59,10 @@ const CACHE_TTL_MEDIUM = 300; // 5 minute cache
 const LARGE_CACHE_CHUNK_SIZE = 90000; // stay below 100k Apps Script cache limit per entry
 const ATTENDANCE_CACHE_VERSION = 'v4';
 
+const ATTENDANCE_EXPORT_FOLDER_NAME = 'Lumina Attendance Exports';
+const ATTENDANCE_EXPORT_FOLDER_DESCRIPTION = 'Centralized daily pivot exports generated from Lumina Attendance.';
+const ATTENDANCE_EXPORT_FOLDER_PROP_KEY = 'ATTENDANCE_EXPORT_FOLDER_ID';
+
 function cloneDate(value) {
   if (value instanceof Date && !isNaN(value.getTime())) {
     return new Date(value.getTime());
@@ -160,6 +164,34 @@ function normalizeDateValue(value) {
   }
 
   return null;
+}
+
+function formatDateIdentifier(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return '';
+  }
+
+  if (typeof Utilities !== 'undefined' && Utilities.formatDate) {
+    return Utilities.formatDate(date, ATTENDANCE_TIMEZONE, 'yyyy-MM-dd');
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatDisplayDate(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return '';
+  }
+
+  if (typeof Utilities !== 'undefined' && Utilities.formatDate) {
+    return Utilities.formatDate(date, ATTENDANCE_TIMEZONE, 'MMM d, yyyy');
+  }
+
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
 }
 
 function toIsoDateString(date) {
@@ -314,6 +346,115 @@ function rpc(label, fn, fallback, maxTime = 20000) {
     }
     return (typeof fallback === 'function') ? fallback(err) : fallback;
   }
+}
+
+function getActiveUserEmailSafe() {
+  if (typeof Session === 'undefined' || typeof Session.getActiveUser !== 'function') {
+    return '';
+  }
+
+  try {
+    const activeUser = Session.getActiveUser();
+    if (!activeUser || typeof activeUser.getEmail !== 'function') {
+      return '';
+    }
+
+    const email = activeUser.getEmail();
+    if (typeof email === 'string' && email && !/anonymous/i.test(email)) {
+      return email.trim();
+    }
+  } catch (error) {
+    console.warn('Failed to resolve active user email:', error);
+  }
+
+  return '';
+}
+
+function ensureDriveEntityAccessForUser(entity, userEmail) {
+  if (!entity || typeof entity.addEditor !== 'function' || !userEmail) {
+    return;
+  }
+
+  try {
+    const existingEditors = (typeof entity.getEditors === 'function')
+      ? entity.getEditors().map(editor => {
+        if (editor && typeof editor.getEmail === 'function') {
+          const email = editor.getEmail();
+          return typeof email === 'string' ? email.toLowerCase() : '';
+        }
+        return '';
+      })
+      : [];
+
+    if (!existingEditors.includes(userEmail.toLowerCase())) {
+      entity.addEditor(userEmail);
+    }
+  } catch (error) {
+    console.warn('Unable to ensure Drive access for user:', error);
+  }
+}
+
+function getOrCreateAttendanceExportFolder_() {
+  if (typeof DriveApp === 'undefined') {
+    throw new Error('Drive services unavailable');
+  }
+
+  const props = (typeof PropertiesService !== 'undefined' && PropertiesService.getScriptProperties)
+    ? PropertiesService.getScriptProperties()
+    : null;
+
+  if (props) {
+    const cachedId = props.getProperty(ATTENDANCE_EXPORT_FOLDER_PROP_KEY);
+    if (cachedId) {
+      try {
+        const cachedFolder = DriveApp.getFolderById(cachedId);
+        if (cachedFolder) {
+          return cachedFolder;
+        }
+      } catch (error) {
+        console.warn('Cached attendance export folder unavailable:', error);
+        props.deleteProperty(ATTENDANCE_EXPORT_FOLDER_PROP_KEY);
+      }
+    }
+  }
+
+  let folder = null;
+  try {
+    const matches = DriveApp.getFoldersByName(ATTENDANCE_EXPORT_FOLDER_NAME);
+    if (matches.hasNext()) {
+      folder = matches.next();
+    }
+  } catch (error) {
+    console.warn('Error while locating attendance export folder:', error);
+  }
+
+  if (!folder) {
+    folder = DriveApp.createFolder(ATTENDANCE_EXPORT_FOLDER_NAME);
+    try {
+      folder.setDescription(ATTENDANCE_EXPORT_FOLDER_DESCRIPTION);
+    } catch (descError) {
+      console.warn('Unable to set attendance export folder description:', descError);
+    }
+  }
+
+  if (props && folder) {
+    try {
+      props.setProperty(ATTENDANCE_EXPORT_FOLDER_PROP_KEY, folder.getId());
+    } catch (error) {
+      console.warn('Failed to cache attendance export folder id:', error);
+    }
+  }
+
+  return folder;
+}
+
+function ensureAttendanceExportFolderForActiveUser() {
+  const folder = getOrCreateAttendanceExportFolder_();
+  const userEmail = getActiveUserEmailSafe();
+  if (folder && userEmail) {
+    ensureDriveEntityAccessForUser(folder, userEmail);
+  }
+  return folder;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1884,15 +2025,22 @@ function generateEnhancedDailyPivotMatrix(params) {
   try {
     const { period, users, userSelection, dailyPivotOptions } = params;
     const hourPolicyOptions = params.hourPolicy || (dailyPivotOptions && dailyPivotOptions.hourPolicy) || {};
-    let granularity, periodValue;
+    let granularity = period.type || 'Week';
+    let periodValue = period.value;
+    let periodLabel = periodValue ? `${granularity} ${periodValue}` : granularity;
+    let customRangeInfo = null;
 
     // Determine period
     if (period.type === 'custom') {
-      granularity = 'Week';
-      periodValue = weekStringFromDate(new Date(period.start));
-    } else {
-      granularity = period.type;
-      periodValue = period.value;
+      const normalizedRange = normalizeCustomRangeBounds(period.start, period.end);
+      customRangeInfo = {
+        startIso: normalizedRange.startIso,
+        endIso: normalizedRange.endIso,
+        displayLabel: normalizedRange.displayLabel
+      };
+      granularity = 'CustomRange';
+      periodValue = `${customRangeInfo.startIso}::${customRangeInfo.endIso}`;
+      periodLabel = customRangeInfo.displayLabel;
     }
 
     // Get analytics data
@@ -1918,18 +2066,30 @@ function generateEnhancedDailyPivotMatrix(params) {
     // Generate enhanced export file (XLSX when possible, CSV fallback otherwise)
     const exportFile = generateEnhancedDailyPivotExport(pivotMatrix, params, {
       granularity,
-      periodValue
+      periodValue,
+      periodLabel,
+      customRange: customRangeInfo
     });
 
-    return {
+    const response = {
       success: true,
       type: 'daily_pivot_matrix',
       users: pivotMatrix.users.length,
       days: pivotMatrix.dateRange.length,
       dateRange: pivotMatrix.dateRange.length > 0 ?
         `${pivotMatrix.dateRange[0].date} to ${pivotMatrix.dateRange[pivotMatrix.dateRange.length - 1].date}` : 'No data',
+      periodValue,
+      periodLabel,
       ...exportFile
     };
+
+    if (customRangeInfo) {
+      response.rangeStart = customRangeInfo.startIso;
+      response.rangeEnd = customRangeInfo.endIso;
+      response.customRange = customRangeInfo;
+    }
+
+    return response;
 
   } catch (error) {
     console.error('Enhanced daily pivot matrix generation failed:', error);
@@ -2289,8 +2449,14 @@ function generateEnhancedDailyPivotExport(pivotMatrix, params, context) {
       .setFontSize(11);
 
     currentRow += 1;
-    const periodDescription = `${context.granularity || 'Period'} ${context.periodValue || 'Custom Range'}`;
-    sheet.getRange(currentRow, 1).setValue(`Period: ${periodDescription}`);
+    const friendlyGranularity = context.granularity === 'CustomRange'
+      ? 'Custom Range'
+      : (context.granularity || 'Period');
+    const periodDetails = (context.customRange && context.customRange.displayLabel)
+      || context.periodLabel
+      || context.periodValue
+      || 'Custom Range';
+    sheet.getRange(currentRow, 1).setValue(`Period: ${friendlyGranularity} – ${periodDetails}`);
     sheet.getRange(currentRow, 1, 1, exportWidth).merge()
       .setFontColor('#475569')
       .setFontSize(11);
@@ -2678,14 +2844,66 @@ function generateEnhancedDailyPivotExport(pivotMatrix, params, context) {
       file.setName(spreadsheetName);
     }
 
+    try {
+      const metadataDescription = `Exported ${Utilities.formatDate(new Date(), ATTENDANCE_TIMEZONE, 'MMM d, yyyy h:mm a')} • ${context.periodLabel || context.periodValue || 'Custom Range'}`;
+      file.setDescription(metadataDescription);
+    } catch (descriptionError) {
+      console.warn('Unable to set export file description:', descriptionError);
+    }
+
+    let folderId = '';
+    let folderUrl = '';
+    let folderName = '';
+    const activeUserEmail = getActiveUserEmailSafe();
+
+    try {
+      const exportFolder = ensureAttendanceExportFolderForActiveUser();
+      if (exportFolder) {
+        folderId = exportFolder.getId();
+        folderName = exportFolder.getName();
+        folderUrl = exportFolder.getUrl();
+
+        exportFolder.addFile(file);
+        try {
+          DriveApp.getRootFolder().removeFile(file);
+        } catch (removeError) {
+          console.warn('Unable to detach export from root folder:', removeError);
+        }
+
+        if (activeUserEmail) {
+          ensureDriveEntityAccessForUser(file, activeUserEmail);
+        }
+      }
+    } catch (folderError) {
+      console.warn('Unable to route export into attendance folder:', folderError);
+      if (activeUserEmail) {
+        try {
+          ensureDriveEntityAccessForUser(file, activeUserEmail);
+        } catch (shareError) {
+          console.warn('Failed to share export file with active user:', shareError);
+        }
+      }
+    }
+
     const spreadsheetUrl = spreadsheet.getUrl();
+    const createdAt = file.getDateCreated();
+    const updatedAt = file.getLastUpdated();
 
     return {
       fileId,
       spreadsheetUrl,
       mimeType: 'application/vnd.google-apps.spreadsheet',
       filename: `${spreadsheetName}.gsheet`,
-      fileType: 'google_sheet'
+      fileType: 'google_sheet',
+      spreadsheetName,
+      sheetTitle: sheet.getName(),
+      periodLabel: context.periodLabel,
+      customRange: context.customRange,
+      folderId,
+      folderName,
+      folderUrl,
+      createdAtIso: createdAt instanceof Date ? createdAt.toISOString() : '',
+      updatedAtIso: updatedAt instanceof Date ? updatedAt.toISOString() : ''
     };
   } catch (error) {
     try {
@@ -2858,6 +3076,87 @@ function generateEnhancedDailyPivotCsvFallback(pivotMatrix, params, context) {
     filename: `${fileBaseName}.csv`,
     mimeType: 'text/csv;charset=utf-8;'
   };
+}
+
+function listAttendanceExportFiles() {
+  return rpc('listAttendanceExportFiles', () => {
+    if (typeof DriveApp === 'undefined') {
+      throw new Error('Drive services unavailable');
+    }
+
+    const folder = ensureAttendanceExportFolderForActiveUser();
+    if (!folder) {
+      return { success: false, error: 'Attendance export folder is unavailable.' };
+    }
+
+    const timezone = ATTENDANCE_TIMEZONE
+      || ((typeof Session !== 'undefined' && typeof Session.getScriptTimeZone === 'function')
+        ? Session.getScriptTimeZone()
+        : 'America/Jamaica');
+    const files = [];
+    const iterator = folder.getFiles();
+    const userEmail = getActiveUserEmailSafe();
+
+    while (iterator.hasNext()) {
+      const file = iterator.next();
+      try {
+        const createdAt = file.getDateCreated();
+        const updatedAt = file.getLastUpdated();
+        const description = typeof file.getDescription === 'function' ? file.getDescription() : '';
+
+        if (userEmail) {
+          try {
+            ensureDriveEntityAccessForUser(file, userEmail);
+          } catch (shareFileError) {
+            console.warn('Unable to confirm export file sharing for active user:', shareFileError);
+          }
+        }
+
+        files.push({
+          id: file.getId(),
+          name: file.getName(),
+          url: file.getUrl(),
+          description,
+          mimeType: file.getMimeType && file.getMimeType(),
+          createdAtIso: createdAt instanceof Date ? createdAt.toISOString() : '',
+          updatedAtIso: updatedAt instanceof Date ? updatedAt.toISOString() : '',
+          createdAtDisplay: (createdAt instanceof Date && !isNaN(createdAt.getTime()))
+            ? Utilities.formatDate(createdAt, timezone, 'MMM d, yyyy h:mm a')
+            : '',
+          updatedAtDisplay: (updatedAt instanceof Date && !isNaN(updatedAt.getTime()))
+            ? Utilities.formatDate(updatedAt, timezone, 'MMM d, yyyy h:mm a')
+            : ''
+        });
+      } catch (fileError) {
+        console.warn('Unable to capture export file metadata:', fileError);
+      }
+    }
+
+    files.sort((a, b) => {
+      const left = b.updatedAtIso || b.createdAtIso || '';
+      const right = a.updatedAtIso || a.createdAtIso || '';
+      return left.localeCompare(right);
+    });
+
+    const folderUrl = folder.getUrl();
+    const folderId = folder.getId();
+    const folderName = folder.getName();
+    if (userEmail) {
+      try {
+        ensureDriveEntityAccessForUser(folder, userEmail);
+      } catch (shareError) {
+        console.warn('Unable to confirm export folder sharing for active user:', shareError);
+      }
+    }
+
+    return {
+      success: true,
+      folderId,
+      folderName,
+      folderUrl,
+      files
+    };
+  }, { success: false, error: 'Unable to load attendance export history.', files: [] }, MAX_PROCESSING_TIME);
 }
 
 function buildDailyPivotFileBase(granularity, periodValue) {
@@ -3548,6 +3847,53 @@ function createEmptyAnalytics() {
 // PERIOD CALCULATION UTILITIES
 // ────────────────────────────────────────────────────────────────────────────
 
+function normalizeCustomRangeBounds(startInput, endInput) {
+  const startDate = normalizeDateValue(startInput);
+  const endDate = normalizeDateValue(endInput);
+
+  if (!(startDate instanceof Date) || isNaN(startDate.getTime())) {
+    throw new Error('Invalid custom range start date');
+  }
+  if (!(endDate instanceof Date) || isNaN(endDate.getTime())) {
+    throw new Error('Invalid custom range end date');
+  }
+
+  const start = createDateInLocalTime(
+    startDate.getFullYear(),
+    startDate.getMonth() + 1,
+    startDate.getDate(),
+    0,
+    0,
+    0
+  ) || new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate(), 0, 0, 0, 0);
+
+  const end = createDateInLocalTime(
+    endDate.getFullYear(),
+    endDate.getMonth() + 1,
+    endDate.getDate(),
+    23,
+    59,
+    59
+  ) || new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate(), 23, 59, 59, 999);
+
+  end.setMilliseconds(999);
+
+  if (end.getTime() < start.getTime()) {
+    throw new Error('Custom range end date must be on or after the start date');
+  }
+
+  const startIso = formatDateIdentifier(start);
+  const endIso = formatDateIdentifier(end);
+
+  return {
+    start,
+    end,
+    startIso,
+    endIso,
+    displayLabel: `${formatDisplayDate(start)} to ${formatDisplayDate(end)}`
+  };
+}
+
 function derivePeriodBounds(granularity, id) {
   function weekStartLocal(d) {
     const day = d.getDay();
@@ -3607,6 +3953,16 @@ function derivePeriodBounds(granularity, id) {
     return [new Date(y, 0, 1, 0, 0, 0, 0), new Date(y, 11, 31, 23, 59, 59, 999)];
   }
 
+  if (granularity === 'CustomRange') {
+    if (!id || typeof id !== 'string' || id.indexOf('::') === -1) {
+      throw new Error(`Invalid custom range identifier: ${id}`);
+    }
+
+    const [startToken, endToken] = id.split('::');
+    const { start, end } = normalizeCustomRangeBounds(startToken, endToken);
+    return [start, end];
+  }
+
   throw new Error(`Unknown granularity: ${granularity}`);
 }
 
@@ -3641,6 +3997,12 @@ function validateEnhancedExportParams(params) {
   if (params.period && params.period.type === 'custom') {
     if (!params.period.start || !params.period.end) {
       errors.push('Start and end dates are required for custom period');
+    } else {
+      try {
+        normalizeCustomRangeBounds(params.period.start, params.period.end);
+      } catch (rangeError) {
+        errors.push(rangeError.message);
+      }
     }
   }
   


### PR DESCRIPTION
## Summary
- route generated Google Sheets exports into a dedicated Drive folder shared with the active user
- return folder metadata and timestamps so the client can surface saved export history
- add a Saved Exports viewer in Attendance Reports to open Drive files and refresh the listing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec2f048b083269b4a1a94394a4c2c)