### PR TITLE
Normalize attendance date handling to prevent stale statuses

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -3701,7 +3701,6 @@
                     }
                     await this.refreshHolidays();
                     this.showToast('System ready! All data loaded successfully.', 'success');
-                    console.log('✅ Unified system state loaded successfully');
                     return;
                 }
 
@@ -14207,20 +14206,29 @@
 
                 const displayValue = displayName || userName;
                 const resolvedCell = cellElement instanceof HTMLElement ? cellElement : null;
+                const previousStatus = this.getCachedAttendanceStatus(userName, date);
+
+                // Optimistically update the UI and caches for a snappier experience
+                this.updateAttendanceRecordCache(userName, date, trimmedStatus);
+                this.updateAttendanceDashboardRecord(userName, date, trimmedStatus);
+                this.updateAttendanceCalendarCell(userName, date, trimmedStatus, resolvedCell);
 
                 try {
                     const result = await this.callServerFunction('clientMarkAttendanceStatus', userName, date, trimmedStatus);
                     if (result && result.success) {
+                        await this.syncAttendanceStatusFromServer(userName, date);
                         this.showToast(`Marked ${displayValue} as ${trimmedStatus} on ${date}`, 'success');
-                        this.updateAttendanceRecordCache(userName, date, trimmedStatus);
-                        this.updateAttendanceDashboardRecord(userName, date, trimmedStatus);
-                        this.updateAttendanceCalendarCell(userName, date, trimmedStatus, resolvedCell);
                     } else {
                         throw new Error(result?.error || 'Failed to mark attendance');
                     }
                 } catch (error) {
                     console.error('Error marking attendance:', error);
                     this.showToast('Failed to mark attendance: ' + error.message, 'danger');
+
+                    // Revert to the previous status if the server call fails
+                    this.updateAttendanceRecordCache(userName, date, previousStatus || '');
+                    this.updateAttendanceDashboardRecord(userName, date, previousStatus || '');
+                    this.updateAttendanceCalendarCell(userName, date, previousStatus || '', resolvedCell);
                 }
             }
 
@@ -14231,20 +14239,67 @@
 
                 const displayValue = displayName || userName;
                 const resolvedCell = cellElement instanceof HTMLElement ? cellElement : null;
+                const previousStatus = this.getCachedAttendanceStatus(userName, date);
+
+                // Optimistically clear the status for instant feedback
+                this.updateAttendanceRecordCache(userName, date, '');
+                this.updateAttendanceDashboardRecord(userName, date, '');
+                this.updateAttendanceCalendarCell(userName, date, '', resolvedCell);
 
                 try {
                     const result = await this.callServerFunction('clientRemoveAttendanceStatus', userName, date);
                     if (result && result.success) {
+                        await this.syncAttendanceStatusFromServer(userName, date);
                         this.showToast(`Cleared attendance status for ${displayValue} on ${date}`, 'info');
-                        this.updateAttendanceRecordCache(userName, date, '');
-                        this.updateAttendanceDashboardRecord(userName, date, '');
-                        this.updateAttendanceCalendarCell(userName, date, '', resolvedCell);
                     } else {
                         throw new Error(result?.error || 'Failed to clear attendance status');
                     }
                 } catch (error) {
                     console.error('Error clearing attendance status:', error);
                     this.showToast('Failed to clear attendance status: ' + error.message, 'danger');
+
+                    // Restore previous status if clearing fails
+                    this.updateAttendanceRecordCache(userName, date, previousStatus || '');
+                    this.updateAttendanceDashboardRecord(userName, date, previousStatus || '');
+                    this.updateAttendanceCalendarCell(userName, date, previousStatus || '', resolvedCell);
+                }
+            }
+
+            async syncAttendanceStatusFromServer(userName, date) {
+                const isoDate = this.normalizeAttendanceDateValue(date);
+                if (!userName || !isoDate) {
+                    return;
+                }
+
+                const normalizedUser = this.normalizePersonKey(userName);
+                const campaignId = this.getCurrentCampaignId ? this.getCurrentCampaignId() || null : null;
+
+                try {
+                    const response = await this.callServerFunction(
+                        'clientGetAttendanceDataRange',
+                        isoDate,
+                        isoDate,
+                        campaignId
+                    );
+
+                    if (!response || !response.success || !Array.isArray(response.records)) {
+                        return;
+                    }
+
+                    const match = response.records.find(record => {
+                        const recordUser = record?.userName || record?.UserName || record?.user || record?.User || '';
+                        const recordDate = record?.date || record?.Date || record?.timestamp || record?.Timestamp || '';
+                        return this.normalizePersonKey(recordUser) === normalizedUser
+                            && this.normalizeAttendanceDateValue(recordDate) === isoDate;
+                    });
+
+                    const latestStatus = (match?.status || match?.Status || '').toString();
+                    this.updateAttendanceRecordCache(userName, isoDate, latestStatus);
+                    this.updateAttendanceDashboardRecord(userName, isoDate, latestStatus);
+                    this.updateAttendanceCalendarCell(userName, isoDate, latestStatus, null);
+                    this.updateAttendancePrefetchCache(userName, isoDate, latestStatus);
+                } catch (error) {
+                    console.warn('Unable to sync attendance status from server:', error);
                 }
             }
 
