### PR TITLE
Add weekly QA matrix export with link type selection

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -1111,6 +1111,11 @@
     <select id="qa-agent" class="form-select" aria-label="Select agent">
       <option value="">All Agents</option>
     </select>
+    <label for="qa-export-link-type" class="visually-hidden">Select link type for export</label>
+    <select id="qa-export-link-type" class="form-select" aria-label="Choose which links to export">
+      <option value="pdf" selected>Google Drive / PDF links</option>
+      <option value="call">Call recording links</option>
+    </select>
     <button type="button" class="btn btn-primary" id="qa-refresh">
       <i class="fa-solid fa-rotate"></i>
       <span class="ms-1">Refresh</span>
@@ -1555,6 +1560,7 @@
         campaignId: '',
         program: ''
       },
+      exportLinkType: 'pdf',
       loading: false,
       data: null,
       agentLookup: {},
@@ -1583,6 +1589,7 @@
       period: document.getElementById('qa-period'),
       agent: document.getElementById('qa-agent'),
       refresh: document.getElementById('qa-refresh'),
+      exportLinkType: document.getElementById('qa-export-link-type'),
       exportMatrix: document.getElementById('qa-export-matrix'),
       summaryCards: dashboardEl.querySelectorAll('[data-metric]'),
       error: document.getElementById('qa-dashboard-error'),
@@ -1654,6 +1661,10 @@
       notesMeta: document.getElementById('qa-notes-meta'),
       notesCard: document.getElementById('qa-notes-card')
     };
+
+    if (dom.exportLinkType && dom.exportLinkType.value) {
+      state.exportLinkType = dom.exportLinkType.value;
+    }
 
     function tooltipPercentLabel(context) {
       if (!context) {
@@ -1910,16 +1921,50 @@
       setTimeout(() => window.URL.revokeObjectURL(link.href), 0);
     }
 
+    function setExportBusy(isBusy) {
+      if (!dom.exportMatrix) {
+        return;
+      }
+
+      if (isBusy) {
+        dom.exportMatrix.disabled = true;
+        dom.exportMatrix.setAttribute('aria-busy', 'true');
+      } else {
+        dom.exportMatrix.setAttribute('aria-busy', 'false');
+        updateExportButton(state && state.data ? state.data.agentMatrix : null);
+      }
+    }
+
     function exportAgentMatrix() {
+      const request = buildRequest();
+      request.linkType = state.exportLinkType || (dom.exportLinkType ? dom.exportLinkType.value : 'pdf');
+      request.granularity = 'Week';
+      if (state.filters.granularity !== 'Week') {
+        request.period = '';
+      }
+
+      setExportBusy(true);
+
+      if (window.google && google.script && google.script.run) {
+        google.script.run
+          .withSuccessHandler(handleExportResponse)
+          .withFailureHandler(handleExportFailure)
+          .clientExportWeeklyAgentMatrix(request);
+        return;
+      }
+
+      console.warn('google.script.run unavailable; falling back to on-page CSV export.');
       const matrix = state && state.data ? state.data.agentMatrix : null;
       if (!matrix || !Array.isArray(matrix.periods) || !matrix.periods.length) {
         console.warn('Agent matrix export requested but no data available.');
+        setExportBusy(false);
         return;
       }
 
       const csv = buildAgentMatrixCsv(matrix);
       if (!csv) {
         console.warn('Agent matrix export is empty.');
+        setExportBusy(false);
         return;
       }
 
@@ -1927,6 +1972,25 @@
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const filename = `qa-agent-matrix-${granularity.toLowerCase()}-${timestamp}.csv`;
       triggerCsvDownload(csv, filename);
+      setExportBusy(false);
+    }
+
+    function handleExportResponse(result) {
+      setExportBusy(false);
+      if (!result || !result.success) {
+        handleExportFailure(result && result.error ? new Error(result.error) : new Error('Export failed.'));
+        return;
+      }
+
+      if (result.spreadsheetUrl) {
+        window.open(result.spreadsheetUrl, '_blank');
+      }
+    }
+
+    function handleExportFailure(error) {
+      setExportBusy(false);
+      console.error('Weekly matrix export failed:', error);
+      showError(error && error.message ? error.message : 'Unable to export weekly view.');
     }
 
     function updateExportButton(matrix) {
@@ -3817,7 +3881,8 @@
         period: state.filters.period,
         agent: state.filters.agent,
         campaignId: state.filters.campaignId,
-        program: state.filters.program
+        program: state.filters.program,
+        linkType: state.exportLinkType
       };
     }
 
