### PR TITLE
Add attendance filters and Google Sheets violations export

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1458,9 +1458,56 @@
   <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5><i class="fas fa-users"></i>Employee Attendance Summary</h5>
-      <button class="btn btn-sm btn-outline-primary" onclick="exportData()">
-        <i class="fas fa-download me-1"></i>Export
-      </button>
+      <div class="d-flex gap-2 align-items-center flex-wrap">
+        <button class="btn btn-sm btn-outline-primary" onclick="exportData()">
+          <i class="fas fa-download me-1"></i>Export
+        </button>
+        <div class="btn-group">
+          <button class="btn btn-sm btn-outline-danger" onclick="exportAttendanceViolations('sheet')">
+            <i class="fas fa-file-excel me-1"></i>Export Violations
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-danger dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="visually-hidden">Toggle Dropdown</span>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#" onclick="exportAttendanceViolations('sheet')"><i class="fas fa-file-excel me-2"></i>Google Sheets (styled)</a></li>
+            <li><a class="dropdown-item" href="#" onclick="exportAttendanceViolations('csv')"><i class="fas fa-file-csv me-2"></i>CSV</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="card-body border-top py-3 bg-light">
+      <div class="row g-3 align-items-end">
+        <div class="col-md-3">
+          <label class="form-label fw-bold">Start Date</label>
+          <input type="date" class="form-control" id="attendanceFilterStart" />
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-bold">End Date</label>
+          <input type="date" class="form-control" id="attendanceFilterEnd" />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label fw-bold">User Scope</label>
+          <div class="d-flex flex-wrap gap-3 align-items-center">
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="attendanceUserFilter" id="attendanceFilterAll" value="all" checked>
+              <label class="form-check-label" for="attendanceFilterAll">All Users</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="attendanceUserFilter" id="attendanceFilterSingle" value="single">
+              <label class="form-check-label" for="attendanceFilterSingle">Single User</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="attendanceUserFilter" id="attendanceFilterMultiple" value="multiple">
+              <label class="form-check-label" for="attendanceFilterMultiple">Selected Users</label>
+            </div>
+          </div>
+          <div class="mt-2 d-flex gap-2 flex-wrap">
+            <select class="form-select" id="attendanceSingleSelect" style="min-width: 200px;" disabled></select>
+            <select class="form-select" id="attendanceMultiSelect" style="min-width: 240px;" multiple disabled></select>
+          </div>
+        </div>
+      </div>
     </div>
     <div id="attendanceTableContainer" class="card-body">
       <div class="loading-state">
@@ -2233,6 +2280,15 @@
       this.originalUserComplianceMap = new Map();
       this.suppressRenderToast = false;
 
+      this.summaryFilters = {
+        dateFrom: '',
+        dateTo: '',
+        userMode: 'all',
+        selectedUsers: []
+      };
+
+      this.xlsxLib = null;
+
       this.loadDataDebounced = debounce(() => this.loadData(), 250);
       this._reqSeq = 0;
 
@@ -2244,6 +2300,7 @@
       this.setupEventListeners();
       this.initializeControls();
       this.initializeLoginLogoutEditor();
