### PR TITLE
Fix logout flow to clear stale session tokens

### DIFF
--- a/Login.html
+++ b/Login.html
@@ -2194,6 +2194,38 @@
       state.sessionExpiresAt = null;
     }
 
+    function clearStoredSession(reasonLabel) {
+      try {
+        clearAuthCookie();
+      } catch (clearErr) {
+        console.warn('clearStoredSession: unable to clear auth cookie', clearErr);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.removeItem('lumina.session.token');
+          localStorage.removeItem('lumina.auth.sessionToken');
+          localStorage.removeItem('lumina.auth.fallbackToken');
+        }
+      } catch (localErr) {
+        console.warn('clearStoredSession: unable to clear localStorage tokens', localErr);
+      }
+
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.removeItem('lumina.session.token');
+          sessionStorage.removeItem('lumina.auth.sessionToken');
+          sessionStorage.removeItem('lumina.auth.fallbackToken');
+        }
+      } catch (sessionErr) {
+        console.warn('clearStoredSession: unable to clear sessionStorage tokens', sessionErr);
+      }
+
+      if (reasonLabel === 'manual') {
+        state.hasAttemptedResume = true;
+      }
+    }
+
     function broadcastSessionTokenChange(token) {
       try {
         if (typeof window === 'undefined') {
@@ -3999,6 +4031,10 @@
       const shouldShowAutoTimeout = !error && !message && logoutReason === 'auto';
       const shouldShowManualLogout = !error && !message && logoutReason === 'manual';
 
+      if (logoutReason) {
+        clearStoredSession(logoutReason);
+      }
+
       let shouldReplaceUrl = false;
 
       if (urlParams.has('token')) {
@@ -4028,7 +4064,8 @@
         window.history.replaceState({}, document.title, cleanUrl);
       }
 
-      const resumed = attemptSessionResume();
+      const allowResume = logoutReason !== 'manual';
+      const resumed = allowResume ? attemptSessionResume() : false;
 
       if (!resumed && (shouldShowAutoTimeout || shouldShowManualLogout)) {
         showAlert('info', 'Session tokens expire when you log out or after 30 minutes of inactivity. Please sign in again to continue.');


### PR DESCRIPTION
## Summary
- clear stored authentication cookies and fallback tokens when returning to the login page after logout
- skip session resume attempts after manual logout to avoid redirect loops and stale tokens
- keep logout metadata while ensuring stored tokens are removed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197cd4f3608326a748c7b103735aee)