### PR TITLE
Simplify period option builder and remove unused token tool

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4637,14 +4637,6 @@
       const BREAK_ALLOWANCE_SECS = 30 * 60;
       const LUNCH_ALLOWANCE_SECS = 30 * 60;
 
-      const escapeCsv = (value) => {
-        const stringValue = value === undefined || value === null ? '' : String(value);
-        if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
-          return '"' + stringValue.replace(/"/g, '""') + '"';
-        }
-        return stringValue;
-      };
-
       const formatMinutes = (seconds, allowance) => {
         const minutes = Math.max(0, (Math.max(0, seconds) - allowance) / 60);
         return Math.round(minutes * 100) / 100;
@@ -4690,15 +4682,15 @@
       const csvLines = [header.join(',')];
       rows.forEach((row) => {
         csvLines.push([
-          escapeCsv(row.employee),
-          escapeCsv(row.breakHours.toFixed(2)),
-          escapeCsv(row.breakOverMinutes.toFixed(2)),
-          escapeCsv(row.breakViolationDays),
-          escapeCsv(row.lunchHours.toFixed(2)),
-          escapeCsv(row.lunchOverMinutes.toFixed(2)),
-          escapeCsv(row.lunchViolationDays),
-          escapeCsv(row.weeklyOverages),
-          escapeCsv(row.adherencePercent)
+          this.escapeCsv(row.employee),
+          this.escapeCsv(row.breakHours.toFixed(2)),
+          this.escapeCsv(row.breakOverMinutes.toFixed(2)),
+          this.escapeCsv(row.breakViolationDays),
+          this.escapeCsv(row.lunchHours.toFixed(2)),
+          this.escapeCsv(row.lunchOverMinutes.toFixed(2)),
+          this.escapeCsv(row.lunchViolationDays),
+          this.escapeCsv(row.weeklyOverages),
+          this.escapeCsv(row.adherencePercent)
         ].join(','));
       });
 
@@ -4953,7 +4945,7 @@
         const complianceScore = this.calculateComplianceScore(row);
         const status = this.getComplianceStatusLabel(complianceScore);
         lines.push([
-          escapeCsv(row.user || row.employee || 'Unknown'),
+          this.escapeCsv(row.user || row.employee || 'Unknown'),
           summarizeHours(row.baseBillableSecs || row.adjustedBillableSecs),
           summarizeHours(row.breakCreditSecs || row.breakSecs),
           summarizeHours(row.lunchAdjustmentSecs || row.lunchSecs * -1),
@@ -5744,6 +5736,14 @@
       } catch (error) { console.error('Error rendering intelligent insights:', error); }
     }
 
+    escapeCsv(value) {
+      const stringValue = value === undefined || value === null ? '' : String(value);
+      if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+        return '"' + stringValue.replace(/"/g, '""') + '"';
+      }
+      return stringValue;
+    }
+
     calculateComplianceScore(user) {
       const breakDays = Number.isFinite(user?.exceededBreakDays) ? user.exceededBreakDays : 0;
       const lunchDays = Number.isFinite(user?.exceededLunchDays) ? user.exceededLunchDays : 0;
@@ -6227,62 +6227,57 @@
       }
     }
 
-    populatePeriodOptions(type, options = {}) {
+    populatePeriodOptions(type, options) {
       const select = document.getElementById('periodSelect');
       if (!select) return;
 
-      const { resetSelection = false } = options;
-      const yearValue = document.getElementById('yearSelect')?.value || new Date().getFullYear().toString();
+      const resetSelection = !!(options && options.resetSelection);
+      const yearSelect = document.getElementById('yearSelect');
+      const selectedYearText = (yearSelect && yearSelect.value) ? yearSelect.value : '';
       const fallbackYear = new Date().getFullYear();
-      const year = parseInt(yearValue, 10) || fallbackYear;
+      const parsedYear = parseInt(selectedYearText, 10);
+      const year = isNaN(parsedYear) ? fallbackYear : parsedYear;
       const previousValue = select.value;
 
       select.innerHTML = '<option value="">Select a period...</option>';
 
       const fragment = document.createDocumentFragment();
 
-      switch (type) {
-        case 'Week': {
-          const totalWeeks = this.getISOWeeksInYear(year);
-          for (let week = 1; week <= totalWeeks; week++) {
-            const option = document.createElement('option');
-            option.value = `${year}-W${week.toString().padStart(2, '0')}`;
-            option.textContent = `Week ${week}, ${year}`;
-            fragment.appendChild(option);
-          }
-          break;
+      if (type === 'Week') {
+        const totalWeeks = this.getISOWeeksInYear(year);
+        for (let week = 1; week <= totalWeeks; week++) {
+          const option = document.createElement('option');
+          const paddedWeek = week.toString().padStart(2, '0');
+          option.value = year + '-W' + paddedWeek;
+          option.textContent = 'Week ' + week + ', ' + year;
+          fragment.appendChild(option);
         }
-
-        case 'Month': {
-          const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-          for (let month = 1; month <= 12; month++) {
-            const option = document.createElement('option');
-            option.value = `${year}-${month.toString().padStart(2, '0')}`;
-            option.textContent = `${months[month - 1]} ${year}`;
-            fragment.appendChild(option);
-          }
-          break;
+      } else if (type === 'Month') {
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        for (let month = 1; month <= 12; month++) {
+          const option = document.createElement('option');
+          const paddedMonth = month.toString().padStart(2, '0');
+          option.value = year + '-' + paddedMonth;
+          option.textContent = months[month - 1] + ' ' + year;
+          fragment.appendChild(option);
         }
-
-        case 'Quarter': {
-          for (let quarter = 1; quarter <= 4; quarter++) {
-            const option = document.createElement('option');
-            option.value = `Q${quarter}-${year}`;
-            option.textContent = `Q${quarter} ${year}`;
-            fragment.appendChild(option);
-          }
-          break;
+      } else if (type === 'Quarter') {
+        for (let quarter = 1; quarter <= 4; quarter++) {
+          const option = document.createElement('option');
+          option.value = 'Q' + quarter + '-' + year;
+          option.textContent = 'Q' + quarter + ' ' + year;
+          fragment.appendChild(option);
         }
       }
 
       select.appendChild(fragment);
 
       let newValue = '';
-      if (!resetSelection && previousValue && select.querySelector(`[value="${previousValue}"]`)) {
+      if (!resetSelection && previousValue && select.querySelector('[value="' + previousValue + '"]')) {
         newValue = previousValue;
       } else {
         newValue = this.getDefaultPeriodForType(type, year);
-        if (newValue && !select.querySelector(`[value="${newValue}"]`)) {
+        if (newValue && !select.querySelector('[value="' + newValue + '"]')) {
           newValue = '';
         }
       }


### PR DESCRIPTION
## Summary
- rebuild period option generation with simple string concatenation and safer year parsing to avoid unexpected token errors
- preserve default selection handling while keeping week, month, and quarter options populated
- remove the unused Python utility to keep the Apps Script codebase lean

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0a831bd88326adb5202a319413d6)