@@ -3869,6 +3934,12 @@
         dom.agent.addEventListener('change', event => {
           state.filters.agent = event.target.value;
           loadData();
+        });
+      }
+
+      if (dom.exportLinkType) {
+        dom.exportLinkType.addEventListener('change', event => {
+          state.exportLinkType = event.target.value || 'pdf';
         });
       }
 

--- a/QAService.js
+++ b/QAService.js
@@ -1684,6 +1684,67 @@ function clientGetQADashboardSnapshot(request = {}) {
   }
 }
 
+function clientExportWeeklyAgentMatrix(request = {}) {
+  try {
+    const linkType = normalizeLinkType_(request.linkType);
+    const rawRecords = getAllQA();
+    const normalization = normalizeIntelligenceRequest_(request, rawRecords) || {};
+    const normalizedRecords = Array.isArray(normalization.records) ? normalization.records : [];
+    const baseContext = normalization.context || {
+      granularity: 'Week',
+      period: '',
+      timezone: Session.getScriptTimeZone(),
+      filters: { agent: '', campaignId: '', program: '' },
+      depth: 6,
+      agentUniverse: null,
+      passMark: QA_INTEL_PASS_MARK
+    };
+
+    const context = Object.assign({}, baseContext, {
+      granularity: 'Week',
+      depth: 1,
+      period: baseContext.period || determineLatestPeriod_('Week', normalizedRecords)
+    });
+
+    if (!context.period) {
+      return { success: false, error: 'No weekly period available to export.' };
+    }
+
+    const agentLookup = buildAgentDisplayLookup_(normalizedRecords);
+    const matrix = buildAgentGranularityMatrix_(context, normalizedRecords, { displayLookup: agentLookup });
+    const periodEntry = (matrix.periods || []).find(period => period && period.period === context.period)
+      || (matrix.periods || [])[0]
+      || null;
+
+    const weeklyRecords = filterRecordsForIntelligence_(normalizedRecords, { ...context, period: context.period });
+    const rows = buildWeeklyAgentExportRows_(context, periodEntry, weeklyRecords, {
+      linkType,
+      agentLookup
+    });
+
+    const file = writeWeeklyAgentExport_(rows, context, linkType);
+
+    return {
+      success: true,
+      linkType,
+      period: context.period,
+      granularity: context.granularity,
+      spreadsheetId: file.spreadsheetId,
+      spreadsheetUrl: file.spreadsheetUrl,
+      spreadsheetName: file.spreadsheetName,
+      sheetName: file.sheetName,
+      rows: rows.length
+    };
+  } catch (error) {
+    console.error('clientExportWeeklyAgentMatrix failed:', error);
+    writeError('clientExportWeeklyAgentMatrix', error);
+    return {
+      success: false,
+      error: error && error.message ? error.message : 'Unable to export weekly view.'
+    };
+  }
+}
+
 function normalizeIntelligenceRequest_(request, rawRecords) {
   const granularity = request && typeof request.granularity === 'string'
     ? request.granularity
@@ -2608,6 +2669,123 @@ function buildAgentGranularityMatrix_(context, records, options = {}) {
   };
 }
 