+      this.setupAttendanceSummaryFilters();
 
       if (window.INITIAL_ATTENDANCE_DATA && Object.keys(window.INITIAL_ATTENDANCE_DATA).length) {
         try {
@@ -2254,6 +2311,7 @@
           this.resetManualAdjustmentsIfContextChanged();
           this.applyManualSecondsAdjustmentsToCurrentData();
           this.renderDashboard();
+          this.refreshAttendanceFilterOptions();
         } catch (bootstrapError) {
           console.warn('Unable to bootstrap dashboard from initial data:', bootstrapError);
         }
@@ -2337,6 +2395,75 @@
       this.loadUserList();
       this.updateViewMode();
       this.syncHourPolicyControls();
+
+      const periodInfo = window.INITIAL_ATTENDANCE_DATA?.periodInfo || {};
+      const startInput = document.getElementById('attendanceFilterStart');
+      const endInput = document.getElementById('attendanceFilterEnd');
+      if (startInput && periodInfo.startDate) startInput.value = periodInfo.startDate;
+      if (endInput && periodInfo.endDate) endInput.value = periodInfo.endDate;
+      if (startInput && startInput.value) this.summaryFilters.dateFrom = startInput.value;
+      if (endInput && endInput.value) this.summaryFilters.dateTo = endInput.value;
+    }
+
+    setupAttendanceSummaryFilters() {
+      const startInput = document.getElementById('attendanceFilterStart');
+      const endInput = document.getElementById('attendanceFilterEnd');
+      if (startInput) {
+        startInput.addEventListener('change', (e) => {
+          this.summaryFilters.dateFrom = e.target.value || '';
+          this.renderAttendanceTable();
+        });
+      }
+      if (endInput) {
+        endInput.addEventListener('change', (e) => {
+          this.summaryFilters.dateTo = e.target.value || '';
+          this.renderAttendanceTable();
+        });
+      }
+
+      const userRadios = document.querySelectorAll('input[name="attendanceUserFilter"]');
+      userRadios.forEach((radio) => {
+        radio.addEventListener('change', (e) => {
+          this.summaryFilters.userMode = e.target.value;
+          this.syncAttendanceUserControls();
+          this.renderAttendanceTable();
+        });
+      });
+
+      const singleSelect = document.getElementById('attendanceSingleSelect');
+      const multiSelect = document.getElementById('attendanceMultiSelect');
+
+      if (singleSelect) {
+        singleSelect.addEventListener('change', (e) => {
+          this.summaryFilters.selectedUsers = e.target.value ? [e.target.value] : [];
+          this.renderAttendanceTable();
+        });
+      }
+
+      if (multiSelect) {
+        multiSelect.addEventListener('change', () => {
+          const values = Array.from(multiSelect.selectedOptions).map(opt => opt.value);
+          this.summaryFilters.selectedUsers = values;
+          this.renderAttendanceTable();
+        });
+      }
+    }
+
+    syncAttendanceUserControls() {
+      const singleSelect = document.getElementById('attendanceSingleSelect');
+      const multiSelect = document.getElementById('attendanceMultiSelect');
+      const mode = this.summaryFilters.userMode;
+
+      if (singleSelect) {
+        singleSelect.disabled = mode !== 'single';
+        if (mode !== 'single') singleSelect.value = '';
+      }
+      if (multiSelect) {
+        multiSelect.disabled = mode !== 'multiple';
+        if (mode !== 'multiple') {
+          Array.from(multiSelect.options).forEach(opt => { opt.selected = false; });
+        }
+      }
     }
 
     setCurrentPeriod(value) {
@@ -2375,6 +2502,25 @@
       if (capButton) {
         capButton.disabled = false;
       }
+    }
+
+    refreshAttendanceFilterOptions() {
+      const users = Array.isArray(this.currentData?.userCompliance)
+        ? this.currentData.userCompliance.map(u => u.user).filter(Boolean)
+        : [];
+      const uniqueUsers = Array.from(new Set(users)).sort();
+
+      const singleSelect = document.getElementById('attendanceSingleSelect');
+      const multiSelect = document.getElementById('attendanceMultiSelect');
+
+      if (singleSelect) {
+        singleSelect.innerHTML = '<option value="">Select user...</option>' + uniqueUsers.map(u => `<option value="${escapeHtml(u)}">${escapeHtml(u)}</option>`).join('');
+      }
+      if (multiSelect) {
+        multiSelect.innerHTML = uniqueUsers.map(u => `<option value="${escapeHtml(u)}">${escapeHtml(u)}</option>`).join('');
+      }
+
+      this.syncAttendanceUserControls();
     }
 
     applyHourPolicyFromData(policy) {
@@ -3110,8 +3256,21 @@
           this.currentData.manualSecondsDeltaHours = Math.round((this.currentData.manualSecondsDelta / 3600) * 100) / 100;
         }
 
+        const periodInfo = this.currentData.periodInfo || {};
+        const startInput = document.getElementById('attendanceFilterStart');
+        const endInput = document.getElementById('attendanceFilterEnd');
+        if (startInput && !this.summaryFilters.dateFrom && periodInfo.startDate) {
+          startInput.value = periodInfo.startDate;
+          this.summaryFilters.dateFrom = periodInfo.startDate;
+        }
+        if (endInput && !this.summaryFilters.dateTo && periodInfo.endDate) {
+          endInput.value = periodInfo.endDate;
+          this.summaryFilters.dateTo = periodInfo.endDate;
+        }
+
         this.applyManualSecondsAdjustmentsToCurrentData();
         this.renderDashboard();
