### PR TITLE
Optimize call report analytics for large datasets

### DIFF
--- a/CallReportService.js
+++ b/CallReportService.js
@@ -413,6 +413,76 @@ function __invalidateCallReportCache() {
   __analyticsCache = Object.create(null);
 }
 
+// Internal: read only the columns needed for analytics and filter by date/agent
+function __readCallReportRowsForAnalytics(startDate, endDate, agentFilter) {
+  const sh = __getCallReportSheet();
+  const lr = sh.getLastRow();
+  const lc = sh.getLastColumn();
+  if (lr < 2 || lc < CALL_REPORT_HEADERS.length) return [];
+
+  const headers = sh.getRange(1, 1, 1, lc).getValues()[0].map(String);
+  const headerIndex = {};
+  headers.forEach((h, i) => { headerIndex[h] = i; });
+
+  const answerHeader = __CALL_REPORT_ANSWER_HEADER_ALIASES.find(h => typeof headerIndex[h] === 'number');
+  const requiredHeaders = [
+    'CreatedDate',
+    'ToSFUser',
+    'TalkTimeMinutes',
+    'CSAT',
+    'FromRoutingPolicy',
+    'WrapupLabel'
+  ];
+
+  if (answerHeader) {
+    requiredHeaders.push(answerHeader);
+  }
+
+  const existingHeaders = requiredHeaders.filter(h => typeof headerIndex[h] === 'number');
+  if (!existingHeaders.length) return [];
+
+  const requiredColumns = existingHeaders.map(h => sh.getRange(2, headerIndex[h] + 1, lr - 1, 1).getValues());
+
+  const start = __startOfDay(startDate) || null;
+  const end = __endOfDay(endDate) || null;
+  const filteredRows = [];
+
+  for (let i = 0; i < lr - 1; i++) {
+    const rowObj = {};
+
+    existingHeaders.forEach((h, colIdx) => {
+      rowObj[h] = requiredColumns[colIdx][i][0];
+    });
+
+    if (rowObj.CreatedDate && !(rowObj.CreatedDate instanceof Date)) {
+      const d = new Date(rowObj.CreatedDate);
+      if (!isNaN(d)) rowObj.CreatedDate = d;
+    }
+
+    const created = rowObj.CreatedDate instanceof Date ? rowObj.CreatedDate : new Date(rowObj.CreatedDate);
+    if (!(created instanceof Date) || isNaN(created)) {
+      continue;
+    }
+
+    const createdDay = new Date(created.getFullYear(), created.getMonth(), created.getDate());
+    if (start && createdDay < start) continue;
+    if (end && createdDay > end) continue;
+
+    if (agentFilter && agentFilter !== '' && rowObj.ToSFUser !== agentFilter) {
+      continue;
+    }
+
+    // Ensure the answer value is available under all aliases
+    if (answerHeader && rowObj[answerHeader] !== undefined) {
+      __applyAnswerFieldAliases(rowObj, rowObj[answerHeader]);
+    }
+
+    filteredRows.push(rowObj);
+  }
+
+  return filteredRows;
+}
+
 // Internal: read all rows to objects using header row
 function __readAllCallReportRows() {
   try {
@@ -649,12 +719,7 @@ function getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter) {
   const weekRequirements = buildWeekRequirements(normalizedStart, normalizedEnd, tz);
 
   // Filter by date range (CreatedDate, date-only)
-  const dateFiltered = __readAllCallReportRows().filter(r => {
-    const dt = r.CreatedDate instanceof Date ? r.CreatedDate : new Date(r.CreatedDate);
-    if (isNaN(dt)) return false;
-    const d = new Date(dt.getFullYear(), dt.getMonth(), dt.getDate());
-    return d >= startDate && d <= endDate;
-  });
+  const dateFiltered = __readCallReportRowsForAnalytics(startDate, endDate, agentFilter);
 
   // Agents active in this window
   const activeAgents = Array.from(new Set(dateFiltered.map(r => r.ToSFUser || '—'))).sort();

--- a/Code.js
+++ b/Code.js
@@ -3707,7 +3707,7 @@ function handleCallReportsData(tpl, e, user, campaignId) {
     const selectedAgent = e.parameter.agent || "";
 
     if (typeof getAnalyticsByPeriod === 'function') {
-      const analytics = getAnalyticsByPeriod("Week", periodValue, "");
+      const analytics = getAnalyticsByPeriod(granularity, periodValue, selectedAgent);
       const rawReps = analytics.repMetrics || [];
       const pageNum = parseInt(e.parameter.page, 10) || 1;
       const PAGE_SIZE = 50;
@@ -3717,9 +3717,10 @@ function handleCallReportsData(tpl, e, user, campaignId) {
       const formattedReps = pageSlice.map((r) => {
         const totalCalls = r.totalCalls || 0;
         const totalTalkDecimal = parseFloat(r.totalTalk) || 0;
-        const totalTalkFormatted = formatDuration ? formatDuration(totalTalkDecimal) : totalTalkDecimal;
+        const formatDurationFn = (typeof formatDuration === 'function') ? formatDuration : null;
+        const totalTalkFormatted = formatDurationFn ? formatDurationFn(totalTalkDecimal) : totalTalkDecimal;
         const avgTalkDecimal = totalCalls > 0 ? totalTalkDecimal / totalCalls : 0;
-        const avgTalkFormatted = formatDuration ? formatDuration(avgTalkDecimal) : avgTalkDecimal;
+        const avgTalkFormatted = formatDurationFn ? formatDurationFn(avgTalkDecimal) : avgTalkDecimal;
         return {
           agent: r.agent,
           totalCalls: totalCalls,


### PR DESCRIPTION
## Summary
- add a lightweight call report reader that only fetches the columns needed for analytics and filters by date/agent up front
- use the analytics reader inside getAnalyticsByPeriod to reduce memory use on large sheets
- honor granularity/agent parameters when populating the Call Reports view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca04ccbe483268195fb4ff4417c2b)