### PR TITLE
Expand escalation tracking for remote issues

### DIFF
--- a/EscalationService.js
+++ b/EscalationService.js
@@ -10,7 +10,10 @@
  *       id:        string,
  *       timestamp: Date,
  *       user:      string,
- *       type:      string,       // "Client" or "Supervisor"
+ *       category:  string,
+ *       issueType: string,
+ *       impact:    string,
+ *       status:    string,
  *       notes:     string,
  *       createdAt: Date,
  *       updatedAt: Date
@@ -27,7 +30,7 @@
 
 /**
  * Returns all escalations in a form your client-side expects:
- *   { id, user, type, timestamp, notes }
+ *   { id, user, category, issueType, impact, status, timestamp, notes }
  */
 function fetchAllEscalations() {
   const tz = Session.getScriptTimeZone();
@@ -35,7 +38,10 @@ function fetchAllEscalations() {
   return rows.map(r => ({
     id: r.ID,
     user: r.User,
-    type: r.Type,
+    category: r.Category || '',
+    issueType: r.IssueType || '',
+    impact: r.ImpactLevel || '',
+    status: r.Status || '',
     timestamp: r.Timestamp instanceof Date
       ? Utilities.formatDate(r.Timestamp, tz, 'yyyy-MM-dd HH:mm:ss')
       : r.Timestamp,
@@ -45,7 +51,15 @@ function fetchAllEscalations() {
 
 /**
  * Inserts a new escalation record.
- * @param {{user:string, type:string, timestamp:string, notes:string}} rec
+ * @param {{
+ *   user:string,
+ *   category:string,
+ *   issueType:string,
+ *   impact:string,
+ *   status:string,
+ *   timestamp:string,
+ *   notes:string
+ * }} rec
  * @return {string} the generated ID
  */
 function addEscalation(rec) {
@@ -56,12 +70,18 @@ function addEscalation(rec) {
   const tsDate = rec.timestamp
     ? new Date(rec.timestamp.replace('T', ' '))
     : now;
-  // ESCALATIONS_HEADERS = ["ID","Timestamp","User","Type","Notes","CreatedAt","UpdatedAt"]
+  // ESCALATIONS_HEADERS = [
+  //   "ID","Timestamp","User","Category","IssueType","ImpactLevel",
+  //   "Status","Notes","CreatedAt","UpdatedAt"
+  // ]
   sheet.appendRow([
     id,
     tsDate,
     rec.user,
-    rec.type,
+    rec.category,
+    rec.issueType,
+    rec.impact,
+    rec.status || 'Open',
     rec.notes,
     now,
     now
@@ -72,7 +92,15 @@ function addEscalation(rec) {
 /**
  * Updates an existing escalation by ID.
  * @param {string} id
- * @param {{user:string, type:string, timestamp:string, notes:string}} rec
+ * @param {{
+ *   user:string,
+ *   category:string,
+ *   issueType:string,
+ *   impact:string,
+ *   status:string,
+ *   timestamp:string,
+ *   notes:string
+ * }} rec
  */
 function updateEscalation(id, rec) {
   const sheet = getIBTRSpreadsheet()
@@ -86,15 +114,18 @@ function updateEscalation(id, rec) {
   for (let i = 1; i < data.length; i++) {
     if (data[i][0] === id) {
       const row = i + 1;
-      const createdAt = data[i][5];  // preserve original CreatedAt
+      const createdAt = data[i][8];  // preserve original CreatedAt
       const tsDate = rec.timestamp
         ? new Date(rec.timestamp.replace('T', ' '))
         : new Date();
-      // overwrite Timestamp, User, Type, Notes, keep CreatedAt, set UpdatedAt
-      sheet.getRange(row, 2, 1, 6).setValues([[
+      // overwrite Timestamp + metadata, keep CreatedAt, set UpdatedAt
+      sheet.getRange(row, 2, 1, 9).setValues([[
         tsDate,
         rec.user,
-        rec.type,
+        rec.category,
+        rec.issueType,
+        rec.impact,
+        rec.status,
         rec.notes,
         createdAt,
         now

--- a/Escalations.html
+++ b/Escalations.html
@@ -302,6 +302,7 @@
 
   .modern-table {
     width: 100%;
+    min-width: 960px;
     border-collapse: collapse;
     background: white;
     margin: 0;
@@ -341,37 +342,132 @@
     border-bottom: none;
   }
 
-  /* Type Badge */
-  .type-badge {
+  /* Category Badge */
+  .category-badge {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.25rem 0.75rem;
-    border-radius: 20px;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: none;
+    border: 1px solid transparent;
+  }
+
+  .category-badge .dot,
+  .impact-badge .dot,
+  .status-chip .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+    display: inline-block;
+  }
+
+  .category-connectivity {
+    background: rgba(0, 191, 255, 0.12);
+    border-color: rgba(0, 191, 255, 0.3);
+    color: #0369a1;
+  }
+
+  .category-power {
+    background: rgba(255, 184, 0, 0.14);
+    border-color: rgba(255, 184, 0, 0.3);
+    color: #b45309;
+  }
+
+  .category-hardware {
+    background: rgba(59, 130, 246, 0.14);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: #1d4ed8;
+  }
+
+  .category-software {
+    background: rgba(14, 116, 144, 0.14);
+    border-color: rgba(14, 116, 144, 0.3);
+    color: #0f766e;
+  }
+
+  .category-access {
+    background: rgba(168, 85, 247, 0.14);
+    border-color: rgba(168, 85, 247, 0.3);
+    color: #7c3aed;
+  }
+
+  .category-telephony {
+    background: rgba(249, 115, 22, 0.14);
+    border-color: rgba(249, 115, 22, 0.3);
+    color: #c2410c;
+  }
+
+  .category-security {
+    background: rgba(244, 63, 94, 0.14);
+    border-color: rgba(244, 63, 94, 0.3);
+    color: #b91c1c;
+  }
+
+  .category-hr {
+    background: rgba(250, 204, 21, 0.14);
+    border-color: rgba(250, 204, 21, 0.3);
+    color: #92400e;
+  }
+
+  .category-scheduling {
+    background: rgba(45, 212, 191, 0.14);
+    border-color: rgba(45, 212, 191, 0.3);
+    color: #0f766e;
+  }
+
+  .category-facilities {
+    background: rgba(96, 165, 250, 0.14);
+    border-color: rgba(96, 165, 250, 0.3);
+    color: #1d4ed8;
+  }
+
+  .category-other {
+    background: rgba(148, 163, 184, 0.14);
+    border-color: rgba(148, 163, 184, 0.3);
+    color: #475569;
+  }
+
+  /* Impact Badge */
+  .impact-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    text-transform: uppercase;
+  }
+
+  .impact-critical { background: rgba(248, 113, 113, 0.18); color: #b91c1c; }
+  .impact-high { background: rgba(252, 211, 77, 0.2); color: #b45309; }
+  .impact-moderate { background: rgba(134, 239, 172, 0.22); color: #047857; }
+  .impact-low { background: rgba(191, 219, 254, 0.25); color: #1d4ed8; }
+
+  /* Status Chip */
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.85rem;
+    border-radius: 10px;
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.3px;
   }
 
-  .type-client {
-    background: rgba(0, 191, 255, 0.1);
-    color: var(--cyan-accent);
-    border: 1px solid rgba(0, 191, 255, 0.2);
-  }
-
-  .type-supervisor {
-    background: rgba(255, 184, 0, 0.1);
-    color: var(--gold-highlight);
-    border: 1px solid rgba(255, 184, 0, 0.2);
-  }
-
-  .type-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: currentColor;
-  }
+  .status-open { background: rgba(6, 182, 212, 0.18); color: #0e7490; }
+  .status-progress { background: rgba(129, 140, 248, 0.18); color: #4338ca; }
+  .status-monitoring { background: rgba(163, 230, 53, 0.2); color: #4d7c0f; }
+  .status-resolved { background: rgba(134, 239, 172, 0.22); color: #047857; }
+  .status-closed { background: rgba(148, 163, 184, 0.18); color: #475569; }
 
   /* Enhanced Spaz Animation */
   @keyframes pulse {
@@ -541,16 +637,55 @@
           </div>
 
           <div class="form-floating">
-            <select id="escType" class="form-select" required>
-              <option value="Client">Client</option>
-              <option value="Supervisor">Supervisor</option>
+            <select id="escCategory" class="form-select" required>
+              <option value="">Select category</option>
+              <option value="Connectivity (Internet/VPN)">Connectivity (Internet/VPN)</option>
+              <option value="Power/Utility">Power/Utility</option>
+              <option value="Hardware/Equipment">Hardware/Equipment</option>
+              <option value="Software/Application">Software/Application</option>
+              <option value="Credential &amp; Access">Credential &amp; Access</option>
+              <option value="Telephony/Voice">Telephony/Voice</option>
+              <option value="Security/Compliance">Security/Compliance</option>
+              <option value="HR/Payroll/Benefits">HR/Payroll/Benefits</option>
+              <option value="Scheduling/Timekeeping">Scheduling/Timekeeping</option>
+              <option value="Facilities/Onsite Support">Facilities/Onsite Support</option>
+              <option value="Other / General">Other / General</option>
             </select>
-            <label for="escType">Escalation Type</label>
+            <label for="escCategory">Issue Category</label>
+          </div>
+
+          <div class="form-floating">
+            <select id="escIssueType" class="form-select" required>
+              <option value="">Select issue type</option>
+            </select>
+            <label for="escIssueType">Issue Type</label>
           </div>
 
           <div class="form-floating">
             <input type="datetime-local" id="escTimestamp" class="form-control">
             <label for="escTimestamp">Timestamp</label>
+          </div>
+
+          <div class="form-floating">
+            <select id="escImpact" class="form-select" required>
+              <option value="">Select impact level</option>
+              <option value="Critical - Unable to Work">Critical - Unable to Work</option>
+              <option value="High - Severe Degradation">High - Severe Degradation</option>
+              <option value="Moderate - Workaround Available">Moderate - Workaround Available</option>
+              <option value="Low - Minimal Impact">Low - Minimal Impact</option>
+            </select>
+            <label for="escImpact">Impact Level</label>
+          </div>
+
+          <div class="form-floating">
+            <select id="escStatus" class="form-select" required>
+              <option value="Open" selected>Open</option>
+              <option value="In Progress">In Progress</option>
+              <option value="Monitoring">Monitoring</option>
+              <option value="Resolved">Resolved</option>
+              <option value="Closed">Closed</option>
+            </select>
+            <label for="escStatus">Escalation Status</label>
           </div>
 
           <div class="quill-container" style="grid-column: 1 / -1;">
@@ -591,8 +726,20 @@
                   User
                 </th>
                 <th>
-                  <i class="fas fa-tag me-2"></i>
-                  Type
+                  <i class="fas fa-layer-group me-2"></i>
+                  Category
+                </th>
+                <th>
+                  <i class="fas fa-flag me-2"></i>
+                  Issue Type
+                </th>
+                <th>
+                  <i class="fas fa-bolt me-2"></i>
+                  Impact
+                </th>
+                <th>
+                  <i class="fas fa-signal me-2"></i>
+                  Status
                 </th>
                 <th>
                   <i class="fas fa-clock me-2"></i>
@@ -610,7 +757,7 @@
             </thead>
             <tbody>
               <tr>
-                <td colspan="5" class="text-center py-4">Loading…</td>
+                <td colspan="8" class="text-center py-4">Loading…</td>
               </tr>
             </tbody>
           </table>
@@ -628,17 +775,175 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('escForm');
   const tableBody = document.querySelector('#escalationsTable tbody');
   const quill = new Quill('#escNotesEditor', { theme: 'snow' });
+  const categoryField = document.getElementById('escCategory');
+  const issueTypeField = document.getElementById('escIssueType');
+  const impactField = document.getElementById('escImpact');
+  const statusField = document.getElementById('escStatus');
+  const timestampField = document.getElementById('escTimestamp');
   let editingId = null;
+
+  const issueTypeCatalog = {
+    'Connectivity (Internet/VPN)': [
+      'Internet Outage',
+      'Intermittent Connectivity',
+      'ISP Maintenance / Degradation',
+      'VPN / Firewall Blocked',
+      'VoIP / Softphone Quality'
+    ],
+    'Power/Utility': [
+      'Power Outage',
+      'Power Surge / Fluctuation',
+      'Backup Power Failure'
+    ],
+    'Hardware/Equipment': [
+      'Device Failure',
+      'Peripheral Issue (Headset / Camera)',
+      'Logistics / Replacement Needed'
+    ],
+    'Software/Application': [
+      'Application Outage',
+      'Application Performance',
+      'Update / Patch Issue'
+    ],
+    'Credential & Access': [
+      'Password Reset Required',
+      'Account Locked',
+      'MFA / Authentication Failure',
+      'Provisioning Delay'
+    ],
+    'Telephony/Voice': [
+      'Telephony Platform Outage',
+      'Call Quality / Dropped Calls',
+      'Routing / Queue Issue'
+    ],
+    'Security/Compliance': [
+      'Security Incident',
+      'Policy Violation',
+      'Suspicious Activity'
+    ],
+    'HR/Payroll/Benefits': [
+      'Payroll Concern',
+      'Timecard Dispute',
+      'Benefits / Leave Question'
+    ],
+    'Scheduling/Timekeeping': [
+      'Unable to Clock In/Out',
+      'Schedule Discrepancy',
+      'Shift Swap / Coverage Escalation'
+    ],
+    'Facilities/Onsite Support': [
+      'Badging / Building Access',
+      'Equipment Pickup/Drop-off',
+      'Workspace Safety Concern'
+    ],
+    'Other / General': [
+      'Unable to Work - Other',
+      'Policy or Compliance Concern',
+      'Wellness / Safety Concern',
+      'Other (Specify in Notes)'
+    ]
+  };
+
+  const categoryClassMap = {
+    'Connectivity (Internet/VPN)': 'connectivity',
+    'Power/Utility': 'power',
+    'Hardware/Equipment': 'hardware',
+    'Software/Application': 'software',
+    'Credential & Access': 'access',
+    'Telephony/Voice': 'telephony',
+    'Security/Compliance': 'security',
+    'HR/Payroll/Benefits': 'hr',
+    'Scheduling/Timekeeping': 'scheduling',
+    'Facilities/Onsite Support': 'facilities',
+    'Other / General': 'other'
+  };
+
+  const impactClassMap = {
+    'Critical - Unable to Work': 'critical',
+    'High - Severe Degradation': 'high',
+    'Moderate - Workaround Available': 'moderate',
+    'Low - Minimal Impact': 'low'
+  };
+
+  const statusClassMap = {
+    'Open': 'open',
+    'In Progress': 'progress',
+    'Monitoring': 'monitoring',
+    'Resolved': 'resolved',
+    'Closed': 'closed'
+  };
+
+  const escapeHtml = value => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  const stripHtml = (value = '') => {
+    const div = document.createElement('div');
+    div.innerHTML = value;
+    return div.textContent || div.innerText || '';
+  };
+
+  const buildCategoryBadge = category => {
+    const key = categoryClassMap[category] || 'other';
+    const label = escapeHtml(category || 'Uncategorized');
+    return `<span class="category-badge category-${key}"><span class="dot"></span>${label}</span>`;
+  };
+
+  const buildImpactBadge = impact => {
+    const key = impactClassMap[impact] || 'moderate';
+    const label = escapeHtml(impact || 'Not Set');
+    return `<span class="impact-badge impact-${key}"><span class="dot"></span>${label}</span>`;
+  };
+
+  const buildStatusChip = status => {
+    const hasStatus = Boolean(status);
+    const key = hasStatus ? (statusClassMap[status] || 'open') : 'closed';
+    const label = escapeHtml(hasStatus ? status : 'Untracked');
+    return `<span class="status-chip status-${key}"><span class="dot"></span>${label}</span>`;
+  };
+
+  const populateIssueTypeOptions = (category, selectedValue = '') => {
+    const options = issueTypeCatalog[category] || issueTypeCatalog['Other / General'];
+    const opts = ['<option value="">Select issue type</option>']
+      .concat(options.map(option => {
+        const selected = option === selectedValue ? ' selected' : '';
+        return `<option value="${escapeHtml(option)}"${selected}>${escapeHtml(option)}</option>`;
+      }));
+    issueTypeField.innerHTML = opts.join('');
+  };
+
+  const setDefaultTimestamp = () => {
+    const now = new Date();
+    const offset = now.getTimezoneOffset();
+    const local = new Date(now.getTime() - offset * 60000)
+      .toISOString()
+      .slice(0, 16);
+    timestampField.value = local;
+  };
+
+  const resetForm = () => {
+    form.reset();
+    populateIssueTypeOptions(categoryField.value || 'Other / General');
+    setDefaultTimestamp();
+    statusField.value = 'Open';
+    quill.root.innerHTML = '';
+  };
 
   const showOverlay = () => overlay.classList.add('show');
   const hideOverlay = () => overlay.classList.remove('show');
 
-  // Fetch & render
+  categoryField.addEventListener('change', () => {
+    populateIssueTypeOptions(categoryField.value);
+  });
+
   function loadEscalations() {
     showOverlay();
     google.script.run
       .withSuccessHandler(renderEscalations)
-      .withFailureHandler(err => { alert(err.message||err); hideOverlay(); })
+      .withFailureHandler(err => { alert(err.message || err); hideOverlay(); })
       .fetchAllEscalations();
   }
 
@@ -647,7 +952,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!items.length) {
       tableBody.innerHTML = `
         <tr>
-          <td colspan="5" class="empty-state">
+          <td colspan="8" class="empty-state">
             <i class="fas fa-clipboard-list"></i>
             <h3>No Escalations Found</h3>
             <p>No escalation records available. Start by logging a new escalation.</p>
@@ -656,42 +961,50 @@ document.addEventListener('DOMContentLoaded', () => {
       hideOverlay();
       return;
     }
+
     items.forEach(it => {
       const tr = document.createElement('tr');
       tr.classList.add('spaz');
-      
-      // Create type badge
-      const typeClass = it.type.toLowerCase() === 'client' ? 'type-client' : 'type-supervisor';
-      const typeBadge = `<span class="type-badge ${typeClass}">
-        <span class="type-dot"></span>
-        ${it.type}
-      </span>`;
-      
+
+      const notesPlain = stripHtml(it.notes || '');
+      const shortenedNotes = notesPlain.length > 100
+        ? `${notesPlain.substring(0, 100)}…`
+        : notesPlain;
+
       tr.innerHTML = `
-        <td><strong>${it.user}</strong></td>
-        <td>${typeBadge}</td>
-        <td>${it.timestamp}</td>
-        <td><span class="text-muted">${it.notes.length > 100 ? it.notes.substring(0, 100) + '...' : it.notes}</span></td>
+        <td><strong>${escapeHtml(it.user || '')}</strong></td>
+        <td>${buildCategoryBadge(it.category)}</td>
+        <td>${escapeHtml(it.issueType || '')}</td>
+        <td>${buildImpactBadge(it.impact)}</td>
+        <td>${buildStatusChip(it.status)}</td>
+        <td>${escapeHtml(it.timestamp || '')}</td>
+        <td><span class="text-muted">${escapeHtml(shortenedNotes)}</span></td>
         <td>
-          <button class="modern-btn modern-btn-warning modern-btn-sm me-2">
+          <button class="modern-btn modern-btn-warning modern-btn-sm me-2" title="Edit escalation">
             <i class="fas fa-edit"></i>
           </button>
-          <button class="modern-btn modern-btn-danger modern-btn-sm">
+          <button class="modern-btn modern-btn-danger modern-btn-sm" title="Delete escalation">
             <i class="fas fa-trash"></i>
           </button>
         </td>`;
-      
-      // Edit:
+
       tr.querySelector('.modern-btn-warning').addEventListener('click', () => {
         editingId = it.id;
         document.getElementById('escUser').value = it.user;
-        document.getElementById('escType').value = it.type;
-        document.getElementById('escTimestamp').value = it.timestamp.replace(' ', 'T').slice(0,16);
-        quill.root.innerHTML = it.notes;
+        categoryField.value = it.category || '';
+        populateIssueTypeOptions(categoryField.value || 'Other / General', it.issueType || '');
+        impactField.value = it.impact || '';
+        statusField.value = it.status || 'Open';
+        if (it.timestamp) {
+          const tsValue = it.timestamp.replace(' ', 'T').slice(0, 16);
+          timestampField.value = tsValue;
+        } else {
+          setDefaultTimestamp();
+        }
+        quill.root.innerHTML = it.notes || '';
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
-      
-      // Delete:
+
       tr.querySelector('.modern-btn-danger').addEventListener('click', () => {
         if (!confirm('Delete this escalation?')) return;
         showOverlay();
@@ -700,55 +1013,59 @@ document.addEventListener('DOMContentLoaded', () => {
           .withFailureHandler(() => hideOverlay())
           .removeEscalation(it.id);
       });
-      
+
       tableBody.appendChild(tr);
       setTimeout(() => tr.classList.remove('spaz'), 500);
     });
     hideOverlay();
   }
 
-  // Form submit
   form.addEventListener('submit', e => {
     e.preventDefault();
-    const rec = {
+    const record = {
       user: document.getElementById('escUser').value,
-      type: document.getElementById('escType').value,
-      timestamp: document.getElementById('escTimestamp').value,
+      category: categoryField.value,
+      issueType: issueTypeField.value,
+      impact: impactField.value,
+      status: statusField.value || 'Open',
+      timestamp: timestampField.value,
       notes: quill.root.innerHTML
     };
+
     showOverlay();
-    const runner = editingId
-      ? google.script.run
-          .withSuccessHandler(() => {
-            editingId = null; form.reset(); quill.root.innerHTML = '';
-            loadEscalations();
-          })
-          .withFailureHandler(() => hideOverlay())
-          .updateEscalation(editingId, rec)
-      : google.script.run
-          .withSuccessHandler(() => {
-            form.reset(); quill.root.innerHTML = '';
-            loadEscalations();
-          })
-          .withFailureHandler(() => hideOverlay())
-          .addEscalation(rec);
+    if (editingId) {
+      google.script.run
+        .withSuccessHandler(() => {
+          editingId = null;
+          resetForm();
+          loadEscalations();
+        })
+        .withFailureHandler(() => hideOverlay())
+        .updateEscalation(editingId, record);
+    } else {
+      google.script.run
+        .withSuccessHandler(() => {
+          resetForm();
+          loadEscalations();
+        })
+        .withFailureHandler(() => hideOverlay())
+        .addEscalation(record);
+    }
   });
 
-  // Cancel edit
   document.getElementById('escCancel').addEventListener('click', () => {
     editingId = null;
-    form.reset();
-    quill.root.innerHTML = '';
+    resetForm();
   });
 
-  // Populate users
   google.script.run.withSuccessHandler(users => {
     const sel = document.getElementById('escUser');
     sel.innerHTML = '<option value="">Choose user</option>' +
-      users.map(u => `<option>${u}</option>`).join('');
+      users.map(u => `<option>${escapeHtml(u)}</option>`).join('');
   }).getAttendanceUserList();
 
-  // Initial load
+  populateIssueTypeOptions(categoryField.value || 'Other / General');
+  setDefaultTimestamp();
   loadEscalations();
 });
 </script>

--- a/IBTRUtilities.js
+++ b/IBTRUtilities.js
@@ -80,7 +80,18 @@
     ];
   }
   if (typeof G.QA_COLLAB_HEADERS === 'undefined') G.QA_COLLAB_HEADERS = G.QA_HEADERS.slice();
-  if (typeof G.ESCALATIONS_HEADERS === 'undefined') G.ESCALATIONS_HEADERS = ['ID','Timestamp','User','Type','Notes','CreatedAt','UpdatedAt'];
+  if (typeof G.ESCALATIONS_HEADERS === 'undefined') G.ESCALATIONS_HEADERS = [
+    'ID',
+    'Timestamp',
+    'User',
+    'Category',
+    'IssueType',
+    'ImpactLevel',
+    'Status',
+    'Notes',
+    'CreatedAt',
+    'UpdatedAt'
+  ];
 if (typeof G.BOOKMARKS_HEADERS === 'undefined') {
   G.BOOKMARKS_HEADERS = [
     'ID', 'UserID', 'UserEmail', 'Title', 'URL', 'Description', 'Tags',


### PR DESCRIPTION
## Summary
- redesign the Escalations page to capture detailed remote-work incidents including category, issue type, impact level, and status
- add dynamic issue type catalogs, richer badges, and improved table rendering for escalation records
- extend the EscalationService schema and headers to persist the new escalation metadata

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691389c8af408326bd0baccb5a5f09cd)