### PR TITLE
Add matrix export and custom date ranges to call reports

### DIFF
--- a/CallReportService.js
+++ b/CallReportService.js
@@ -351,6 +351,25 @@ function __resolveCallReportPeriod(granularity, periodIdentifier) {
     return { startDate: start, endDate: __endOfDay(end) };
   }
 
+  if (granularity === 'Custom') {
+    if (typeof periodIdentifier === 'string') {
+      const parts = periodIdentifier.split('::');
+      if (parts.length === 2) {
+        const start = __startOfDay(parts[0]);
+        const end = __endOfDay(parts[1]);
+        if (start && end && start <= end) {
+          return { startDate: start, endDate: end };
+        }
+      }
+    }
+    const today = __startOfDay(new Date());
+    const defaultEnd = __endOfDay(new Date());
+    const defaultStart = today ? new Date(today.getTime() - (13 * __MS_PER_DAY)) : null;
+    if (defaultStart && defaultEnd) {
+      return { startDate: defaultStart, endDate: defaultEnd };
+    }
+  }
+
   return fallbackRange();
 }
 
@@ -1592,4 +1611,113 @@ function exportCallCsatCsv(granularity, periodIdentifier, agentFilter) {
 
   const toCsv = rws => rws.map(r => r.map(c => `"${c}"`).join(',')).join('\r\n');
   return toCsv([headers].concat(rows));
+}
+
+/**
+ * exportCallPerformanceMatrixCsv(granularity, periodIdentifier, agentFilter)
+ * Exports a matrix with per-agent counts, percentages, and leader callouts.
+ */
+function exportCallPerformanceMatrixCsv(granularity, periodIdentifier, agentFilter) {
+  const analytics = getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter);
+  const reps = Array.isArray(analytics.repMetrics) ? analytics.repMetrics : [];
+
+  const totals = reps.reduce((acc, r) => {
+    const calls = Number(r.totalCalls || 0);
+    const talk = Number(r.totalTalk || 0);
+    const csatTotal = Number(r.csatTotal || 0);
+    const csatYes = Number(r.csatYes || 0);
+    return {
+      totalCalls: acc.totalCalls + (isFinite(calls) ? calls : 0),
+      totalTalk: acc.totalTalk + (isFinite(talk) ? talk : 0),
+      totalCsat: acc.totalCsat + (isFinite(csatTotal) ? csatTotal : 0),
+      totalCsatYes: acc.totalCsatYes + (isFinite(csatYes) ? csatYes : 0)
+    };
+  }, { totalCalls: 0, totalTalk: 0, totalCsat: 0, totalCsatYes: 0 });
+
+  const pct = (num, den) => {
+    if (!isFinite(num) || !isFinite(den) || den <= 0) return 0;
+    return Math.round((num / den) * 1000) / 10;
+  };
+
+  const round1 = (num) => {
+    const n = Number(num);
+    if (!isFinite(n)) return 0;
+    return Math.round(n * 10) / 10;
+  };
+
+  const summaryRows = [['Leaderboard', 'Agent', 'Metric', 'Value']];
+  if (reps.length) {
+    const byCalls = reps.slice().sort((a, b) => (Number(b.totalCalls || 0) - Number(a.totalCalls || 0)));
+    const byTalk = reps.slice().sort((a, b) => (Number(b.totalTalk || 0) - Number(a.totalTalk || 0)));
+    const byCsat = reps.slice().sort((a, b) => (pct(b.csatYes, b.csatTotal) - pct(a.csatYes, a.csatTotal)));
+
+    summaryRows.push([
+      'Most Calls',
+      byCalls[0].agent,
+      'Total Calls',
+      Number(byCalls[0].totalCalls || 0)
+    ]);
+    summaryRows.push([
+      'Least Calls',
+      byCalls[byCalls.length - 1].agent,
+      'Total Calls',
+      Number(byCalls[byCalls.length - 1].totalCalls || 0)
+    ]);
+    summaryRows.push([
+      'Most Talk Time',
+      byTalk[0].agent,
+      'Total Talk (min)',
+      round1(byTalk[0].totalTalk || 0)
+    ]);
+    summaryRows.push([
+      'Highest CSAT %',
+      byCsat[0].agent,
+      'CSAT %',
+      `${pct(byCsat[0].csatYes, byCsat[0].csatTotal)}%`
+    ]);
+  } else {
+    summaryRows.push(['No data', '—', '—', '—']);
+  }
+
+  const detailHeader = [
+    'Agent',
+    'Total Calls',
+    'Call %',
+    'Total Talk (min)',
+    'Talk %',
+    'CSAT Total',
+    'CSAT %',
+    'Avg Talk (min)',
+    'Avg Answer (s)',
+    '≤30s Answer %'
+  ];
+
+  const detailRows = reps.map(r => {
+    const callPct = pct(r.totalCalls || 0, totals.totalCalls || 0);
+    const talkPct = pct(r.totalTalk || 0, totals.totalTalk || 0);
+    const csatPct = pct(r.csatYes || 0, r.csatTotal || 0);
+    const avgTalk = (isFinite(r.totalTalk) && isFinite(r.totalCalls) && r.totalCalls > 0)
+      ? (r.totalTalk / r.totalCalls)
+      : 0;
+    const answerSeconds = isFinite(r.averageAnswerSeconds) ? r.averageAnswerSeconds : 0;
+    const fastAnswerRate = isFinite(r.fastAnswerRate) ? r.fastAnswerRate : 0;
+
+    return [
+      r.agent,
+      Number(r.totalCalls || 0),
+      `${callPct}%`,
+      round1(r.totalTalk || 0),
+      `${talkPct}%`,
+      Number(r.csatTotal || 0),
+      `${csatPct}%`,
+      round1(avgTalk),
+      round1(answerSeconds),
+      `${round1(fastAnswerRate)}%`
+    ];
+  });
+
+  const toCsv = rws => rws.map(r => r.map(c => `"${c}"`).join(',')).join('\r\n');
+  return [summaryRows, [detailHeader].concat(detailRows)]
+    .map(toCsv)
+    .join('\r\n\r\n');
 }

