### PR TITLE
Fix syntax error in verifyToken

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -379,7 +379,6 @@ function verifyToken(token) {
       reason: sessionState.reason || 'SESSION_EXPIRED'
     };
   }
-  var email = resolution.user ? resolution.user.email : '';
 
   var user = (sessionState && sessionState.user) ? sessionState.user : null;
   if (!user) {
@@ -407,8 +406,6 @@ function verifyToken(token) {
       deleteTokenRecord(payload.jti);
       return { valid: false, reason: 'SESSION_MISMATCH' };
     }
-  } catch (error) {
-    console.warn('verifyPassword: SHA-256 fallback failed', error);
   }
 
   var expiresAtMs = payload.exp;


### PR DESCRIPTION
## Summary
- remove stray catch block and undefined variable in verifyToken that caused syntax error
- tidy session/user validation logic to ensure token verification proceeds correctly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191242673c8326a57b267ce32729d0)