+function buildWeeklyAgentExportRows_(context, periodEntry, records, options = {}) {
+  const linkType = normalizeLinkType_(options.linkType);
+  const agentLookup = options.agentLookup || {};
+  const metrics = (periodEntry && periodEntry.metrics) ? periodEntry.metrics : {};
+  const totalEvaluations = periodEntry && typeof periodEntry.totalEvaluations === 'number'
+    ? periodEntry.totalEvaluations
+    : records.length;
+  const periodLabel = periodEntry ? (periodEntry.label || '') : formatPeriodLabel_(context.granularity || 'Week', context.period);
+  const linkLabel = linkType === 'call' ? 'Call Recording Link' : 'Google Drive/PDF Link';
+
+  const headers = [
+    'Granularity',
+    'Period Key',
+    'Period Label',
+    'Agent Identifier',
+    'Agent Name',
+    'Average Score (%)',
+    'Pass Rate (%)',
+    'Evaluations',
+    'Evaluation Share (%)',
+    'Call Date',
+    'Call Identifier',
+    'Call Score (%)',
+    'Link Type',
+    linkLabel
+  ];
+
+  const rows = [headers];
+  const agents = new Set(Object.keys(metrics));
+  records.forEach(record => agents.add(record.agent || 'Unassigned'));
+
+  Array.from(agents).sort((a, b) => {
+    const nameA = resolveAgentDisplayNameFromLookup_(a, agentLookup).toLowerCase();
+    const nameB = resolveAgentDisplayNameFromLookup_(b, agentLookup).toLowerCase();
+    return nameA.localeCompare(nameB);
+  }).forEach(agentId => {
+    const detail = metrics[agentId] || {};
+    const agentName = resolveAgentDisplayNameFromLookup_(agentId, agentLookup);
+    const evaluationShare = detail.evaluationShare !== undefined && detail.evaluationShare !== null
+      ? detail.evaluationShare
+      : (totalEvaluations ? roundOneDecimal_(((detail.evaluations || 0) / totalEvaluations) * 100) : null);
+
+    const calls = records.filter(record => (record.agent || 'Unassigned') === agentId);
+
+    if (!calls.length) {
+      rows.push([
+        context.granularity || 'Week',
+        context.period || '',
+        periodLabel,
+        agentId || 'Unassigned',
+        agentName || 'Unassigned',
+        detail.avgScore ?? '',
+        detail.passRate ?? '',
+        detail.evaluations ?? '',
+        evaluationShare ?? '',
+        '',
+        '',
+        '',
+        linkType === 'call' ? 'Call Recording' : 'QA PDF',
+        ''
+      ]);
+      return;
+    }
+
+    calls.forEach(call => {
+      const callDate = call.callDateIso || (call.callDate instanceof Date
+        ? Utilities.formatDate(call.callDate, context.timezone || Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm:ssXXX")
+        : '');
+      const callId = extractCallIdentifierFromRecord_(call.raw || {});
+      const link = extractLinkForType_(call.raw || {}, linkType);
+      const callScore = typeof call.recordScore === 'number' && !Number.isNaN(call.recordScore)
+        ? call.recordScore
+        : (typeof call.percentage === 'number' ? Math.round(call.percentage * 100) : '');
+
+      rows.push([
+        context.granularity || 'Week',
+        context.period || '',
+        periodLabel,
+        agentId || 'Unassigned',
+        agentName || 'Unassigned',
+        detail.avgScore ?? '',
+        detail.passRate ?? '',
+        detail.evaluations ?? '',
+        evaluationShare ?? '',
+        callDate,
+        callId || '',
+        callScore,
+        linkType === 'call' ? 'Call Recording' : 'QA PDF',
+        link || ''
+      ]);
+    });
+  });
+
+  return rows;
+}
+
+function writeWeeklyAgentExport_(rows, context, linkType) {
+  const safeRows = Array.isArray(rows) && rows.length ? rows : [['No data available for the selected week']];
+  const sheetName = 'Weekly Agent Matrix';
+  const label = formatPeriodLabel_(context.granularity || 'Week', context.period || '');
+  const spreadsheetName = `Weekly Agent Matrix - ${label || context.period || 'Latest'} (${linkType === 'call' ? 'Calls' : 'PDFs'})`;
+
+  const spreadsheet = SpreadsheetApp.create(spreadsheetName);
+  const sheet = spreadsheet.getSheets()[0];
+  sheet.setName(sheetName);
+  sheet.getRange(1, 1, safeRows.length, safeRows[0].length).setValues(safeRows);
+
+  sheet.autoResizeColumns(1, safeRows[0].length);
+
+  return {
+    spreadsheetId: spreadsheet.getId(),
+    spreadsheetUrl: spreadsheet.getUrl(),
+    spreadsheetName,
+    sheetName
+  };
+}
+
 function buildAgentDisplayLookup_(records) {
   const lookup = {};
 
@@ -3258,6 +3436,74 @@ function getRecordFieldValue_(record, candidates) {
   }
 
   return null;
+}
+
+function normalizeLinkType_(value) {
+  const raw = String(value || '').toLowerCase();
+  if (raw.indexOf('call') !== -1 || raw.indexOf('record') !== -1) {
+    return 'call';
+  }
+  return 'pdf';
+}
+
+function extractLinkForType_(record, linkType) {
+  if (!record || typeof record !== 'object') {
+    return '';
+  }
+
+  const normalizedType = normalizeLinkType_(linkType);
+  const linkCandidates = normalizedType === 'call'
+    ? [
+      'CallLink', 'Call Link', 'CallRecording', 'Call Recording', 'RecordingUrl', 'Recording URL',
+      'CallUrl', 'Call URL', 'AudioUrl', 'Audio URL', 'CallRecordingUrl', 'Call Recording Url'
+    ]
+    : [
+      'PdfUrl', 'PDF Url', 'Pdf Link', 'PDF Link', 'QA Pdf', 'QA PDF', 'Drive Link', 'Google Drive Link'
+    ];
+
+  const directLink = getRecordFieldValue_(record, linkCandidates);
+  if (directLink) {
+    return directLink;
+  }
+
+  const fuzzyMatch = Object.keys(record).find(key => {
+    const normalized = normalizeFieldKey_(key);
+    if (!normalized) {
+      return false;
+    }
+    if (normalizedType === 'call') {
+      return normalized.indexOf('calllink') !== -1
+        || normalized.indexOf('recording') !== -1
+        || normalized.indexOf('callurl') !== -1
+        || normalized.indexOf('audiourl') !== -1;
+    }
+    return normalized.indexOf('pdfurl') !== -1
+      || normalized.indexOf('pdflink') !== -1
+      || normalized.indexOf('drive') !== -1;
+  });
+
+  return fuzzyMatch ? record[fuzzyMatch] : '';
+}
+
+function extractCallIdentifierFromRecord_(record) {
+  if (!record || typeof record !== 'object') {
+    return '';
+  }
+
+  const candidates = [
+    'ID', 'Id', 'QaId', 'QA ID', 'Evaluation ID', 'CaseNumber', 'Case Number', 'CallId', 'Call ID', 'Ticket'
+  ];
+  const direct = getRecordFieldValue_(record, candidates);
+  if (direct) {
+    return direct;
+  }
+
+  const normalizedKey = Object.keys(record).find(key => {
+    const normalized = normalizeFieldKey_(key);
+    return normalized.indexOf('case') !== -1 || normalized.indexOf('ticket') !== -1;
+  });
+
+  return normalizedKey ? record[normalizedKey] : '';
 }
 
 function clamp01_(value) {


### PR DESCRIPTION
## Summary
- add server-side weekly export that builds agent metrics with per-call links and writes to a new spreadsheet
- allow choosing PDF or call recording links while exporting and include all weekly calls for each agent
- update QA dashboard export control to trigger the new Apps Script export and provide a link-type selector

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e43e3e01083268c491bf80f5d4dfb)