### PR TITLE
Build multi-period quality report export

### DIFF
--- a/QADashboard.html
+++ b/QADashboard.html
@@ -1028,50 +1028,61 @@
   .qa-export-modal {
     border-radius: 20px;
     border: 1px solid rgba(148, 163, 184, 0.2);
-    box-shadow: 0 24px 70px rgba(15, 23, 42, 0.2);
+    box-shadow: 0 28px 80px rgba(15, 23, 42, 0.35);
+    background: linear-gradient(145deg, #0f172a 0%, #0b1220 100%);
+    color: #e2e8f0;
+  }
+
+  .qa-export-dialog {
+    max-width: 1100px;
+    width: min(96vw, 1100px);
   }
 
   .qa-export-modal__header {
-    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     padding: 1.25rem 1.5rem 1rem;
+    background: linear-gradient(120deg, rgba(79, 70, 229, 0.16), rgba(14, 165, 233, 0.12));
   }
 
   .qa-export-modal__body {
     padding: 1.5rem;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), rgba(14, 165, 233, 0.05));
+    background: #0b1220;
   }
 
   .qa-export-modal__footer {
-    border-top: 1px solid rgba(148, 163, 184, 0.16);
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
     padding: 1rem 1.5rem;
-    background: #f8fafc;
+    background: #0b1220;
     border-radius: 0 0 20px 20px;
   }
 
   .qa-export-modal__eyebrow {
-    color: var(--qa-primary);
-    font-weight: 700;
-    letter-spacing: 0.05em;
+    color: #cbd5e1;
+    font-weight: 800;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     font-size: 0.8rem;
   }
 
   .qa-export-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 1rem;
   }
 
   .qa-export-card {
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(148, 163, 184, 0.22);
-    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 18px;
     padding: 1rem 1.1rem;
-    box-shadow: var(--qa-shadow-soft);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(4px);
   }
 
   .qa-export-card--summary {
-    grid-column: span 2;
+    grid-column: 1 / -1;
+    background: linear-gradient(160deg, rgba(34, 197, 94, 0.08), rgba(125, 211, 252, 0.1));
+    border-color: rgba(34, 197, 94, 0.45);
   }
 
   @media (max-width: 768px) {
@@ -1081,15 +1092,18 @@
   }
 
   .qa-export-label {
-    font-weight: 700;
-    color: #0f172a;
+    font-weight: 800;
+    color: #e2e8f0;
     font-size: 0.95rem;
+    letter-spacing: 0.04em;
   }
 
   .qa-export-segmented .btn,
   .qa-export-user-toggle .btn,
   .qa-export-modal .btn-group .btn {
-    font-weight: 600;
+    font-weight: 700;
+    border-radius: 12px !important;
+    color: #e2e8f0;
   }
 
   .qa-export-user-toggle,
@@ -1099,11 +1113,11 @@
   }
 
   .qa-export-pill {
-    background: rgba(37, 99, 235, 0.1);
-    color: var(--qa-primary);
-    padding: 0.4rem 0.8rem;
+    background: rgba(37, 99, 235, 0.16);
+    color: #bfdbfe;
+    padding: 0.45rem 0.9rem;
     border-radius: 999px;
-    font-weight: 700;
+    font-weight: 800;
     font-size: 0.9rem;
   }
 
@@ -1120,6 +1134,22 @@
   .qa-export-modal .form-select,
   .qa-export-modal .form-control {
     border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #e2e8f0;
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .qa-export-helper {
+    color: #94a3b8;
+    font-size: 0.9rem;
+  }
+
+  .qa-export-custom {
+    display: none;
+  }
+
+  .qa-export-custom.active {
+    display: block;
   }
 
   @media (max-width: 992px) {
@@ -1642,7 +1672,7 @@
   </div>
 
   <div class="modal fade" id="qa-export-modal" tabindex="-1" aria-labelledby="qa-export-modal-label" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-dialog modal-dialog-centered modal-xl qa-export-dialog">
       <div class="modal-content qa-export-modal">
         <div class="modal-header qa-export-modal__header">
           <div>
@@ -1651,7 +1681,7 @@
               Export Matrix
             </p>
             <h5 class="modal-title" id="qa-export-modal-label">QA Weekly Matrix</h5>
-            <p class="mb-0 text-muted">Choose how you want to export this weekly view, including which links to include.</p>
+            <p class="mb-0 qa-export-helper">Choose how you want to export this weekly view, including which links to include.</p>
           </div>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
@@ -1661,19 +1691,19 @@
               <div class="d-flex justify-content-between align-items-center mb-2">
                 <div>
                   <div class="qa-export-label">Time period</div>
-                  <small class="text-muted">Match the weekly dashboard view or pick another period.</small>
+                  <small class="qa-export-helper">Match the weekly dashboard view or pick another period.</small>
                 </div>
                 <span class="badge text-bg-light">QA Matrix</span>
               </div>
               <div class="btn-group w-100" role="group" aria-label="Select export granularity">
                 <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-week" value="Week" checked>
                 <label class="btn btn-outline-primary" for="qa-export-granularity-week">Weekly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-month" value="Month" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-month" title="Monthly export coming soon">Monthly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-quarter" value="Quarter" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-quarter" title="Quarterly export coming soon">Quarterly</label>
-                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-custom" value="Custom" disabled>
-                <label class="btn btn-outline-secondary" for="qa-export-granularity-custom" title="Custom ranges coming soon">Custom Range</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-month" value="Month">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-month">Monthly</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-quarter" value="Quarter">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-quarter">Quarterly</label>
+                <input type="radio" class="btn-check" name="qa-export-granularity" id="qa-export-granularity-custom" value="Custom">
+                <label class="btn btn-outline-primary" for="qa-export-granularity-custom">Custom Range</label>
               </div>
               <div class="row gx-3 mt-3">
                 <div class="col-8">
@@ -1684,6 +1714,19 @@
                   <label for="qa-export-year" class="qa-export-label">Year</label>
                   <input type="text" id="qa-export-year" class="form-control" value="" readonly>
                 </div>
+              </div>
+              <div class="qa-export-custom mt-3" id="qa-export-custom-range">
+                <div class="row gx-3">
+                  <div class="col-6">
+                    <label for="qa-export-start" class="qa-export-label">Start date</label>
+                    <input type="date" id="qa-export-start" class="form-control" aria-label="Custom range start date">
+                  </div>
+                  <div class="col-6">
+                    <label for="qa-export-end" class="qa-export-label">End date</label>
+                    <input type="date" id="qa-export-end" class="form-control" aria-label="Custom range end date">
+                  </div>
+                </div>
+                <p class="qa-export-helper mt-2 mb-0"><i class="fa-regular fa-calendar me-1"></i>Pick any Monday start and Sunday end for custom exports.</p>
               </div>
               <div class="d-flex align-items-center gap-2 mt-3 small text-muted" id="qa-export-period-summary"></div>
             </div>
@@ -1772,7 +1815,16 @@
         period: '',
         agent: '',
         agentScope: '',
-        linkType: 'pdf'
+        linkType: 'pdf',
+        customRange: {
+          start: '',
+          end: ''
+        }
+      },
+      exportPeriods: {
+        Week: [],
+        Month: [],
+        Quarter: []
       },
       loading: false,
       data: null,
@@ -1865,6 +1917,9 @@
       exportPeriod: document.getElementById('qa-export-period'),
       exportYear: document.getElementById('qa-export-year'),
       exportPeriodSummary: document.getElementById('qa-export-period-summary'),
+      exportCustomRange: document.getElementById('qa-export-custom-range'),
+      exportStart: document.getElementById('qa-export-start'),
+      exportEnd: document.getElementById('qa-export-end'),
       exportAgent: document.getElementById('qa-export-agent'),
       exportAgentScope: document.querySelectorAll('input[name="qa-export-agent-scope"]'),
       exportPill: document.getElementById('qa-export-pill'),
@@ -2105,7 +2160,53 @@
         }
       });
 
