### PR TITLE
Fix attendance dashboard export date serialization

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -9371,8 +9371,8 @@
                     const response = await this.callServerFunction(
                         'exportAttendanceDashboard',
                         selection.granularity,
-                        selection.start,
-                        selection.end
+                        selection.start?.toISOString(),
+                        selection.end?.toISOString()
                     );
 
                     if (!response || response.success !== true || !response.fileUrl) {


### PR DESCRIPTION
## Summary
- send attendance dashboard export date range to the backend as ISO strings to avoid illegal value errors during serialization

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f032ac63c83268498a4312f6ad496)