--- a/CallReports.html
+++ b/CallReports.html
@@ -1310,6 +1310,9 @@
             <button type="button" class="btn btn-outline-light btn-sm" id="exportCallCsatBtn">
                 <i class="fas fa-chart-pie me-2"></i>Export CSAT
             </button>
+            <button type="button" class="btn btn-outline-light btn-sm" id="exportCallMatrixBtn">
+                <i class="fas fa-table me-2"></i>Export Matrix
+            </button>
             <a class="btn btn-outline-glass btn-sm" id="importCallReportsLink" href="<?= __importCallReportUrl ?>">
                 <i class="fas fa-file-import me-2"></i>Import Call Reports
             </a>
@@ -1323,6 +1326,7 @@
                     <option value="Month">📆 Monthly</option>
                     <option value="Quarter">📋 Quarterly</option>
                     <option value="Year">📊 Yearly</option>
+                    <option value="Custom">🗓️ Custom Range</option>
                 </select>
             </div>
 
@@ -1374,6 +1378,13 @@
                     placeholder="YYYY"
                     min="2000"
                     max="2100"/>
+            </div>
+            <div class="ms-0 ms-sm-2" id="customPicker" style="display: none;">
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                    <input type="date" class="form-control form-control-sm" id="customStartInput" aria-label="Custom start date" />
+                    <span class="text-muted" style="font-size: 0.9rem;">to</span>
+                    <input type="date" class="form-control form-control-sm" id="customEndInput" aria-label="Custom end date" />
+                </div>
             </div>
         </div>
     </div>
@@ -1661,6 +1672,63 @@
   let currentPeriod = "<?= selectedPeriod ?>"; // initial ISO week, e.g. "2025-W23"
   let currentAgent = "<?= selectedAgent ?>";  // initial agent filter (probably "")
 
