### PR TITLE
Add CSAT export for call reports

### DIFF
--- a/CallReportService.js
+++ b/CallReportService.js
@@ -1483,3 +1483,23 @@ function exportCallAnalyticsCsv(granularity, periodIdentifier, agentFilter) {
 
   return [toCsv(repRows), toCsv(policyRows), toCsv(wrapRows), toCsv(callTrendRows), toCsv(talkTrendRows), toCsv(csatRows)].join('\r\n\r\n');
 }
+
+/**
+ * exportCallCsatCsv(granularity, periodIdentifier, agentFilter)
+ * Exports CSAT totals and percentage per agent for the selected window.
+ */
+function exportCallCsatCsv(granularity, periodIdentifier, agentFilter) {
+  const analytics = getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter);
+
+  const headers = ['Agent', 'CSAT Yes', 'Total CSAT', 'CSAT %'];
+  const rows = analytics.repMetrics
+    .map(r => {
+      const yes = Number(r.csatYes || 0);
+      const total = Number(r.csatTotal || 0);
+      const pct = total > 0 ? Math.round((yes / total) * 1000) / 10 : 0;
+      return [r.agent, yes, total, `${pct}%`];
+    });
+
+  const toCsv = rws => rws.map(r => r.map(c => `"${c}"`).join(',')).join('\r\n');
+  return toCsv([headers].concat(rows));
+}

--- a/CallReports.html
+++ b/CallReports.html
@@ -1307,6 +1307,9 @@
             <button type="button" class="btn btn-outline-light btn-sm" id="exportCallCsvBtn">
                 <i class="fas fa-file-export me-2"></i>Export CSV
             </button>
+            <button type="button" class="btn btn-outline-light btn-sm" id="exportCallCsatBtn">
+                <i class="fas fa-chart-pie me-2"></i>Export CSAT
+            </button>
             <a class="btn btn-outline-glass btn-sm" id="importCallReportsLink" href="<?= __importCallReportUrl ?>">
                 <i class="fas fa-file-import me-2"></i>Import Call Reports
             </a>
@@ -1772,6 +1775,18 @@
         const url = baseUrl
           + "&page=CallReports"
           + "&action=exportCallCsv"
+          + "&granularity=" + encodeURIComponent(currentGran)
+          + "&period=" + encodeURIComponent(currentPeriod)
+          + "&agent=" + encodeURIComponent(currentAgent);
+        window.open(url, "_blank");
+      });
+
+    document
+      .getElementById("exportCallCsatBtn")
+      .addEventListener("click", () => {
+        const url = baseUrl
+          + "&page=CallReports"
+          + "&action=exportCallCsat"
           + "&granularity=" + encodeURIComponent(currentGran)
           + "&period=" + encodeURIComponent(currentPeriod)
           + "&agent=" + encodeURIComponent(currentAgent);

--- a/Code.js
+++ b/Code.js
@@ -2572,6 +2572,16 @@ function doGet(e) {
         .downloadAsFile(`callAnalytics_${period}.csv`);
     }
 
+    if (page === "callreports" && e.parameter.action === "exportCallCsat") {
+      const gran = e.parameter.granularity || "Week";
+      const period = e.parameter.period || weekStringFromDate(new Date());
+      const agent = e.parameter.agent || "";
+      const csv = exportCallCsatCsv(gran, period, agent);
+      return ContentService.createTextOutput(csv)
+        .setMimeType(ContentService.MimeType.CSV)
+        .downloadAsFile(`callCsat_${period}.csv`);
+    }
+
     if (page === 'attendancereports' && e.parameter.action === 'exportCsv') {
       const gran = e.parameter.granularity || 'Week';
       const period = e.parameter.period || weekStringFromDate(new Date());


### PR DESCRIPTION
## Summary
- add CSAT-specific export button to call reports
- provide per-agent CSAT CSV with filtered yes counts, totals, and percentages
- route new export action through the backend using existing analytics filters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692568e04ce88326ab6079c9a84646ce)