### PR TITLE
Direct agents to the Agent Experience hub

### DIFF
--- a/AgentExperience.html
+++ b/AgentExperience.html
@@ -1,5 +1,5 @@
 <!-- AgentExperience.html -->
-<?!= include('layout', { baseUrl: baseUrl || '', scriptUrl: scriptUrl, user: user || {}, currentPage: currentPage || 'agent-experience', pageTitle: 'Agent Experience Hub', pageDescription: 'Personalized operations cockpit for support specialists' }) ?>
+<?!= include('layout', { baseUrl: baseUrl || '', scriptUrl: scriptUrl, user: user || {}, currentPage: currentPage || 'agent-experience', pageTitle: 'Agent Experience Hub', pageDescription: 'Personalized operations cockpit for support specialists', sidebarMode: 'hidden' }) ?>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-9xK8gX1SO1kVpWw2X2gYdEx+kt1/3uzMdGII4XESyqCCpt5TR1+t0NenE2no0RvrRZtGJPD7W82dMan3Z8Ykg==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -4743,7 +4743,7 @@ var AuthenticationService = (function () {
         || textHas(combinedPersonaText, agentPatterns);
 
       if (isAgent) {
-        return 'userprofile';
+        return 'agent-experience';
       }
 
       const isGuest = hasPage('collaborationreporting')

--- a/layout.html
+++ b/layout.html
@@ -2054,6 +2054,31 @@
       left: var(--sidebar-collapsed);
     }
 
+    body.layout-no-sidebar #topbar {
+      left: 0;
+      width: 100%;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+    }
+
+    body.layout-no-sidebar #topbar .breadcrumb-nav {
+      order: 1;
+    }
+
+    body.layout-no-sidebar #topbar .topbar-agent-nav {
+      order: 2;
+      margin-left: 0;
+    }
+
+    body.layout-no-sidebar #topbar .top-actions {
+      order: 3;
+      margin-left: auto;
+    }
+
+    body.layout-no-sidebar #mobileToggle {
+      display: none !important;
+    }
+
     .topbar-toggle {
       background: none;
       border: none;
@@ -2094,6 +2119,138 @@
     .breadcrumb-nav i {
       opacity: 0.6;
       font-size: 0.875rem;
+    }
+
+    .topbar-agent-nav {
+      position: relative;
+      margin-left: 1.5rem;
+      display: flex;
+      align-items: center;
+    }
+
+    .agent-nav-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      background: var(--topbar-icon-bg);
+      border: 1px solid var(--topbar-icon-border);
+      color: var(--topbar-text-strong);
+      font-weight: 600;
+      padding: 0.55rem 1rem;
+      border-radius: 999px;
+      transition: var(--transition-smooth);
+      font-size: 0.95rem;
+    }
+
+    .agent-nav-toggle i {
+      font-size: 0.95rem;
+    }
+
+    .agent-nav-toggle:hover,
+    .topbar-agent-nav[data-open="true"] .agent-nav-toggle {
+      background: var(--topbar-icon-hover-bg);
+      border-color: var(--topbar-icon-hover-border);
+      color: var(--topbar-icon-hover-color);
+    }
+
+    .agent-nav-dropdown {
+      position: absolute;
+      top: calc(100% + 0.65rem);
+      left: 0;
+      min-width: min(340px, 80vw);
+      max-height: min(70vh, 540px);
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 1rem;
+      border-radius: 16px;
+      background: var(--topbar-bg);
+      border: 1px solid var(--topbar-border);
+      box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+      z-index: 1300;
+    }
+
+    .agent-nav-dropdown[hidden] {
+      display: none !important;
+    }
+
+    .agent-nav-section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+
+    .agent-nav-section-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--topbar-text-muted);
+    }
+
+    .agent-nav-links {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .agent-nav-link {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      color: var(--topbar-text-strong);
+      text-decoration: none;
+      transition: var(--transition-smooth);
+      border: 1px solid transparent;
+    }
+
+    .agent-nav-link:hover {
+      background: rgba(14, 165, 233, 0.08);
+      border-color: rgba(14, 165, 233, 0.25);
+      color: var(--topbar-text-strong);
+    }
+
+    .agent-nav-link.active {
+      background: rgba(14, 165, 233, 0.12);
+      border-color: rgba(14, 165, 233, 0.3);
+    }
+
+    .agent-nav-link-icon {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(14, 165, 233, 0.12);
+      color: var(--primary);
+      font-size: 1rem;
+    }
+
+    .agent-nav-link-body {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .agent-nav-link-title {
+      font-weight: 600;
+      display: block;
+      font-size: 0.95rem;
+    }
+
+    .agent-nav-link-description {
+      display: block;
+      font-size: 0.8rem;
+      color: var(--topbar-text-muted);
+      line-height: 1.35;
+      margin-top: 0.15rem;
     }
 
 
@@ -2461,6 +2618,15 @@
       margin-left: calc(var(--sidebar-collapsed) + 0.3rem);
     }
 
+    body.layout-no-sidebar #maincontent {
+      margin-left: clamp(0.75rem, 3vw, 1.5rem);
+      margin-right: clamp(0.75rem, 3vw, 1.5rem);
+    }
+
+    body.layout-no-sidebar .mobile-overlay {
+      display: none;
+    }
+
     /* Unified global page banner */
     .lumina-banner {
       position: relative;
@@ -2800,9 +2966,13 @@
 </head>
 
 <body
+  <? if (__layoutBodyClassAttr) { ?>
+  class="<?= __layoutBodyClassAttr ?>"
+  <? } ?>
   data-theme="light"
   data-page-slug="<?!= __layoutSlugCandidate ?>"
   data-return-url="<?!= __layoutRawReturnUrl ?>"
+  data-sidebar-visible="<?!= __layoutSidebarVisibleAttr ?>"
 >
   <?
     // Shared layout context so navigation components can stay in sync
@@ -2893,6 +3063,91 @@
       __layoutRoleNames = ['System Administrator'];
     }
 