+  function formatDateInputValue(dateObj) {
+    if (!(dateObj instanceof Date) || isNaN(dateObj)) return "";
+    const year = dateObj.getFullYear();
+    const month = String(dateObj.getMonth() + 1).padStart(2, "0");
+    const day = String(dateObj.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  function buildCustomPeriodValue(options = {}) {
+    const { quietMissing = false } = options;
+    const startEl = document.getElementById("customStartInput");
+    const endEl = document.getElementById("customEndInput");
+    if (!startEl || !endEl) return null;
+
+    const startVal = startEl.value;
+    const endVal = endEl.value;
+    if (!startVal || !endVal) {
+      if (!quietMissing) {
+        showToast("Select both a start and end date to use the custom range.", "warning");
+      }
+      return null;
+    }
+
+    const startDate = new Date(startVal);
+    const endDate = new Date(endVal);
+    if (isNaN(startDate) || isNaN(endDate)) {
+      showToast("Invalid custom date range provided.", "warning");
+      return null;
+    }
+
+    if (startDate > endDate) {
+      showToast("Start date must be on or before the end date.", "warning");
+      return null;
+    }
+
+    const normalizedStart = formatDateInputValue(startDate);
+    const normalizedEnd = formatDateInputValue(endDate);
+    return `${normalizedStart}::${normalizedEnd}`;
+  }
+
+  function resolvePeriodForRequest() {
+    if (currentGran !== "Custom") {
+      if (!currentPeriod) {
+        if (currentGran === "Week") {
+          const wk = document.getElementById("weekInput");
+          if (wk && wk.value) {
+            currentPeriod = wk.value;
+          }
+        }
+      }
+      return currentPeriod;
+    }
+    const resolved = buildCustomPeriodValue();
+    if (resolved) currentPeriod = resolved;
+    return resolved;
+  }
+
   // Enhanced Chart.js defaults
   function setupChartDefaults() {
     if (typeof Chart === 'undefined' || !Chart?.defaults) {
@@ -1755,36 +1823,108 @@
       triggerLoadAnalytics();
     });
 
+    const customStartInput = document.getElementById("customStartInput");
+    const customEndInput = document.getElementById("customEndInput");
+    const customPattern = /^\d{4}-\d{2}-\d{2}::\d{4}-\d{2}-\d{2}$/;
+
+    function seedCustomRangeDefaults() {
+      if (!customStartInput || !customEndInput) return;
+      if (!customStartInput.value) {
+        const start = new Date();
+        start.setDate(start.getDate() - 13);
+        customStartInput.value = formatDateInputValue(start);
+      }
+      if (!customEndInput.value) {
+        customEndInput.value = formatDateInputValue(new Date());
+      }
+    }
+
+    if (customPattern.test(currentPeriod)) {
+      const [start, end] = currentPeriod.split("::");
+      if (customStartInput && customEndInput) {
+        customStartInput.value = start;
+        customEndInput.value = end;
+      }
+    } else {
+      seedCustomRangeDefaults();
+    }
+
+    const handleCustomRangeChange = () => {
+      if (currentGran !== "Custom") return;
+      const value = buildCustomPeriodValue({ quietMissing: true });
+      if (value) {
+        currentPeriod = value;
+        triggerLoadAnalytics();
+      }
+    };
+
+    customStartInput?.addEventListener("change", handleCustomRangeChange);
+    customEndInput?.addEventListener("change", handleCustomRangeChange);
+
     // Keep existing picker initialization
-    document.getElementById("weekPicker").style.display = "none";
-    document.getElementById("biWeekPicker").style.display = "none";
-    document.getElementById("monthPicker").style.display = "none";
-    document.getElementById("quarterPicker").style.display = "none";
-    document.getElementById("yearPicker").style.display = "none";
+    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker", "customPicker"].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = "none";
+    });
 
     populateBiWeeklyOptions();
 
     const today = new Date();
     const weekPattern = /^\d{4}-W\d{2}$/i;
