### PR TITLE
Add admin routing for payroll management page

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2706,6 +2706,10 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       return serveAdminPage('CampaignManagement', e, baseUrl, user);
     }
 
+    if (page === 'payroll' || page === 'payrollmanagement' || page === 'payroll-management') {
+      return serveAdminPage('PayrollManagement', e, baseUrl, user);
+    }
+
     // Schedule Management (Default Page)
     if (page === 'schedule' || page === 'schedulemanagement') {
       return serveGlobalPage('ScheduleManagement', e, baseUrl, user);


### PR DESCRIPTION
## Summary
- route payroll management requests through the admin page handler with payroll-related aliases
- align payroll access with other administrator-only pages so authorized admins are not redirected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f33234cec83268d17ede44905cbf6)