### PR TITLE
Guard clientGetAllUsers logging to avoid null returns

### DIFF
--- a/UserService.js
+++ b/UserService.js
@@ -1948,7 +1948,12 @@ function clientGetAllUsers(requestingUserId) {
       } else {
         users = readSheet(G.USERS_SHEET);
       }
-    } catch (e) { writeError('clientGetAllUsers - readSheet', e); return []; }
+    } catch (e) {
+      if (typeof writeError === 'function') {
+        writeError('clientGetAllUsers - readSheet', e);
+      }
+      return [];
+    }
     if (!Array.isArray(users) || users.length === 0) return [];
 
     const enhancedUsers = [];
@@ -2033,7 +2038,12 @@ function clientGetAllUsers(requestingUserId) {
       }
     }
     return filteredUsers;
-  } catch (globalError) { writeError('clientGetAllUsers', globalError); return []; }
+  } catch (globalError) {
+    if (typeof writeError === 'function') {
+      writeError('clientGetAllUsers', globalError);
+    }
+    return [];
+  }
 }
 
 function createSafeUserObject(user) {


### PR DESCRIPTION
## Summary
- guard clientGetAllUsers logging to avoid reference errors when writeError is unavailable
- ensure user retrieval always falls back to an empty list instead of returning null

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee7a450748326b6a68d6a31da8e26)