-    if (currentPeriod && weekPattern.test(currentPeriod)) {
-      wk.value = currentPeriod;
-    } else {
-      const isoWeek = weekStringFromDate(today);
-      wk.value = isoWeek;
-      if (!currentPeriod || !currentPeriod.length) {
-        currentPeriod = isoWeek;
+    const monthPattern = /^\d{4}-\d{2}$/;
+    const quarterPattern = /^Q[1-4]-\d{4}$/i;
+    if (currentGran === "BiWeekly") {
+      const select = document.getElementById("biWeekSelect");
+      if (select) {
+        if (currentPeriod && Array.from(select.options).some(opt => opt.value === currentPeriod)) {
+          select.value = currentPeriod;
+        }
+        document.getElementById("biWeekPicker").style.display = "block";
       }
+    } else if (currentGran === "Month") {
+      if (m && monthPattern.test(currentPeriod)) {
+        m.value = currentPeriod;
+      }
+      document.getElementById("monthPicker").style.display = "block";
+    } else if (currentGran === "Quarter") {
+      if (quarterPattern.test(currentPeriod)) {
+        const [selectedQuarter, selectedYear] = currentPeriod.split("-");
+        if (qs) qs.value = selectedQuarter;
+        if (qy) qy.value = selectedYear;
+      }
+      document.getElementById("quarterPicker").style.display = "block";
+    } else if (currentGran === "Year") {
+      if (yr && currentPeriod) {
+        yr.value = currentPeriod;
+      }
+      document.getElementById("yearPicker").style.display = "block";
+    } else if (currentGran === "Custom") {
+      document.getElementById("customPicker").style.display = "block";
+      const seeded = buildCustomPeriodValue({ quietMissing: true });
+      if (seeded) currentPeriod = seeded;
+    } else {
+      if (currentPeriod && weekPattern.test(currentPeriod)) {
+        wk.value = currentPeriod;
+      } else {
+        const isoWeek = weekStringFromDate(today);
+        wk.value = isoWeek;
+        if (!currentPeriod || !currentPeriod.length) {
+          currentPeriod = isoWeek;
+        }
+      }
+      document.getElementById("weekPicker").style.display = "block";
     }
-    document.getElementById("weekPicker").style.display = "block";
 
     document
       .getElementById("exportCallCsvBtn")
       .addEventListener("click", () => {
+        const safePeriod = resolvePeriodForRequest();
+        if (!safePeriod) return;
         const url = baseUrl
           + "&page=CallReports"
           + "&action=exportCallCsv"
           + "&granularity=" + encodeURIComponent(currentGran)
-          + "&period=" + encodeURIComponent(currentPeriod)
+          + "&period=" + encodeURIComponent(safePeriod)
           + "&agent=" + encodeURIComponent(currentAgent);
         window.open(url, "_blank");
       });
@@ -1792,11 +1932,27 @@
     document
       .getElementById("exportCallCsatBtn")
       .addEventListener("click", () => {
+        const safePeriod = resolvePeriodForRequest();
+        if (!safePeriod) return;
         const url = baseUrl
           + "&page=CallReports"
           + "&action=exportCallCsat"
           + "&granularity=" + encodeURIComponent(currentGran)
-          + "&period=" + encodeURIComponent(currentPeriod)
+          + "&period=" + encodeURIComponent(safePeriod)
+          + "&agent=" + encodeURIComponent(currentAgent);
+        window.open(url, "_blank");
+      });
+
+    document
+      .getElementById("exportCallMatrixBtn")
+      .addEventListener("click", () => {
+        const safePeriod = resolvePeriodForRequest();
+        if (!safePeriod) return;
+        const url = baseUrl
+          + "&page=CallReports"
+          + "&action=exportCallMatrix"
+          + "&granularity=" + encodeURIComponent(currentGran)
+          + "&period=" + encodeURIComponent(safePeriod)
           + "&agent=" + encodeURIComponent(currentAgent);
         window.open(url, "_blank");
       });
@@ -1861,13 +2017,16 @@
 
     // Load initial analytics - keep existing function call
     if (chartsReady !== false) {
-      loadAnalytics(currentGran, currentPeriod, currentAgent);
+      const safePeriod = resolvePeriodForRequest();
+      if (safePeriod) {
+        loadAnalytics(currentGran, safePeriod, currentAgent);
+      }
     }
   });
 
   // Keep all existing functions exactly as they were, just enhance the rendering
   function onGranChange() {
-    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker"].forEach(id => {
+    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker", "customPicker"].forEach(id => {
       document.getElementById(id).style.display = "none";
     });
 
@@ -1901,13 +2060,21 @@
       document.getElementById("yearPicker").style.display = "block";
       const yr = document.getElementById("yearInput");
       currentPeriod = yr.value;
+    } else if (currentGran === "Custom") {
+      document.getElementById("customPicker").style.display = "block";
+      const seeded = buildCustomPeriodValue({ quietMissing: true });
+      if (seeded) {
+        currentPeriod = seeded;
+      }
     }
 
     triggerLoadAnalytics();
   }
 
   function triggerLoadAnalytics() {
-    loadAnalytics(currentGran, currentPeriod, currentAgent);
+    const safePeriod = resolvePeriodForRequest();
+    if (!safePeriod) return;
+    loadAnalytics(currentGran, safePeriod, currentAgent);
   }
 
   function renderEverything(analytics) {

--- a/Code.js
+++ b/Code.js
@@ -2582,6 +2582,16 @@ function doGet(e) {
         .downloadAsFile(`callCsat_${period}.csv`);
     }
 
+    if (page === "callreports" && e.parameter.action === "exportCallMatrix") {
+      const gran = e.parameter.granularity || "Week";
+      const period = e.parameter.period || weekStringFromDate(new Date());
+      const agent = e.parameter.agent || "";
+      const csv = exportCallPerformanceMatrixCsv(gran, period, agent);
+      return ContentService.createTextOutput(csv)
+        .setMimeType(ContentService.MimeType.CSV)
+        .downloadAsFile(`callMatrix_${period}.csv`);
+    }
+
     if (page === 'attendancereports' && e.parameter.action === 'exportCsv') {
       const gran = e.parameter.granularity || 'Week';
       const period = e.parameter.period || weekStringFromDate(new Date());


### PR DESCRIPTION
## Summary
- add a custom date range picker alongside existing period controls for call reports and export actions
- introduce an export matrix option covering CSAT totals/percentages, call and talk share, and answer-speed metrics with leader callouts
- support the new custom range parameter and matrix export server-side for CSV downloads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb7a0bc7c8326929b1f0e48f4ff78)