+        this.refreshAttendanceFilterOptions();
 
       } catch (error) {
         const msg = (error && error.message) ? String(error.message) : String(error);
@@ -3565,9 +3724,9 @@
         if (!container) return;
 
         const weeklyTableContainer = document.getElementById('weeklyLoginLogoutContainer');
-        const userCompliance = this.currentData.userCompliance || [];
+        const filteredCompliance = this.getFilteredComplianceData();
 
-        if (userCompliance.length === 0) {
+        if (!filteredCompliance.length) {
           this.weeklyPagination.totalItems = 0;
           this.weeklyPagination.totalPages = 0;
           this.weeklyPagination.currentPage = 1;
@@ -3578,7 +3737,7 @@
           return;
         }
 
-        this.pagination.totalItems = userCompliance.length;
+        this.pagination.totalItems = filteredCompliance.length;
         this.pagination.totalPages = Math.ceil(this.pagination.totalItems / this.pagination.itemsPerPage);
 
         if (this.pagination.currentPage > this.pagination.totalPages) {
@@ -3586,8 +3745,8 @@
         }
 
         const startIndex = (this.pagination.currentPage - 1) * this.pagination.itemsPerPage;
-        const endIndex = Math.min(startIndex + this.pagination.itemsPerPage, userCompliance.length);
-        const currentPageData = userCompliance.slice(startIndex, endIndex);
+        const endIndex = Math.min(startIndex + this.pagination.itemsPerPage, filteredCompliance.length);
+        const currentPageData = filteredCompliance.slice(startIndex, endIndex);
 
         const BREAK_ALLOWANCE_SECS = 30 * 60;
         const LUNCH_ALLOWANCE_SECS = 30 * 60;
@@ -4192,6 +4351,254 @@
       } catch (error) {
         console.error('Error rendering attendance table:', error);
       }
+    }
+
+    exportAttendanceViolations(format = 'sheet') {
+      if (!this.currentData || !Array.isArray(this.currentData.userCompliance) || this.currentData.userCompliance.length === 0) {
+        this.showToast('No attendance data available to export.', 'warning');
+        return;
+      }
+
+      const BREAK_ALLOWANCE_SECS = 30 * 60;
+      const LUNCH_ALLOWANCE_SECS = 30 * 60;
+
+      const escapeCsv = (value) => {
+        const stringValue = value === undefined || value === null ? '' : String(value);
+        if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+          return '"' + stringValue.replace(/"/g, '""') + '"';
+        }
+        return stringValue;
+      };
+
+      const formatMinutes = (seconds, allowance) => {
+        const minutes = Math.max(0, (Math.max(0, seconds) - allowance) / 60);
+        return Math.round(minutes * 100) / 100;
+      };
+
+      const filteredCompliance = this.getFilteredComplianceData();
+      const rows = filteredCompliance.map((entry) => {
+        const breakSecs = Number(entry?.breakSecs) || 0;
+        const lunchSecs = Number(entry?.lunchSecs) || 0;
+        const breakOverMinutes = formatMinutes(breakSecs, BREAK_ALLOWANCE_SECS);
+        const lunchOverMinutes = formatMinutes(lunchSecs, LUNCH_ALLOWANCE_SECS);
+        const adherencePercent = this.calculateComplianceScore(entry);
+
+        return {
+          employee: entry?.user || 'Unknown',
+          breakHours: convertSecondsToDecimalHours(breakSecs),
+          breakOverMinutes,
+          breakViolationDays: Number.isFinite(entry?.exceededBreakDays) ? entry.exceededBreakDays : 0,
+          lunchHours: convertSecondsToDecimalHours(lunchSecs),
+          lunchOverMinutes,
+          lunchViolationDays: Number.isFinite(entry?.exceededLunchDays) ? entry.exceededLunchDays : 0,
+          weeklyOverages: Number.isFinite(entry?.exceededWeeklyCount) ? entry.exceededWeeklyCount : 0,
+          adherencePercent
+        };
+      });
+
+      const overallAdherence = rows.length > 0
+        ? Math.round(rows.reduce((sum, row) => sum + (Number(row.adherencePercent) || 0), 0) / rows.length)
+        : 0;
+
+      const header = [
+        'Employee',
+        'Break Hours Recorded',
+        'Break Over Minutes',
+        'Break Violation Days',
+        'Lunch Hours Recorded',
+        'Lunch Over Minutes',
+        'Lunch Violation Days',
+        'Weekly Overages',
+        'Adherence %'
+      ];
+
+      const csvLines = [header.join(',')];
+      rows.forEach((row) => {
+        csvLines.push([
+          escapeCsv(row.employee),
+          escapeCsv(row.breakHours.toFixed(2)),
+          escapeCsv(row.breakOverMinutes.toFixed(2)),
+          escapeCsv(row.breakViolationDays),
+          escapeCsv(row.lunchHours.toFixed(2)),
+          escapeCsv(row.lunchOverMinutes.toFixed(2)),
+          escapeCsv(row.lunchViolationDays),
+          escapeCsv(row.weeklyOverages),
+          escapeCsv(row.adherencePercent)
+        ].join(','));
+      });
+
+      csvLines.push('');
+      csvLines.push(`Overall Adherence,${overallAdherence}%`);
+
+      if (format === 'csv') {
+        const blob = new Blob([csvLines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `adherence-break-lunch-violations-${new Date().toISOString().slice(0, 10)}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+
+        this.showToast('Adherence break & lunch violations exported.', 'success');
+        return;
+      }
+
+      this.exportViolationsWorkbook(rows, overallAdherence);
+    }
+
+    getFilteredComplianceData() {
+      let compliance = Array.isArray(this.currentData?.userCompliance) ? [...this.currentData.userCompliance] : [];
+      const { userMode, selectedUsers, dateFrom, dateTo } = this.summaryFilters;
+
+      if (userMode === 'single' && selectedUsers.length === 1) {
+        compliance = compliance.filter(u => u.user === selectedUsers[0]);
+      } else if (userMode === 'multiple' && selectedUsers.length > 0) {
+        const set = new Set(selectedUsers);
+        compliance = compliance.filter(u => set.has(u.user));
+      }
+
+      if (dateFrom || dateTo) {
+        const fromDate = dateFrom ? new Date(dateFrom) : null;
+        const toDate = dateTo ? new Date(dateTo) : null;
+
+        compliance = compliance.map((entry) => {
+          if (!Array.isArray(entry?.dailyBreakdown)) return entry;
+          const filteredDays = entry.dailyBreakdown.filter((d) => {
+            if (!d?.dateKey) return false;
+            const candidate = new Date(d.dateKey);
+            if (Number.isNaN(candidate.getTime())) return true;
+            if (fromDate && candidate < fromDate) return false;
+            if (toDate && candidate > toDate) return false;
+            return true;
+          });
+          if (filteredDays.length === entry.dailyBreakdown.length) return entry;
+
+          const clone = { ...entry };
+          clone.dailyBreakdown = filteredDays;
+
+          const sumSeconds = filteredDays.reduce((acc, day) => {
+            const available = Number(day.availableSecs) || 0;
+            const breakSecs = Number(day.breakSecs) || 0;
+            const lunchSecs = Number(day.lunchSecs) || 0;
+            const weekend = Number(day.weekendSecs) || 0;
+            return {
+              available: acc.available + available,
+              break: acc.break + breakSecs,
+              lunch: acc.lunch + lunchSecs,
+              weekend: acc.weekend + weekend,
+              base: acc.base + (Number(day.baseBillableSecs) || 0),
+              adjusted: acc.adjusted + (Number(day.adjustedBillableSecs) || 0),
+              breakViolations: acc.breakViolations + (Number.isFinite(day.exceededBreakDays) ? day.exceededBreakDays : 0),
+              lunchViolations: acc.lunchViolations + (Number.isFinite(day.exceededLunchDays) ? day.exceededLunchDays : 0),
+              weeklyOverages: acc.weeklyOverages + (Number.isFinite(day.exceededWeeklyCount) ? day.exceededWeeklyCount : 0)
+            };
+          }, { available: 0, break: 0, lunch: 0, weekend: 0, base: 0, adjusted: 0, breakViolations: 0, lunchViolations: 0, weeklyOverages: 0 });
+
+          clone.availableSecsWeekday = sumSeconds.available;
+          clone.weekendSecs = sumSeconds.weekend;
+          clone.breakSecs = sumSeconds.break;
+          clone.lunchSecs = sumSeconds.lunch;
+          clone.baseBillableSecs = sumSeconds.base;
+          clone.adjustedBillableSecs = sumSeconds.adjusted;
+          clone.exceededBreakDays = sumSeconds.breakViolations;
+          clone.exceededLunchDays = sumSeconds.lunchViolations;
+          clone.exceededWeeklyCount = sumSeconds.weeklyOverages;
+
+          return clone;
+        });
+      }
+
+      return compliance;
+    }
+
+    async ensureXlsxLib() {
+      if (this.xlsxLib) return this.xlsxLib;
+      if (window.XLSX) {
+        this.xlsxLib = window.XLSX;
+        return this.xlsxLib;
+      }
+      try {
+        const module = await import('https://cdn.sheetjs.com/xlsx-latest/package/xlsx.mjs');
+        this.xlsxLib = module;
+        window.XLSX = module;
+        return this.xlsxLib;
+      } catch (error) {
+        console.error('Failed to load SheetJS library', error);
+        this.showToast('Unable to load Excel export library. CSV fallback used instead.', 'warning');
+        return null;
+      }
+    }
+
+    async exportViolationsWorkbook(rows, overallAdherence) {
+      const XLSX = await this.ensureXlsxLib();
+      if (!XLSX) {
+        this.exportAttendanceViolations('csv');
+        return;
+      }
+
+      const header = [
+        'Employee',
+        'Break Hours Recorded',
+        'Break Over Minutes',
+        'Break Violation Days',
+        'Lunch Hours Recorded',
+        'Lunch Over Minutes',
+        'Lunch Violation Days',
+        'Weekly Overages',
+        'Adherence %'
+      ];
+
+      const data = [header, ...rows.map((row) => [
+        row.employee,
+        Number(row.breakHours.toFixed(2)),
+        Number(row.breakOverMinutes.toFixed(2)),
+        row.breakViolationDays,
+        Number(row.lunchHours.toFixed(2)),
+        Number(row.lunchOverMinutes.toFixed(2)),
+        row.lunchViolationDays,
+        row.weeklyOverages,
+        row.adherencePercent
+      ])];
+
+      data.push([]);
+      data.push(['Overall Adherence', `${overallAdherence}%`]);
+
+      const worksheet = XLSX.utils.aoa_to_sheet(data);
+
+      worksheet['!freeze'] = { xSplit: 0, ySplit: 1, topLeftCell: 'A2', activePane: 'bottomLeft', state: 'frozen' };
+      worksheet['!cols'] = [
+        { wch: 24 }, { wch: 18 }, { wch: 18 }, { wch: 18 }, { wch: 18 }, { wch: 18 }, { wch: 18 }, { wch: 16 }, { wch: 14 }
+      ];
+
+      const headerStyle = {
+        font: { bold: true, color: { rgb: 'FFFFFFFF' } },
+        fill: { fgColor: { rgb: 'FF1E293B' } },
+        alignment: { horizontal: 'center', vertical: 'center' }
+      };
+
+      header.forEach((_, idx) => {
+        const cellRef = XLSX.utils.encode_cell({ c: idx, r: 0 });
+        if (!worksheet[cellRef]) return;
+        worksheet[cellRef].s = headerStyle;
+      });
+
+      const summaryCell = XLSX.utils.encode_cell({ c: 1, r: data.length - 1 });
+      if (worksheet[summaryCell]) {
+        worksheet[summaryCell].s = {
+          font: { bold: true },
+          alignment: { horizontal: 'left' }
+        };
+      }
+
+      const workbook = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(workbook, worksheet, 'Adherence');
+
+      const arrayBuffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx', cellStyles: true });
+      const blob = new Blob([arrayBuffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+      this.downloadFile(blob, `adherence-break-lunch-violations-${new Date().toISOString().slice(0, 10)}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      this.showToast('Adherence violations exported to Google Sheets ready format.', 'success');
     }
 
     renderWeeklyPaginationControls() {
@@ -6018,6 +6425,14 @@
 
   function exportData() {
     showEnhancedExportModal();
+  }
+
+  function exportAttendanceViolations(format) {
+    if (dashboard && typeof dashboard.exportAttendanceViolations === 'function') {
+      dashboard.exportAttendanceViolations(format);
+    } else {
+      console.warn('Attendance dashboard not ready for adherence violation export.');
+    }
   }
 
   function showModalLoading(containerId, message) {


### PR DESCRIPTION
## Summary
- add date and user scope filters to the Employee Attendance Summary and refresh pagination on the filtered view
- extend violations export with adherence percentages, Google Sheets-friendly formatting, and a styled header row
- allow choosing CSV or a Google Sheets-ready workbook when exporting violations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ca42e1748326ac15ba47a2e5b3e8)