-      const rows = [[
+      const allAgents = new Set(Object.keys(agentDisplay));
+      matrix.periods.forEach(period => {
+        if (period && period.metrics) {
+          Object.keys(period.metrics).forEach(key => allAgents.add(key));
+        }
+      });
+
+      const agentOrder = Array.from(allAgents).sort((a, b) => {
+        const nameA = (agentDisplay[a] || a || '').toString().toLowerCase();
+        const nameB = (agentDisplay[b] || b || '').toString().toLowerCase();
+        return nameA.localeCompare(nameB);
+      });
+
+      const agentStats = {};
+      const periodKeys = new Set();
+      let totalEvaluations = 0;
+      let totalWeightedScore = 0;
+      let totalWeightedPass = 0;
+
+      function performanceTone(avgScore, passRate) {
+        const avg = typeof avgScore === 'number' && !Number.isNaN(avgScore) ? avgScore : null;
+        const pass = typeof passRate === 'number' && !Number.isNaN(passRate) ? passRate : null;
+        if (avg === null && pass === null) {
+          return 'No data';
+        }
+        if ((avg !== null && avg < 80) || (pass !== null && pass < 80)) {
+          return 'Risk (red)';
+        }
+        if ((avg !== null && avg < 90) || (pass !== null && pass < 90)) {
+          return 'Caution (amber)';
+        }
+        return 'Pass (green)';
+      }
+
+      const rows = [
+        ['QA Quality Report', '', ''],
+        [
+          'Granularity',
+          matrix.granularity || '',
+          'Freeze row 1 to keep headers visible; apply colors: Pass=green, Caution=amber, Risk=red.'
+        ],
+        ['Generated', new Date().toISOString(), ''],
+        []
+      ];
+
+      rows.push(['Period matrix (agent by period)']);
+      rows.push([
         'Granularity',
         'Period Key',
         'Period Label',
@@ -2114,27 +2215,15 @@
         'Average Score (%)',
         'Pass Rate (%)',
         'Evaluations',
-        'Evaluation Share (%)'
-      ]];
-
-      const allAgents = new Set(Object.keys(agentDisplay));
-      matrix.periods.forEach(period => {
-        if (period && period.metrics) {
-          Object.keys(period.metrics).forEach(key => allAgents.add(key));
-        }
-      });
-
-      const agentOrder = Array.from(allAgents);
-      agentOrder.sort((a, b) => {
-        const nameA = (agentDisplay[a] || a || '').toString().toLowerCase();
-        const nameB = (agentDisplay[b] || b || '').toString().toLowerCase();
-        return nameA.localeCompare(nameB);
-      });
+        'Evaluation Share (%)',
+        'Performance Tone'
+      ]);
 
       matrix.periods.forEach(period => {
         if (!period) {
           return;
         }
+        periodKeys.add(period.period || period.label || '');
         const metrics = period.metrics || {};
 
         agentOrder.forEach(agentId => {
@@ -2152,6 +2241,50 @@
             ? detail.evaluationShare
             : '';
 
+          const numericEvals = typeof evaluations === 'number' ? evaluations : 0;
+          const numericAvg = typeof avgScore === 'number' ? avgScore : null;
+          const numericPass = typeof passRate === 'number' ? passRate : null;
+
+          if (!agentStats[agentId]) {
+            agentStats[agentId] = {
+              id: agentId,
+              name: agentDisplay[agentId] || agentId || 'Unassigned',
+              evaluations: 0,
+              weightedScore: 0,
+              weightedPass: 0,
+              periods: new Set(),
+              shares: [],
+              touches: 0
+            };
+          }
+
+          if (numericEvals > 0) {
+            agentStats[agentId].evaluations += numericEvals;
+            agentStats[agentId].touches += 1;
+          }
+          if (numericAvg !== null && numericEvals > 0) {
+            agentStats[agentId].weightedScore += numericAvg * numericEvals;
+          }
+          if (numericPass !== null && numericEvals > 0) {
+            agentStats[agentId].weightedPass += numericPass * numericEvals;
+          }
+          if (numericEvals > 0 || numericAvg !== null || numericPass !== null) {
+            agentStats[agentId].periods.add(period.period || period.label || '');
+          }
+          if (typeof share === 'number') {
+            agentStats[agentId].shares.push(share);
+          }
+
+          if (numericEvals > 0) {
+            totalEvaluations += numericEvals;
+            if (numericAvg !== null) {
+              totalWeightedScore += numericAvg * numericEvals;
+            }
+            if (numericPass !== null) {
+              totalWeightedPass += numericPass * numericEvals;
+            }
+          }
+
           rows.push([
             matrix.granularity || '',
             period.period || '',
@@ -2161,9 +2294,126 @@
             avgScore,
             passRate,
             evaluations,
-            share
+            share,
+            performanceTone(avgScore, passRate)
           ]);
         });
+      });
+
+      rows.push([]);
+      rows.push(['Agent overall scores (all periods)']);
+      rows.push([
+        'Agent Identifier',
+        'Agent Name',
+        'Average Score (%)',
+        'Pass Rate (%)',
+        'Evaluations',
+        'Periods Covered',
+        'Performance Tone'
+      ]);
+
+      agentOrder.forEach(agentId => {
+        const stats = agentStats[agentId] || { periods: new Set(), shares: [] };
+        const evals = stats.evaluations || 0;
+        const avgScore = evals > 0 && stats.weightedScore > 0 ? stats.weightedScore / evals : '';
+        const passRate = evals > 0 && stats.weightedPass >= 0 ? stats.weightedPass / evals : '';
+        rows.push([
+          agentId || '',
+          stats.name || agentDisplay[agentId] || agentId || 'Unassigned',
+          typeof avgScore === 'number' && !Number.isNaN(avgScore) ? Math.round(avgScore * 10) / 10 : '',
+          typeof passRate === 'number' && !Number.isNaN(passRate) ? Math.round(passRate * 10) / 10 : '',
+          evals,
+          Array.from(stats.periods).filter(Boolean).length,
+          performanceTone(avgScore, passRate)
+        ]);
+      });
+
+      const overallAvg = totalEvaluations > 0 ? totalWeightedScore / totalEvaluations : '';
+      const overallPass = totalEvaluations > 0 ? totalWeightedPass / totalEvaluations : '';
+      const portfolioTone = performanceTone(overallAvg, overallPass);
+
+      rows.push([]);
+      rows.push(['Portfolio totals and coverage']);
+      rows.push([
+        'Overall Avg Score (%)',
+        'Overall Pass Rate (%)',
+        'Total Evaluations',
+        'Active Agents',
+        'Periods Analyzed',
+        'Performance Tone'
+      ]);
+      rows.push([
+        typeof overallAvg === 'number' && !Number.isNaN(overallAvg) ? Math.round(overallAvg * 10) / 10 : '',
+        typeof overallPass === 'number' && !Number.isNaN(overallPass) ? Math.round(overallPass * 10) / 10 : '',
+        totalEvaluations,
+        agentOrder.length,
+        Array.from(periodKeys).filter(Boolean).length,
+        portfolioTone
+      ]);
+
+      const rankedAgents = agentOrder
+        .map(id => ({
+          id,
+          name: agentStats[id] ? agentStats[id].name : (agentDisplay[id] || id || 'Unassigned'),
+          evals: agentStats[id] ? agentStats[id].evaluations : 0,
+          avg: agentStats[id] && agentStats[id].evaluations > 0
+            ? agentStats[id].weightedScore / agentStats[id].evaluations
+            : null,
+          pass: agentStats[id] && agentStats[id].evaluations > 0
+            ? agentStats[id].weightedPass / agentStats[id].evaluations
+            : null,
+          touches: agentStats[id] ? agentStats[id].touches : 0
+        }))
+        .filter(agent => agent.evals > 0 && agent.avg !== null)
+        .sort((a, b) => (b.avg || 0) - (a.avg || 0));
+
+      const coachingNeeds = agentOrder
+        .map(id => {
+          const stats = agentStats[id];
+          const evals = stats ? stats.evaluations : 0;
+          const avg = stats && evals > 0 ? stats.weightedScore / evals : null;
+          const pass = stats && evals > 0 ? stats.weightedPass / evals : null;
+          if (!evals) {
+            return {
+              name: stats ? stats.name : (agentDisplay[id] || id || 'Unassigned'),
+              note: 'Needs more evaluations to assess performance.'
+            };
+          }
+          const gaps = [];
+          if (avg !== null && avg < 90) {
+            gaps.push('lift average QA score');
+          }
+          if (pass !== null && pass < 90) {
+            gaps.push('improve pass consistency');
+          }
+          return {
+            name: stats ? stats.name : (agentDisplay[id] || id || 'Unassigned'),
+            note: gaps.length ? gaps.join(' and ') : 'Maintain trajectory with current behaviors.'
+          };
+        })
+        .filter(item => item && item.note);
+
+      rows.push([]);
+      rows.push(['Quality highlights & readiness', 'Detail']);
+      rows.push([
+        'Top performer',
+        rankedAgents.length
+          ? `${rankedAgents[0].name} (${Math.round(rankedAgents[0].avg * 10) / 10}% avg score, ${Math.round((rankedAgents[0].pass || 0) * 10) / 10}% pass across ${rankedAgents[0].evals} evals)`
+          : 'No qualifying agents yet.'
+      ]);
+      rows.push([
+        'Operational coverage',
+        `${agentOrder.length} agents across ${Array.from(periodKeys).filter(Boolean).length} periods (${totalEvaluations} total evaluations).`
+      ]);
+      rows.push([
+        'Data completeness',
+        totalEvaluations > 0 ? 'Ready for review with agent-level rollups and links.' : 'Collect more QA forms to enable analysis.'
+      ]);
+
+      rows.push([]);
+      rows.push(['Agent coaching needs', 'Focus area']);
+      coachingNeeds.forEach(item => {
+        rows.push([item.name, item.note]);
       });
 
       return rows
