### PR TITLE
Harden attendance calendar export date handling

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9395,13 +9395,21 @@
                 const month = monthInput ? parseInt(monthInput.value, 10) : NaN;
                 const year = yearInput ? parseInt(yearInput.value, 10) : NaN;
 
-                if (!Number.isFinite(month) || !Number.isFinite(year)) {
+                const monthInRange = Number.isFinite(month) && month >= 1 && month <= 12;
+                const yearInRange = Number.isFinite(year) && year >= 1900 && year <= 2500;
+
+                if (!monthInRange || !yearInRange) {
                     this.showToast('Select a month and year before exporting.', 'warning');
                     return;
                 }
 
                 const start = new Date(year, month - 1, 1, 0, 0, 0, 0);
                 const end = new Date(year, month, 0, 23, 59, 59, 999);
+
+                if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+                    this.showToast('Invalid date range. Please pick a valid month and year.', 'warning');
+                    return;
+                }
 
                 try {
                     this.showLoading(true, {
@@ -9412,8 +9420,8 @@
                     const response = await this.callServerFunction(
                         'exportAttendanceCalendar',
                         'Month',
-                        start,
-                        end
+                        start.toISOString(),
+                        end.toISOString()
                     );
 
                     if (!response || response.success !== true || !response.fileUrl) {

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -4048,10 +4048,15 @@ function normalizeDateRangeForExport(periodType, startDate, endDate) {
     throw new Error('A valid start and end date are required for export.');
   }
 
+  const normalizedStart = new Date(safeStart.getTime());
+  const normalizedEnd = new Date(safeEnd.getTime());
+  normalizedStart.setHours(0, 0, 0, 0);
+  normalizedEnd.setHours(23, 59, 59, 999);
+
   const type = typeof periodType === 'string' && periodType.trim() ? periodType.trim() : 'Custom';
   const pad = (num) => String(num).padStart(2, '0');
-  const startIso = `${safeStart.getFullYear()}-${pad(safeStart.getMonth() + 1)}-${pad(safeStart.getDate())}`;
-  const endIso = `${safeEnd.getFullYear()}-${pad(safeEnd.getMonth() + 1)}-${pad(safeEnd.getDate())}`;
+  const startIso = `${normalizedStart.getFullYear()}-${pad(normalizedStart.getMonth() + 1)}-${pad(normalizedStart.getDate())}`;
+  const endIso = `${normalizedEnd.getFullYear()}-${pad(normalizedEnd.getMonth() + 1)}-${pad(normalizedEnd.getDate())}`;
   const label = (() => {
     switch (type.toLowerCase()) {
       case 'week':
@@ -4074,7 +4079,7 @@ function normalizeDateRangeForExport(periodType, startDate, endDate) {
     }
   })();
 
-  return { type, start: safeStart, end: safeEnd, startIso, endIso, label };
+  return { type, start: normalizedStart, end: normalizedEnd, startIso, endIso, label };
 }
 
 function ensureAttendanceExportSheet(name) {


### PR DESCRIPTION
## Summary
- add client-side validation for attendance calendar month/year inputs and avoid invalid date submissions
- normalize server-side export date ranges to start/end of day for consistent processing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203082443c8326a1e070a14c7a511e)