### PR TITLE
Fix adherence export download handling

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4788,7 +4788,22 @@
 
       const arrayBuffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx', cellStyles: true });
       const blob = new Blob([arrayBuffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-      this.downloadFile(blob, `adherence-compliance-${new Date().toISOString().slice(0, 10)}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      if (typeof this.downloadFile === 'function') {
+        this.downloadFile(
+          blob,
+          `adherence-compliance-${new Date().toISOString().slice(0, 10)}.xlsx`,
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        );
+      } else {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `adherence-compliance-${new Date().toISOString().slice(0, 10)}.xlsx`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
       this.showToast('Google Sheets-ready adherence & compliance workbook generated.', 'success');
     }
 
@@ -4883,7 +4898,23 @@
 
       const arrayBuffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx', cellStyles: true });
       const blob = new Blob([arrayBuffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-      this.downloadFile(blob, `adherence-break-lunch-violations-${new Date().toISOString().slice(0, 10)}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      const violationsFilename = `adherence-break-lunch-violations-${new Date().toISOString().slice(0, 10)}.xlsx`;
+      if (typeof this.downloadFile === 'function') {
+        this.downloadFile(
+          blob,
+          violationsFilename,
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        );
+      } else {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = violationsFilename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
       this.showToast('Adherence violations exported to Google Sheets ready format.', 'success');
     }
 


### PR DESCRIPTION
## Summary
- add a graceful fallback in adherence workbook exports when the class download helper is unavailable
- ensure both compliance and violation exports still trigger downloads via direct blob links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c025a144832685286c2d256ada09)