@@ -2226,6 +2476,53 @@
       return 'Week';
     }
 
+    function seedCustomRangeFromSelection(force) {
+      if (!state.exportOptions.customRange) {
+        state.exportOptions.customRange = { start: '', end: '' };
+      }
+
+      const { start, end } = state.exportOptions.customRange;
+      if (!force && start && end) {
+        return;
+      }
+
+      const option = dom.exportPeriod
+        ? dom.exportPeriod.options[dom.exportPeriod.selectedIndex]
+        : null;
+      const date = option ? parseDateValue(option.value, option.textContent) : new Date();
+      const normalized = normalizeWeekRange(date || new Date());
+      if (normalized) {
+        state.exportOptions.customRange = {
+          start: normalized.monday.toISOString().slice(0, 10),
+          end: normalized.sunday.toISOString().slice(0, 10)
+        };
+      }
+    }
+
+    function handleExportGranularityChange() {
+      const granularity = getSelectedExportGranularity();
+      buildExportPeriodCollections();
+      toggleCustomRange(granularity);
+      if (granularity !== 'Custom') {
+        populateExportPeriodSelect(granularity);
+      } else {
+        seedCustomRangeFromSelection(!state.exportOptions.customRange.start || !state.exportOptions.customRange.end);
+      }
+
+      if (granularity === 'Custom') {
+        if (dom.exportStart) {
+          dom.exportStart.value = state.exportOptions.customRange.start || '';
+        }
+        if (dom.exportEnd) {
+          dom.exportEnd.value = state.exportOptions.customRange.end || '';
+        }
+      }
+      syncExportYear();
+      updateExportPeriodSummary();
+      updateExportPill();
+      updateExportNote();
+    }
+
     function toggleExportAgentScope(scopeValue) {
       if (!dom.exportAgent) {
         return;
@@ -2257,15 +2554,167 @@
       return '';
     }
 
+    function parseDateValue(value, labelText) {
+      const tryParse = input => {
+        if (!input) return null;
+        const parsed = Date.parse(input);
+        return Number.isNaN(parsed) ? null : new Date(parsed);
+      };
+
+      const candidates = [value, labelText];
+      for (let i = 0; i < candidates.length; i += 1) {
+        const candidate = candidates[i];
+        const date = tryParse(candidate);
+        if (date) {
+          return date;
+        }
+        const match = candidate && candidate.match(/(20\d{2}-\d{2}-\d{2})/);
+        if (match) {
+          const fallbackDate = tryParse(match[1]);
+          if (fallbackDate) {
+            return fallbackDate;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    function formatDisplayDate(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+    }
+
+    function normalizeWeekRange(date) {
+      if (!(date instanceof Date)) {
+        return null;
+      }
+      const monday = new Date(date);
+      const day = monday.getDay();
+      const diff = day === 0 ? -6 : 1 - day;
+      monday.setDate(monday.getDate() + diff);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+      return { monday, sunday };
+    }
+
+    function formatWeekSummary(date, fallbackLabel) {
+      const range = normalizeWeekRange(date);
+      if (!range) {
+        return fallbackLabel || 'Latest available period';
+      }
+      return `${formatDisplayDate(range.monday)} – ${formatDisplayDate(range.sunday)}`;
+    }
+
     function syncExportYear() {
       if (!dom.exportYear) {
         return;
       }
 
-      const periodValue = dom.exportPeriod ? (dom.exportPeriod.value || '') : (state.filters.period || '');
+      const granularity = getSelectedExportGranularity();
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const preferred = parseDateValue(start || end, start || end);
+        dom.exportYear.value = preferred ? String(preferred.getFullYear()) : String(new Date().getFullYear());
+        return;
+      }
+
+      const option = dom.exportPeriod
+        ? dom.exportPeriod.options[dom.exportPeriod.selectedIndex]
+        : null;
+      const periodValue = option && option.value ? option.value : (state.filters.period || '');
       const yearMatch = periodValue && /(20\d{2})/.exec(periodValue);
       const year = yearMatch ? yearMatch[1] : String(new Date().getFullYear());
       dom.exportYear.value = year;
+    }
+
+    function buildExportPeriodCollections() {
+      const periodOptions = dom.period && dom.period.options
+        ? Array.from(dom.period.options)
+        : [];
+
+      const weekOptions = periodOptions
+        .filter(option => option && option.value)
+        .map(option => {
+          const label = option.textContent ? option.textContent.trim() : option.value;
+          const date = parseDateValue(option.value, label);
+          const summary = formatWeekSummary(date, label);
+          return {
+            value: option.value,
+            label,
+            summary,
+            date
+          };
+        });
+
+      const monthLookup = {};
+      weekOptions.forEach(option => {
+        if (!option.date) {
+          return;
+        }
+        const start = new Date(option.date.getFullYear(), option.date.getMonth(), 1);
+        const end = new Date(option.date.getFullYear(), option.date.getMonth() + 1, 0);
+        const key = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+        if (!monthLookup[key]) {
+          monthLookup[key] = {
+            value: key,
+            label: `${start.toLocaleString('en-US', { month: 'long' })} ${start.getFullYear()}`,
+            summary: `${formatDisplayDate(start)} – ${formatDisplayDate(end)}`,
+            date: start
+          };
+        }
+      });
+
+      const quarterLookup = {};
+      weekOptions.forEach(option => {
+        if (!option.date) {
+          return;
+        }
+        const quarterIndex = Math.floor(option.date.getMonth() / 3);
+        const quarterStartMonth = quarterIndex * 3;
+        const start = new Date(option.date.getFullYear(), quarterStartMonth, 1);
+        const end = new Date(option.date.getFullYear(), quarterStartMonth + 3, 0);
+        const key = `${start.getFullYear()}-Q${quarterIndex + 1}`;
+        if (!quarterLookup[key]) {
+          quarterLookup[key] = {
+            value: key,
+            label: `Q${quarterIndex + 1} ${start.getFullYear()}`,
+            summary: `${formatDisplayDate(start)} – ${formatDisplayDate(end)}`,
+            date: start
+          };
+        }
+      });
+
+      state.exportPeriods.Week = weekOptions;
+      state.exportPeriods.Month = Object.values(monthLookup).sort((a, b) => (b.value > a.value ? 1 : -1));
+      state.exportPeriods.Quarter = Object.values(quarterLookup).sort((a, b) => (b.value > a.value ? 1 : -1));
+    }
+
+    function populateExportPeriodSelect(granularity) {
+      if (!dom.exportPeriod) {
+        return;
+      }
+
+      const options = state.exportPeriods[granularity] || [];
+      dom.exportPeriod.innerHTML = '';
+
+      options.forEach(option => {
+        const opt = document.createElement('option');
+        opt.value = option.value;
+        opt.textContent = option.label;
+        if (option.summary) {
+          opt.dataset.summary = option.summary;
+        }
+        dom.exportPeriod.appendChild(opt);
+      });
+
+      const current = options.find(option => option.value === state.exportOptions.period) || options[0];
+      if (current) {
+        dom.exportPeriod.value = current.value;
+        state.exportOptions.period = current.value;
+      }
     }
 
     function updateExportPeriodSummary() {
@@ -2273,12 +2722,27 @@
         return;
       }
 
+      const granularity = getSelectedExportGranularity();
+
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const startDate = parseDateValue(start, start);
+        const endDate = parseDateValue(end, end);
+        const startLabel = startDate ? formatDisplayDate(startDate) : 'Start';
+        const endLabel = endDate ? formatDisplayDate(endDate) : 'End';
+        dom.exportPeriodSummary.innerHTML = `<i class="fa-solid fa-calendar-week me-2"></i>${startLabel} – ${endLabel}`;
+        return;
+      }
+
       const option = dom.exportPeriod
         ? dom.exportPeriod.options[dom.exportPeriod.selectedIndex]
         : null;
-      const summaryText = option && option.textContent
-        ? option.textContent.trim()
-        : 'Latest available period';
+      let summaryText = 'Latest available period';
+      if (option) {
+        summaryText = option.dataset && option.dataset.summary
+          ? option.dataset.summary
+          : (option.textContent ? option.textContent.trim() : summaryText);
+      }
 
       dom.exportPeriodSummary.innerHTML = `<i class="fa-solid fa-calendar-week me-2"></i>${summaryText}`;
     }
@@ -2291,7 +2755,24 @@
       const granularity = getSelectedExportGranularity();
       const linkType = getSelectedExportLinkType();
       const linkLabel = linkType === 'call' ? 'Call links' : 'PDF links';
-      dom.exportPill.textContent = `${granularity} • ${linkLabel}`;
+
+      let periodLabel = '';
+      if (granularity === 'Custom' && state.exportOptions.customRange) {
+        const { start, end } = state.exportOptions.customRange;
+        const startDate = parseDateValue(start, start);
+        const endDate = parseDateValue(end, end);
+        periodLabel = `${startDate ? formatDisplayDate(startDate) : 'Start'} → ${endDate ? formatDisplayDate(endDate) : 'End'}`;
+      } else if (dom.exportPeriod) {
+        const option = dom.exportPeriod.options[dom.exportPeriod.selectedIndex];
+        if (option) {
+          periodLabel = option.dataset && option.dataset.summary
+            ? option.dataset.summary
+            : option.textContent;
+        }
+      }
+
+      const labelParts = [granularity, linkLabel].filter(Boolean).join(' • ');
+      dom.exportPill.textContent = periodLabel ? `${labelParts} • ${periodLabel}` : labelParts;
     }
 
     function updateExportNote() {
@@ -2305,15 +2786,31 @@
         : null;
       const isSingle = scope && scope.value === 'single';
       const agent = isSingle && dom.exportAgent ? dom.exportAgent.value : '';
+      const linkType = getSelectedExportLinkType();
+      const linkLabel = linkType === 'call' ? 'call recording links' : 'PDF links';
       const agentNote = agent ? 'Limited to the selected agent.' : 'Includes all agents in the view.';
-      dom.exportNote.textContent = `${granularity} metrics with per-call links. ${agentNote}`;
+      const periodNote = granularity === 'Custom'
+        ? 'Custom range honors Monday starts and Sunday endings.'
+        : `${granularity} metrics with ${linkLabel}.`;
+      const contentNote = 'Report adds color-coded headers, per-period matrix, agent rollups, portfolio totals, and coaching focus areas.';
+      dom.exportNote.textContent = `${periodNote} ${agentNote} ${contentNote}`;
+    }
+
+    function toggleCustomRange(granularity) {
+      const useCustom = granularity === 'Custom';
+      if (dom.exportCustomRange) {
+        dom.exportCustomRange.classList.toggle('active', useCustom);
+      }
+      if (dom.exportPeriod) {
+        dom.exportPeriod.disabled = useCustom;
+        dom.exportPeriod.classList.toggle('disabled', useCustom);
+      }
     }
 
     function syncExportModalForm() {
-      if (dom.exportPeriod && dom.period) {
-        dom.exportPeriod.innerHTML = dom.period.innerHTML;
-        dom.exportPeriod.value = state.filters.period || dom.period.value || '';
-      }
+      buildExportPeriodCollections();
+      const granularity = getSelectedExportGranularity();
+      populateExportPeriodSelect(granularity);
 
       if (dom.exportAgent && dom.agent) {
         dom.exportAgent.innerHTML = dom.agent.innerHTML;
@@ -2325,6 +2822,7 @@
         : null;
       toggleExportAgentScope(scope && scope.value ? scope.value : '');
 
+      toggleCustomRange(granularity);
       syncExportYear();
       updateExportPeriodSummary();
       updateExportPill();
@@ -2373,8 +2871,9 @@
       const periodValue = dom.exportPeriod ? dom.exportPeriod.value : state.filters.period;
 
       request.linkType = getSelectedExportLinkType();
-      request.granularity = granularity === 'Week' ? 'Week' : 'Week';
-      request.period = granularity === 'Week' ? periodValue : '';
+      request.granularity = granularity;
+      request.period = granularity === 'Custom' ? '' : periodValue;
+      request.customRange = granularity === 'Custom' ? (state.exportOptions.customRange || null) : null;
       request.agent = selectedAgent || state.filters.agent || '';
 
       state.exportOptions.period = request.period;
@@ -4213,6 +4712,8 @@
       if (dom.granularity && response && response.context && response.context.granularity) {
         dom.granularity.value = response.context.granularity;
       }
+
+      buildExportPeriodCollections();
     }
 
     function showError(message) {
@@ -4410,16 +4911,17 @@
       if (dom.exportGranularity && dom.exportGranularity.length) {
         dom.exportGranularity.forEach(radio => {
           radio.addEventListener('change', () => {
-            updateExportPill();
-            updateExportNote();
+            handleExportGranularityChange();
           });
         });
       }
 
       if (dom.exportPeriod) {
         dom.exportPeriod.addEventListener('change', () => {
+          state.exportOptions.period = dom.exportPeriod.value;
           syncExportYear();
           updateExportPeriodSummary();
+          updateExportPill();
         });
       }
 
@@ -4436,6 +4938,24 @@
             toggleExportAgentScope(event.target.value);
             updateExportNote();
           });
+        });
+      }
+
+      if (dom.exportStart) {
+        dom.exportStart.addEventListener('change', event => {
+          state.exportOptions.customRange.start = event.target.value;
+          syncExportYear();
+          updateExportPeriodSummary();
+          updateExportPill();
+        });
+      }
+
+      if (dom.exportEnd) {
+        dom.exportEnd.addEventListener('change', event => {
+          state.exportOptions.customRange.end = event.target.value;
+          syncExportYear();
+          updateExportPeriodSummary();
+          updateExportPill();
         });
       }
 

