### PR TITLE
Fix user profile chart sizing

### DIFF
--- a/UserProfile.html
+++ b/UserProfile.html
@@ -596,6 +596,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    position: relative;
+    overflow: hidden;
   }
 
   .profile-hero__chart header {
@@ -612,9 +614,16 @@
     color: var(--profile-text-secondary);
   }
 
+  .profile-hero__chart-visual {
+    position: relative;
+    height: clamp(220px, 32vh, 360px);
+  }
+
   .profile-hero__chart canvas {
-    width: 100%;
-    height: 200px;
+    position: absolute;
+    inset: 0;
+    width: 100% !important;
+    height: 100% !important;
   }
 
   .profile-hero__chart-empty {
@@ -2444,9 +2453,14 @@
     chartHeader.appendChild(chartSubtitle);
     chartCard.appendChild(chartHeader);
 
+    const chartVisual = document.createElement('div');
+    chartVisual.className = 'profile-hero__chart-visual';
+
     const canvas = document.createElement('canvas');
     canvas.id = 'profilePerformanceChart';
-    chartCard.appendChild(canvas);
+    chartVisual.appendChild(canvas);
+
+    chartCard.appendChild(chartVisual);
 
     const emptyState = document.createElement('div');
     emptyState.className = 'profile-hero__chart-empty';


### PR DESCRIPTION
## Summary
- add bounded chart wrapper on the user profile page to prevent the performance chart from stretching vertically
- ensure the chart canvas fills only its container while keeping existing styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691994af91108326b35d10e7be4cec53)