### PR TITLE
Deduct break and lunch overages from productive hours

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4121,7 +4121,7 @@
           <div class="mt-3">
             <small class="text-muted">
               <i class="fas fa-info-circle me-1"></i>
-              Break credits add up to 0.50h daily when within policy and all break or lunch overages deduct minute-for-minute from billable availability. ${policyNote} All durations shown in decimal hours using ${timezoneLabel} (${timezoneValue}).
+              Up to 30 minutes of daily break time remains paid and billable while any break or lunch overages deduct minute-for-minute from productive availability. ${policyNote} All durations shown in decimal hours using ${timezoneLabel} (${timezoneValue}).
             </small>
           </div>`;
 

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -1379,7 +1379,7 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
         }
       }
 
-      const baseProd = Math.max(0, metrics.prod);
+      const baseProd = Math.max(0, metrics.prod - breakOver);
       const baseCapped = Math.min(baseProd, hourPolicy.effectiveCapSeconds);
       const { applied: appliedBreak, result: afterBreak } = applyCappedAdjustment(baseCapped, breakCredit, hourPolicy.effectiveCapSeconds);
       const { applied: appliedLunch, result: adjustedTotal } = applyCappedAdjustment(afterBreak, lunchAdjustment, hourPolicy.effectiveCapSeconds);
@@ -1958,8 +1958,7 @@ function calculateBreakOverageSecs(breakSeconds) {
 
 function calculateBreakCreditSecs(breakSeconds) {
   const total = Number.isFinite(breakSeconds) ? breakSeconds : 0;
-  const overage = Math.max(0, total - DAILY_BREAKS_SECS);
-  return DAILY_BREAKS_SECS - overage;
+  return Math.max(0, Math.min(total, DAILY_BREAKS_SECS));
 }
 
 function calculateLunchAdjustmentSecs(lunchSeconds) {
@@ -3622,7 +3621,7 @@ function exportAttendanceCsv(granularity, periodId, agentFilter, policyOptions) 
     const notes = [];
     notes.push('');
     notes.push('# Notes');
-    notes.push('# - Billable hours include a 0.50 hour break credit each day with overages deducted minute-for-minute.');
+    notes.push('# - Billable hours include up to 30 minutes of paid break time; break or lunch overages deduct minute-for-minute.');
     notes.push('# - Lunch adjustments reflect time under or over the 30 minute allowance.');
     notes.push(`# - Hours are capped at ${hourPolicy.effectiveCapHours.toFixed(2)} hours per day (${(hourPolicy.baseCapHours * 5).toFixed(2)} hours per standard week) unless overtime is enabled.`);
     if (hourPolicy.overtimeEnabled) {
@@ -4250,9 +4249,10 @@ function createBasicAnalytics(filtered, granularity, periodId, agentFilter, peri
   let fallbackBaseBillableSecs = 0;
   let fallbackAdjustedBillableSecs = 0;
   fallbackDayMetrics.forEach(dayMetrics => {
+    const breakOver = calculateBreakOverageSecs(dayMetrics.break);
     const breakCredit = calculateBreakCreditSecs(dayMetrics.break);
     const lunchAdjustment = calculateLunchAdjustmentSecs(dayMetrics.lunch);
-    const baseProd = Math.max(0, dayMetrics.prod || 0);
+    const baseProd = Math.max(0, (dayMetrics.prod || 0) - breakOver);
     const baseCapped = Math.min(baseProd, safeHourPolicy.effectiveCapSeconds);
     const { applied: appliedBreak, result: afterBreak } = applyCappedAdjustment(baseCapped, breakCredit, safeHourPolicy.effectiveCapSeconds);
     const { applied: appliedLunch, result: adjustedTotal } = applyCappedAdjustment(afterBreak, lunchAdjustment, safeHourPolicy.effectiveCapSeconds);


### PR DESCRIPTION
## Summary
- cap paid break credit at the 30-minute allowance and subtract any break overages from productive time
- keep lunch overage deductions while updating export and attendance table notes to describe the allowance-based policy

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f5bf1b7083268a3116e8a0974bbf)