### PR TITLE
Add call report analytics fallbacks

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -3765,6 +3765,14 @@ function handleCallReportsData(tpl, e, user, campaignId) {
     tpl.PAGE_SIZE = 50;
     tpl.data = [];
     tpl.userList = [];
+    tpl.callVolumeLast7 = JSON.stringify([]);
+    tpl.hourlyHeatmapLast7 = JSON.stringify([]);
+    tpl.avgIntervalByAgentLast7 = JSON.stringify([]);
+    tpl.talkTimeByAgentLast7 = JSON.stringify([]);
+    tpl.wrapupCountsLast7 = JSON.stringify([]);
+    tpl.csatDistLast7 = JSON.stringify([]);
+    tpl.policyCountsLast7 = JSON.stringify([]);
+    tpl.agentLeaderboardLast7 = JSON.stringify([]);
   }
 }
 


### PR DESCRIPTION
## Summary
- add default empty analytics payloads when call report data handling throws to keep the Call Reports page rendering
- retain baseline pagination and user list values during failures so templates stay well-formed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ed29a77c83269ac002b9f16e1ddc)