### PR TITLE
Implement modal-driven call matrix export

### DIFF
--- a/CallReportService.js
+++ b/CallReportService.js
@@ -12,6 +12,13 @@ const __MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const __CALL_REPORT_CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes of warm cache
 const __ANALYTICS_CACHE_TTL_MS = 90 * 1000; // aggressively reuse analytics payloads
+const __MATRIX_EXPORT_TZ = (function () {
+  try {
+    return Session.getScriptTimeZone();
+  } catch (err) {
+    return 'UTC';
+  }
+})();
 let __callReportCache = null;
 let __analyticsCache = Object.create(null);
 
@@ -351,7 +358,109 @@ function __resolveCallReportPeriod(granularity, periodIdentifier) {
     return { startDate: start, endDate: __endOfDay(end) };
   }
 
+  if (granularity === 'Custom') {
+    if (typeof periodIdentifier === 'string') {
+      const parts = periodIdentifier.split('::');
+      if (parts.length === 2) {
+        const start = __startOfDay(parts[0]);
+        const end = __endOfDay(parts[1]);
+        if (start && end && start <= end) {
+          return { startDate: start, endDate: end };
+        }
+      }
+    }
+    const today = __startOfDay(new Date());
+    const defaultEnd = __endOfDay(new Date());
+    const defaultStart = today ? new Date(today.getTime() - (13 * __MS_PER_DAY)) : null;
+    if (defaultStart && defaultEnd) {
+      return { startDate: defaultStart, endDate: defaultEnd };
+    }
+  }
+
   return fallbackRange();
