### PR TITLE
Disable caching on user reads for freshness

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -4579,7 +4579,9 @@ function _uiUserShape_(u, cmap) {
 
 function _readUsersSheetSafe_() {
   try {
-    return (typeof readSheet === 'function') ? (readSheet('Users') || []) : [];
+    return (typeof readSheet === 'function')
+      ? (readSheet('Users', { cache: false, useCache: false }) || [])
+      : [];
   } catch (err) {
     console.warn('Unable to read Users sheet:', err);
     return [];
@@ -4588,7 +4590,9 @@ function _readUsersSheetSafe_() {
 
 function _readManagerUsersSheetSafe_() {
   try {
-    return (typeof readSheet === 'function') ? (readSheet('MANAGER_USERS') || []) : [];
+    return (typeof readSheet === 'function')
+      ? (readSheet('MANAGER_USERS', { cache: false, useCache: false }) || [])
+      : [];
   } catch (err) {
     console.warn('Unable to read MANAGER_USERS sheet:', err);
     return [];
@@ -4902,7 +4906,7 @@ function getUsersByCampaign(campaignId) {
 function getAllUsersRaw() {
   try {
     if (typeof readSheet === 'function') {
-      return readSheet('Users') || [];
+      return readSheet('Users', { cache: false, useCache: false }) || [];
     }
     return [];
   } catch (error) {

--- a/UserService.js
+++ b/UserService.js
@@ -1946,9 +1946,14 @@ function clientGetAllUsers(requestingUserId) {
       if (typeof getAllUsersRaw === 'function') {
         users = getAllUsersRaw();
       } else {
-        users = readSheet(G.USERS_SHEET);
+        users = readSheet(G.USERS_SHEET, { cache: false, useCache: false });
       }
-    } catch (e) { writeError('clientGetAllUsers - readSheet', e); return []; }
+    } catch (e) {
+      if (typeof writeError === 'function') {
+        writeError('clientGetAllUsers - readSheet', e);
+      }
+      return [];
+    }
     if (!Array.isArray(users) || users.length === 0) return [];
 
     const enhancedUsers = [];
@@ -2033,7 +2038,12 @@ function clientGetAllUsers(requestingUserId) {
       }
     }
     return filteredUsers;
-  } catch (globalError) { writeError('clientGetAllUsers', globalError); return []; }
+  } catch (globalError) {
+    if (typeof writeError === 'function') {
+      writeError('clientGetAllUsers', globalError);
+    }
+    return [];
+  }
 }
 
 function createSafeUserObject(user) {


### PR DESCRIPTION
## Summary
- disable script cache usage when reading Users and MANAGER_USERS so new entries appear immediately
- ensure clientGetAllUsers bypasses sheet cache when falling back to direct reads
- avoid caching oversized Users payloads by skipping cache usage for raw user fetches

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee7a450748326b6a68d6a31da8e26)