### PR TITLE
Enhance QA export matrix export controls

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -1028,30 +1028,33 @@
   .qa-export-modal {
     border-radius: 20px;
     border: 1px solid rgba(148, 163, 184, 0.2);
-    box-shadow: 0 24px 70px rgba(15, 23, 42, 0.2);
+    box-shadow: 0 28px 80px rgba(15, 23, 42, 0.35);
+    background: linear-gradient(145deg, #0f172a 0%, #0b1220 100%);
+    color: #e2e8f0;
   }
 
   .qa-export-modal__header {
-    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     padding: 1.25rem 1.5rem 1rem;
+    background: linear-gradient(120deg, rgba(79, 70, 229, 0.16), rgba(14, 165, 233, 0.12));
   }
 
   .qa-export-modal__body {
     padding: 1.5rem;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(14, 165, 233, 0.05));
+    background: #0b1220;
   }
 
   .qa-export-modal__footer {
-    border-top: 1px solid rgba(148, 163, 184, 0.16);
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
     padding: 1rem 1.5rem;
-    background: #f8fafc;
+    background: #0b1220;
     border-radius: 0 0 20px 20px;
   }
 
   .qa-export-modal__eyebrow {
-    color: var(--qa-primary);
-    font-weight: 700;
-    letter-spacing: 0.05em;
+    color: #cbd5e1;
+    font-weight: 800;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     font-size: 0.8rem;
   }
@@ -1063,15 +1066,18 @@
   }
 
   .qa-export-card {
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(148, 163, 184, 0.22);
-    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 18px;
     padding: 1rem 1.1rem;
-    box-shadow: var(--qa-shadow-soft);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(4px);
   }
 
   .qa-export-card--summary {
     grid-column: span 2;
+    background: linear-gradient(160deg, rgba(34, 197, 94, 0.08), rgba(125, 211, 252, 0.1));
+    border-color: rgba(34, 197, 94, 0.45);
   }
 
   @media (max-width: 768px) {
@@ -1081,15 +1087,18 @@
   }
 
   .qa-export-label {
-    font-weight: 700;
-    color: #0f172a;
+    font-weight: 800;
+    color: #e2e8f0;
     font-size: 0.95rem;
+    letter-spacing: 0.04em;
   }
 
   .qa-export-segmented .btn,
   .qa-export-user-toggle .btn,
   .qa-export-modal .btn-group .btn {
-    font-weight: 600;
+    font-weight: 700;
+    border-radius: 12px !important;
+    color: #e2e8f0;
   }
 
   .qa-export-user-toggle,
@@ -1099,11 +1108,11 @@
   }
 
   .qa-export-pill {
-    background: rgba(37, 99, 235, 0.1);
-    color: var(--qa-primary);
-    padding: 0.4rem 0.8rem;
+    background: rgba(37, 99, 235, 0.16);
+    color: #bfdbfe;
+    padding: 0.45rem 0.9rem;
     border-radius: 999px;
-    font-weight: 700;
+    font-weight: 800;
     font-size: 0.9rem;
   }
 
