### PR TITLE
Disable Users table caching to avoid script cache overflow

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -4579,7 +4579,9 @@ function _uiUserShape_(u, cmap) {
 
 function _readUsersSheetSafe_() {
   try {
-    return (typeof readSheet === 'function') ? (readSheet('Users') || []) : [];
+    return (typeof readSheet === 'function')
+      ? (readSheet('Users', { cache: false, useCache: false }) || [])
+      : [];
   } catch (err) {
     console.warn('Unable to read Users sheet:', err);
     return [];
@@ -4588,7 +4590,9 @@ function _readUsersSheetSafe_() {
 
 function _readManagerUsersSheetSafe_() {
   try {
-    return (typeof readSheet === 'function') ? (readSheet('MANAGER_USERS') || []) : [];
+    return (typeof readSheet === 'function')
+      ? (readSheet('MANAGER_USERS', { cache: false, useCache: false }) || [])
+      : [];
   } catch (err) {
     console.warn('Unable to read MANAGER_USERS sheet:', err);
     return [];
@@ -4902,7 +4906,7 @@ function getUsersByCampaign(campaignId) {
 function getAllUsersRaw() {
   try {
     if (typeof readSheet === 'function') {
-      return readSheet('Users') || [];
+      return readSheet('Users', { cache: false, useCache: false }) || [];
     }
     return [];
   } catch (error) {

--- a/DatabaseBindings.js
+++ b/DatabaseBindings.js
@@ -51,7 +51,7 @@
   }
 
   function attemptRegisterKnownSchemas() {
-    registerIfDefined(global.USERS_SHEET || 'Users', global.USERS_HEADERS, 'ID', { cacheTTL: 1800 });
+    registerIfDefined(global.USERS_SHEET || 'Users', global.USERS_HEADERS, 'ID', { cache: false, cacheTTL: 0 });
     registerIfDefined(global.ROLES_SHEET || 'Roles', global.ROLES_HEADER, 'ID', { cacheTTL: 3600 });
     registerIfDefined(global.USER_ROLES_SHEET || 'UserRoles', global.USER_ROLES_HEADER, 'UserId', { cacheTTL: 1800 });
     registerIfDefined(global.USER_CLAIMS_SHEET || 'UserClaims', global.CLAIMS_HEADERS, 'ID', { cacheTTL: 1800 });

--- a/DatabaseManager.js
+++ b/DatabaseManager.js
@@ -134,7 +134,10 @@
     } else {
       this.idColumn = DEFAULT_ID_COLUMN;
     }
-    this.cacheTTL = (config && config.cacheTTL) || DEFAULT_CACHE_TTL;
+    this.cacheTTL = (config && typeof config.cacheTTL !== 'undefined')
+      ? config.cacheTTL
+      : DEFAULT_CACHE_TTL;
+    this.cacheEnabled = !(config && config.cache === false) && this.cacheTTL !== 0;
     if (config && config.timestamps === false) {
       this.timestamps = null;
     } else if (config && config.timestamps) {
@@ -653,7 +656,7 @@
     options = options || {};
     var prepared = this.prepareTenantOptions(options, context, true);
     var finalOptions = prepared.options;
-    var useCache = finalOptions.cache !== false;
+    var useCache = this.cacheEnabled && finalOptions.cache !== false && this.cacheTTL > 0;
     var cache = CacheService.getScriptCache();
     var headers = this.headers;
 

--- a/UserService.js
+++ b/UserService.js
@@ -1946,9 +1946,14 @@ function clientGetAllUsers(requestingUserId) {
       if (typeof getAllUsersRaw === 'function') {
         users = getAllUsersRaw();
       } else {
-        users = readSheet(G.USERS_SHEET);
+        users = readSheet(G.USERS_SHEET, { cache: false, useCache: false });
       }
-    } catch (e) { writeError('clientGetAllUsers - readSheet', e); return []; }
+    } catch (e) {
+      if (typeof writeError === 'function') {
+        writeError('clientGetAllUsers - readSheet', e);
+      }
+      return [];
+    }
     if (!Array.isArray(users) || users.length === 0) return [];
 
     const enhancedUsers = [];
@@ -2033,7 +2038,12 @@ function clientGetAllUsers(requestingUserId) {
       }
     }
     return filteredUsers;
-  } catch (globalError) { writeError('clientGetAllUsers', globalError); return []; }
+  } catch (globalError) {
+    if (typeof writeError === 'function') {
+      writeError('clientGetAllUsers', globalError);
+    }
+    return [];
+  }
 }
 
 function createSafeUserObject(user) {


### PR DESCRIPTION
## Summary
- add cacheEnabled flag in DatabaseManager tables so cache can be disabled via schema
- register Users schema with caching disabled to avoid script cache overflow warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee7a450748326b6a68d6a31da8e26)