+}
+
+function __resolveMatrixPeriod(periodType, startDate, endDate) {
+  const normalized = (periodType || '').toLowerCase();
+  const today = __startOfDay(new Date());
+  const cloneDay = (d) => d ? new Date(d.getTime()) : null;
+
+  if (normalized === 'custom') {
+    const start = __startOfDay(startDate);
+    const end = __endOfDay(endDate);
+    if (!start || !end || start > end) return null;
+    return {
+      startDate: start,
+      endDate: end,
+      label: Utilities.formatDate(start, __MATRIX_EXPORT_TZ, 'yyyyMMdd') + '_' + Utilities.formatDate(end, __MATRIX_EXPORT_TZ, 'yyyyMMdd')
+    };
+  }
+
+  if (!today || isNaN(today)) return null;
+
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const quarterStartMonth = Math.floor(month / 3) * 3;
+
+  const ranges = {
+    weekly: () => {
+      const monday = __ensureMondayStart(today);
+      const end = new Date(monday.getTime());
+      end.setDate(end.getDate() + 6);
+      return { startDate: monday, endDate: __endOfDay(end), label: Utilities.formatDate(monday, __MATRIX_EXPORT_TZ, 'yyyy_MM_dd') + '_W' };
+    },
+    biweekly: () => {
+      const monday = __ensureMondayStart(today);
+      const end = new Date(monday.getTime());
+      end.setDate(end.getDate() + 13);
+      return { startDate: monday, endDate: __endOfDay(end), label: Utilities.formatDate(monday, __MATRIX_EXPORT_TZ, 'yyyy_MM_dd') + '_BW' };
+    },
+    monthly: () => {
+      const start = new Date(year, month, 1);
+      const end = new Date(year, month + 1, 0);
+      return { startDate: start, endDate: __endOfDay(end), label: Utilities.formatDate(start, __MATRIX_EXPORT_TZ, 'yyyy_MM') };
+    },
+    quarterly: () => {
+      const start = new Date(year, quarterStartMonth, 1);
+      const end = new Date(year, quarterStartMonth + 3, 0);
+      const qNum = Math.floor(month / 3) + 1;
+      return { startDate: start, endDate: __endOfDay(end), label: `${year}_Q${qNum}` };
+    },
+    yearly: () => {
+      const start = new Date(year, 0, 1);
+      const end = new Date(year, 11, 31);
+      return { startDate: start, endDate: __endOfDay(end), label: `${year}` };
+    }
+  };
+
+  const resolver = ranges[normalized];
+  if (resolver) {
+    const range = resolver();
+    if (range && range.startDate && range.endDate) {
+      return { startDate: cloneDay(range.startDate), endDate: cloneDay(range.endDate), label: range.label };
+    }
+  }
+
+  return null;
+}
+
+function __extractHoldSeconds(record) {
+  if (!record || typeof record !== 'object') return 0;
+  const candidates = ['HoldTimeSeconds', 'HoldTime', 'Hold Duration', 'HundredTime', 'HundredTimeSeconds'];
+  for (let i = 0; i < candidates.length; i++) {
+    const key = candidates[i];
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      const raw = record[key];
+      const num = Number(raw);
+      if (isFinite(num) && num >= 0) {
+        if (num > 0 && num < 1) {
+          return num * 86400; // spreadsheet time stored as fraction of a day
+        }
+        return num;
+      }
+    }
+  }
+  return 0;
 }
 
 var __CALL_REPORT_ANSWER_HEADER_ALIASES = (function (global) {
@@ -428,10 +537,18 @@ function __readCallReportRowsForAnalytics(startDate, endDate, agentFilter) {
   const requiredHeaders = [
     'CreatedDate',
     'ToSFUser',
+    'UserID',
     'TalkTimeMinutes',
     'CSAT',
     'FromRoutingPolicy',
-    'WrapupLabel'
+    'WrapupLabel',
+    'HoldTimeSeconds',
+    'HoldTime',
+    'Hold Duration',
+    'HundredTime',
+    'HundredTimeSeconds',
+    'Team',
+    'Program'
   ];
 
   if (answerHeader) {
@@ -1592,4 +1709,304 @@ function exportCallCsatCsv(granularity, periodIdentifier, agentFilter) {
 
   const toCsv = rws => rws.map(r => r.map(c => `"${c}"`).join(',')).join('\r\n');
   return toCsv([headers].concat(rows));
+}
+
+/**
+ * exportCallPerformanceMatrixCsv(granularity, periodIdentifier, agentFilter)
+ * Exports a matrix with per-agent counts, percentages, and leader callouts.
+ */
+function exportCallPerformanceMatrixCsv(granularity, periodIdentifier, agentFilter) {
+  const analytics = getAnalyticsByPeriod(granularity, periodIdentifier, agentFilter);
+  const reps = Array.isArray(analytics.repMetrics) ? analytics.repMetrics : [];
+
+  const totals = reps.reduce((acc, r) => {
+    const calls = Number(r.totalCalls || 0);
+    const talk = Number(r.totalTalk || 0);
+    const csatTotal = Number(r.csatTotal || 0);
+    const csatYes = Number(r.csatYes || 0);
+    return {
+      totalCalls: acc.totalCalls + (isFinite(calls) ? calls : 0),
+      totalTalk: acc.totalTalk + (isFinite(talk) ? talk : 0),
+      totalCsat: acc.totalCsat + (isFinite(csatTotal) ? csatTotal : 0),
+      totalCsatYes: acc.totalCsatYes + (isFinite(csatYes) ? csatYes : 0)
+    };
+  }, { totalCalls: 0, totalTalk: 0, totalCsat: 0, totalCsatYes: 0 });
+
+  const pct = (num, den) => {
+    if (!isFinite(num) || !isFinite(den) || den <= 0) return 0;
+    return Math.round((num / den) * 1000) / 10;
+  };
+
+  const round1 = (num) => {
+    const n = Number(num);
+    if (!isFinite(n)) return 0;
+    return Math.round(n * 10) / 10;
+  };
+
+  const summaryRows = [['Leaderboard', 'Agent', 'Metric', 'Value']];
+  if (reps.length) {
+    const byCalls = reps.slice().sort((a, b) => (Number(b.totalCalls || 0) - Number(a.totalCalls || 0)));
+    const byTalk = reps.slice().sort((a, b) => (Number(b.totalTalk || 0) - Number(a.totalTalk || 0)));
+    const byCsat = reps.slice().sort((a, b) => (pct(b.csatYes, b.csatTotal) - pct(a.csatYes, a.csatTotal)));
+
+    summaryRows.push([
+      'Most Calls',
+      byCalls[0].agent,
+      'Total Calls',
+      Number(byCalls[0].totalCalls || 0)
+    ]);
+    summaryRows.push([
+      'Least Calls',
+      byCalls[byCalls.length - 1].agent,
+      'Total Calls',
+      Number(byCalls[byCalls.length - 1].totalCalls || 0)
+    ]);
+    summaryRows.push([
+      'Most Talk Time',
+      byTalk[0].agent,
+      'Total Talk (min)',
+      round1(byTalk[0].totalTalk || 0)
+    ]);
+    summaryRows.push([
+      'Highest CSAT %',
+      byCsat[0].agent,
+      'CSAT %',
+      `${pct(byCsat[0].csatYes, byCsat[0].csatTotal)}%`
+    ]);
+  } else {
+    summaryRows.push(['No data', '—', '—', '—']);
+  }
+
+  const detailHeader = [
+    'Agent',
+    'Total Calls',
+    'Call %',
+    'Total Talk (min)',
+    'Talk %',
+    'CSAT Total',
+    'CSAT %',
+    'Avg Talk (min)',
+    'Avg Answer (s)',
+    '≤30s Answer %'
+  ];
+
+  const detailRows = reps.map(r => {
+    const callPct = pct(r.totalCalls || 0, totals.totalCalls || 0);
+    const talkPct = pct(r.totalTalk || 0, totals.totalTalk || 0);
+    const csatPct = pct(r.csatYes || 0, r.csatTotal || 0);
+    const avgTalk = (isFinite(r.totalTalk) && isFinite(r.totalCalls) && r.totalCalls > 0)
+      ? (r.totalTalk / r.totalCalls)
+      : 0;
+    const answerSeconds = isFinite(r.averageAnswerSeconds) ? r.averageAnswerSeconds : 0;
+    const fastAnswerRate = isFinite(r.fastAnswerRate) ? r.fastAnswerRate : 0;
+
+    return [
+      r.agent,
+      Number(r.totalCalls || 0),
+      `${callPct}%`,
+      round1(r.totalTalk || 0),
+      `${talkPct}%`,
+      Number(r.csatTotal || 0),
+      `${csatPct}%`,
+      round1(avgTalk),
+      round1(answerSeconds),
+      `${round1(fastAnswerRate)}%`
+    ];
+  });
+
+  const toCsv = rws => rws.map(r => r.map(c => `"${c}"`).join(',')).join('\r\n');
+  return [summaryRows, [detailHeader].concat(detailRows)]
+    .map(toCsv)
+    .join('\r\n\r\n');
+}
+
+function __buildRankMap(items, key, direction) {
+  const sorted = items.slice().sort((a, b) => {
+    const av = Number(a[key] || 0);
+    const bv = Number(b[key] || 0);
+    return direction === 'asc' ? av - bv : bv - av;
+  });
+  const ranks = Object.create(null);
+  let currentRank = 0;
+  let lastValue = null;
+  sorted.forEach((item, idx) => {
+    const val = Number(item[key] || 0);
+    if (lastValue === null || val !== lastValue) {
+      currentRank = idx + 1;
+      lastValue = val;
+    }
+    ranks[item.agent] = isFinite(val) ? currentRank : '-';
+  });
+  return ranks;
+}
+
+function exportCallReportMatrix(config) {
+  const cfg = Object.assign({
+    periodType: 'weekly',
+    includeCalls: true,
+    includeCsat: true,
+    agent: ''
+  }, config || {});
+
+  const period = __resolveMatrixPeriod(cfg.periodType, cfg.startDate, cfg.endDate);
+  if (!period || !period.startDate || !period.endDate) {
+    throw new Error('Unable to resolve the requested export period. Please check your selection.');
+  }
+
+  const rows = __readCallReportRowsForAnalytics(period.startDate, period.endDate, cfg.agent || cfg.agentFilter || '');
+  const includeCalls = cfg.includeCalls !== false;
+  const includeCsat = cfg.includeCsat !== false;
+
+  const agentMap = Object.create(null);
+
+  rows.forEach(r => {
+    const agent = r.ToSFUser || '—';
+    if (!agentMap[agent]) {
+      agentMap[agent] = {
+        agent,
+        userId: r.UserID || '',
+        team: r.Team || r.Program || '',
+        totalCalls: 0,
+        talkSeconds: 0,
+        holdSeconds: 0,
+        csatYes: 0,
+        csatTotal: 0,
+        totalAnswerSeconds: 0,
+        answeredCount: 0,
+        fastAnswerCount: 0
+      };
+    }
+
+    if (includeCalls) {
+      agentMap[agent].totalCalls += 1;
+      const talkMinutes = Number(r.TalkTimeMinutes || 0);
+      if (isFinite(talkMinutes)) {
+        agentMap[agent].talkSeconds += Math.max(0, talkMinutes) * 60;
+      }
+      agentMap[agent].holdSeconds += __extractHoldSeconds(r);
+    }
+
+    const csatValue = (r.CSAT || '').toString().trim().toLowerCase();
+    if (includeCsat && csatValue) {
+      if (csatValue === 'yes' || csatValue === 'true' || csatValue === '1') {
+        agentMap[agent].csatYes += 1;
+        agentMap[agent].csatTotal += 1;
+      } else if (csatValue === 'no' || csatValue === 'false' || csatValue === '0') {
+        agentMap[agent].csatTotal += 1;
+      }
+    }
+
+    const answerSeconds = __parseAnswerSeconds(__getAnswerFieldValue(r), r.CreatedDate);
+    if (isFinite(answerSeconds)) {
+      agentMap[agent].totalAnswerSeconds += answerSeconds;
+      agentMap[agent].answeredCount += 1;
+      if (answerSeconds <= 30) {
+        agentMap[agent].fastAnswerCount += 1;
+      }
+    }
+  });
+
+  const agents = Object.values(agentMap);
+
+  const totals = agents.reduce((acc, a) => {
+    acc.calls += a.totalCalls;
+    acc.talkSeconds += a.talkSeconds;
+    acc.holdSeconds += a.holdSeconds;
+    acc.csatYes += a.csatYes;
+    acc.csatTotal += a.csatTotal;
+    acc.answered += a.answeredCount;
+    acc.answerSeconds += a.totalAnswerSeconds;
+    return acc;
+  }, { calls: 0, talkSeconds: 0, holdSeconds: 0, csatYes: 0, csatTotal: 0, answered: 0, answerSeconds: 0 });
+
+  const pct = (num, den) => {
+    if (!isFinite(num) || !isFinite(den) || den <= 0) return 0;
+    return Math.round((num / den) * 1000) / 10;
+  };
+
+  const callRanks = includeCalls ? __buildRankMap(agents, 'totalCalls', 'desc') : {};
+  const talkRanks = includeCalls ? __buildRankMap(agents, 'talkSeconds', 'desc') : {};
+  const csatRanks = includeCsat ? __buildRankMap(agents.map(a => Object.assign({}, a, { csatPercent: pct(a.csatYes, a.csatTotal) })), 'csatPercent', 'desc') : {};
+
+  const detailHeaders = [
+    'Agent Name', 'Agent ID', 'Team/Program', 'Total Calls', 'Call %', 'CSAT Count', 'CSAT %',
+    'Total Talk (min)', 'Talk %', 'Avg Talk (min)', 'Total Hold (min)', 'Hold %', 'Avg Hold (min)',
+    'Avg Answer (s)', '≤30s Answer %', 'Call Rank', 'Talk Rank', 'CSAT Rank'
+  ];
+
+  const detailRows = agents.map(a => {
+    const avgTalkMin = (a.totalCalls > 0 && a.talkSeconds > 0) ? (a.talkSeconds / 60) / a.totalCalls : 0;
+    const avgHoldMin = (a.totalCalls > 0 && a.holdSeconds > 0) ? (a.holdSeconds / 60) / a.totalCalls : 0;
+    const avgAnswer = (a.answeredCount > 0 && a.totalAnswerSeconds > 0) ? (a.totalAnswerSeconds / a.answeredCount) : 0;
+    const fastAnswerPct = (a.answeredCount > 0) ? pct(a.fastAnswerCount, a.answeredCount) : 0;
+    const csatPercent = includeCsat ? pct(a.csatYes, a.csatTotal) : 0;
+
+    return [
+      a.agent,
+      a.userId,
+      a.team,
+      includeCalls ? Number(a.totalCalls || 0) : 0,
+      includeCalls ? `${pct(a.totalCalls, totals.calls)}%` : '0%',
+      includeCsat ? Number(a.csatTotal || 0) : 0,
+      includeCsat ? `${csatPercent}%` : '0%',
+      includeCalls ? Math.round((a.talkSeconds / 60) * 10) / 10 : 0,
+      includeCalls ? `${pct(a.talkSeconds, totals.talkSeconds)}%` : '0%',
+      includeCalls ? Math.round(avgTalkMin * 10) / 10 : 0,
+      includeCalls ? Math.round((a.holdSeconds / 60) * 10) / 10 : 0,
+      includeCalls ? `${pct(a.holdSeconds, totals.holdSeconds)}%` : '0%',
+      includeCalls ? Math.round(avgHoldMin * 10) / 10 : 0,
+      Math.round(avgAnswer * 10) / 10,
+      `${Math.round(fastAnswerPct * 10) / 10}%`,
+      includeCalls ? (callRanks[a.agent] || '-') : '-',
+      includeCalls ? (talkRanks[a.agent] || '-') : '-',
+      includeCsat ? (csatRanks[a.agent] || '-') : '-'
+    ];
+  });
+
+  const ss = SpreadsheetApp.create(`CallReport_Matrix_${period.label}`);
+  const matrixSheet = ss.getActiveSheet();
+  matrixSheet.setName('Matrix');
+  matrixSheet.appendRow(detailHeaders);
+  if (detailRows.length) {
+    matrixSheet.getRange(2, 1, detailRows.length, detailHeaders.length).setValues(detailRows);
+  }
+  matrixSheet.getRange(1, 1, 1, detailHeaders.length).setFontWeight('bold');
+  matrixSheet.setFrozenRows(1);
+
+  const summarySheet = ss.insertSheet('Leaders');
+  summarySheet.appendRow(['Metric', 'Agent', 'Value', 'Period']);
+  summarySheet.getRange(1, 1, 1, 4).setFontWeight('bold');
+
+  const callsSorted = includeCalls ? agents.slice().sort((a, b) => Number(b.totalCalls || 0) - Number(a.totalCalls || 0)) : [];
+  const talkSorted = includeCalls ? agents.slice().sort((a, b) => Number(b.talkSeconds || 0) - Number(a.talkSeconds || 0)) : [];
+  const csatSorted = includeCsat ? agents.slice().sort((a, b) => pct(b.csatYes, b.csatTotal) - pct(a.csatYes, a.csatTotal)) : [];
+
+  if (includeCalls && callsSorted.length) {
+    const leastCalls = callsSorted.slice().reverse().find(a => a.totalCalls > 0) || callsSorted[callsSorted.length - 1];
+    summarySheet.appendRow(['Most Calls', callsSorted[0].agent, Number(callsSorted[0].totalCalls || 0), period.label]);
+    summarySheet.appendRow(['Least Calls', leastCalls.agent, Number(leastCalls.totalCalls || 0), period.label]);
+  }
+
+  if (includeCalls && talkSorted.length) {
+    const leastTalk = talkSorted.slice().reverse().find(a => a.talkSeconds > 0) || talkSorted[talkSorted.length - 1];
+    summarySheet.appendRow(['Most Talk Time', talkSorted[0].agent, Math.round((talkSorted[0].talkSeconds / 60) * 10) / 10, period.label]);
+    summarySheet.appendRow(['Least Talk Time', leastTalk.agent, Math.round((leastTalk.talkSeconds / 60) * 10) / 10, period.label]);
+  }
+
+  if (includeCsat && csatSorted.length) {
+    const topCsat = csatSorted[0];
+    const bottomCsat = csatSorted.slice().reverse().find(a => a.csatTotal > 0) || csatSorted[csatSorted.length - 1];
+    summarySheet.appendRow(['Highest CSAT %', topCsat.agent, `${pct(topCsat.csatYes, topCsat.csatTotal)}%`, period.label]);
+    summarySheet.appendRow(['Lowest CSAT %', bottomCsat.agent, `${pct(bottomCsat.csatYes, bottomCsat.csatTotal)}%`, period.label]);
+  }
+
+  summarySheet.appendRow(['Period Start', Utilities.formatDate(period.startDate, __MATRIX_EXPORT_TZ, 'yyyy-MM-dd'), '', period.label]);
+  summarySheet.appendRow(['Period End', Utilities.formatDate(period.endDate, __MATRIX_EXPORT_TZ, 'yyyy-MM-dd'), '', period.label]);
+
+  return {
+    spreadsheetUrl: ss.getUrl(),
+    spreadsheetId: ss.getId(),
+    sheetName: matrixSheet.getName(),
+    periodLabel: period.label
+  };
 }

--- a/CallReports.html
+++ b/CallReports.html
@@ -1236,7 +1236,7 @@
     @media (max-width: 576px) {
         .btn-ai,
         .btn-outline-glass,
-        #exportCallCsvBtn {
+        #matrixExportBtn {
             width: 100%;
             justify-content: center;
         }
@@ -1304,11 +1304,8 @@
             <button type="button" class="btn btn-ai btn-sm" id="aiAnalyzerBtn" aria-expanded="false">
                 <i class="fas fa-robot me-2"></i><span class="btn-label">AI Analyzer</span>
             </button>
-            <button type="button" class="btn btn-outline-light btn-sm" id="exportCallCsvBtn">
-                <i class="fas fa-file-export me-2"></i>Export CSV
-            </button>
-            <button type="button" class="btn btn-outline-light btn-sm" id="exportCallCsatBtn">
-                <i class="fas fa-chart-pie me-2"></i>Export CSAT
+            <button type="button" class="btn btn-outline-light btn-sm" id="matrixExportBtn">
+                <i class="fas fa-table me-2"></i>Export Matrix
             </button>
             <a class="btn btn-outline-glass btn-sm" id="importCallReportsLink" href="<?= __importCallReportUrl ?>">
                 <i class="fas fa-file-import me-2"></i>Import Call Reports
@@ -1323,6 +1320,7 @@
                     <option value="Month">📆 Monthly</option>
                     <option value="Quarter">📋 Quarterly</option>
                     <option value="Year">📊 Yearly</option>
+                    <option value="Custom">🗓️ Custom Range</option>
                 </select>
             </div>
 
@@ -1374,6 +1372,13 @@
                     placeholder="YYYY"
                     min="2000"
                     max="2100"/>
+            </div>
+            <div class="ms-0 ms-sm-2" id="customPicker" style="display: none;">
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                    <input type="date" class="form-control form-control-sm" id="customStartInput" aria-label="Custom start date" />
+                    <span class="text-muted" style="font-size: 0.9rem;">to</span>
+                    <input type="date" class="form-control form-control-sm" id="customEndInput" aria-label="Custom end date" />
+                </div>
             </div>
         </div>
     </div>
@@ -1430,6 +1435,103 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="matrixExportModal" tabindex="-1" aria-labelledby="matrixExportModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="matrixExportModalLabel"><i class="fas fa-table me-2"></i>Export Performance Matrix</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted mb-3">Choose the window and metrics to generate a single matrix that blends calls, CSAT, talk time, and hold time with leaderboards.</p>
+                <div class="row g-3 mb-3">
+                    <div class="col-md-6">
+                        <div class="card h-100 shadow-sm">
+                            <div class="card-body">
+                                <div class="fw-bold mb-2">Time period</div>
+                                <div class="d-flex flex-column gap-2" id="matrixPeriodGroup">
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="weekly" checked>
+                                        <span class="form-check-label">Weekly</span>
+                                    </label>
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="biweekly">
+                                        <span class="form-check-label">Bi-Weekly</span>
+                                    </label>
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="monthly">
+                                        <span class="form-check-label">Monthly</span>
+                                    </label>
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="quarterly">
+                                        <span class="form-check-label">Quarterly</span>
+                                    </label>
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="yearly">
+                                        <span class="form-check-label">Yearly</span>
+                                    </label>
+                                    <label class="form-check">
+                                        <input class="form-check-input" type="radio" name="matrixPeriod" value="custom">
+                                        <span class="form-check-label">Custom date range</span>
+                                    </label>
+                                    <div class="mt-2 d-none" id="matrixCustomRange">
+                                        <div class="row g-2">
+                                            <div class="col-6">
+                                                <label class="form-label small text-muted">Start date</label>
+                                                <input type="date" class="form-control" id="matrixStartDate">
+                                            </div>
+                                            <div class="col-6">
+                                                <label class="form-label small text-muted">End date</label>
+                                                <input type="date" class="form-control" id="matrixEndDate">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100 shadow-sm">
+                            <div class="card-body d-flex flex-column gap-3">
+                                <div>
+                                    <div class="fw-bold mb-1">Metrics to include</div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" id="matrixIncludeCalls" checked>
+                                        <label class="form-check-label" for="matrixIncludeCalls">Call metrics (volume, talk time, hold time, rankings)</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" id="matrixIncludeCsat" checked>
+                                        <label class="form-check-label" for="matrixIncludeCsat">CSAT metrics (counts, % satisfied, CSAT rank)</label>
+                                    </div>
+                                </div>
+                                <div>
+                                    <div class="fw-bold mb-1">What you'll get</div>
+                                    <ul class="small text-muted ps-3 mb-0">
+                                        <li>One row per agent with calls, talk, hold, and CSAT performance</li>
+                                        <li>Call %, Talk %, Hold %, CSAT % plus Average Talk/Hold and answer speed</li>
+                                        <li>Call/Talk/CSAT ranks and leader highlights for top and bottom performers</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="alert alert-light border d-flex align-items-center gap-2" id="matrixExportStatus" role="status">
+                    <i class="fas fa-info-circle text-primary"></i>
+                    <span>Exports open in a new Google Sheet. Your current agent filter is applied automatically.</span>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="matrixExportConfirmBtn">
+                    <span class="export-action-label"><i class="fas fa-download me-2"></i>Export Matrix</span>
+                    <span class="export-action-progress d-none"><i class="fas fa-circle-notch fa-spin me-2"></i>Preparing…</span>
+                </button>
             </div>
         </div>
     </div>
@@ -1639,6 +1741,7 @@
 <script>
   // Keep all existing server-side variables exactly as they were
   const baseUrl = '<?= baseUrl ?>';
+  const scriptUrl = '<?= typeof scriptUrl !== "undefined" ? scriptUrl : baseUrl ?>';
   const callVolumeLast7 = <?= callVolumeLast7 ?>;
   const hourlyHeatmapLast7 = <?= hourlyHeatmapLast7 ?>;
   const avgIntervalByAgentLast7= <?= avgIntervalByAgentLast7 ?>;
@@ -1660,6 +1763,148 @@
   let currentGran = "Week";
   let currentPeriod = "<?= selectedPeriod ?>"; // initial ISO week, e.g. "2025-W23"
   let currentAgent = "<?= selectedAgent ?>";  // initial agent filter (probably "")
+
+  function formatDateInputValue(dateObj) {
+    if (!(dateObj instanceof Date) || isNaN(dateObj)) return "";
+    const year = dateObj.getFullYear();
+    const month = String(dateObj.getMonth() + 1).padStart(2, "0");
+    const day = String(dateObj.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  function buildCustomPeriodValue(options = {}) {
+    const { quietMissing = false } = options;
+    const startEl = document.getElementById("customStartInput");
+    const endEl = document.getElementById("customEndInput");
+    if (!startEl || !endEl) return null;
+
+    const startVal = startEl.value;
+    const endVal = endEl.value;
+    if (!startVal || !endVal) {
+      if (!quietMissing) {
+        showToast("Select both a start and end date to use the custom range.", "warning");
+      }
+      return null;
+    }
+
+    const startDate = new Date(startVal);
+    const endDate = new Date(endVal);
+    if (isNaN(startDate) || isNaN(endDate)) {
+      showToast("Invalid custom date range provided.", "warning");
+      return null;
+    }
+
+    if (startDate > endDate) {
+      showToast("Start date must be on or before the end date.", "warning");
+      return null;
+    }
+
+    const normalizedStart = formatDateInputValue(startDate);
+    const normalizedEnd = formatDateInputValue(endDate);
+    return `${normalizedStart}::${normalizedEnd}`;
+  }
+
+  function resolvePeriodForRequest() {
+    if (currentGran !== "Custom") {
+      if (!currentPeriod) {
+        if (currentGran === "Week") {
+          const wk = document.getElementById("weekInput");
+          if (wk && wk.value) {
+            currentPeriod = wk.value;
+          }
+        }
+      }
+      return currentPeriod;
+    }
+    const resolved = buildCustomPeriodValue();
+    if (resolved) currentPeriod = resolved;
+    return resolved;
+  }
+
+  function setMatrixStatus(message, tone = 'info') {
+    const status = document.getElementById('matrixExportStatus');
+    if (!status) return;
+    status.classList.remove('alert-info', 'alert-danger', 'alert-success', 'alert-warning', 'alert-light');
+    status.classList.add(`alert-${tone === 'danger' ? 'danger' : tone}`);
+    const textNode = status.querySelector('span');
+    if (textNode) textNode.textContent = message;
+  }
+
+  function toggleMatrixCustomRange() {
+    const selected = document.querySelector('input[name="matrixPeriod"]:checked');
+    const isCustom = selected && selected.value === 'custom';
+    const wrapper = document.getElementById('matrixCustomRange');
+    if (wrapper) {
+      wrapper.classList.toggle('d-none', !isCustom);
+    }
+  }
+
+  function resolveMatrixSelection() {
+    const selected = document.querySelector('input[name="matrixPeriod"]:checked');
+    const includeCalls = document.getElementById('matrixIncludeCalls')?.checked !== false;
+    const includeCsat = document.getElementById('matrixIncludeCsat')?.checked !== false;
+    const startDate = document.getElementById('matrixStartDate')?.value;
+    const endDate = document.getElementById('matrixEndDate')?.value;
+
+    const periodType = selected ? selected.value : 'weekly';
+    if (periodType === 'custom') {
+      if (!startDate || !endDate) {
+        showToast('Select both start and end dates for a custom export.', 'warning');
+        return null;
+      }
+      const start = new Date(startDate);
+      const end = new Date(endDate);
+      if (isNaN(start) || isNaN(end) || start > end) {
+        showToast('Custom date range is invalid. Please correct it and try again.', 'danger');
+        return null;
+      }
+    }
+
+    return {
+      periodType,
+      startDate,
+      endDate,
+      includeCalls,
+      includeCsat,
+      agent: currentAgent
+    };
+  }
+
+  function runMatrixExport(modalInstance) {
+    const selection = resolveMatrixSelection();
+    if (!selection) return;
+
+    const confirmBtn = document.getElementById('matrixExportConfirmBtn');
+    const label = confirmBtn?.querySelector('.export-action-label');
+    const progress = confirmBtn?.querySelector('.export-action-progress');
+    if (confirmBtn) confirmBtn.disabled = true;
+    if (label) label.classList.add('d-none');
+    if (progress) progress.classList.remove('d-none');
+    setMatrixStatus('Preparing export…', 'info');
+
+    google.script.run
+      .withSuccessHandler((res) => {
+        if (confirmBtn) confirmBtn.disabled = false;
+        if (label) label.classList.remove('d-none');
+        if (progress) progress.classList.add('d-none');
+        if (res && res.spreadsheetUrl) {
+          setMatrixStatus('Export ready. Opening your matrix in a new tab…', 'success');
+          window.open(res.spreadsheetUrl, '_blank');
+          modalInstance?.hide?.();
+        } else {
+          setMatrixStatus('Export completed but no file link was returned.', 'warning');
+        }
+      })
+      .withFailureHandler((err) => {
+        if (confirmBtn) confirmBtn.disabled = false;
+        if (label) label.classList.remove('d-none');
+        if (progress) progress.classList.add('d-none');
+        const msg = err && err.message ? err.message : 'Matrix export failed.';
+        setMatrixStatus(msg, 'danger');
+        showToast(msg, 'danger');
+      })
+      .exportCallReportMatrix(selection);
+  }
 
   // Enhanced Chart.js defaults
   function setupChartDefaults() {
@@ -1755,51 +2000,166 @@
       triggerLoadAnalytics();
     });
 
+    const customStartInput = document.getElementById("customStartInput");
+    const customEndInput = document.getElementById("customEndInput");
+    const customPattern = /^\d{4}-\d{2}-\d{2}::\d{4}-\d{2}-\d{2}$/;
+
+    function seedCustomRangeDefaults() {
+      if (!customStartInput || !customEndInput) return;
+      if (!customStartInput.value) {
+        const start = new Date();
+        start.setDate(start.getDate() - 13);
+        customStartInput.value = formatDateInputValue(start);
+      }
+      if (!customEndInput.value) {
+        customEndInput.value = formatDateInputValue(new Date());
+      }
+    }
+
+    if (customPattern.test(currentPeriod)) {
+      const [start, end] = currentPeriod.split("::");
+      if (customStartInput && customEndInput) {
+        customStartInput.value = start;
+        customEndInput.value = end;
+      }
+    } else {
+      seedCustomRangeDefaults();
+    }
+
+    const handleCustomRangeChange = () => {
+      if (currentGran !== "Custom") return;
+      const value = buildCustomPeriodValue({ quietMissing: true });
+      if (value) {
+        currentPeriod = value;
+        triggerLoadAnalytics();
+      }
+    };
+
+    customStartInput?.addEventListener("change", handleCustomRangeChange);
+    customEndInput?.addEventListener("change", handleCustomRangeChange);
+
     // Keep existing picker initialization
-    document.getElementById("weekPicker").style.display = "none";
-    document.getElementById("biWeekPicker").style.display = "none";
-    document.getElementById("monthPicker").style.display = "none";
-    document.getElementById("quarterPicker").style.display = "none";
-    document.getElementById("yearPicker").style.display = "none";
+    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker", "customPicker"].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = "none";
+    });
 
     populateBiWeeklyOptions();
 
     const today = new Date();
     const weekPattern = /^\d{4}-W\d{2}$/i;
-    if (currentPeriod && weekPattern.test(currentPeriod)) {
-      wk.value = currentPeriod;
+    const monthPattern = /^\d{4}-\d{2}$/;
+    const quarterPattern = /^Q[1-4]-\d{4}$/i;
+    if (currentGran === "BiWeekly") {
+      const select = document.getElementById("biWeekSelect");
+      if (select) {
+        if (currentPeriod && Array.from(select.options).some(opt => opt.value === currentPeriod)) {
+          select.value = currentPeriod;
+        }
+        document.getElementById("biWeekPicker").style.display = "block";
+      }
+    } else if (currentGran === "Month") {
+      if (m && monthPattern.test(currentPeriod)) {
+        m.value = currentPeriod;
+      }
+      document.getElementById("monthPicker").style.display = "block";
+    } else if (currentGran === "Quarter") {
+      if (quarterPattern.test(currentPeriod)) {
+        const [selectedQuarter, selectedYear] = currentPeriod.split("-");
+        if (qs) qs.value = selectedQuarter;
+        if (qy) qy.value = selectedYear;
+      }
+      document.getElementById("quarterPicker").style.display = "block";
+    } else if (currentGran === "Year") {
+      if (yr && currentPeriod) {
+        yr.value = currentPeriod;
+      }
+      document.getElementById("yearPicker").style.display = "block";
+    } else if (currentGran === "Custom") {
+      document.getElementById("customPicker").style.display = "block";
+      const seeded = buildCustomPeriodValue({ quietMissing: true });
+      if (seeded) currentPeriod = seeded;
     } else {
-      const isoWeek = weekStringFromDate(today);
-      wk.value = isoWeek;
-      if (!currentPeriod || !currentPeriod.length) {
-        currentPeriod = isoWeek;
+      if (currentPeriod && weekPattern.test(currentPeriod)) {
+        wk.value = currentPeriod;
+      } else {
+        const isoWeek = weekStringFromDate(today);
+        wk.value = isoWeek;
+        if (!currentPeriod || !currentPeriod.length) {
+          currentPeriod = isoWeek;
+        }
+      }
+      document.getElementById("weekPicker").style.display = "block";
+    }
+
+    const matrixExportBtn = document.getElementById("matrixExportBtn");
+    const matrixExportModalEl = document.getElementById("matrixExportModal");
+    const matrixExportConfirmBtn = document.getElementById("matrixExportConfirmBtn");
+
+    if (matrixExportBtn && matrixExportModalEl) {
+      if (matrixExportModalEl.parentNode !== document.body) {
+        document.body.appendChild(matrixExportModalEl);
+      }
+      const bootstrapModal = window.bootstrap?.Modal;
+      const bindPeriodRadios = () => {
+        document.querySelectorAll('input[name="matrixPeriod"]').forEach(radio => {
+          radio.addEventListener('change', toggleMatrixCustomRange);
+        });
+        toggleMatrixCustomRange();
+      };
+      bindPeriodRadios();
+
+      if (bootstrapModal) {
+        const matrixModal = new bootstrapModal(matrixExportModalEl);
+        matrixExportBtn.addEventListener("click", () => {
+          setMatrixStatus('Exports open in a new Google Sheet. Your current agent filter is applied automatically.', 'info');
+          const granMap = { Week: 'weekly', BiWeekly: 'biweekly', Month: 'monthly', Quarter: 'quarterly', Year: 'yearly', Custom: 'custom' };
+          const targetValue = granMap[currentGran] || 'weekly';
+          const targetRadio = document.querySelector(`input[name="matrixPeriod"][value="${targetValue}"]`);
+          if (targetRadio) {
+            targetRadio.checked = true;
+          }
+          if (targetValue === 'custom') {
+            const customStart = document.getElementById('customStartInput')?.value;
+            const customEnd = document.getElementById('customEndInput')?.value;
+            if (customStart) document.getElementById('matrixStartDate').value = customStart;
+            if (customEnd) document.getElementById('matrixEndDate').value = customEnd;
+          }
+          toggleMatrixCustomRange();
+          matrixModal.show();
+        });
+        matrixExportConfirmBtn?.addEventListener("click", () => runMatrixExport(matrixModal));
+      } else {
+        matrixExportBtn.addEventListener("click", () => {
+          const isOpen = matrixExportModalEl.classList.toggle("show");
+          matrixExportModalEl.setAttribute("aria-hidden", (!isOpen).toString());
+          if (isOpen) {
+            const granMap = { Week: 'weekly', BiWeekly: 'biweekly', Month: 'monthly', Quarter: 'quarterly', Year: 'yearly', Custom: 'custom' };
+            const targetValue = granMap[currentGran] || 'weekly';
+            const targetRadio = document.querySelector(`input[name="matrixPeriod"][value="${targetValue}"]`);
+            if (targetRadio) targetRadio.checked = true;
+            if (targetValue === 'custom') {
+              const customStart = document.getElementById('customStartInput')?.value;
+              const customEnd = document.getElementById('customEndInput')?.value;
+              if (customStart) document.getElementById('matrixStartDate').value = customStart;
+              if (customEnd) document.getElementById('matrixEndDate').value = customEnd;
+            }
+            toggleMatrixCustomRange();
+            setMatrixStatus('Exports open in a new Google Sheet. Your current agent filter is applied automatically.', 'info');
+          }
+        });
+        matrixExportConfirmBtn?.addEventListener("click", () => runMatrixExport({ hide: () => {
+          matrixExportModalEl.classList.remove("show");
+          matrixExportModalEl.setAttribute("aria-hidden", "true");
+        }}));
+        matrixExportModalEl
+          .querySelectorAll('[data-bs-dismiss="modal"]')
+          .forEach(btn => btn.addEventListener("click", () => {
+            matrixExportModalEl.classList.remove("show");
+            matrixExportModalEl.setAttribute("aria-hidden", "true");
+          }));
       }
     }
-    document.getElementById("weekPicker").style.display = "block";
-
-    document
-      .getElementById("exportCallCsvBtn")
-      .addEventListener("click", () => {
-        const url = baseUrl
-          + "&page=CallReports"
-          + "&action=exportCallCsv"
-          + "&granularity=" + encodeURIComponent(currentGran)
-          + "&period=" + encodeURIComponent(currentPeriod)
-          + "&agent=" + encodeURIComponent(currentAgent);
-        window.open(url, "_blank");
-      });
-
-    document
-      .getElementById("exportCallCsatBtn")
-      .addEventListener("click", () => {
-        const url = baseUrl
-          + "&page=CallReports"
-          + "&action=exportCallCsat"
-          + "&granularity=" + encodeURIComponent(currentGran)
-          + "&period=" + encodeURIComponent(currentPeriod)
-          + "&agent=" + encodeURIComponent(currentAgent);
-        window.open(url, "_blank");
-      });
 
     const aiAnalyzerBtn = document.getElementById("aiAnalyzerBtn");
     const aiAnalyzerModalEl = document.getElementById("aiAnalyzerModal");
@@ -1861,13 +2221,16 @@
 
     // Load initial analytics - keep existing function call
     if (chartsReady !== false) {
-      loadAnalytics(currentGran, currentPeriod, currentAgent);
+      const safePeriod = resolvePeriodForRequest();
+      if (safePeriod) {
+        loadAnalytics(currentGran, safePeriod, currentAgent);
+      }
     }
   });
 
   // Keep all existing functions exactly as they were, just enhance the rendering
   function onGranChange() {
-    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker"].forEach(id => {
+    ["weekPicker", "biWeekPicker", "monthPicker", "quarterPicker", "yearPicker", "customPicker"].forEach(id => {
       document.getElementById(id).style.display = "none";
     });
 
@@ -1901,13 +2264,21 @@
       document.getElementById("yearPicker").style.display = "block";
       const yr = document.getElementById("yearInput");
       currentPeriod = yr.value;
+    } else if (currentGran === "Custom") {
+      document.getElementById("customPicker").style.display = "block";
+      const seeded = buildCustomPeriodValue({ quietMissing: true });
+      if (seeded) {
+        currentPeriod = seeded;
+      }
     }
 
     triggerLoadAnalytics();
   }
 
   function triggerLoadAnalytics() {
-    loadAnalytics(currentGran, currentPeriod, currentAgent);
+    const safePeriod = resolvePeriodForRequest();
+    if (!safePeriod) return;
+    loadAnalytics(currentGran, safePeriod, currentAgent);
   }
 
   function renderEverything(analytics) {

--- a/Code.js
+++ b/Code.js
@@ -2582,6 +2582,16 @@ function doGet(e) {
         .downloadAsFile(`callCsat_${period}.csv`);
     }
 
+    if (page === "callreports" && e.parameter.action === "exportCallMatrix") {
+      const gran = e.parameter.granularity || "Week";
+      const period = e.parameter.period || weekStringFromDate(new Date());
+      const agent = e.parameter.agent || "";
+      const csv = exportCallPerformanceMatrixCsv(gran, period, agent);
+      return ContentService.createTextOutput(csv)
+        .setMimeType(ContentService.MimeType.CSV)
+        .downloadAsFile(`callMatrix_${period}.csv`);
+    }
+
     if (page === 'attendancereports' && e.parameter.action === 'exportCsv') {
       const gran = e.parameter.granularity || 'Week';
       const period = e.parameter.period || weekStringFromDate(new Date());


### PR DESCRIPTION
## Summary
- replace the dashboard export options with a single Export Matrix button that opens a configuration modal for period and metric selection
- add modal UX for weekly/bi-weekly/monthly/quarterly/yearly or custom ranges plus call/CSAT toggles and status messaging
- implement Apps Script matrix export that builds per-agent call, talk, hold, CSAT metrics with percentages, ranks, and leader summaries in a Google Sheet

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb7a0bc7c8326929b1f0e48f4ff78)