--- a/QAService.js
+++ b/QAService.js
@@ -1697,32 +1697,39 @@ function clientExportWeeklyAgentMatrix(request = {}) {
       filters: { agent: '', campaignId: '', program: '' },
       depth: 6,
       agentUniverse: null,
-      passMark: QA_INTEL_PASS_MARK
+      passMark: QA_INTEL_PASS_MARK,
+      customRange: null
     };
 
     const context = Object.assign({}, baseContext, {
-      granularity: 'Week',
+      granularity: baseContext.granularity || 'Week',
       depth: 1,
-      period: baseContext.period || determineLatestPeriod_('Week', normalizedRecords)
+      period: baseContext.granularity === 'Custom'
+        ? buildCustomPeriodKey_(baseContext.customRange)
+        : (baseContext.period || determineLatestPeriod_(baseContext.granularity || 'Week', normalizedRecords))
     });
 
-    if (!context.period) {
-      return { success: false, error: 'No weekly period available to export.' };
+    if (!context.period && context.granularity !== 'Custom') {
+      return { success: false, error: 'No period available to export.' };
     }
 
     const agentLookup = buildAgentDisplayLookup_(normalizedRecords);
-    const matrix = buildAgentGranularityMatrix_(context, normalizedRecords, { displayLookup: agentLookup });
-    const periodEntry = (matrix.periods || []).find(period => period && period.period === context.period)
-      || (matrix.periods || [])[0]
-      || null;
+    const currentPeriodRecords = filterRecordsForIntelligence_(normalizedRecords, context);
+    const previousPeriod = context.granularity !== 'Custom'
+      ? getPreviousPeriod_(context.granularity, context.period)
+      : '';
+    const previousPeriodRecords = previousPeriod
+      ? filterRecordsForIntelligence_(normalizedRecords, { ...context, period: previousPeriod })
+      : [];
 
-    const weeklyRecords = filterRecordsForIntelligence_(normalizedRecords, { ...context, period: context.period });
-    const rows = buildWeeklyAgentExportRows_(context, periodEntry, weeklyRecords, {
+    const report = buildQualityReport_(context, currentPeriodRecords, {
       linkType,
-      agentLookup
+      agentLookup,
+      previousPeriodRecords,
+      previousPeriod
     });
 
-    const file = writeWeeklyAgentExport_(rows, context, linkType);
+    const file = writeWeeklyAgentExport_(report, context, linkType);
 
     return {
       success: true,
@@ -1733,7 +1740,7 @@ function clientExportWeeklyAgentMatrix(request = {}) {
       spreadsheetUrl: file.spreadsheetUrl,
       spreadsheetName: file.spreadsheetName,
       sheetName: file.sheetName,
-      rows: rows.length
+      rows: report && report.detail && report.detail.rows ? report.detail.rows.length : 0
     };
   } catch (error) {
     console.error('clientExportWeeklyAgentMatrix failed:', error);
@@ -1767,13 +1774,14 @@ function normalizeIntelligenceRequest_(request, rawRecords) {
   const depth = Number(request.depth) > 0 ? Math.min(Number(request.depth), 12) : 6;
 
   const passMark = typeof request.passMark === 'number' ? request.passMark : QA_INTEL_PASS_MARK;
+  const customRange = normalizeCustomRange_(request.customRange, timezone);
 
   const normalizedRecords = (rawRecords || [])
     .map(record => normalizeQaRecord_(record, timezone, passMark))
     .filter(record => record.callDate instanceof Date);
 
   let period = (request && request.period) ? String(request.period) : '';
-  if (!period) {
+  if (!period && granularity !== 'Custom') {
     period = determineLatestPeriod_(granularity, normalizedRecords);
   }
 
@@ -1785,9 +1793,10 @@ function normalizeIntelligenceRequest_(request, rawRecords) {
       filters,
       depth,
       agentUniverse,
-    passMark
-  },
-  records: normalizedRecords
+      passMark,
+      customRange
+    },
+    records: normalizedRecords
   };
 }
 
@@ -1899,6 +1908,14 @@ function filterRecordsForIntelligence_(records, context) {
     if (filters.agent && record.agent !== filters.agent) return false;
     if (filters.campaignId && record.campaign !== filters.campaignId) return false;
     if (filters.program && record.raw && record.raw.Program !== filters.program) return false;
+
+    if (granularity === 'Custom' && context.customRange && context.customRange.start && context.customRange.end) {
+      const callDate = record.callDate;
+      if (!(callDate instanceof Date)) {
+        return false;
+      }
+      return callDate >= context.customRange.start && callDate <= context.customRange.end;
+    }
 
     if (!period) return true;
 
@@ -2669,114 +2686,104 @@ function buildAgentGranularityMatrix_(context, records, options = {}) {
   };
 }
 
-function buildWeeklyAgentExportRows_(context, periodEntry, records, options = {}) {
+function buildQualityReport_(context, records, options = {}) {
   const linkType = normalizeLinkType_(options.linkType);
   const agentLookup = options.agentLookup || {};
-  const metrics = (periodEntry && periodEntry.metrics) ? periodEntry.metrics : {};
-  const totalEvaluations = periodEntry && typeof periodEntry.totalEvaluations === 'number'
-    ? periodEntry.totalEvaluations
-    : records.length;
-  const periodLabel = periodEntry ? (periodEntry.label || '') : formatPeriodLabel_(context.granularity || 'Week', context.period);
-  const linkLabel = linkType === 'call' ? 'Call Recording Link' : 'Google Drive/PDF Link';
+  const passMark = typeof context.passMark === 'number' ? context.passMark : QA_INTEL_PASS_MARK;
+  const timezone = context.timezone || Session.getScriptTimeZone();
+  const categories = qaCategories_();
 
-  const headers = [
-    'Granularity',
-    'Period Key',
-    'Period Label',
-    'Agent Identifier',
-    'Agent Name',
-    'Average Score (%)',
-    'Pass Rate (%)',
-    'Evaluations',
-    'Evaluation Share (%)',
-    'Call Date',
-    'Call Identifier',
-    'Call Score (%)',
-    'Link Type',
-    linkLabel
-  ];
-
-  const rows = [headers];
-  const agents = new Set(Object.keys(metrics));
-  records.forEach(record => agents.add(record.agent || 'Unassigned'));
-
-  Array.from(agents).sort((a, b) => {
-    const nameA = resolveAgentDisplayNameFromLookup_(a, agentLookup).toLowerCase();
-    const nameB = resolveAgentDisplayNameFromLookup_(b, agentLookup).toLowerCase();
-    return nameA.localeCompare(nameB);
-  }).forEach(agentId => {
-    const detail = metrics[agentId] || {};
-    const agentName = resolveAgentDisplayNameFromLookup_(agentId, agentLookup);
-    const evaluationShare = detail.evaluationShare !== undefined && detail.evaluationShare !== null
-      ? detail.evaluationShare
-      : (totalEvaluations ? roundOneDecimal_(((detail.evaluations || 0) / totalEvaluations) * 100) : null);
-
-    const calls = records.filter(record => (record.agent || 'Unassigned') === agentId);
-
-    if (!calls.length) {
-      rows.push([
-        context.granularity || 'Week',
-        context.period || '',
-        periodLabel,
-        agentId || 'Unassigned',
-        agentName || 'Unassigned',
-        detail.avgScore ?? '',
-        detail.passRate ?? '',
-        detail.evaluations ?? '',
-        evaluationShare ?? '',
-        '',
-        '',
-        '',
-        linkType === 'call' ? 'Call Recording' : 'QA PDF',
-        ''
-      ]);
-      return;
-    }
-
-    calls.forEach(call => {
-      const callDate = call.callDateIso || (call.callDate instanceof Date
-        ? Utilities.formatDate(call.callDate, context.timezone || Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm:ssXXX")
-        : '');
-      const callId = extractCallIdentifierFromRecord_(call.raw || {});
-      const link = extractLinkForType_(call.raw || {}, linkType);
-      const callScore = typeof call.recordScore === 'number' && !Number.isNaN(call.recordScore)
-        ? call.recordScore
-        : (typeof call.percentage === 'number' ? Math.round(call.percentage * 100) : '');
-
-      rows.push([
-        context.granularity || 'Week',
-        context.period || '',
-        periodLabel,
-        agentId || 'Unassigned',
-        agentName || 'Unassigned',
-        detail.avgScore ?? '',
-        detail.passRate ?? '',
-        detail.evaluations ?? '',
-        evaluationShare ?? '',
-        callDate,
-        callId || '',
-        callScore,
-        linkType === 'call' ? 'Call Recording' : 'QA PDF',
-        link || ''
-      ]);
-    });
+  const detail = buildQualityDetailRows_(records, {
+    linkType,
+    agentLookup,
+    passMark,
+    timezone,
+    categories,
+    periodLabel: formatPeriodLabelSafe_(context)
   });
 
-  return rows;
+  const agentSummary = buildAgentSummaryRows_(records, {
+    agentLookup,
+    passMark,
+    categories,
+    previousRecords: options.previousPeriodRecords || [],
+    previousPeriod: options.previousPeriod || ''
+  });
+
+  const teamSummary = buildTeamSummaryRows_(records, {
+    agentLookup,
+    passMark,
+    categories,
+    agentUniverse: context.agentUniverse,
+    previousRecords: options.previousPeriodRecords || [],
+    previousPeriod: options.previousPeriod || '',
+    granularity: context.granularity,
+    periodLabel: formatPeriodLabelSafe_(context)
+  });
+
+  const improvement = buildImprovementRows_(records, {
+    agentLookup,
+    passMark,
+    categories,
+    timezone
+  });
+
+  return {
+    detail,
+    agentSummary,
+    teamSummary,
+    improvement,
+    context,
+    linkType
+  };
 }
 
-function writeWeeklyAgentExport_(rows, context, linkType) {
-  const safeRows = Array.isArray(rows) && rows.length ? rows : [['No data available for the selected week']];
-  const sheetName = 'Weekly Agent Matrix';
-  const label = formatPeriodLabel_(context.granularity || 'Week', context.period || '');
-  const spreadsheetName = `Weekly Agent Matrix - ${label || context.period || 'Latest'} (${linkType === 'call' ? 'Calls' : 'PDFs'})`;
+function writeWeeklyAgentExport_(report, context, linkType) {
+  const detailRows = (report.detail && report.detail.rows && report.detail.rows.length)
+    ? report.detail.rows
+    : [['No data available for the selected period']];
+  const sheetName = 'Quality Report';
+  const label = formatPeriodLabelSafe_(context);
+  const spreadsheetName = `${context.granularity || 'Quality'} Report - ${label || context.period || 'Latest'} (${linkType === 'call' ? 'Calls' : 'PDFs'})`;
 
   const spreadsheet = SpreadsheetApp.create(spreadsheetName);
-  const sheet = spreadsheet.getSheets()[0];
-  sheet.setName(sheetName);
-  sheet.getRange(1, 1, safeRows.length, safeRows[0].length).setValues(safeRows);
+  const detailSheet = spreadsheet.getSheets()[0];
+  detailSheet.setName('Detail');
+  detailSheet.getRange(1, 1, detailRows.length, detailRows[0].length).setValues(detailRows);
+  applyHeaderStyling_(detailSheet, 1);
+  detailSheet.setFrozenRows(1);
+  applyPassFailFormatting_(detailSheet, report.detail.scoreColumns, detailRows.length, passMarkForContext_(context));
+  detailSheet.autoResizeColumns(1, detailRows[0].length);
 
-  sheet.autoResizeColumns(1, safeRows[0].length);
+  if (report.agentSummary && report.agentSummary.rows && report.agentSummary.rows.length) {
+    const agentSheet = spreadsheet.insertSheet('Agent Summary');
+    agentSheet.getRange(1, 1, report.agentSummary.rows.length, report.agentSummary.rows[0].length)
+      .setValues(report.agentSummary.rows);
+    applyHeaderStyling_(agentSheet, 1);
+    agentSheet.setFrozenRows(1);
+    applyPassFailFormatting_(agentSheet, report.agentSummary.scoreColumns, report.agentSummary.rows.length, passMarkForContext_(context));
+    agentSheet.autoResizeColumns(1, report.agentSummary.rows[0].length);
+  }
+
+  if (report.teamSummary && report.teamSummary.rows && report.teamSummary.rows.length) {
+    const teamSheet = spreadsheet.insertSheet('Team Summary');
+    teamSheet.getRange(1, 1, report.teamSummary.rows.length, report.teamSummary.rows[0].length)
+      .setValues(report.teamSummary.rows);
+    applyHeaderStyling_(teamSheet, 1);
+    teamSheet.setFrozenRows(1);
+    applyPassFailFormatting_(teamSheet, report.teamSummary.scoreColumns, report.teamSummary.rows.length, passMarkForContext_(context));
+    teamSheet.autoResizeColumns(1, report.teamSummary.rows[0].length);
+  }
+
+  if (report.improvement && report.improvement.rows && report.improvement.rows.length) {
+    const improvementSheet = spreadsheet.insertSheet('Agent Improvement Areas');
+    improvementSheet.getRange(1, 1, report.improvement.rows.length, report.improvement.rows[0].length)
+      .setValues(report.improvement.rows);
+    applyHeaderStyling_(improvementSheet, 1);
+    improvementSheet.setFrozenRows(1);
+    applyPassFailFormatting_(improvementSheet, report.improvement.scoreColumns, report.improvement.rows.length, passMarkForContext_(context));
+    improvementSheet.autoResizeColumns(1, report.improvement.rows[0].length);
+  }
 
   return {
     spreadsheetId: spreadsheet.getId(),
@@ -2784,6 +2791,389 @@ function writeWeeklyAgentExport_(rows, context, linkType) {
     spreadsheetName,
     sheetName
   };
+}
+
+function buildQualityDetailRows_(records, options) {
+  const rows = [[
+    'Agent ID',
+    'Agent Name',
+    'Call Date',
+    'Program/Campaign',
+    'Period',
+    'Overall QA Score (%)',
+    'Pass/Fail',
+    'Compliance (%)',
+    'Resolution (%)',
+    'Case Documentation (%)',
+    'Process Compliance (%)',
+    'Critical Fail',
+    'Link Type',
+    options.linkType === 'call' ? 'Call Recording Link' : 'QA PDF/Drive Link',
+    'Evaluator',
+    'Notes',
+    'Evaluation ID'
+  ]];
+
+  const scoreColumns = [6, 8, 9, 10, 11];
+  const timezone = options.timezone || Session.getScriptTimeZone();
+  (records || []).forEach(record => {
+    const categories = computeCategoryMetrics_([record]);
+    const compliance = categories['Courtesy & Communication'] ? categories['Courtesy & Communication'].avgScore : '';
+    const resolution = categories.Resolution ? categories.Resolution.avgScore : '';
+    const documentation = categories['Case Documentation'] ? categories['Case Documentation'].avgScore : '';
+    const process = categories['Process Compliance'] ? categories['Process Compliance'].avgScore : '';
+    const callDate = record.callDate instanceof Date
+      ? Utilities.formatDate(record.callDate, timezone, 'yyyy-MM-dd')
+      : '';
+    const evaluator = getRecordFieldValue_(record.raw || {}, ['Evaluator', 'QA Agent', 'Quality Analyst', 'QA']);
+    const notes = getRecordFieldValue_(record.raw || {}, ['Notes', 'Summary', 'Comments', 'Agent Feedback']) || '';
+    const evaluationId = getRecordFieldValue_(record.raw || {}, ['QAID', 'ID', 'Eval ID', 'Evaluation ID']);
+    const overallScore = typeof record.recordScore === 'number' ? record.recordScore : Math.round((record.percentage || 0) * 100);
+    const link = extractLinkForType_(record.raw || {}, options.linkType);
+    const callId = extractCallIdentifierFromRecord_(record.raw || {});
+
+    rows.push([
+      record.agent || 'Unassigned',
+      resolveAgentDisplayNameFromLookup_(record.agent, options.agentLookup),
+      callDate,
+      resolveProgramNameFromRecord_(record),
+      options.periodLabel || '',
+      overallScore,
+      record.pass ? 'Pass' : 'Fail',
+      compliance,
+      resolution,
+      documentation,
+      process,
+      hasCriticalFail_(record.raw || {}) ? 'Yes' : 'No',
+      options.linkType === 'call' ? 'Call Recording' : 'QA PDF',
+      link || callId || '',
+      evaluator || '',
+      notes || '',
+      evaluationId || ''
+    ]);
+  });
+
+  return { rows, scoreColumns };
+}
+
+function buildAgentSummaryRows_(records, options) {
+  const headers = [
+    'Agent ID', 'Agent Name', 'Evaluations', 'Average QA Score (%)', 'Pass Rate (%)', 'Passes', 'Fails', 'Critical Fails',
+    'Compliance Avg (%)', 'Resolution Avg (%)', 'Documentation Avg (%)', 'Process Avg (%)', 'Trend vs Prior'
+  ];
+  const rows = [headers];
+  const scoreColumns = [4, 5, 9, 10, 11, 12];
+  const grouped = groupRecordsByAgent_(records);
+  const previousGrouped = groupRecordsByAgent_(options.previousRecords || []);
+
+  Object.keys(grouped).sort().forEach(agentId => {
+    const agentRecords = grouped[agentId];
+    const stats = summarizeAgentMetrics_(agentRecords, options.passMark, options.categories);
+    const priorStats = previousGrouped[agentId]
+      ? summarizeAgentMetrics_(previousGrouped[agentId], options.passMark, options.categories)
+      : null;
+    const trend = priorStats && typeof stats.avgScore === 'number' && typeof priorStats.avgScore === 'number'
+      ? describeTrend_(stats.avgScore, priorStats.avgScore)
+      : 'N/A';
+
+    rows.push([
+      agentId,
+      resolveAgentDisplayNameFromLookup_(agentId, options.agentLookup),
+      stats.evaluations,
+      stats.avgScore,
+      stats.passRate,
+      stats.passCount,
+      stats.failCount,
+      stats.criticalFails,
+      stats.categories['Courtesy & Communication'],
+      stats.categories.Resolution,
+      stats.categories['Case Documentation'],
+      stats.categories['Process Compliance'],
+      trend
+    ]);
+  });
+
+  return { rows, scoreColumns };
+}
+
+function buildTeamSummaryRows_(records, options) {
+  const totalEvaluations = records.length;
+  const uniqueAgents = new Set((records || []).map(r => r.agent).filter(Boolean));
+  const avgScore = totalEvaluations
+    ? Math.round((records.reduce((sum, r) => sum + (r.recordScore || Math.round((r.percentage || 0) * 100)), 0) / totalEvaluations) * 10) / 10
+    : 0;
+  const passCount = (records || []).filter(r => r.pass).length;
+  const passRate = totalEvaluations ? Math.round((passCount / totalEvaluations) * 1000) / 10 : 0;
+  const coverage = options.agentUniverse
+    ? Math.min(Math.round((uniqueAgents.size / options.agentUniverse) * 1000) / 10, 100)
+    : (uniqueAgents.size > 0 ? 100 : 0);
+  const categories = computeCategoryMetrics_(records);
+  const criticalFails = (records || []).filter(r => hasCriticalFail_(r.raw || {})).length;
+  const distribution = buildScoreDistribution_(records);
+  const programCounts = buildProgramCounts_(records);
+  const previousStats = summarizeAgentMetrics_(options.previousRecords || [], options.passMark, options.categories);
+  const avgTrend = previousStats && typeof previousStats.avgScore === 'number'
+    ? describeTrend_(avgScore, previousStats.avgScore)
+    : 'N/A';
+  const passTrend = previousStats && typeof previousStats.passRate === 'number'
+    ? describeTrend_(passRate, previousStats.passRate)
+    : 'N/A';
+  const impactAgents = identifyImpactAgents_(records, options.passMark, options.categories);
+  const topBottom = rankAgentsByScore_(records, options.categories, 3);
+
+  const rows = [[
+    'Metric', 'Value'
+  ],
+  ['Granularity', options.granularity || ''],
+  ['Period', options.periodLabel || ''],
+  ['Evaluations', totalEvaluations],
+  ['Agents Evaluated', uniqueAgents.size],
+  ['Agent Coverage (%)', coverage],
+  ['Average QA Score (%)', avgScore],
+  ['Pass Rate (%)', passRate],
+  ['Critical Fails', criticalFails],
+  ['Avg Compliance (%)', categories['Courtesy & Communication'] ? categories['Courtesy & Communication'].avgScore : ''],
+  ['Avg Resolution (%)', categories.Resolution ? categories.Resolution.avgScore : ''],
+  ['Avg Documentation (%)', categories['Case Documentation'] ? categories['Case Documentation'].avgScore : ''],
+  ['Avg Process (%)', categories['Process Compliance'] ? categories['Process Compliance'].avgScore : ''],
+  ['Trend (Avg Score)', avgTrend],
+  ['Trend (Pass Rate)', passTrend],
+  ['Top Performers', topBottom.top.join(', ') || ''],
+  ['Lowest Performers', topBottom.bottom.join(', ') || ''],
+  ['Highest Impact Agents', impactAgents.join(', ') || '']
+  ];
+
+  rows.push(['', '']);
+  rows.push(['Score Distribution', 'Count']);
+  distribution.forEach(entry => rows.push([entry.label, entry.count]));
+
+  rows.push(['', '']);
+  rows.push(['Evaluations by Program/Campaign', 'Count']);
+  programCounts.forEach(entry => rows.push([entry.program, entry.count]));
+
+  return { rows, scoreColumns: [2] };
+}
+
+function buildImprovementRows_(records, options) {
+  const headers = ['Agent ID', 'Agent Name', 'Key Weaknesses', 'Suggested Coaching Focus', 'Supporting Evaluations'];
+  const rows = [headers];
+  const grouped = groupRecordsByAgent_(records);
+
+  Object.keys(grouped).sort().forEach(agentId => {
+    const agentRecords = grouped[agentId];
+    const categoryStats = summarizeAgentMetrics_(agentRecords, options.passMark, options.categories);
+    const weakAreas = Object.keys(categoryStats.categories)
+      .map(key => ({ key, value: categoryStats.categories[key] }))
+      .filter(item => typeof item.value === 'number' && item.value < options.passMark)
+      .sort((a, b) => a.value - b.value)
+      .slice(0, 3)
+      .map(item => `${item.key} (${item.value}%)`);
+
+    const notes = aggregateNotes_(agentRecords).slice(0, 2).join(' | ');
+    const failDates = agentRecords
+      .filter(r => !r.pass || hasCriticalFail_(r.raw || {}))
+      .map(r => r.callDate instanceof Date ? Utilities.formatDate(r.callDate, options.timezone || Session.getScriptTimeZone(), 'yyyy-MM-dd') : '')
+      .filter(Boolean)
+      .slice(0, 3)
+      .join(', ');
+
+    const focus = weakAreas.length
+      ? `Improve on ${weakAreas.join(', ')}. ${notes || 'Reinforce SOP adherence and documentation.'}`
+      : (notes || 'Maintain consistency and reinforce strengths.');
+
+    rows.push([
+      agentId,
+      resolveAgentDisplayNameFromLookup_(agentId, options.agentLookup),
+      weakAreas.join(', ') || 'None flagged',
+      focus,
+      failDates || 'Recent evaluations referenced'
+    ]);
+  });
+
+  return { rows, scoreColumns: [] };
+}
+
+function applyHeaderStyling_(sheet, headerRow) {
+  const range = sheet.getRange(headerRow, 1, 1, sheet.getLastColumn());
+  range.setBackground('#0f172a').setFontColor('#ffffff').setFontWeight('bold').setHorizontalAlignment('center');
+}
+
+function applyPassFailFormatting_(sheet, scoreColumns, rowCount, passMark) {
+  if (!scoreColumns || !scoreColumns.length || rowCount <= 1) {
+    return;
+  }
+  const rules = sheet.getConditionalFormatRules() || [];
+  scoreColumns.forEach(col => {
+    const range = sheet.getRange(2, col, rowCount - 1, 1);
+    rules.push(SpreadsheetApp.newConditionalFormatRule()
+      .whenNumberGreaterThanOrEqualTo(passMark)
+      .setBackground('#d1fae5')
+      .setRanges([range])
+      .build());
+    rules.push(SpreadsheetApp.newConditionalFormatRule()
+      .whenNumberLessThan(passMark)
+      .setBackground('#fee2e2')
+      .setRanges([range])
+      .build());
+  });
+  sheet.setConditionalFormatRules(rules);
+}
+
+function formatPeriodLabelSafe_(context) {
+  if (context.granularity === 'Custom' && context.customRange) {
+    const start = context.customRange.start
+      ? Utilities.formatDate(context.customRange.start, context.timezone || Session.getScriptTimeZone(), 'yyyy-MM-dd')
+      : 'Start';
+    const end = context.customRange.end
+      ? Utilities.formatDate(context.customRange.end, context.timezone || Session.getScriptTimeZone(), 'yyyy-MM-dd')
+      : 'End';
+    return `${start} to ${end}`;
+  }
+  return formatPeriodLabel_(context.granularity || 'Week', context.period || '');
+}
+
+function passMarkForContext_(context) {
+  return typeof context.passMark === 'number' ? context.passMark : QA_INTEL_PASS_MARK;
+}
+
+function normalizeCustomRange_(range, timezone) {
+  if (!range || (!range.start && !range.end)) {
+    return null;
+  }
+  const start = coerceDateValue_(range.start || range.from);
+  const end = coerceDateValue_(range.end || range.to);
+  if (!(start instanceof Date) || !(end instanceof Date)) {
+    return null;
+  }
+  const tz = timezone || Session.getScriptTimeZone();
+  const startDate = new Date(Utilities.formatDate(start, tz, 'yyyy-MM-dd'));
+  const endDate = new Date(Utilities.formatDate(end, tz, 'yyyy-MM-dd'));
+  const startOffset = (startDate.getDay() + 6) % 7;
+  const endOffset = (7 - endDate.getDay()) % 7;
+  startDate.setDate(startDate.getDate() - startOffset);
+  endDate.setDate(endDate.getDate() + endOffset);
+  return { start: startDate, end: endDate };
+}
+
+function buildCustomPeriodKey_(range) {
+  if (!range || !range.start || !range.end) {
+    return '';
+  }
+  return `${Utilities.formatDate(range.start, Session.getScriptTimeZone(), 'yyyyMMdd')}_${Utilities.formatDate(range.end, Session.getScriptTimeZone(), 'yyyyMMdd')}`;
+}
+
+function summarizeAgentMetrics_(records, passMark, categories) {
+  const total = records.length;
+  const passCount = records.filter(r => r.pass).length;
+  const avgScore = total
+    ? Math.round((records.reduce((sum, r) => sum + (typeof r.recordScore === 'number' ? r.recordScore : Math.round((r.percentage || 0) * 100)), 0) / total) * 10) / 10
+    : 0;
+  const catMetrics = computeCategoryMetrics_(records, categories || qaCategories_());
+  const critFails = records.filter(r => hasCriticalFail_(r.raw || {})).length;
+  return {
+    evaluations: total,
+    avgScore,
+    passRate: total ? Math.round((passCount / total) * 1000) / 10 : 0,
+    passCount,
+    failCount: total - passCount,
+    criticalFails: critFails,
+    categories: {
+      'Courtesy & Communication': catMetrics['Courtesy & Communication'] ? catMetrics['Courtesy & Communication'].avgScore : null,
+      'Resolution': catMetrics.Resolution ? catMetrics.Resolution.avgScore : null,
+      'Case Documentation': catMetrics['Case Documentation'] ? catMetrics['Case Documentation'].avgScore : null,
+      'Process Compliance': catMetrics['Process Compliance'] ? catMetrics['Process Compliance'].avgScore : null
+    }
+  };
+}
+
+function groupRecordsByAgent_(records) {
+  const grouped = {};
+  (records || []).forEach(record => {
+    const id = record.agent || 'Unassigned';
+    if (!grouped[id]) {
+      grouped[id] = [];
+    }
+    grouped[id].push(record);
+  });
+  return grouped;
+}
+
+function describeTrend_(current, previous) {
+  const delta = Math.round((current - previous) * 10) / 10;
+  if (delta > 0.5) return `Up (+${delta})`;
+  if (delta < -0.5) return `Down (${delta})`;
+  return 'Flat';
+}
+
+function buildScoreDistribution_(records) {
+  const buckets = [
+    { label: '100%', min: 100, max: 100 },
+    { label: '90-99%', min: 90, max: 99.99 },
+    { label: '80-89%', min: 80, max: 89.99 },
+    { label: '70-79%', min: 70, max: 79.99 },
+    { label: '<70%', min: 0, max: 69.99 }
+  ];
+  const scores = (records || []).map(r => typeof r.recordScore === 'number' ? r.recordScore : Math.round((r.percentage || 0) * 100));
+  buckets.forEach(bucket => {
+    bucket.count = scores.filter(score => score >= bucket.min && score <= bucket.max).length;
+  });
+  return buckets;
+}
+
+function buildProgramCounts_(records) {
+  const counts = {};
+  (records || []).forEach(record => {
+    const program = resolveProgramNameFromRecord_(record) || 'Unspecified';
+    counts[program] = (counts[program] || 0) + 1;
+  });
+  return Object.keys(counts).sort((a, b) => counts[b] - counts[a]).map(key => ({ program: key, count: counts[key] }));
+}
+
+function identifyImpactAgents_(records, passMark, categories) {
+  const grouped = groupRecordsByAgent_(records);
+  const impact = Object.keys(grouped).map(agentId => {
+    const stats = summarizeAgentMetrics_(grouped[agentId], passMark, categories);
+    return { agentId, evals: stats.evaluations, avg: stats.avgScore };
+  }).filter(entry => entry.evals >= 3);
+
+  impact.sort((a, b) => (b.evals * b.avg) - (a.evals * a.avg));
+  return impact.slice(0, 5).map(entry => `${entry.agentId} (${entry.evals} evals @ ${entry.avg}%)`);
+}
+
+function rankAgentsByScore_(records, categories, limit) {
+  const grouped = groupRecordsByAgent_(records);
+  const stats = Object.keys(grouped).map(agentId => {
+    const detail = summarizeAgentMetrics_(grouped[agentId], QA_INTEL_PASS_MARK, categories);
+    return { agentId, avg: detail.avgScore, evals: detail.evaluations };
+  }).filter(entry => entry.evals >= 2);
+
+  const sorted = stats.sort((a, b) => b.avg - a.avg);
+  return {
+    top: sorted.slice(0, limit || 3).map(entry => `${entry.agentId} (${entry.avg}%)`),
+    bottom: sorted.slice(-(limit || 3)).map(entry => `${entry.agentId} (${entry.avg}%)`)
+  };
+}
+
+function aggregateNotes_(records) {
+  return (records || [])
+    .map(r => getRecordFieldValue_(r.raw || {}, ['Notes', 'Summary', 'Comments', 'Agent Feedback']))
+    .filter(Boolean)
+    .map(note => String(note))
+    .slice(0, 5);
+}
+
+function hasCriticalFail_(record) {
+  if (!record) {
+    return false;
+  }
+  return Object.keys(record).some(key => {
+    const normalized = key.toLowerCase();
+    if (normalized.indexOf('critical') === -1) return false;
+    const value = record[key];
+    if (typeof value === 'boolean') return value;
+    const text = String(value || '').toLowerCase();
+    return ['yes', 'true', 'y'].some(token => text === token || text === token + 's') || text === '1';
+  });
 }
 
 function buildAgentDisplayLookup_(records) {


### PR DESCRIPTION
## Summary
- enhance export endpoint to honor all granularities and custom ranges while carrying pass mark and lookup context
- generate multi-sheet quality report with detailed call rows, per-agent rollups, team summary metrics, and improvement focus areas
- style exported sheets with frozen headers and conditional formatting for pass/fail visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ebf9e94088326ac5c0d46394ae12b)