+    function __layoutMatchToken(value) {
+      if (value === null || typeof value === 'undefined') {
+        return '';
+      }
+      return String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+    }
+
+    var __layoutHasAgentRole = Array.isArray(__layoutRoleNames) && __layoutRoleNames.some(function (roleName) {
+      if (!roleName && roleName !== 0) {
+        return false;
+      }
+      return String(roleName).toLowerCase().indexOf('agent') !== -1;
+    });
+
+    var __layoutSidebarPreference = '';
+    if (typeof sidebarMode !== 'undefined' && sidebarMode !== null && sidebarMode !== '') {
+      __layoutSidebarPreference = String(sidebarMode).toLowerCase();
+    } else if (typeof hideSidebar !== 'undefined' && hideSidebar) {
+      __layoutSidebarPreference = 'hidden';
+    }
+
+    var __layoutPageTokenCandidates = [
+      __layoutCurrentPageName,
+      (typeof pageSlug !== 'undefined' && pageSlug) ? pageSlug : '',
+      __layoutSlugCandidate,
+      __layoutPageTitleText
+    ];
+
+    var __layoutCurrentPageToken = '';
+    for (var __layoutTokenIndex = 0; __layoutTokenIndex < __layoutPageTokenCandidates.length; __layoutTokenIndex++) {
+      var __layoutCandidateToken = __layoutMatchToken(__layoutPageTokenCandidates[__layoutTokenIndex]);
+      if (__layoutCandidateToken) {
+        __layoutCurrentPageToken = __layoutCandidateToken;
+        break;
+      }
+    }
+
+    var __layoutAgentPageTokens = {
+      agentexperience: true,
+      workspaceagent: true
+    };
+
+    var __layoutShowSidebar = true;
+    if (__layoutSidebarPreference === 'hidden' || __layoutSidebarPreference === 'none') {
+      __layoutShowSidebar = false;
+    }
+
+    if (__layoutShowSidebar && !__layoutSidebarPreference) {
+      if (__layoutAgentPageTokens[__layoutCurrentPageToken] && __layoutHasAgentRole) {
+        __layoutShowSidebar = false;
+      }
+    }
+
+    var __layoutSidebarVisibleAttr = __layoutShowSidebar ? 'true' : 'false';
+
+    var __layoutBodyClassAttr = '';
+    (function () {
+      var classes = [];
+      if (typeof bodyClass !== 'undefined' && bodyClass) {
+        String(bodyClass)
+          .split(/\s+/)
+          .forEach(function (cls) {
+            var trimmed = String(cls || '').trim();
+            if (trimmed) {
+              classes.push(trimmed);
+            }
+          });
+      }
+
+      if (!__layoutShowSidebar) {
+        classes.push('layout-no-sidebar');
+      }
+
+      var seen = Object.create(null);
+      __layoutBodyClassAttr = classes.filter(function (cls) {
+        if (!cls || seen[cls]) {
+          return false;
+        }
+        seen[cls] = true;
+        return true;
+      }).join(' ');
+    })();
+
     function __layoutFormatEmployment(status) {
       if (!status) {
         return { status: '', cls: '', icon: 'fas fa-briefcase' };
@@ -2937,25 +3192,29 @@
 
   <div class="mobile-overlay" id="mobileOverlay"></div>
 
-  <?!= include('navigationSidebar', {
-        baseUrl: (typeof baseUrl !== 'undefined') ? baseUrl : '',
-        scriptUrl: (typeof scriptUrl !== 'undefined') ? scriptUrl : ((typeof baseUrl !== 'undefined') ? baseUrl : ''),
-        currentPage: typeof currentPage !== 'undefined' ? currentPage : '',
-        user: __layoutUser || {},
-        isAdmin: __layoutIsAdmin,
-        campaignId: __layoutCampaignId,
-        campaignName: __layoutCampaignName,
-        roleNames: __layoutRoleNames,
-        navigation: __layoutNavigation,
-        employmentMeta: __layoutEmploymentMeta
-      }) ?>
+  <? if (__layoutShowSidebar) { ?>
+    <?!= include('navigationSidebar', {
+          baseUrl: (typeof baseUrl !== 'undefined') ? baseUrl : '',
+          scriptUrl: (typeof scriptUrl !== 'undefined') ? scriptUrl : ((typeof baseUrl !== 'undefined') ? baseUrl : ''),
+          currentPage: typeof currentPage !== 'undefined' ? currentPage : '',
+          user: __layoutUser || {},
+          isAdmin: __layoutIsAdmin,
+          campaignId: __layoutCampaignId,
+          campaignName: __layoutCampaignName,
+          roleNames: __layoutRoleNames,
+          navigation: __layoutNavigation,
+          employmentMeta: __layoutEmploymentMeta
+        }) ?>
+  <? } ?>
 
   <?!= include('navigationTopbar', {
         baseUrl: (typeof baseUrl !== 'undefined') ? baseUrl : '',
         scriptUrl: (typeof scriptUrl !== 'undefined') ? scriptUrl : ((typeof baseUrl !== 'undefined') ? baseUrl : ''),
         currentPage: typeof currentPage !== 'undefined' ? currentPage : '',
         campaignName: __layoutCampaignName,
-        isAdmin: __layoutIsAdmin
+        isAdmin: __layoutIsAdmin,
+        sidebarVisible: __layoutShowSidebar,
+        navigation: __layoutNavigation
       }) ?>
 
   
@@ -4763,6 +5022,64 @@
                 } else if (typeof topbarMenuBreakpoint.addListener === 'function') {
                     topbarMenuBreakpoint.addListener(handleTopbarMenuBreakpointChange);
                 }
+            }
+
+            const agentNav = document.querySelector('[data-agent-nav]');
+            const agentNavToggle = agentNav ? agentNav.querySelector('[data-agent-nav-toggle]') : null;
+            const agentNavDropdown = agentNav ? agentNav.querySelector('[data-agent-nav-dropdown]') : null;
+
+            const setAgentNavState = function(isOpen) {
+                if (!agentNav || !agentNavToggle || !agentNavDropdown) {
+                    return;
+                }
+
+                agentNav.setAttribute('data-open', isOpen ? 'true' : 'false');
+                if (isOpen) {
+                    agentNavDropdown.removeAttribute('hidden');
+                } else {
+                    agentNavDropdown.setAttribute('hidden', '');
+                }
+                agentNavToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            };
+
+            const closeAgentNav = function() {
+                setAgentNavState(false);
+            };
+
+            const openAgentNav = function() {
+                setAgentNavState(true);
+            };
+
+            if (agentNav && agentNavToggle && agentNavDropdown) {
+                agentNavToggle.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const isOpen = agentNav.getAttribute('data-open') === 'true';
+                    if (isOpen) {
+                        closeAgentNav();
+                    } else {
+                        openAgentNav();
+                    }
+                });
+
+                agentNavDropdown.addEventListener('click', function(event) {
+                    const interactive = event.target && event.target.closest ? event.target.closest('[data-menu-close="true"]') : null;
+                    if (interactive) {
+                        closeAgentNav();
+                    }
+                });
+
+                document.addEventListener('click', function(event) {
+                    if (!agentNav.contains(event.target)) {
+                        closeAgentNav();
+                    }
+                });
+
+                document.addEventListener('keydown', function(event) {
+                    if (event.key === 'Escape') {
+                        closeAgentNav();
+                    }
+                });
             }
 
             const sidebar = document.getElementById('sidebar');

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -49,6 +49,156 @@
   var campaignNameValue = (typeof campaignName !== 'undefined' && campaignName) ? campaignName : '';
   var isAdminValue = Boolean(isAdmin);
 
