### PR TITLE
Stop redundant profile chart re-render loop

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -1338,6 +1338,7 @@
   };
 
   let profileHeroChartInstance = null;
+  let profileHeroChartSignature = null;
 
   function safeString(value) {
     if (value === null || typeof value === 'undefined') return '';
@@ -2061,6 +2062,7 @@
         profileHeroChartInstance.destroy();
         profileHeroChartInstance = null;
       }
+      profileHeroChartSignature = null;
       if (canvas) {
         canvas.style.display = 'none';
       }
@@ -2083,6 +2085,29 @@
       return;
     }
 
+    const labels = Array.isArray(trend.labels) ? trend.labels.slice() : [];
+    const values = Array.isArray(trend.values) ? trend.values.slice() : [];
+    const signature = JSON.stringify({ labels, values });
+
+    if (profileHeroChartInstance && profileHeroChartSignature === signature) {
+      profileHeroChartInstance.data.labels = labels;
+      if (profileHeroChartInstance.data.datasets && profileHeroChartInstance.data.datasets[0]) {
+        const dataset = profileHeroChartInstance.data.datasets[0];
+        dataset.data = values;
+        dataset.borderColor = 'rgba(14, 165, 233, 0.9)';
+        dataset.backgroundColor = 'rgba(14, 165, 233, 0.18)';
+        dataset.pointBackgroundColor = '#0ea5e9';
+        dataset.pointBorderColor = '#ffffff';
+        dataset.pointBorderWidth = 2;
+        dataset.pointRadius = 4;
+        dataset.pointHoverRadius = 5;
+        dataset.borderWidth = 3;
+      }
+      profileHeroChartInstance.update('none');
+      profileHeroChartSignature = signature;
+      return;
+    }
+
     if (profileHeroChartInstance) {
       profileHeroChartInstance.destroy();
       profileHeroChartInstance = null;
@@ -2091,11 +2116,11 @@
     profileHeroChartInstance = new Chart(context, {
       type: 'line',
       data: {
-        labels: trend.labels,
+        labels,
         datasets: [
           {
             label: 'Performance',
-            data: trend.values,
+            data: values,
             fill: true,
             tension: 0.35,
             borderColor: 'rgba(14, 165, 233, 0.9)',
@@ -2151,6 +2176,8 @@
         }
       }
     });
+
+    profileHeroChartSignature = signature;
   }
 
   function renderProfileHero(summary) {


### PR DESCRIPTION
## Summary
- track the rendered dataset for the User Profile performance chart
- reuse the existing Chart.js instance when the data has not changed to prevent looping animations
- reset the cached signature whenever the chart is cleared so the chart can rebuild when data changes

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691743a6e4c08326be856ad4f689ab53)