@@ -1120,6 +1129,22 @@
   .qa-export-modal .form-select,
   .qa-export-modal .form-control {
     border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #e2e8f0;
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .qa-export-helper {
+    color: #94a3b8;
+    font-size: 0.9rem;
+  }
+
+  .qa-export-custom {
+    display: none;
+  }
+
+  .qa-export-custom.active {
+    display: block;
   }
 
   @media (max-width: 992px) {
@@ -1651,7 +1676,7 @@
               Export Matrix
             </p>
             <h5 class="modal-title" id="qa-export-modal-label">QA Weekly Matrix</h5>
-            <p class="mb-0 text-muted">Choose how you want to export this weekly view, including which links to include.</p>
+            <p class="mb-0 qa-export-helper">Choose how you want to export this weekly view, including which links to include.</p>
           </div>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
@@ -1661,19 +1686,19 @@
               <div class="d-flex justify-content-between align-items-center mb-2">
                 <div>
                   <div class="qa-export-label">Time period</div>
-                  <small class="text-muted">Match the weekly dashboard view or pick another period.</small>
+                  <small class="qa-export-helper">Match the weekly dashboard view or pick another period.</small>
                 </div>
                 <span class="badge text-bg-light">QA Matrix</span>
               </div>
               <div class="btn-group w-100" role="group" aria-label="Select export granularity">
                 <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-week" value="Week" checked>
                 <label class="btn btn-outline-primary" for="qa-export-granularity-week">Weekly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-month" value="Month" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-month" title="Monthly export coming soon">Monthly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-quarter" value="Quarter" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-quarter" title="Quarterly export coming soon">Quarterly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-custom" value="Custom" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-custom" title="Custom ranges coming soon">Custom Range</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-month" value="Month">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-month">Monthly</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-quarter" value="Quarter">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-quarter">Quarterly</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-custom" value="Custom">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-custom">Custom Range</label>
               </div>
               <div class="row gx-3 mt-3">
                 <div class="col-8">
@@ -1684,6 +1709,19 @@
                   <label for="qa-export-year" class="qa-export-label">Year</label>
                   <input type="text" id="qa-export-year" class="form-control" value="" readonly>
                 </div>
+              </div>
+              <div class="qa-export-custom mt-3" id="qa-export-custom-range">
+                <div class="row gx-3">
+                  <div class="col-6">
+                    <label for="qa-export-start" class="qa-export-label">Start date</label>
+                    <input type="date" id="qa-export-start" class="form-control" aria-label="Custom range start date">
+                  </div>
+                  <div class="col-6">
+                    <label for="qa-export-end" class="qa-export-label">End date</label>
+                    <input type="date" id="qa-export-end" class="form-control" aria-label="Custom range end date">
+                  </div>
+                </div>
+                <p class="qa-export-helper mt-2 mb-0"><i class="fa-regular fa-calendar me-1"></i>Pick any Monday start and Sunday end for custom exports.</p>
               </div>
               <div class="d-flex align-items-center gap-2 mt-3 small text-muted" id="qa-export-period-summary"></div>
             </div>
@@ -1772,7 +1810,16 @@
         period: '',
         agent: '',
         agentScope: '',
-        linkType: 'pdf'
+        linkType: 'pdf',
+        customRange: {
+          start: '',
+          end: ''
+        }
+      },
+      exportPeriods: {
+        Week: [],
+        Month: [],
+        Quarter: []
       },
       loading: false,
       data: null,
@@ -1865,6 +1912,9 @@
       exportPeriod: document.getElementById('qa-export-period'),
       exportYear: document.getElementById('qa-export-year'),
       exportPeriodSummary: document.getElementById('qa-export-period-summary'),
+      exportCustomRange: document.getElementById('qa-export-custom-range'),
+      exportStart: document.getElementById('qa-export-start'),
+      exportEnd: document.getElementById('qa-export-end'),
       exportAgent: document.getElementById('qa-export-agent'),
       exportAgentScope: document.querySelectorAll('input[name="qa-export-agent-scope"]'),
       exportPill: document.getElementById('qa-export-pill'),
@@ -2226,6 +2276,37 @@
       return 'Week';
     }
 
