### PR TITLE
Add export for adherence violations in attendance summary

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1458,9 +1458,14 @@
   <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5><i class="fas fa-users"></i>Employee Attendance Summary</h5>
-      <button class="btn btn-sm btn-outline-primary" onclick="exportData()">
-        <i class="fas fa-download me-1"></i>Export
-      </button>
+      <div class="d-flex gap-2">
+        <button class="btn btn-sm btn-outline-primary" onclick="exportData()">
+          <i class="fas fa-download me-1"></i>Export
+        </button>
+        <button class="btn btn-sm btn-outline-danger" onclick="exportAttendanceViolations()">
+          <i class="fas fa-file-excel me-1"></i>Export Violations
+        </button>
+      </div>
     </div>
     <div id="attendanceTableContainer" class="card-body">
       <div class="loading-state">
@@ -4194,6 +4199,84 @@
       }
     }
 
+    exportAttendanceViolations() {
+      if (!this.currentData || !Array.isArray(this.currentData.userCompliance) || this.currentData.userCompliance.length === 0) {
+        this.showToast('No attendance data available to export.', 'warning');
+        return;
+      }
+
+      const BREAK_ALLOWANCE_SECS = 30 * 60;
+      const LUNCH_ALLOWANCE_SECS = 30 * 60;
+
+      const escapeCsv = (value) => {
+        const stringValue = value === undefined || value === null ? '' : String(value);
+        if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+          return '"' + stringValue.replace(/"/g, '""') + '"';
+        }
+        return stringValue;
+      };
+
+      const formatMinutes = (seconds, allowance) => {
+        const minutes = Math.max(0, (Math.max(0, seconds) - allowance) / 60);
+        return Math.round(minutes * 100) / 100;
+      };
+
+      const rows = this.currentData.userCompliance.map((entry) => {
+        const breakSecs = Number(entry?.breakSecs) || 0;
+        const lunchSecs = Number(entry?.lunchSecs) || 0;
+        const breakOverMinutes = formatMinutes(breakSecs, BREAK_ALLOWANCE_SECS);
+        const lunchOverMinutes = formatMinutes(lunchSecs, LUNCH_ALLOWANCE_SECS);
+
+        return {
+          employee: entry?.user || 'Unknown',
+          breakHours: convertSecondsToDecimalHours(breakSecs),
+          breakOverMinutes,
+          breakViolationDays: Number.isFinite(entry?.exceededBreakDays) ? entry.exceededBreakDays : 0,
+          lunchHours: convertSecondsToDecimalHours(lunchSecs),
+          lunchOverMinutes,
+          lunchViolationDays: Number.isFinite(entry?.exceededLunchDays) ? entry.exceededLunchDays : 0,
+          weeklyOverages: Number.isFinite(entry?.exceededWeeklyCount) ? entry.exceededWeeklyCount : 0
+        };
+      });
+
+      const header = [
+        'Employee',
+        'Break Hours Recorded',
+        'Break Over Minutes',
+        'Break Violation Days',
+        'Lunch Hours Recorded',
+        'Lunch Over Minutes',
+        'Lunch Violation Days',
+        'Weekly Overages'
+      ];
+
+      const csvLines = [header.join(',')];
+      rows.forEach((row) => {
+        csvLines.push([
+          escapeCsv(row.employee),
+          escapeCsv(row.breakHours.toFixed(2)),
+          escapeCsv(row.breakOverMinutes.toFixed(2)),
+          escapeCsv(row.breakViolationDays),
+          escapeCsv(row.lunchHours.toFixed(2)),
+          escapeCsv(row.lunchOverMinutes.toFixed(2)),
+          escapeCsv(row.lunchViolationDays),
+          escapeCsv(row.weeklyOverages)
+        ].join(','));
+      });
+
+      const blob = new Blob([csvLines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `adherence-break-lunch-violations-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      this.showToast('Adherence break & lunch violations exported.', 'success');
+    }
+
     renderWeeklyPaginationControls() {
       const totalPages = this.weeklyPagination.totalPages;
       const currentPage = this.weeklyPagination.currentPage;
@@ -6018,6 +6101,14 @@
 
   function exportData() {
     showEnhancedExportModal();
+  }
+
+  function exportAttendanceViolations() {
+    if (dashboard && typeof dashboard.exportAttendanceViolations === 'function') {
+      dashboard.exportAttendanceViolations();
+    } else {
+      console.warn('Attendance dashboard not ready for adherence violation export.');
+    }
   }
 
   function showModalLoading(containerId, message) {


### PR DESCRIPTION
## Summary
- add a dedicated export action on the Employee Attendance Summary for adherence violations
- generate a CSV focused on break and lunch overages with related violation counts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ca42e1748326ac15ba47a2e5b3e8)