### PR TITLE
Add modal-based custom range selection for attendance exports

### DIFF
--- a/ScheduleManagement.html
+++ b/ScheduleManagement.html
@@ -2553,7 +2553,7 @@
                                     <i class="fas fa-plus"></i>
                                     Quick Mark
                                 </button>
-                                <button class="btn btn-outline-modern btn-modern" onclick="exportAttendanceCalendarReport()">
+                                <button class="btn btn-outline-modern btn-modern" onclick="openAttendanceExportModal('calendar')">
                                     <i class="fas fa-download"></i>
                                     Export Calendar
                                 </button>
@@ -2915,6 +2915,53 @@
         </div>
     </div>
 
+    <!-- Attendance Export Modal -->
+    <div class="modal fade" id="attendanceExportModal" tabindex="-1" aria-hidden="true" aria-labelledby="attendanceExportModalLabel">
+        <div class="modal-dialog modal-md">
+            <div class="modal-content">
+                <form id="attendanceExportForm">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="attendanceExportModalLabel">Export Attendance</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="alert alert-info small" role="status" id="attendanceExportContextHint">
+                            Choose a period to export attendance data.
+                        </div>
+                        <div class="mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="attendanceExportRangeMode" id="attendanceExportRangeSelected" value="selected" checked>
+                                <label class="form-check-label" for="attendanceExportRangeSelected">
+                                    Use selected period <span class="text-muted" id="attendanceExportSelectedLabel"></span>
+                                </label>
+                            </div>
+                            <div class="form-check mt-2">
+                                <input class="form-check-input" type="radio" name="attendanceExportRangeMode" id="attendanceExportRangeCustom" value="custom">
+                                <label class="form-check-label" for="attendanceExportRangeCustom">Custom range</label>
+                            </div>
+                        </div>
+                        <div class="row g-3" id="attendanceExportCustomFields">
+                            <div class="col-md-6">
+                                <label class="form-label" for="attendanceExportStart">Start date</label>
+                                <input type="date" class="form-control" id="attendanceExportStart">
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="attendanceExportEnd">End date</label>
+                                <input type="date" class="form-control" id="attendanceExportEnd">
+                            </div>
+                        </div>
+                        <div class="form-text" id="attendanceExportHelp">Exported data will align to the chosen range.</div>
+                        <div class="alert alert-warning d-none mt-3" id="attendanceExportFeedback" role="alert"></div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Export</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
@@ -2993,6 +3040,10 @@
                 this.attendanceCalendarUserEntries = [];
                 this.attendanceCalendarUserLookup = new Map();
                 this.attendanceCalendarRange = null;
+                this.attendanceExportModalInstance = null;
+                this.attendanceExportContext = 'dashboard';
+                this.attendanceExportSelectedRange = null;
+                this.attendanceExportRangeMode = 'selected';
                 this.bulkAttendanceModalInstance = null;
                 this.bulkAttendanceApplying = false;
                 this.unifiedState = null;
@@ -8650,9 +8701,7 @@
                 if (exportButton && !exportButton.dataset.luminaAttendanceExportListener) {
                     exportButton.addEventListener('click', (event) => {
                         event.preventDefault();
-                        this.exportAttendanceDashboardSummary().catch(error => {
-                            console.error('Attendance export failed:', error);
-                        });
+                        this.openAttendanceExportModal('dashboard');
                     });
                     exportButton.dataset.luminaAttendanceExportListener = 'true';
                 }
@@ -9354,13 +9403,44 @@
                 };
             }
 