+    function handleExportGranularityChange() {
+      const granularity = getSelectedExportGranularity();
+      toggleCustomRange(granularity);
+      if (granularity !== 'Custom') {
+        populateExportPeriodSelect(granularity);
+      } else if (dom.exportPeriod && (!state.exportOptions.customRange.start || !state.exportOptions.customRange.end)) {
+        const option = dom.exportPeriod.options[dom.exportPeriod.selectedIndex];
+        const date = option ? parseDateValue(option.value, option.textContent) : new Date();
+        const normalized = normalizeWeekRange(date || new Date());
+        if (normalized) {
+          state.exportOptions.customRange = {
+            start: normalized.monday.toISOString().slice(0, 10),
+            end: normalized.sunday.toISOString().slice(0, 10)
+          };
+        }
+      }
+
+      if (granularity === 'Custom') {
+        if (dom.exportStart) {
+          dom.exportStart.value = state.exportOptions.customRange.start || '';
+        }
+        if (dom.exportEnd) {
+          dom.exportEnd.value = state.exportOptions.customRange.end || '';
+        }
+      }
+      syncExportYear();
+      updateExportPeriodSummary();
+      updateExportPill();
+      updateExportNote();
+    }
+
     function toggleExportAgentScope(scopeValue) {
       if (!dom.exportAgent) {
         return;
@@ -2257,15 +2338,167 @@
       return '';
     }
 
+    function parseDateValue(value, labelText) {
+      const tryParse = input => {
+        if (!input) return null;
+        const parsed = Date.parse(input);
+        return Number.isNaN(parsed) ? null : new Date(parsed);
+      };
+
+      const candidates = [value, labelText];
+      for (let i = 0; i < candidates.length; i += 1) {
+        const candidate = candidates[i];
+        const date = tryParse(candidate);
+        if (date) {
+          return date;
+        }
+        const match = candidate && candidate.match(/(20\d{2}-\d{2}-\d{2})/);
+        if (match) {
+          const fallbackDate = tryParse(match[1]);
+          if (fallbackDate) {
+            return fallbackDate;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    function formatDisplayDate(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+    }
+
+    function normalizeWeekRange(date) {
+      if (!(date instanceof Date)) {
+        return null;
+      }
+      const monday = new Date(date);
+      const day = monday.getDay();
+      const diff = day === 0 ? -6 : 1 - day;
+      monday.setDate(monday.getDate() + diff);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+      return { monday, sunday };
+    }
+
+    function formatWeekSummary(date, fallbackLabel) {
+      const range = normalizeWeekRange(date);
+      if (!range) {
+        return fallbackLabel || 'Latest available period';
+      }
+      return `${formatDisplayDate(range.monday)} – ${formatDisplayDate(range.sunday)}`;
+    }
+
     function syncExportYear() {
       if (!dom.exportYear) {
         return;
       }
 
-      const periodValue = dom.exportPeriod ? (dom.exportPeriod.value || '') : (state.filters.period || '');
+      const granularity = getSelectedExportGranularity();
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const preferred = parseDateValue(start || end, start || end);
+        dom.exportYear.value = preferred ? String(preferred.getFullYear()) : String(new Date().getFullYear());
+        return;
+      }
+
+      const option = dom.exportPeriod
+        ? dom.exportPeriod.options[dom.exportPeriod.selectedIndex]
+        : null;
+      const periodValue = option && option.value ? option.value : (state.filters.period || '');
       const yearMatch = periodValue && /(20\d{2})/.exec(periodValue);
       const year = yearMatch ? yearMatch[1] : String(new Date().getFullYear());
       dom.exportYear.value = year;
+    }
+
+    function buildExportPeriodCollections() {
+      const periodOptions = dom.period && dom.period.options
+        ? Array.from(dom.period.options)
+        : [];
+
+      const weekOptions = periodOptions
+        .filter(option => option && option.value)
+        .map(option => {
+          const label = option.textContent ? option.textContent.trim() : option.value;
+          const date = parseDateValue(option.value, label);
+          const summary = formatWeekSummary(date, label);
+          return {
+            value: option.value,
+            label,
+            summary,
+            date
+          };
+        });
+
+      const monthLookup = {};
+      weekOptions.forEach(option => {
+        if (!option.date) {
+          return;
+        }
+        const start = new Date(option.date.getFullYear(), option.date.getMonth(), 1);
+        const end = new Date(option.date.getFullYear(), option.date.getMonth() + 1, 0);
+        const key = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+        if (!monthLookup[key]) {
+          monthLookup[key] = {
+            value: key,
+            label: `${start.toLocaleString('en-US', { month: 'long' })} ${start.getFullYear()}`,
+            summary: `${formatDisplayDate(start)} – ${formatDisplayDate(end)}`,
+            date: start
+          };
+        }
+      });
+
+      const quarterLookup = {};
+      weekOptions.forEach(option => {
+        if (!option.date) {
+          return;
+        }
+        const quarterIndex = Math.floor(option.date.getMonth() / 3);
+        const quarterStartMonth = quarterIndex * 3;
+        const start = new Date(option.date.getFullYear(), quarterStartMonth, 1);
+        const end = new Date(option.date.getFullYear(), quarterStartMonth + 3, 0);
+        const key = `${start.getFullYear()}-Q${quarterIndex + 1}`;
+        if (!quarterLookup[key]) {
+          quarterLookup[key] = {
+            value: key,
+            label: `Q${quarterIndex + 1} ${start.getFullYear()}`,
+            summary: `${formatDisplayDate(start)} – ${formatDisplayDate(end)}`,
+            date: start
+          };
+        }
+      });
+
+      state.exportPeriods.Week = weekOptions;
+      state.exportPeriods.Month = Object.values(monthLookup).sort((a, b) => (b.value > a.value ? 1 : -1));
+      state.exportPeriods.Quarter = Object.values(quarterLookup).sort((a, b) => (b.value > a.value ? 1 : -1));
+    }
+
+    function populateExportPeriodSelect(granularity) {
+      if (!dom.exportPeriod) {
+        return;
+      }
+
+      const options = state.exportPeriods[granularity] || [];
+      dom.exportPeriod.innerHTML = '';
+
+      options.forEach(option => {
+        const opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label;
+        if (option.summary) {
+          opt.dataset.summary = option.summary;
+        }
+        dom.exportPeriod.appendChild(opt);
+      });
+
+      const current = options.find(option => option.value === state.exportOptions.period) || options[0];
+      if (current) {
+        dom.exportPeriod.value = current.value;
+        state.exportOptions.period = current.value;
+      }
     }
 
     function updateExportPeriodSummary() {
@@ -2273,12 +2506,27 @@
         return;
       }
 
+      const granularity = getSelectedExportGranularity();
+
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const startDate = parseDateValue(start, start);
+        const endDate = parseDateValue(end, end);
+        const startLabel = startDate ? formatDisplayDate(startDate) : 'Start';
+        const endLabel = endDate ? formatDisplayDate(endDate) : 'End';
+        dom.exportPeriodSummary.innerHTML = `<i class="fa-solid fa-calendar-week me-2"></i>${startLabel} – ${endLabel}`;
+        return;
+      }
+
       const option = dom.exportPeriod
         ? dom.exportPeriod.options[dom.exportPeriod.selectedIndex]
         : null;
-      const summaryText = option && option.textContent
-        ? option.textContent.trim()
-        : 'Latest available period';
+      let summaryText = 'Latest available period';
+      if (option) {
+        summaryText = option.dataset && option.dataset.summary
+          ? option.dataset.summary
+          : (option.textContent ? option.textContent.trim() : summaryText);
+      }
 
       dom.exportPeriodSummary.innerHTML = `<i class="fa-solid fa-calendar-week me-2"></i>${summaryText}`;
     }
@@ -2291,7 +2539,24 @@
       const granularity = getSelectedExportGranularity();
       const linkType = getSelectedExportLinkType();
       const linkLabel = linkType === 'call' ? 'Call links' : 'PDF links';
-      dom.exportPill.textContent = `${granularity} • ${linkLabel}`;
+
+      let periodLabel = '';
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const startDate = parseDateValue(start, start);
+        const endDate = parseDateValue(end, end);
+        periodLabel = `${startDate ? formatDisplayDate(startDate) : 'Start'} → ${endDate ? formatDisplayDate(endDate) : 'End'}`;
+      } else if (dom.exportPeriod) {
+        const option = dom.exportPeriod.options[dom.exportPeriod.selectedIndex];
+        if (option) {
+          periodLabel = option.dataset && option.dataset.summary
+            ? option.dataset.summary
+            : option.textContent;
+        }
+      }
+
+      const labelParts = [granularity, linkLabel].filter(Boolean).join(' • ');
+      dom.exportPill.textContent = periodLabel ? `${labelParts} • ${periodLabel}` : labelParts;
     }
 
     function updateExportNote() {
@@ -2305,15 +2570,30 @@
         : null;
       const isSingle = scope && scope.value === 'single';
       const agent = isSingle && dom.exportAgent ? dom.exportAgent.value : '';
+      const linkType = getSelectedExportLinkType();
+      const linkLabel = linkType === 'call' ? 'call recording links' : 'PDF links';
       const agentNote = agent ? 'Limited to the selected agent.' : 'Includes all agents in the view.';
-      dom.exportNote.textContent = `${granularity} metrics with per-call links. ${agentNote}`;
+      const periodNote = granularity === 'Custom'
+        ? 'Custom range honors Monday starts and Sunday endings.'
+        : `${granularity} metrics with ${linkLabel}.`;
+      dom.exportNote.textContent = `${periodNote} ${agentNote}`;
+    }
+
+    function toggleCustomRange(granularity) {
+      const useCustom = granularity === 'Custom';
+      if (dom.exportCustomRange) {
+        dom.exportCustomRange.classList.toggle('active', useCustom);
+      }
+      if (dom.exportPeriod) {
+        dom.exportPeriod.disabled = useCustom;
+        dom.exportPeriod.classList.toggle('disabled', useCustom);
+      }
     }
 
     function syncExportModalForm() {
-      if (dom.exportPeriod && dom.period) {
-        dom.exportPeriod.innerHTML = dom.period.innerHTML;
-        dom.exportPeriod.value = state.filters.period || dom.period.value || '';
-      }
+      buildExportPeriodCollections();
+      const granularity = getSelectedExportGranularity();
+      populateExportPeriodSelect(granularity);
 
       if (dom.exportAgent && dom.agent) {
         dom.exportAgent.innerHTML = dom.agent.innerHTML;
@@ -2325,6 +2605,7 @@
         : null;
       toggleExportAgentScope(scope && scope.value ? scope.value : '');
 
+      toggleCustomRange(granularity);
       syncExportYear();
       updateExportPeriodSummary();
       updateExportPill();
@@ -2373,8 +2654,9 @@
       const periodValue = dom.exportPeriod ? dom.exportPeriod.value : state.filters.period;
 
       request.linkType = getSelectedExportLinkType();
-      request.granularity = granularity === 'Week' ? 'Week' : 'Week';
-      request.period = granularity === 'Week' ? periodValue : '';
+      request.granularity = granularity;
+      request.period = granularity === 'Custom' ? '' : periodValue;
+      request.customRange = granularity === 'Custom' ? (state.exportOptions.customRange || null) : null;
       request.agent = selectedAgent || state.filters.agent || '';
 
       state.exportOptions.period = request.period;
@@ -4213,6 +4495,8 @@
       if (dom.granularity && response && response.context && response.context.granularity) {
         dom.granularity.value = response.context.granularity;
       }
+
+      buildExportPeriodCollections();
     }
 
     function showError(message) {
@@ -4410,16 +4694,17 @@
       if (dom.exportGranularity && dom.exportGranularity.length) {
         dom.exportGranularity.forEach(radio => {
           radio.addEventListener('change', () => {
-            updateExportPill();
-            updateExportNote();
+            handleExportGranularityChange();
           });
         });
       }
 
       if (dom.exportPeriod) {
         dom.exportPeriod.addEventListener('change', () => {
+          state.exportOptions.period = dom.exportPeriod.value;
           syncExportYear();
           updateExportPeriodSummary();
+          updateExportPill();
         });
       }
 
@@ -4436,6 +4721,24 @@
             toggleExportAgentScope(event.target.value);
             updateExportNote();
           });
+        });
+      }
+
+      if (dom.exportStart) {
+        dom.exportStart.addEventListener('change', event => {
+          state.exportOptions.customRange.start = event.target.value;
+          syncExportYear();
+          updateExportPeriodSummary();
+          updateExportPill();
+        });
+      }
+
+      if (dom.exportEnd) {
+        dom.exportEnd.addEventListener('change', event => {
+          state.exportOptions.customRange.end = event.target.value;
+          syncExportYear();
+          updateExportPeriodSummary();
+          updateExportPill();
         });
       }
 


### PR DESCRIPTION
## Summary
- restyle the QA export matrix modal with a sharper, darker visual treatment and helper text
- enable monthly, quarterly, and custom range export selections with Monday-to-Sunday week normalization
- add custom date range inputs and improved export summaries/notes that reflect selected granularity and link types

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ebf9e94088326ac5c0d46394ae12b)