@@ -14300,6 +14355,78 @@
                         Status: trimmedStatus
                     });
                 }
+
+                this.updateAttendancePrefetchCache(userName, isoDate, trimmedStatus);
+            }
+
+            getCachedAttendanceStatus(userName, date) {
+                const isoDate = this.normalizeAttendanceDateValue(date);
+                const normalizedUser = this.normalizePersonKey(userName);
+
+                if (!isoDate || !normalizedUser || !Array.isArray(this.attendanceCalendarRecords)) {
+                    return '';
+                }
+
+                const match = this.attendanceCalendarRecords.find(record => {
+                    const recordUser = record?.userName || record?.UserName || record?.user || record?.User || '';
+                    const recordDate = record?.date || record?.Date || record?.timestamp || record?.Timestamp || '';
+                    return this.normalizePersonKey(recordUser) === normalizedUser
+                        && this.normalizeAttendanceDateValue(recordDate) === isoDate;
+                });
+
+                return (match?.status || match?.Status || '').toString();
+            }
+
+            updateAttendancePrefetchCache(userName, isoDate, status) {
+                const prefetch = this.attendanceCalendarPrefetch;
+                if (!prefetch || !isoDate || !userName) {
+                    return;
+                }
+
+                const normalizedUser = this.normalizePersonKey(userName);
+                const syncedRecord = {
+                    userName,
+                    UserName: userName,
+                    date: isoDate,
+                    Date: isoDate,
+                    status,
+                    Status: status
+                };
+
+                const syncArray = (records) => {
+                    if (!Array.isArray(records)) {
+                        return;
+                    }
+
+                    let foundIndex = -1;
+                    for (let i = 0; i < records.length; i++) {
+                        const candidate = records[i];
+                        const candidateUser = candidate?.userName || candidate?.UserName || candidate?.user || candidate?.User || '';
+                        const candidateDate = candidate?.date || candidate?.Date || candidate?.timestamp || candidate?.Timestamp || '';
+                        if (this.normalizePersonKey(candidateUser) === normalizedUser
+                            && this.normalizeAttendanceDateValue(candidateDate) === isoDate) {
+                            foundIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (!status && foundIndex >= 0) {
+                        records.splice(foundIndex, 1);
+                        return;
+                    }
+
+                    if (status && foundIndex >= 0) {
+                        records[foundIndex] = Object.assign({}, records[foundIndex], syncedRecord);
+                        return;
+                    }
+
+                    if (status && foundIndex === -1) {
+                        records.push(Object.assign({}, syncedRecord));
+                    }
+                };
+
+                syncArray(prefetch.monthlyRecords);
+                syncArray(prefetch.yearlyRecords);
             }
 
             updateAttendanceDashboardRecord(userName, date, status, notes = '') {

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -4454,18 +4454,61 @@ function clientGetCountryHolidays(countryCode, year) {
   }
 }
 
+function normalizeAttendanceDateValue(value, timeZone = getScheduleTimeZone()) {
+  const zone = timeZone || Session.getScriptTimeZone() || 'UTC';
+
+  if (value instanceof Date && !isNaN(value.getTime())) {
+    return Utilities.formatDate(value, zone, 'yyyy-MM-dd');
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const parsed = new Date(value);
+    if (!isNaN(parsed.getTime())) {
+      return Utilities.formatDate(parsed, zone, 'yyyy-MM-dd');
+    }
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+
+    const isoMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})(?:[T\s].*)?$/);
+    if (isoMatch && isoMatch[1]) {
+      return isoMatch[1];
+    }
+
+    const parsed = new Date(trimmed);
+    if (!isNaN(parsed.getTime())) {
+      return Utilities.formatDate(parsed, zone, 'yyyy-MM-dd');
+    }
+  }
+
+  return '';
+}
+
 function clientMarkAttendanceStatus(userName, date, status, notes = '') {
   try {
     console.log('📝 Marking attendance status:', { userName, date, status, notes });
 
+    const timeZone = getScheduleTimeZone();
+    const normalizedDate = normalizeAttendanceDateValue(date, timeZone);
+
+    if (!normalizedDate) {
+      throw new Error('A valid date is required to update attendance status.');
+    }
+
     // Use ScheduleUtilities to ensure proper sheet structure
     const sheet = ensureScheduleSheetWithHeaders(ATTENDANCE_STATUS_SHEET, ATTENDANCE_STATUS_HEADERS);
 
-    // Check if entry already exists
+    // Check if entry already exists (normalize both sides to avoid duplicate rows)
     const existingData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
-    const existingEntry = existingData.find(entry =>
-      entry.UserName === userName && entry.Date === date
-    );
+    const existingEntry = existingData.find(entry => {
+      const entryDate = normalizeAttendanceDateValue(entry.Date, timeZone);
+      const entryUser = String(entry.UserName || '').trim();
+      return entryUser === String(userName || '').trim() && entryDate === normalizedDate;
+    });
 
     const now = new Date();
 
@@ -4476,6 +4519,7 @@ function clientMarkAttendanceStatus(userName, date, status, notes = '') {
 
       for (let i = 1; i < data.length; i++) {
         if (data[i][0] === existingEntry.ID) {
+          sheet.getRange(i + 1, headers.indexOf('Date') + 1).setValue(normalizedDate);
           sheet.getRange(i + 1, headers.indexOf('Status') + 1).setValue(status);
           sheet.getRange(i + 1, headers.indexOf('Notes') + 1).setValue(notes);
           sheet.getRange(i + 1, headers.indexOf('UpdatedAt') + 1).setValue(now);
@@ -4488,7 +4532,7 @@ function clientMarkAttendanceStatus(userName, date, status, notes = '') {
         ID: Utilities.getUuid(),
         UserID: getUserIdByName(userName) || userName,
         UserName: userName,
-        Date: date,
+        Date: normalizedDate,
         Status: status,
         Notes: notes,
         MarkedBy: Session.getActiveUser().getEmail(),
@@ -4505,7 +4549,7 @@ function clientMarkAttendanceStatus(userName, date, status, notes = '') {
 
     return {
       success: true,
-      message: `Attendance status updated to ${status} for ${userName} on ${date}`
+      message: `Attendance status updated to ${status} for ${userName} on ${normalizedDate}`
     };
 
   } catch (error) {
@@ -4913,7 +4957,7 @@ function clientRemoveAttendanceStatus(userName, date) {
       }
 
       const normalizedUser = String(userName || '').trim();
-      const normalizedDate = String(date || '').trim();
+      const normalizedDate = normalizeAttendanceDateValue(date, getScheduleTimeZone());
 
       if (!normalizedUser || !normalizedDate) {
         throw new Error('Both userName and date are required to clear attendance status.');
@@ -4923,7 +4967,7 @@ function clientRemoveAttendanceStatus(userName, date) {
 
       for (let row = data.length - 1; row >= 1; row--) {
         const rowUser = String(data[row][userNameIndex] || '').trim();
-        const rowDate = String(data[row][dateIndex] || '').trim();
+        const rowDate = normalizeAttendanceDateValue(data[row][dateIndex], getScheduleTimeZone());
 
         if (rowUser === normalizedUser && rowDate === normalizedDate) {
           sheet.deleteRow(row + 1);
@@ -6303,95 +6347,94 @@ function persistScheduleHealthSnapshot(context, evaluation, bundle, options = {}
 function clientGetAttendanceDataRange(startDate, endDate, campaignId = null) {
   try {
     const attendanceData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
+    const timeZone = getScheduleTimeZone();
 
     const normalizeDate = (value) => {
-      if (value instanceof Date) {
-        return isNaN(value.getTime()) ? null : new Date(value.getTime());
+      const iso = normalizeAttendanceDateValue(value, timeZone);
+      if (!iso) {
+        return null;
       }
+      const [year, month, day] = iso.split('-').map(Number);
+      if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+        return null;
+      }
+      return new Date(Date.UTC(year, month - 1, day));
+    };
 
+    const normalizeTimestamp = (value) => {
+      if (value instanceof Date && !isNaN(value.getTime())) {
+        return value.getTime();
+      }
       if (typeof value === 'number' && Number.isFinite(value)) {
         const parsed = new Date(value);
-        return Number.isNaN(parsed.getTime()) ? null : parsed;
+        return isNaN(parsed.getTime()) ? null : parsed.getTime();
       }
-
-      if (typeof value === 'string') {
-        const trimmed = value.trim();
-        if (!trimmed) {
-          return null;
-        }
-
-        const isoDateMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-        if (isoDateMatch) {
-          const year = Number(isoDateMatch[1]);
-          const month = Number(isoDateMatch[2]);
-          const day = Number(isoDateMatch[3]);
-          if (Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(day)) {
-            return new Date(Date.UTC(year, month - 1, day));
-          }
-        }
-
-        const parsed = new Date(trimmed);
-        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      if (typeof value === 'string' && value.trim()) {
+        const parsed = new Date(value.trim());
+        return isNaN(parsed.getTime()) ? null : parsed.getTime();
       }
-
       return null;
     };
 
     const rangeStart = normalizeDate(startDate);
     const rangeEnd = normalizeDate(endDate);
 
-    const filtered = attendanceData.filter(record => {
-      const recordDate = normalizeDate(record.Date || record.date);
+    const deduped = new Map();
+
+    attendanceData.forEach(record => {
+      const isoDate = normalizeAttendanceDateValue(record.Date || record.date, timeZone);
+      if (!isoDate) {
+        return;
+      }
+
+      const recordDate = normalizeDate(isoDate);
       if (!recordDate) {
-        return false;
+        return;
       }
 
       if (rangeStart && recordDate < rangeStart) {
-        return false;
+        return;
       }
       if (rangeEnd && recordDate > rangeEnd) {
-        return false;
+        return;
       }
 
       if (campaignId) {
         const recordCampaign = record.CampaignID || record.CampaignId || record.Campaign || null;
         if (recordCampaign && recordCampaign !== campaignId) {
-          return false;
+          return;
         }
       }
 
-      return true;
-    });
-
-    const toIsoDate = (date) => {
-      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
-        return '';
+      const userName = String(record.UserName || record.User || record.user || '').trim();
+      const status = (record.Status || record.status || record.state || '').toString();
+      if (!userName || !status) {
+        return;
       }
-      const year = date.getUTCFullYear();
-      const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-      const day = String(date.getUTCDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
 
-    const records = filtered
-      .map(record => {
-        const date = normalizeDate(record.Date || record.date);
-        const isoDate = toIsoDate(date);
-        const userName = record.UserName || record.User || record.user || '';
-        const status = record.Status || record.status || record.state || '';
+      const key = `${userName.toLowerCase()}__${isoDate}`;
+      const existing = deduped.get(key);
+      const timestamp = normalizeTimestamp(record.UpdatedAt || record.CreatedAt || record.Updated || record.Created) || 0;
 
-        if (!userName || !isoDate || !status) {
-          return null;
-        }
-
-        return {
+      if (!existing || timestamp >= existing.timestamp) {
+        deduped.set(key, {
           userName,
           status,
           date: isoDate,
-          notes: record.Notes || record.notes || ''
-        };
-      })
-      .filter(Boolean);
+          notes: record.Notes || record.notes || '',
+          timestamp
+        });
+      }
+    });
+
+    const records = Array.from(deduped.values())
+      .filter(entry => entry && entry.userName && entry.date && entry.status)
+      .map(entry => ({
+        userName: entry.userName,
+        status: entry.status,
+        date: entry.date,
+        notes: entry.notes || ''
+      }));
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
- normalize attendance status dates before writing or matching records to avoid duplicate rows
- deduplicate attendance range reads using normalized user/date keys and latest timestamps so refreshes show recent updates
- normalize dates on status removal to keep deletes aligned with stored records

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f88cb51748326ac13e2b4720c4862)