### PR TITLE
Auto-fill Quality Form auditor field with logged-in user

### DIFF
--- a/QualityForm.html
+++ b/QualityForm.html
@@ -16,7 +16,9 @@
   // server-side templating:
   // recordId   is a string ("" or your UUID)
   // record     is a JSON string ( "{}" or '{"CallerName":"…",…}' )
-  const recObj = recordId ? JSON.parse(record) : {};  
+  const recObj = recordId ? JSON.parse(record) : {};
+
+  const __currentUserJSON = JSON.stringify(user || {}).replace(/<\/script>/g, '<\\/script>');
 
   // NEW: resolve a safe users array for this template
   var __users = (typeof users !== 'undefined' && users && users.length)
@@ -487,6 +489,11 @@
   .form-group input[readonly] {
     background: #f8fafc;
     color: var(--text-secondary);
+  }
+
+  .readonly-field {
+    cursor: not-allowed;
+    font-weight: 600;
   }
 
   .campaign-badge-con {
@@ -1777,8 +1784,8 @@
           <div class="form-row">
             <div class="form-group">
               <label for="auditorName">Auditor's Name</label>
-              <input type="text" id="auditorName" name="auditorName" value="<?= recObj.AuditorName||'' ?>"
-                                   placeholder="Enter auditor's full name" required>
+              <input type="text" id="auditorName" name="auditorName" value="<?= recObj.AuditorName||((user&&((user.FullName||user.fullName||user.DisplayName||user.displayName||user.UserName||user.userName||user.name||'').toString().trim()))||'') ?>"
+                                   placeholder="Automatically captured from your profile" required readonly aria-readonly="true" class="readonly-field">
             </div>
             <div class="form-group">
               <label for="auditDate">Audit Date</label>
@@ -2614,6 +2621,7 @@
 <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script>
   // Global variables
+  const CURRENT_USER = <?!= __currentUserJSON ?>;
   let currentQAData = null;
   const recordId = '<?= recordId ?>';
   const record = '<?= record ?>';
@@ -2642,6 +2650,68 @@
     lastRequestedAgent: '',
     offline: false
   };
+
+  function resolveCurrentAuditorName() {
+    if (!CURRENT_USER || typeof CURRENT_USER !== 'object') {
+      return '';
+    }
+
+    const candidates = [
+      CURRENT_USER.FullName,
+      CURRENT_USER.fullName,
+      CURRENT_USER.DisplayName,
+      CURRENT_USER.displayName,
+      CURRENT_USER.UserName,
+      CURRENT_USER.userName,
+      CURRENT_USER.name
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate && String(candidate).trim()) {
+        return String(candidate).trim();
+      }
+    }
+
+    return '';
+  }
+
+  function getAuditorNameForSubmission() {
+    const input = document.getElementById('auditorName');
+    const resolved = resolveCurrentAuditorName();
+    if (resolved) {
+      if (input && input.value !== resolved) {
+        input.value = resolved;
+      }
+      return resolved;
+    }
+
+    const fallback = input ? String(input.value || '').trim() : '';
+    return fallback;
+  }
+
+  function initializeAuditorField() {
+    const input = document.getElementById('auditorName');
+    if (!input) return;
+
+    const resolved = resolveCurrentAuditorName();
+
+    if (resolved) {
+      input.value = resolved;
+    } else {
+      const existing = String(input.value || '').trim();
+      if (existing) {
+        input.value = existing;
+      }
+    }
+
+    input.setAttribute('readonly', 'readonly');
+    input.setAttribute('aria-readonly', 'true');
+    input.classList.add('readonly-field');
+
+    if (!input.placeholder || input.placeholder === "Enter auditor's full name") {
+      input.placeholder = 'Automatically captured from your profile';
+    }
+  }
 
   function normalizeUserEntry(entry) {
     if (!entry || typeof entry !== 'object') return null;
@@ -3638,7 +3708,7 @@
     formData.clientName = document.getElementById('clientName').value || '';
     formData.callDate = document.getElementById('callDate').value || '';
     formData.caseNumber = document.getElementById('caseNumber').value || '';
-    formData.auditorName = document.getElementById('auditorName').value || '';
+    formData.auditorName = getAuditorNameForSubmission();
     formData.auditDate = document.getElementById('auditDate').value || '';
     
     // Feedback shared fields
@@ -3811,9 +3881,15 @@
       { id: 'callDate', name: 'Call Date' },
       { id: 'auditorName', name: 'Auditor Name' }
     ];
-    
+
     for (const field of requiredFields) {
       const element = document.getElementById(field.id);
+      if (field.id === 'auditorName') {
+        const resolved = getAuditorNameForSubmission();
+        if (element && resolved) {
+          element.value = resolved;
+        }
+      }
       if (!element || !element.value || element.value.trim() === '') {
         showToast(`Please fill in ${field.name}`, true);
         if (element) element.focus();
@@ -3919,7 +3995,7 @@
       formData.clientName = document.getElementById('clientName').value || '';
       formData.callDate = document.getElementById('callDate').value || '';
       formData.caseNumber = document.getElementById('caseNumber').value || '';
-      formData.auditorName = document.getElementById('auditorName').value || '';
+      formData.auditorName = getAuditorNameForSubmission();
       formData.auditDate = document.getElementById('auditDate').value || '';
       
       // Feedback shared fields
@@ -4743,8 +4819,10 @@
 
   document.addEventListener('DOMContentLoaded', function() {
     console.log('=== QA FORM INITIALIZATION (Enhanced) ===');
-    
+
     try {
+      initializeAuditorField();
+
       // Initialize Quill editor
       quill = new Quill('#quillEditor', {
         theme: 'snow',


### PR DESCRIPTION
## Summary
- auto-populate the Quality Form auditor field with the logged-in user's full name and render it as read-only in the UI
- centralize auditor name resolution for validation and submission to ensure the logged-in user is always captured
- add a subtle read-only style so the auto-filled auditor field is visually distinguished

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913787c86cc8326a60349ed08f757c0)