### PR TITLE
Handle adherence export without crashing on empty data

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4818,7 +4818,12 @@
         try {
           const result = await safeServerCall('getAdherenceComplianceExportData', [payload], { timeoutMs: 20000 });
           if (!result?.success || !result.exportData) {
-            throw new Error(result?.error || 'Unable to prepare adherence data.');
+            const errorMsg = result?.error && typeof result.error === 'string'
+              ? result.error
+              : 'Unable to prepare adherence data.';
+            const level = errorMsg.toLowerCase().includes('no adherence data') ? 'warning' : 'danger';
+            this.showToast(errorMsg, level);
+            return;
           }
 
           const { exportData } = result;
@@ -4919,7 +4924,9 @@
         const errorMsg = typeof result?.error === 'string' && result.error.trim()
           ? result.error.trim()
           : 'Unable to save adherence export to Google Sheets.';
-        throw new Error(errorMsg);
+
+        const level = errorMsg.toLowerCase().includes('no adherence data') ? 'warning' : 'danger';
+        this.showToast(errorMsg, level);
       } catch (error) {
         console.error('Failed to export adherence to Google Sheets:', error);
         this.showToast('Google Sheets export unavailable. CSV export is still available.', 'warning');


### PR DESCRIPTION
## Summary
- treat empty adherence export responses as user-facing warnings instead of thrown errors
- surface clearer toast messages for missing adherence data during CSV or Sheets exports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693075bf7c1083269bf9d3c9e0592303)