+  var sidebarVisibleValue = true;
+  if (typeof sidebarVisible !== 'undefined') {
+    if (typeof sidebarVisible === 'string') {
+      var sidebarText = sidebarVisible.trim().toLowerCase();
+      sidebarVisibleValue = !(sidebarText === 'false' || sidebarText === '0' || sidebarText === 'no' || sidebarText === 'off');
+    } else {
+      sidebarVisibleValue = !!sidebarVisible;
+    }
+  }
+
+  var navigationConfig = navigation && typeof navigation === 'object'
+    ? navigation
+    : { categories: [], uncategorizedPages: [] };
+
+  function normalizeNavPage(page) {
+    if (!page) {
+      return null;
+    }
+
+    var key = page.key || page.PageKey || page.pageKey || '';
+    var title = page.title || page.PageTitle || page.pageTitle || '';
+    if (!key || !title) {
+      return null;
+    }
+
+    return {
+      key: key,
+      title: title,
+      icon: page.icon || page.PageIcon || page.pageIcon || 'fas fa-file',
+      description: page.description || page.PageDescription || page.pageDescription || title
+    };
+  }
+
+  var navSections = [];
+  var navSeenKeys = Object.create(null);
+
+  function addNavSection(name, icon, pages) {
+    if (!Array.isArray(pages) || !pages.length) {
+      return;
+    }
+
+    var normalizedPages = [];
+    pages.forEach(function(page) {
+      var normalized = normalizeNavPage(page);
+      if (!normalized) {
+        return;
+      }
+
+      var keyLower = normalized.key.toLowerCase();
+      if (navSeenKeys[keyLower]) {
+        return;
+      }
+
+      navSeenKeys[keyLower] = true;
+      normalizedPages.push(normalized);
+    });
+
+    if (!normalizedPages.length) {
+      return;
+    }
+
+    navSections.push({
+      name: name || 'Navigation',
+      icon: icon || 'fas fa-folder',
+      pages: normalizedPages
+    });
+  }
+
+  if (!sidebarVisibleValue) {
+    addNavSection('Agent Tools', 'fas fa-user-gear', [
+      {
+        key: 'agent-experience',
+        title: 'Agent Experience',
+        icon: 'fas fa-user-headset',
+        description: 'Personalized workspace for agents'
+      },
+      {
+        key: 'userprofile',
+        title: 'My Profile',
+        icon: 'fas fa-id-badge',
+        description: 'Review and update your profile'
+      }
+    ]);
+
+    (navigationConfig.categories || []).forEach(function(category) {
+      var categoryPages = (category && (category.pages || category.Pages)) || [];
+      var sectionPages = categoryPages.map(normalizeNavPage).filter(Boolean);
+      addNavSection(
+        category && (category.CategoryName || category.categoryName) || 'Workspace',
+        category && (category.CategoryIcon || category.categoryIcon) || 'fas fa-folder',
+        sectionPages
+      );
+    });
+
+    addNavSection('Other', 'fas fa-list', (navigationConfig.uncategorizedPages || []).map(normalizeNavPage));
+
+    addNavSection('Global', 'fas fa-globe', [
+      {
+        key: 'chat',
+        title: 'Chat',
+        icon: 'fas fa-comments',
+        description: 'Team chat and announcements'
+      },
+      {
+        key: 'collaboration-reporting',
+        title: 'Collab & Reporting',
+        icon: 'fas fa-diagram-project',
+        description: 'Collaboration & reporting hub'
+      },
+      {
+        key: 'search',
+        title: 'Search',
+        icon: 'fas fa-search',
+        description: 'Search knowledge and dashboards'
+      },
+      {
+        key: 'bookmarks',
+        title: 'Bookmarks',
+        icon: 'fas fa-bookmark',
+        description: 'Quick access to saved links'
+      }
+    ]);
+
+    if (isAdminValue) {
+      addNavSection('Administration', 'fas fa-shield-alt', [
+        {
+          key: 'manageuser',
+          title: 'Users',
+          icon: 'fas fa-users',
+          description: 'Manage LuminaHQ users'
+        },
+        {
+          key: 'manageroles',
+          title: 'Roles',
+          icon: 'fas fa-user-shield',
+          description: 'Manage access roles'
+        },
+        {
+          key: 'managecampaign',
+          title: 'Campaigns',
+          icon: 'fas fa-bullhorn',
+          description: 'Manage campaign records'
+        }
+      ]);
+    }
+  }
+
+  var showNavigationDropdown = !sidebarVisibleValue && navSections.length > 0;
+  var currentPageToken = String(currentPageValue || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
   function generateLink(page) {
     var target = __topbarLinkBase;
     if (!target) {
@@ -73,6 +223,53 @@
     <i class="fas fa-chevron-right"></i>
     <span class="current-page"><?= currentPageValue ?></span>
   </div>
+
+  <? if (showNavigationDropdown) { ?>
+  <div class="topbar-agent-nav" data-agent-nav data-open="false">
+    <button class="agent-nav-toggle" type="button" data-agent-nav-toggle aria-haspopup="true"
+      aria-expanded="false" aria-controls="agentNavDropdown">
+      <i class="fas fa-compass"></i>
+      <span>Navigation</span>
+      <i class="fas fa-chevron-down"></i>
+    </button>
+
+    <div class="agent-nav-dropdown" id="agentNavDropdown" hidden data-agent-nav-dropdown>
+      <? navSections.forEach(function(section) { ?>
+      <div class="agent-nav-section">
+        <div class="agent-nav-section-header">
+          <i class="<?= section.icon ?>"></i>
+          <span><?= section.name ?></span>
+        </div>
+        <div class="agent-nav-links">
+          <? section.pages.forEach(function(page) {
+               var pageKeyToken = (page.key || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+               var pageTitleToken = (page.title || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+               var isActive = (currentPageValue === page.key)
+                 || (currentPageValue === page.title)
+                 || (pageKeyToken && pageKeyToken === currentPageToken)
+                 || (pageTitleToken && pageTitleToken === currentPageToken);
+          ?>
+          <a href="<?= generateLink(page.key) ?>"
+            class="agent-nav-link <?= isActive ? 'active' : '' ?>"
+            data-page-key="<?= page.key ?>"
+            data-menu-close="true">
+            <div class="agent-nav-link-icon">
+              <i class="<?= page.icon ?>"></i>
+            </div>
+            <div class="agent-nav-link-body">
+              <span class="agent-nav-link-title"><?= page.title ?></span>
+              <? if (page.description) { ?>
+              <span class="agent-nav-link-description"><?= page.description ?></span>
+              <? } ?>
+            </div>
+          </a>
+          <? }); ?>
+        </div>
+      </div>
+      <? }); ?>
+    </div>
+  </div>
+  <? } ?>
 
   <div class="top-actions">
     <button class="notification-btn top-actions__notification" data-topbar-action="notifications"


### PR DESCRIPTION
## Summary
- route agent-role users to the Agent Experience workspace after authentication
- add a sidebarless layout mode with a top-bar navigation dropdown for agent-focused pages
- configure the Agent Experience page to render with the new agent layout

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691739eecfa88326ad57ca8a4074a4c0)