-            async exportAttendanceDashboardSummary() {
-                const selection = this.resolveSelectedAttendancePeriod();
+            resolveAttendanceCalendarExportRange() {
+                const monthInput = document.getElementById('attendanceMonth');
+                const yearInput = document.getElementById('attendanceYear');
+                const context = this.resolveAttendanceMonthContext(
+                    monthInput ? monthInput.value : '',
+                    yearInput ? yearInput.value : ''
+                );
 
-                if (!selection || !(selection.start instanceof Date) || !(selection.end instanceof Date)) {
+                if (!context || !Number.isFinite(context.year) || !Number.isFinite(context.month)) {
+                    return null;
+                }
+
+                const start = new Date(context.year, context.month - 1, 1, 0, 0, 0, 0);
+                const end = new Date(context.year, context.month - 1, context.daysInMonth, 23, 59, 59, 999);
+
+                if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+                    return null;
+                }
+
+                return {
+                    granularity: 'Month',
+                    start,
+                    end,
+                    label: context.label || ''
+                };
+            }
+
+            async exportAttendanceDashboardSummary(rangeOverride = null) {
+                const selection = rangeOverride || this.resolveSelectedAttendancePeriod();
+                const start = selection?.start instanceof Date ? selection.start : null;
+                const end = selection?.end instanceof Date ? selection.end : null;
+
+                if (!start || !end || Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
                     this.showToast('Select a period to export before downloading.', 'warning');
                     return;
                 }
+
+                const periodType = (rangeOverride?.granularity || selection?.granularity || 'Custom').toString();
 
                 try {
                     this.showLoading(true, {
@@ -9370,9 +9450,9 @@
 
                     const response = await this.callServerFunction(
                         'exportAttendanceDashboard',
-                        selection.granularity,
-                        selection.start?.toISOString(),
-                        selection.end?.toISOString()
+                        periodType,
+                        start.toISOString(),
+                        end.toISOString()
                     );
 
                     if (!response || response.success !== true || !response.fileUrl) {
@@ -9389,27 +9469,17 @@
                 }
             }
 
-            async exportAttendanceCalendarReport() {
-                const monthInput = document.getElementById('attendanceMonth');
-                const yearInput = document.getElementById('attendanceYear');
-                const month = monthInput ? parseInt(monthInput.value, 10) : NaN;
-                const year = yearInput ? parseInt(yearInput.value, 10) : NaN;
+            async exportAttendanceCalendarReport(rangeOverride = null) {
+                const resolvedRange = rangeOverride || this.resolveAttendanceCalendarExportRange();
+                const start = resolvedRange?.start instanceof Date ? resolvedRange.start : null;
+                const end = resolvedRange?.end instanceof Date ? resolvedRange.end : null;
 
-                const monthInRange = Number.isFinite(month) && month >= 1 && month <= 12;
-                const yearInRange = Number.isFinite(year) && year >= 1900 && year <= 2500;
-
-                if (!monthInRange || !yearInRange) {
-                    this.showToast('Select a month and year before exporting.', 'warning');
+                if (!start || !end || Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+                    this.showToast('Select a valid month, year, or custom range before exporting.', 'warning');
                     return;
                 }
 
-                const start = new Date(year, month - 1, 1, 0, 0, 0, 0);
-                const end = new Date(year, month, 0, 23, 59, 59, 999);
-
-                if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-                    this.showToast('Invalid date range. Please pick a valid month and year.', 'warning');
-                    return;
-                }
+                const periodType = (rangeOverride?.granularity || resolvedRange?.granularity || 'Month').toString();
 
                 try {
                     this.showLoading(true, {
@@ -9419,7 +9489,7 @@
 
                     const response = await this.callServerFunction(
                         'exportAttendanceCalendar',
-                        'Month',
+                        periodType,
                         start.toISOString(),
                         end.toISOString()
                     );
@@ -9438,8 +9508,217 @@
                 }
             }
 
-            async exportAttendanceReport() {
-                return this.exportAttendanceCalendarReport();
+            async exportAttendanceReport(rangeOverride = null) {
+                return this.exportAttendanceCalendarReport(rangeOverride);
+            }
+
+            ensureAttendanceExportModal() {
+                const modalElement = document.getElementById('attendanceExportModal');
+                if (!modalElement) {
+                    console.warn('Attendance export modal element is missing.');
+                    return null;
+                }
+
+                if (!this.attendanceExportModalInstance) {
+                    if (typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+                        this.attendanceExportModalInstance = new bootstrap.Modal(modalElement, {
+                            backdrop: 'static'
+                        });
+                    } else {
+                        this.attendanceExportModalInstance = {
+                            show() {
+                                modalElement.classList.add('show');
+                                modalElement.style.display = 'block';
+                            },
+                            hide() {
+                                modalElement.classList.remove('show');
+                                modalElement.style.display = 'none';
+                            }
+                        };
+                    }
+
+                    const form = modalElement.querySelector('#attendanceExportForm');
+                    if (form) {
+                        form.addEventListener('submit', (event) => {
+                            event.preventDefault();
+                            this.handleAttendanceExportSubmit();
+                        });
+                    }
+
+                    const rangeRadios = modalElement.querySelectorAll('input[name="attendanceExportRangeMode"]');
+                    rangeRadios.forEach(radio => {
+                        radio.addEventListener('change', () => this.updateAttendanceExportMode());
+                    });
+                }
+
+                return this.attendanceExportModalInstance;
+            }
+
+            updateAttendanceExportMode() {
+                const modalElement = document.getElementById('attendanceExportModal');
+                if (!modalElement) {
+                    return;
+                }
+
+                const useCustom = modalElement.querySelector('#attendanceExportRangeCustom')?.checked;
+                this.attendanceExportRangeMode = useCustom ? 'custom' : 'selected';
+
+                const customInputs = modalElement.querySelectorAll('#attendanceExportCustomFields input');
+                customInputs.forEach(input => {
+                    if (useCustom) {
+                        input.removeAttribute('disabled');
+                    } else {
+                        input.setAttribute('disabled', 'disabled');
+                    }
+                });
+
+                const feedback = modalElement.querySelector('#attendanceExportFeedback');
+                if (feedback) {
+                    feedback.classList.add('d-none');
+                    feedback.textContent = '';
+                }
+            }
+
+            openAttendanceExportModal(context = 'dashboard') {
+                const modalInstance = this.ensureAttendanceExportModal();
+                const modalElement = document.getElementById('attendanceExportModal');
+                if (!modalInstance || !modalElement) {
+                    this.showToast('Unable to open the export dialog right now.', 'danger');
+                    return;
+                }
+
+                this.attendanceExportContext = context === 'calendar' ? 'calendar' : 'dashboard';
+                const isCalendar = this.attendanceExportContext === 'calendar';
+                const title = isCalendar ? 'Export Attendance Calendar' : 'Export Attendance Dashboard';
+                const contextHint = isCalendar
+                    ? 'Choose a range to export attendance calendar details.'
+                    : 'Choose a range to export attendance dashboard insights.';
+
+                const selectedRange = isCalendar
+                    ? this.resolveAttendanceCalendarExportRange()
+                    : this.resolveSelectedAttendancePeriod();
+
+                const validRange = (selectedRange
+                    && selectedRange.start instanceof Date
+                    && !Number.isNaN(selectedRange.start.getTime())
+                    && selectedRange.end instanceof Date
+                    && !Number.isNaN(selectedRange.end.getTime()))
+                    ? selectedRange
+                    : null;
+
+                this.attendanceExportSelectedRange = validRange;
+                this.attendanceExportRangeMode = validRange ? 'selected' : 'custom';
+
+                const titleElement = modalElement.querySelector('#attendanceExportModalLabel');
+                if (titleElement) {
+                    titleElement.textContent = title;
+                }
+
+                const hintElement = modalElement.querySelector('#attendanceExportContextHint');
+                if (hintElement) {
+                    hintElement.textContent = contextHint;
+                }
+
+                const selectedLabel = modalElement.querySelector('#attendanceExportSelectedLabel');
+                if (selectedLabel) {
+                    const label = validRange?.label || this.formatExportRangeLabel(validRange?.start, validRange?.end) || 'Not selected';
+                    selectedLabel.textContent = label ? `(${label})` : '';
+                }
+
+                const selectedRadio = modalElement.querySelector('#attendanceExportRangeSelected');
+                const customRadio = modalElement.querySelector('#attendanceExportRangeCustom');
+                if (selectedRadio) {
+                    selectedRadio.disabled = !validRange;
+                    selectedRadio.checked = this.attendanceExportRangeMode === 'selected' && !selectedRadio.disabled;
+                }
+                if (customRadio) {
+                    customRadio.checked = this.attendanceExportRangeMode === 'custom' || (selectedRadio && selectedRadio.disabled);
+                }
+
+                const startInput = modalElement.querySelector('#attendanceExportStart');
+                const endInput = modalElement.querySelector('#attendanceExportEnd');
+                const startValue = this.formatDateInputValue(validRange?.start || new Date());
+                const endValue = this.formatDateInputValue(validRange?.end || new Date());
+                if (startInput) {
+                    startInput.value = startValue;
+                }
+                if (endInput) {
+                    endInput.value = endValue;
+                }
+
+                this.updateAttendanceExportMode();
+
+                if (typeof modalInstance.show === 'function') {
+                    modalInstance.show();
+                }
+            }
+
+            async handleAttendanceExportSubmit() {
+                const modalElement = document.getElementById('attendanceExportModal');
+                if (!modalElement) {
+                    this.showToast('Export dialog is unavailable.', 'danger');
+                    return;
+                }
+
+                const useCustom = this.attendanceExportRangeMode === 'custom'
+                    || modalElement.querySelector('#attendanceExportRangeCustom')?.checked;
+
+                const feedback = modalElement.querySelector('#attendanceExportFeedback');
+                const startInput = modalElement.querySelector('#attendanceExportStart');
+                const endInput = modalElement.querySelector('#attendanceExportEnd');
+
+                let selectedRange = null;
+
+                if (useCustom) {
+                    const startValue = startInput ? startInput.value : '';
+                    const endValue = endInput ? endInput.value : '';
+                    const startDate = startValue ? new Date(startValue) : null;
+                    const endDate = endValue ? new Date(endValue) : null;
+
+                    if (!startDate || !endDate || Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+                        if (feedback) {
+                            feedback.textContent = 'Enter a valid start and end date for the export.';
+                            feedback.classList.remove('d-none');
+                        }
+                        return;
+                    }
+
+                    if (endDate < startDate) {
+                        if (feedback) {
+                            feedback.textContent = 'End date must be on or after the start date.';
+                            feedback.classList.remove('d-none');
+                        }
+                        return;
+                    }
+
+                    selectedRange = {
+                        start: startDate,
+                        end: endDate,
+                        granularity: 'Custom',
+                        label: `${this.formatDateInputValue(startDate)} to ${this.formatDateInputValue(endDate)}`
+                    };
+                } else {
+                    selectedRange = this.attendanceExportSelectedRange;
+                }
+
+                if (!selectedRange) {
+                    if (feedback) {
+                        feedback.textContent = 'No export range is available. Please choose a custom range.';
+                        feedback.classList.remove('d-none');
+                    }
+                    return;
+                }
+
+                const modalInstance = this.ensureAttendanceExportModal();
+                if (modalInstance && typeof modalInstance.hide === 'function') {
+                    modalInstance.hide();
+                }
+
+                if (this.attendanceExportContext === 'calendar') {
+                    await this.exportAttendanceCalendarReport(selectedRange);
+                } else {
+                    await this.exportAttendanceDashboardSummary(selectedRange);
+                }
             }
 
             formatPercentage(value) {
@@ -9460,6 +9739,27 @@
                     return '0';
                 }
                 return Math.round(value).toLocaleString();
+            }
+
+            formatDateInputValue(date) {
+                if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+                    return '';
+                }
+
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            }
+
+            formatExportRangeLabel(start, end) {
+                if (!(start instanceof Date) || Number.isNaN(start.getTime()) || !(end instanceof Date) || Number.isNaN(end.getTime())) {
+                    return '';
+                }
+
+                const startLabel = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                const endLabel = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                return startLabel === endLabel ? startLabel : `${startLabel} – ${endLabel}`;
             }
 
             computeIsoWeekInfo(date) {
@@ -9670,9 +9970,7 @@
                 if (exportButton && !exportButton.dataset.luminaAttendanceExportListener) {
                     exportButton.addEventListener('click', (event) => {
                         event.preventDefault();
-                        this.exportAttendanceDashboardSummary().catch(error => {
-                            console.error('Attendance export failed:', error);
-                        });
+                        this.openAttendanceExportModal('dashboard');
                     });
                     exportButton.dataset.luminaAttendanceExportListener = 'true';
                 }
@@ -10326,8 +10624,8 @@
                 `;
             }
 
-            async exportAttendanceReport() {
-                return this.exportAttendanceCalendarReport();
+            async exportAttendanceReport(rangeOverride = null) {
+                return this.exportAttendanceCalendarReport(rangeOverride);
             }
 
             formatPercentage(value) {
@@ -10550,9 +10848,7 @@
                 if (exportButton && !exportButton.dataset.luminaAttendanceExportListener) {
                     exportButton.addEventListener('click', (event) => {
                         event.preventDefault();
-                        this.exportAttendanceDashboardSummary().catch(error => {
-                            console.error('Attendance export failed:', error);
-                        });
+                        this.openAttendanceExportModal('dashboard');
                     });
                     exportButton.dataset.luminaAttendanceExportListener = 'true';
                 }
@@ -11233,8 +11529,8 @@
                 `;
             }
 
-            async exportAttendanceReport() {
-                return this.exportAttendanceCalendarReport();
+            async exportAttendanceReport(rangeOverride = null) {
+                return this.exportAttendanceCalendarReport(rangeOverride);
             }
 
             formatPercentage(value) {
@@ -16613,6 +16909,12 @@
             }
         }
 
+        function openAttendanceExportModal(context) {
+            if (window.scheduleManager && typeof window.scheduleManager.openAttendanceExportModal === 'function') {
+                window.scheduleManager.openAttendanceExportModal(context);
+            }
+        }
+
         function quickMarkAttendance() {
             if (window.scheduleManager) {
                 window.scheduleManager.showToast('Quick attendance marking - coming soon!', 'info');
@@ -16620,18 +16922,14 @@
         }
 
         function exportAttendanceDashboardSummary() {
-            if (window.scheduleManager && typeof window.scheduleManager.exportAttendanceDashboardSummary === 'function') {
-                window.scheduleManager.exportAttendanceDashboardSummary().catch(error => {
-                    console.error('Attendance export failed:', error);
-                });
+            if (window.scheduleManager && typeof window.scheduleManager.openAttendanceExportModal === 'function') {
+                window.scheduleManager.openAttendanceExportModal('dashboard');
             }
         }
 
         function exportAttendanceCalendarReport() {
-            if (window.scheduleManager && typeof window.scheduleManager.exportAttendanceCalendarReport === 'function') {
-                window.scheduleManager.exportAttendanceCalendarReport().catch(error => {
-                    console.error('Attendance export failed:', error);
-                });
+            if (window.scheduleManager && typeof window.scheduleManager.openAttendanceExportModal === 'function') {
+                window.scheduleManager.openAttendanceExportModal('calendar');
             }
         }
 


### PR DESCRIPTION
## Summary
- add a reusable attendance export modal with selected-period and custom date range options
- wire attendance dashboard and calendar exports to launch the modal and validate chosen ranges before exporting
- extend export helpers to handle custom ranges and reuse shared range resolution logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930561c1ed08326bf638f5b49b90d09)