### PR TITLE
Improve authentication token validation and expiry enforcement

### DIFF
--- a/AuthenticationService.js
+++ b/AuthenticationService.js
@@ -16,7 +16,7 @@
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const REMEMBER_ME_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const SESSION_EXPIRATION_ENABLED = false; // Disable automatic session expiration
+const SESSION_EXPIRATION_ENABLED = true; // Enforce automatic session expiration
 
 const BASE_SESSION_COLUMNS = [
   'Token',
@@ -5516,8 +5516,19 @@ var AuthenticationService = (function () {
       if (!resolution || resolution.status !== 'active' || !resolution.entry) {
         if (resolution && resolution.status === 'expired') {
           console.log('getSessionUser: Session expired (' + resolution.reason + ')');
+        } else if (resolution && resolution.status === 'revoked') {
+          console.log('getSessionUser: Session revoked (' + resolution.reason + ')');
         } else {
           console.log('getSessionUser: Session not found');
+        }
+
+        try {
+          if (resolution && resolution.entry) {
+            removeSessionEntry(resolution.entry);
+          }
+          clearActiveSessionState();
+        } catch (cleanupError) {
+          console.warn('getSessionUser: unable to clear invalid session state', cleanupError);
         }
         return null;
       }
@@ -5534,6 +5545,67 @@ var AuthenticationService = (function () {
     } catch (error) {
       console.error('getSessionUser: Error:', error);
       return null;
+    }
+  }
+
+  function validateSessionToken(sessionToken, options) {
+    try {
+      if (!sessionToken) {
+        return { valid: false, status: 'not_found', reason: 'MISSING_TOKEN' };
+      }
+
+      const touch = options && options.touch === true;
+      const resolution = resolveSessionRecord(sessionToken, { touch: touch });
+
+      if (!resolution || resolution.status !== 'active' || !resolution.entry) {
+        const status = (resolution && resolution.status) || 'not_found';
+        const reason = (resolution && resolution.reason) || 'NOT_FOUND';
+
+        try {
+          if (resolution && resolution.entry) {
+            removeSessionEntry(resolution.entry);
+          }
+          clearActiveSessionState();
+        } catch (cleanupError) {
+          console.warn('validateSessionToken: unable to clear invalid session state', cleanupError);
+        }
+
+        return {
+          valid: false,
+          status: status,
+          reason: reason,
+          expired: status === 'expired' || status === 'idle',
+          revoked: status === 'revoked'
+        };
+      }
+
+      const context = buildSessionUserContext(resolution.entry, sessionToken, resolution);
+      if (!context || !context.user) {
+        try {
+          if (resolution.entry) {
+            removeSessionEntry(resolution.entry);
+          }
+          clearActiveSessionState();
+        } catch (cleanupError) {
+          console.warn('validateSessionToken: unable to clear orphaned session state', cleanupError);
+        }
+
+        return { valid: false, status: 'not_found', reason: 'USER_NOT_FOUND' };
+      }
+
+      return {
+        valid: true,
+        status: 'active',
+        user: context.user,
+        sessionToken: sessionToken,
+        sessionExpiresAt: resolution.expiresAt || context.user.sessionExpiresAt || null,
+        sessionTtlSeconds: context.user.sessionTtlSeconds || null,
+        rememberMe: resolution.rememberMe
+      };
+
+    } catch (error) {
+      console.error('validateSessionToken: Error validating session', error);
+      return { valid: false, status: 'error', reason: error.message };
     }
   }
 
@@ -5634,6 +5706,13 @@ var AuthenticationService = (function () {
           const message = reason === 'IDLE_TIMEOUT'
             ? 'Session expired after 30 minutes of inactivity'
             : 'Session expired or invalid';
+          try {
+            if (resolution && resolution.entry) {
+              removeSessionEntry(resolution.entry);
+            }
+          } catch (cleanupError) {
+            console.warn('keepAlive: unable to remove invalid session entry', cleanupError);
+          }
           clearActiveSessionState();
           return {
             success: false,
@@ -5770,6 +5849,7 @@ var AuthenticationService = (function () {
     logout: logout,
     createSessionFor: createSessionFor,
     getSessionUser: getSessionUser,
+    validateSessionToken: validateSessionToken,
     keepAlive: keepAlive,
     findUserByEmail: findUserByEmail,
     findUserById: findUserById,

--- a/Code.js
+++ b/Code.js
@@ -1106,8 +1106,12 @@ function authenticateUser(e) {
       return identity;
     }
 
-    if (token && typeof AuthenticationService !== 'undefined' && AuthenticationService.getSessionUser) {
-      const user = AuthenticationService.getSessionUser(token);
+    if (token && typeof AuthenticationService !== 'undefined' && AuthenticationService) {
+      const validation = typeof AuthenticationService.validateSessionToken === 'function'
+        ? AuthenticationService.validateSessionToken(token, { touch: true })
+        : null;
+
+      const user = validation && validation.valid ? validation.user : null;
       if (user) {
         user.sessionToken = user.sessionToken || token;
 
@@ -1123,6 +1127,9 @@ function authenticateUser(e) {
 
             if (typeof LuminaIdentity.persistActiveSessionToken === 'function') {
               const rememberValue = (function () {
+                if (validation && Object.prototype.hasOwnProperty.call(validation, 'rememberMe')) {
+                  return !!validation.rememberMe;
+                }
                 if (Object.prototype.hasOwnProperty.call(user, 'sessionRememberMe')) {
                   return !!user.sessionRememberMe;
                 }
@@ -1136,8 +1143,8 @@ function authenticateUser(e) {
               })();
 
               const metadata = {
-                sessionExpiresAt: user.sessionExpiresAt || user.expiresAt || user.ExpiresAt || '',
-                sessionTtlSeconds: user.sessionTtlSeconds || user.ttlSeconds || null,
+                sessionExpiresAt: (validation && validation.sessionExpiresAt) || user.sessionExpiresAt || user.expiresAt || user.ExpiresAt || '',
+                sessionTtlSeconds: (validation && validation.sessionTtlSeconds) || user.sessionTtlSeconds || user.ttlSeconds || null,
                 sessionIdleTimeoutMinutes: user.sessionIdleTimeoutMinutes || user.idleTimeoutMinutes || user.IdleTimeoutMinutes || null,
                 lastActivityAt: new Date().toISOString()
               };
@@ -1154,6 +1161,10 @@ function authenticateUser(e) {
         }
 
         return user;
+      }
+
+      if (validation && !validation.valid) {
+        console.log('authenticateUser: session token rejected', validation.reason || validation.status);
       }
     }
 

--- a/Login.html
+++ b/Login.html
@@ -2194,6 +2194,38 @@
       state.sessionExpiresAt = null;
     }
 
+    function clearStoredSession(reasonLabel) {
+      try {
+        clearAuthCookie();
+      } catch (clearErr) {
+        console.warn('clearStoredSession: unable to clear auth cookie', clearErr);
+      }
+
+      try {
+        if (window.localStorage) {
+          localStorage.removeItem('lumina.session.token');
+          localStorage.removeItem('lumina.auth.sessionToken');
+          localStorage.removeItem('lumina.auth.fallbackToken');
+        }
+      } catch (localErr) {
+        console.warn('clearStoredSession: unable to clear localStorage tokens', localErr);
+      }
+
+      try {
+        if (window.sessionStorage) {
+          sessionStorage.removeItem('lumina.session.token');
+          sessionStorage.removeItem('lumina.auth.sessionToken');
+          sessionStorage.removeItem('lumina.auth.fallbackToken');
+        }
+      } catch (sessionErr) {
+        console.warn('clearStoredSession: unable to clear sessionStorage tokens', sessionErr);
+      }
+
+      if (reasonLabel === 'manual') {
+        state.hasAttemptedResume = true;
+      }
+    }
+
     function broadcastSessionTokenChange(token) {
       try {
         if (typeof window === 'undefined') {
@@ -3999,6 +4031,10 @@
       const shouldShowAutoTimeout = !error && !message && logoutReason === 'auto';
       const shouldShowManualLogout = !error && !message && logoutReason === 'manual';
 
+      if (logoutReason) {
+        clearStoredSession(logoutReason);
+      }
+
       let shouldReplaceUrl = false;
 
       if (urlParams.has('token')) {
@@ -4028,7 +4064,8 @@
         window.history.replaceState({}, document.title, cleanUrl);
       }
 
-      const resumed = attemptSessionResume();
+      const allowResume = logoutReason !== 'manual';
+      const resumed = allowResume ? attemptSessionResume() : false;
 
       if (!resumed && (shouldShowAutoTimeout || shouldShowManualLogout)) {
         showAlert('info', 'Session tokens expire when you log out or after 30 minutes of inactivity. Please sign in again to continue.');


### PR DESCRIPTION
## Summary
- enable enforced session expiration and remove invalid session entries during validation and keep-alive checks
- add a reusable validateSessionToken helper to centralize session verification and cleanup
- route authenticateUser through the validation flow to persist session metadata only for active tokens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197cd4f3608326a748c7b103735aee)