### PR TITLE
Use break and lunch details for adherence export

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -3361,8 +3361,9 @@
         }
 
         if (!Array.isArray(data.userCompliance) || data.userCompliance.length === 0) {
-          console.warn('Attendance data returned without compliance rows — hydrating sample metrics for display.');
-          data = this.createSampleAttendanceData();
+          console.warn('Attendance data returned without compliance rows — rendering empty dashboard.');
+          this.showToast('No attendance compliance data available for the selected filters.', 'warning');
+          data = this.createEmptyAttendanceData();
         }
         
         this.currentData = data;
@@ -3431,8 +3432,8 @@
         if (!ChannelClosedRegex.test(msg)) {
           console.error('Error loading data:', error);
           this.performanceMetrics.errors++;
-          this.showToast('Failed to load attendance data: ' + msg + ' — showing sample metrics.', 'warning');
-          this.currentData = this.createSampleAttendanceData();
+          this.showToast('Failed to load attendance data: ' + msg, 'warning');
+          this.currentData = this.createEmptyAttendanceData();
           this.originalTotalsSnapshot = null;
           this.originalTotalsSnapshotKey = null;
           this.originalUserComplianceMap.clear();
@@ -3446,146 +3447,29 @@
     }
 
     createEmptyAttendanceData() {
-      return this.createSampleAttendanceData();
-    }
-
-    createSampleAttendanceData() {
-      const getWeekDates = () => {
-        const today = new Date();
-        const weekday = today.getUTCDay();
-        const diffToMonday = weekday === 0 ? -6 : 1 - weekday;
-        const monday = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + diffToMonday));
-        return Array.from({ length: 7 }, (_, idx) => {
-          const current = new Date(monday);
-          current.setUTCDate(monday.getUTCDate() + idx);
-          return current;
-        });
-      };
-
-      const weekDates = getWeekDates();
-      const buildTimestamp = (dateObj, hours, minutes) => {
-        const copy = new Date(dateObj);
-        copy.setUTCHours(hours, minutes, 0, 0);
-        return copy.getTime();
-      };
-
-      const filteredRows = [];
-      const dailyBreakdown = [];
-      const attendanceStats = [];
-
-      weekDates.forEach((day) => {
-        const dateKey = day.toISOString().slice(0, 10);
-        const loginTs = buildTimestamp(day, 13, 0);
-        const logoutTs = buildTimestamp(day, 21, 0);
-
-        filteredRows.push(
-          { user: 'Jane Doe', state: 'available', timestampMs: loginTs, dateString: dateKey },
-          { user: 'Jane Doe', state: 'end of shift', timestampMs: logoutTs, dateString: dateKey },
-          { user: 'Alex Smith', state: 'available', timestampMs: loginTs + 15 * 60 * 1000, dateString: dateKey },
-          { user: 'Alex Smith', state: 'end of shift', timestampMs: logoutTs - 10 * 60 * 1000, dateString: dateKey }
-        );
-
-        const availableSecs = 8 * 3600;
-        const breakSecs = 15 * 60;
-        const lunchSecs = 45 * 60;
-        const baseBillableSecs = availableSecs - breakSecs - lunchSecs;
-        const adjustedBillableSecs = baseBillableSecs + breakSecs;
-
-        dailyBreakdown.push({
-          dateKey,
-          availableSecs,
-          breakSecs,
-          lunchSecs,
-          weekendSecs: 0,
-          baseBillableSecs,
-          adjustedBillableSecs,
-          exceededBreakDays: 0,
-          exceededLunchDays: 0,
-          exceededWeeklyCount: 0
-        });
-
-        attendanceStats.push({
-          label: dateKey,
-          hours: Number((adjustedBillableSecs / 3600).toFixed(2)),
-          status: 'On Track'
-        });
-      });
-
-      const totalAdjusted = dailyBreakdown.reduce((sum, day) => sum + (day.adjustedBillableSecs || 0), 0);
-      const summary = {
-        Available: dailyBreakdown.reduce((sum, day) => sum + (day.availableSecs || 0), 0),
-        'Administrative Work': 2 * 3600,
-        Training: 1 * 3600,
-        Meeting: 1.5 * 3600,
-        Break: dailyBreakdown.reduce((sum, day) => sum + (day.breakSecs || 0), 0),
-        Lunch: dailyBreakdown.reduce((sum, day) => sum + (day.lunchSecs || 0), 0)
-      };
-
+      const timezone = window.COMPANY_TIMEZONE || COMPANY_TIMEZONE;
+      const timezoneLabel = window.COMPANY_TIMEZONE_LABEL || COMPANY_TIMEZONE_LABEL || timezone;
       return {
-        summary,
-        stateDuration: summary,
-        totalProductiveHours: Number((totalAdjusted / 3600).toFixed(2)),
-        totalNonProductiveHours: Number(((summary.Break + summary.Lunch) / 3600).toFixed(2)),
-        top5Attendance: [
-          { user: 'Jane Doe', hours: 40, compliance: 98 },
-          { user: 'Alex Smith', hours: 39.5, compliance: 96 }
-        ],
-        attendanceStats,
-        attendanceFeed: [
-          { user: 'Jane Doe', action: 'Logged in on time', timestamp: weekDates[0].toISOString() },
-          { user: 'Alex Smith', action: 'Completed week without violations', timestamp: weekDates[6].toISOString() }
-        ],
-        filteredRows,
-        userCompliance: [
-          {
-            user: 'Jane Doe',
-            baseBillableSecs: dailyBreakdown.reduce((sum, d) => sum + (d.baseBillableSecs || 0), 0),
-            breakCreditSecs: dailyBreakdown.reduce((sum, d) => sum + (d.breakSecs || 0), 0),
-            lunchAdjustmentSecs: -1 * 45 * 60,
-            adjustedBillableSecs: totalAdjusted,
-            availableSecsWeekday: summary.Available,
-            weekendSecs: 0,
-            breakSecs: summary.Break,
-            lunchSecs: summary.Lunch,
-            exceededBreakDays: 0,
-            exceededLunchDays: 0,
-            exceededWeeklyCount: 0,
-            dailyBreakdown
-          },
-          {
-            user: 'Alex Smith',
-            baseBillableSecs: dailyBreakdown.reduce((sum, d) => sum + (d.baseBillableSecs || 0), 0) - 30 * 60,
-            breakCreditSecs: dailyBreakdown.reduce((sum, d) => sum + (d.breakSecs || 0), 0),
-            lunchAdjustmentSecs: -1 * 50 * 60,
-            adjustedBillableSecs: totalAdjusted - 20 * 60,
-            availableSecsWeekday: summary.Available,
-            weekendSecs: 0,
-            breakSecs: summary.Break,
-            lunchSecs: summary.Lunch,
-            exceededBreakDays: 1,
-            exceededLunchDays: 0,
-            exceededWeeklyCount: 0,
-            dailyBreakdown
-          }
-        ],
-        shiftMetrics: {
-          avgLoginTime: '09:00',
-          avgLogoutTime: '17:00',
-          avgBreakMinutes: 15
-        },
-        dailyMetrics: dailyBreakdown.map((day) => ({
-          dateKey: day.dateKey,
-          availableHours: Number((day.availableSecs / 3600).toFixed(2)),
-          productiveHours: Number((day.adjustedBillableSecs / 3600).toFixed(2))
-        })),
+        summary: {},
+        stateDuration: {},
+        totalProductiveHours: 0,
+        totalNonProductiveHours: 0,
+        top5Attendance: [],
+        attendanceStats: [],
+        attendanceFeed: [],
+        filteredRows: [],
+        filteredRowCount: 0,
+        userCompliance: [],
+        shiftMetrics: {},
+        dailyMetrics: [],
         periodInfo: {
           granularity: this.currentGranularity,
           periodId: this.currentPeriod,
-          startDateIso: weekDates[0].toISOString(),
-          endDateIso: weekDates[weekDates.length - 1].toISOString(),
-          workingDays: 5,
-          timezone: window.COMPANY_TIMEZONE || COMPANY_TIMEZONE,
-          timezoneLabel: window.COMPANY_TIMEZONE_LABEL || COMPANY_TIMEZONE_LABEL || COMPANY_TIMEZONE
+          startDateIso: this.summaryFilters?.dateFrom || '',
+          endDateIso: this.summaryFilters?.dateTo || '',
+          workingDays: 0,
+          timezone,
+          timezoneLabel
         },
         manualTimingOverrides: [],
         manualSecondsDelta: 0,
@@ -3809,7 +3693,7 @@
           data: {
             labels: topPerformers.map(p => p.user || 'User'),
             datasets: [{
-              label: 'Attendance %',
+              label: 'Adherence %',
               data: topPerformers.map(p => p.percentage || 0),
               backgroundColor: topPerformers.map(p => (p.percentage || 0) >= 95 ? '#10b981' : (p.percentage || 0) >= 85 ? '#00BFFF' : (p.percentage || 0) >= 75 ? '#FFB800' : '#FF4000'),
               borderRadius: 8
@@ -4836,9 +4720,10 @@
             }
           };
 
-          const dailyHeader = ['Date', 'Week Start', 'Agent Name', 'Agent ID', 'Adherence %', 'Compliance %', 'Scheduled Minutes', 'Worked Minutes', 'Compliant Events', 'Non-Compliant Events'];
-          const weeklyHeader = ['Week Start', 'Agent Name', 'Agent ID', 'Adherence %', 'Compliance %', 'Days With Data', 'Total Scheduled Minutes', 'Total Worked Minutes', 'Compliant Events', 'Non-Compliant Events'];
-          const overallHeader = ['Start Date', 'End Date', 'Overall Adherence %', 'Overall Compliance %', 'Total Agent-Days', 'Total Scheduled Minutes', 'Total Worked Minutes', 'Compliant Events', 'Non-Compliant Events'];
+          const dailyHeader = ['Date', 'Week Start', 'Agent Name', 'Agent ID', 'Lunch Minutes', 'Break Minutes', 'Over Lunch Minutes', 'Over Break Minutes', 'Daily Adherence'];
+          const weeklyHeader = ['Week Start', 'Agent Name', 'Agent ID', 'Adherent Days', 'Non-Adherent Days', 'Weekly Adherence %', 'Total Over Minutes'];
+          const agentHeader = ['Agent Name', 'Agent ID', 'Eligible Days', 'Adherent Days', 'Non-Adherent Days', 'Total Over Minutes', 'Adherence %'];
+          const overallHeader = ['Start Date', 'End Date', 'Total Eligible Agent-Days', 'Adherent Agent-Days', 'Non-Adherent Agent-Days', 'Overall Adherence %', 'Total Over Minutes'];
 
           const lines = [];
           lines.push('DAILY DETAIL');
@@ -4849,12 +4734,11 @@
               row.weekStartKey,
               row.agentName,
               row.agentId || '',
-              row.adherencePercent,
-              row.compliancePercent,
-              row.scheduledMinutes,
-              row.workedMinutes,
-              row.compliantEvents,
-              row.nonCompliantEvents
+              row.lunchMinutes,
+              row.breakMinutes,
+              row.overLunchMinutes,
+              row.overBreakMinutes,
+              row.adherenceFlag
             ].join(','));
           });
 
@@ -4866,13 +4750,25 @@
               row.weekStartKey,
               row.agentName,
               row.agentId || '',
+              row.adherentDays,
+              row.nonAdherentDays,
               row.adherencePercent,
-              row.compliancePercent,
-              row.daysWithData,
-              row.scheduledMinutes,
-              row.workedMinutes,
-              row.compliantEvents,
-              row.nonCompliantEvents
+              Math.round(row.totalOverMinutes || 0)
+            ].join(','));
+          });
+
+          lines.push('');
+          lines.push('AGENT SUMMARY');
+          lines.push(agentHeader.join(','));
+          exportData.agentSummaries.forEach((row) => {
+            lines.push([
+              row.agentName,
+              row.agentId || '',
+              row.eligibleDays,
+              row.adherentDays,
+              row.nonAdherentDays,
+              Math.round(row.totalOverMinutes || 0),
+              row.adherencePercent
             ].join(','));
           });
 
@@ -4882,13 +4778,11 @@
           lines.push([
             formatDateValue(exportData.startDate),
             formatDateValue(exportData.endDate),
-            exportData.overall.adherencePercent,
-            exportData.overall.compliancePercent,
-            exportData.overall.agentDays,
-            exportData.overall.scheduledMinutes,
-            exportData.overall.workedMinutes,
-            exportData.overall.compliantEvents,
-            exportData.overall.nonCompliantEvents
+            exportData.overall.totalEligibleDays,
+            exportData.overall.totalAdherentDays,
+            exportData.overall.totalNonAdherentDays,
+            exportData.overall.overallAdherencePercent,
+            Math.round(exportData.overall.totalOverMinutes || 0)
           ].join(','));
 
           const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
@@ -5695,6 +5589,11 @@
     }
 
     calculateComplianceScore(user) {
+      const precomputed = Number(user?.adherencePercent);
+      if (Number.isFinite(precomputed)) {
+        return Math.max(0, Math.round(precomputed));
+      }
+
       const breakDays = Number.isFinite(user?.exceededBreakDays) ? user.exceededBreakDays : 0;
       const lunchDays = Number.isFinite(user?.exceededLunchDays) ? user.exceededLunchDays : 0;
       const weeklyOverages = Number.isFinite(user?.exceededWeeklyCount) ? user.exceededWeeklyCount : 0;

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -1488,6 +1488,12 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
       const lunchAdjustmentTotalSecs = lunchAdjustmentWeekday + lunchAdjustmentWeekend;
       const adjustedBillableSecs = Math.max(0, adjustedWeekday + adjustedWeekend);
 
+      const adherencePercent = computeAdherencePercent_({
+        exceededBreakDays: stats.breakOverageDays,
+        exceededLunchDays: stats.lunchOverageDays,
+        exceededWeeklyCount: stats.weeklyOverages
+      });
+
       return {
         user,
         availableSecsWeekday: adjustedWeekday,
@@ -1504,7 +1510,8 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
         lunchLabel: formatSecsAsHhMm(stats.lunchSecs),
         exceededLunchDays: stats.lunchOverageDays || 0,
         exceededBreakDays: stats.breakOverageDays || 0,
-        exceededWeeklyCount: stats.weeklyOverages || 0
+        exceededWeeklyCount: stats.weeklyOverages || 0,
+        adherencePercent
       };
     });
 
@@ -1517,29 +1524,22 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
         || (agentDirectory.normalizedEmails && agentDirectory.normalizedEmails.size))
     );
 
-    const top5Candidates = Array.from(userTotalAdjustedSecs.entries())
-      .map(([user, secs]) => {
-        const adherencePercent = expectedCapacitySecs > 0
-          ? (secs / expectedCapacitySecs) * 100
-          : 0;
-        const normalizedPercent = expectedCapacitySecs > 0
-          ? Math.min(Math.round(adherencePercent * 10) / 10, 100)
-          : 0;
-        return {
-          user,
-          percentage: Number.isFinite(normalizedPercent) ? normalizedPercent : 0
-        };
-      })
+    const adherenceScores = userCompliance
+      .map(entry => ({
+        user: entry.user,
+        percentage: computeAdherencePercent_(entry)
+      }))
+      .filter(entry => Number.isFinite(entry.percentage))
       .filter(entry => !isManagerPerson_(entry.user, managerDirectory))
       .sort((a, b) => b.percentage - a.percentage);
 
     const agentFilteredTop5 = agentDirectoryHasEntries
-      ? top5Candidates.filter(entry => isAgentPerson_(entry.user, agentDirectory))
-      : top5Candidates;
+      ? adherenceScores.filter(entry => isAgentPerson_(entry.user, agentDirectory))
+      : adherenceScores;
 
     const effectiveTop5 = agentFilteredTop5.length > 0
       ? agentFilteredTop5
-      : top5Candidates;
+      : adherenceScores;
 
     const top5Attendance = effectiveTop5.slice(0, 5);
 
@@ -1993,6 +1993,31 @@ function calculateBreakLunchDeductions(breakSeconds, lunchSeconds) {
   const deduction = Math.max(breakOver + lunchOver, combinedOver);
 
   return { breakOver, lunchOver, combinedOver, deduction };
+}
+
+function computeAdherencePercent_(stats) {
+  if (!stats) return 0;
+
+  const breakDays = Number.isFinite(stats.exceededBreakDays)
+    ? stats.exceededBreakDays
+    : Number(stats.breakOverageDays) || 0;
+  const lunchDays = Number.isFinite(stats.exceededLunchDays)
+    ? stats.exceededLunchDays
+    : Number(stats.lunchOverageDays) || 0;
+  const weeklyOverages = Number.isFinite(stats.exceededWeeklyCount)
+    ? stats.exceededWeeklyCount
+    : Number(stats.weeklyOverages) || 0;
+
+  let score = 100;
+  score -= breakDays * 5;
+  score -= lunchDays * 5;
+  score -= weeklyOverages * 10;
+
+  if (!Number.isFinite(score)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(score)));
 }
 
 function applyCappedAdjustment(baseValue, adjustment, capSeconds) {
@@ -3654,12 +3679,11 @@ function exportAdherenceComplianceSheet(payload) {
       'Week Start',
       'Agent Name',
       'Agent ID',
-      'Adherence %',
-      'Compliance %',
-      'Scheduled Minutes',
-      'Worked Minutes',
-      'Compliant Events',
-      'Non-Compliant Events'
+      'Lunch Minutes',
+      'Break Minutes',
+      'Over Lunch Minutes',
+      'Over Break Minutes',
+      'Daily Adherence'
     ];
     sheet.getRange(currentRow, 1, 1, dailyHeaders.length)
       .setValues([dailyHeaders])
@@ -3673,17 +3697,15 @@ function exportAdherenceComplianceSheet(payload) {
       row.weekStartKey,
       row.agentName,
       row.agentId || '',
-      row.adherencePercent,
-      row.compliancePercent,
-      row.scheduledMinutes,
-      row.workedMinutes,
-      row.compliantEvents,
-      row.nonCompliantEvents
+      row.lunchMinutes,
+      row.breakMinutes,
+      row.overLunchMinutes,
+      row.overBreakMinutes,
+      row.adherenceFlag
     ]);
 
     sheet.getRange(currentRow, 1, dailyValues.length, dailyHeaders.length).setValues(dailyValues);
-    sheet.getRange(currentRow, 5, dailyValues.length, 2).setNumberFormat('0.0');
-    sheet.getRange(currentRow, 7, dailyValues.length, 4).setNumberFormat('0');
+    sheet.getRange(currentRow, 5, dailyValues.length, 4).setNumberFormat('0.00');
     currentRow += dailyValues.length + 2;
 
     // Weekly Summary Section
@@ -3694,13 +3716,10 @@ function exportAdherenceComplianceSheet(payload) {
       'Week Start',
       'Agent Name',
       'Agent ID',
-      'Adherence %',
-      'Compliance %',
-      'Days With Data',
-      'Total Scheduled Minutes',
-      'Total Worked Minutes',
-      'Compliant Events',
-      'Non-Compliant Events'
+      'Adherent Days',
+      'Non-Adherent Days',
+      'Weekly Adherence %',
+      'Total Over Minutes'
     ];
     sheet.getRange(currentRow, 1, 1, weeklyHeaders.length)
       .setValues([weeklyHeaders])
@@ -3713,22 +3732,55 @@ function exportAdherenceComplianceSheet(payload) {
       row.weekStartKey,
       row.agentName,
       row.agentId || '',
+      row.adherentDays,
+      row.nonAdherentDays,
       row.adherencePercent,
-      row.compliancePercent,
-      row.daysWithData,
-      row.scheduledMinutes,
-      row.workedMinutes,
-      row.compliantEvents,
-      row.nonCompliantEvents
+      Math.round(row.totalOverMinutes || 0)
     ]);
 
     if (weeklyValues.length) {
       sheet.getRange(currentRow, 1, weeklyValues.length, weeklyHeaders.length)
         .setValues(weeklyValues);
-      sheet.getRange(currentRow, 4, weeklyValues.length, 2).setNumberFormat('0.0');
-      sheet.getRange(currentRow, 6, weeklyValues.length, 5).setNumberFormat('0');
+      sheet.getRange(currentRow, 6, weeklyValues.length, 2).setNumberFormat('0.0');
     }
     currentRow += weeklyValues.length + 2;
+
+    // Per-Agent Summary Section
+    sheet.getRange(currentRow, 1, 1, 1).setValue('Per-Agent Summary (Selected Period)');
+    sheet.getRange(currentRow, 1).setFontWeight('bold');
+    currentRow += 1;
+    const agentHeaders = [
+      'Agent Name',
+      'Agent ID',
+      'Eligible Days',
+      'Adherent Days',
+      'Non-Adherent Days',
+      'Total Over Minutes',
+      'Adherence %'
+    ];
+    sheet.getRange(currentRow, 1, 1, agentHeaders.length)
+      .setValues([agentHeaders])
+      .setFontWeight('bold')
+      .setBackground('#0b2538')
+      .setFontColor('#ffffff');
+    currentRow += 1;
+
+    const agentValues = exportData.agentSummaries.map(row => [
+      row.agentName,
+      row.agentId || '',
+      row.eligibleDays,
+      row.adherentDays,
+      row.nonAdherentDays,
+      Math.round(row.totalOverMinutes || 0),
+      row.adherencePercent
+    ]);
+
+    if (agentValues.length) {
+      sheet.getRange(currentRow, 1, agentValues.length, agentHeaders.length)
+        .setValues(agentValues);
+      sheet.getRange(currentRow, 7, agentValues.length, 1).setNumberFormat('0.0');
+    }
+    currentRow += agentValues.length + 2;
 
     // Overall Summary Section
     sheet.getRange(currentRow, 1, 1, 1).setValue('Overall Summary (All Agents Combined)');
@@ -3737,13 +3789,11 @@ function exportAdherenceComplianceSheet(payload) {
     const overallHeaders = [
       'Start Date',
       'End Date',
+      'Total Eligible Agent-Days',
+      'Adherent Agent-Days',
+      'Non-Adherent Agent-Days',
       'Overall Adherence %',
-      'Overall Compliance %',
-      'Total Agent-Days',
-      'Total Scheduled Minutes',
-      'Total Worked Minutes',
-      'Compliant Events',
-      'Non-Compliant Events'
+      'Total Over Minutes'
     ];
     sheet.getRange(currentRow, 1, 1, overallHeaders.length)
       .setValues([overallHeaders])
@@ -3756,16 +3806,13 @@ function exportAdherenceComplianceSheet(payload) {
       .setValues([[
         Utilities.formatDate(exportData.startDate, timezone, 'yyyy-MM-dd'),
         Utilities.formatDate(exportData.endDate, timezone, 'yyyy-MM-dd'),
-        exportData.overall.adherencePercent,
-        exportData.overall.compliancePercent,
-        exportData.overall.agentDays,
-        exportData.overall.scheduledMinutes,
-        exportData.overall.workedMinutes,
-        exportData.overall.compliantEvents,
-        exportData.overall.nonCompliantEvents
+        exportData.overall.totalEligibleDays,
+        exportData.overall.totalAdherentDays,
+        exportData.overall.totalNonAdherentDays,
+        exportData.overall.overallAdherencePercent,
+        Math.round(exportData.overall.totalOverMinutes || 0)
       ]]);
-    sheet.getRange(currentRow, 3, 1, 2).setNumberFormat('0.0');
-    sheet.getRange(currentRow, 5, 1, 5).setNumberFormat('0');
+    sheet.getRange(currentRow, 6, 1, 1).setNumberFormat('0.0');
 
     sheet.autoResizeColumns(1, Math.max(dailyHeaders.length, weeklyHeaders.length, overallHeaders.length));
     sheet.setFrozenRows(2);
@@ -3881,163 +3928,102 @@ function buildAdherenceComplianceDataset_(startDateIso, endDateIso, filterUsers,
     ? new Set(filterUsers.map(u => String(u || '').trim().toLowerCase()).filter(Boolean))
     : new Set();
 
-  const dailyRows = loadAdherenceComplianceDaily_(normalizedStart, normalizedEnd, userSet, timezone);
-  const weeklyRows = summarizeWeeklyAdherence_(dailyRows, timezone);
-  const overall = summarizeOverallAdherence_(dailyRows);
+  const adherenceDaily = loadBreakLunchAdherenceDaily_(normalizedStart, normalizedEnd, userSet, timezone);
+  const agentSummaries = summarizeAgentAdherence_(adherenceDaily);
+  const weeklyRows = summarizeWeeklyBreakLunch_(adherenceDaily);
+  const overall = summarizeOverallBreakLunch_(agentSummaries);
 
   const userScopeLabel = userSet.size > 0
     ? `Selected Users (${userSet.size})`
     : 'All Users';
 
-  return { startDate: normalizedStart, endDate: normalizedEnd, dailyRows, weeklyRows, overall, userScopeLabel };
+  return { startDate: normalizedStart, endDate: normalizedEnd, dailyRows: adherenceDaily, weeklyRows, agentSummaries, overall, userScopeLabel };
 }
 
-function loadAdherenceComplianceDaily_(startDate, endDate, userSet, timezone) {
-  if (typeof getScheduleSpreadsheet !== 'function') {
+function loadBreakLunchAdherenceDaily_(startDate, endDate, userSet, timezone) {
+  const allRows = fetchAllAttendanceRows();
+  if (!Array.isArray(allRows) || allRows.length === 0) {
     return [];
   }
 
-  const ss = getScheduleSpreadsheet();
-  if (!ss) {
-    return [];
-  }
+  const startMs = startDate.getTime();
+  const endMs = endDate.getTime();
+  const entries = new Map();
 
-  const sheetName = typeof SCHEDULE_ADHERENCE_SHEET === 'string' ? SCHEDULE_ADHERENCE_SHEET : 'ScheduleAdherence';
-  const sheet = ss.getSheetByName(sheetName);
-  if (!sheet) {
-    return [];
-  }
+  for (let i = 0; i < allRows.length; i++) {
+    const row = allRows[i];
+    if (!row) continue;
 
-  const values = sheet.getDataRange().getValues();
-  if (values.length < 2) {
-    return [];
-  }
+    const comparableMs = ensureComparableMs(row);
+    if (!Number.isFinite(comparableMs)) continue;
+    if (comparableMs < startMs || comparableMs > endMs) continue;
 
-  const headers = values[0].map(h => String(h || '').trim());
-  const findIndex = (candidates) => {
-    const lookups = Array.isArray(candidates) ? candidates : [candidates];
-    const lowerHeaders = headers.map(h => h.toLowerCase());
-    for (let i = 0; i < lookups.length; i++) {
-      const target = String(lookups[i] || '').trim().toLowerCase();
-      const idx = lowerHeaders.indexOf(target);
-      if (idx !== -1) return idx;
-    }
-    return -1;
-  };
+    const user = String(row.user || row.User || row.employee || '').trim();
+    if (!user) continue;
+    const userKey = user.toLowerCase();
+    if (userSet.size > 0 && !userSet.has(userKey)) continue;
 
-  let dateIdx = findIndex(['Date', 'Day', 'DateKey', 'Date ISO', 'DateIso']);
-  let userIdIdx = findIndex(['UserID', 'User Id', 'User', 'AgentID', 'Agent Id', 'Agent', 'EmployeeID', 'Employee Id']);
-  let userNameIdx = findIndex(['UserName', 'User Name', 'AgentName', 'Agent Name', 'EmployeeName', 'Employee', 'Agent Full Name', 'Full Name', 'Name']);
-  const adherenceIdx = findIndex(['AdherenceScore', 'Adherence', 'Adherence %', 'AdherencePercent', 'AdherencePercentage', 'Adherence Score (%)']);
-  const complianceIdx = findIndex(['CompliancePercent', 'CompliancePercentage', 'ComplianceScore', 'Compliance %', 'Compliance']);
-  const compliantEventsIdx = findIndex(['CompliantEvents', 'Compliant', 'Compliant Events']);
-  const nonCompliantEventsIdx = findIndex(['NonCompliantEvents', 'Non-Compliant', 'NonCompliant', 'Non-Compliant Events']);
-  const scheduledStartIdx = findIndex(['ScheduledStart', 'SchedStart', 'Scheduled Start']);
-  const scheduledEndIdx = findIndex(['ScheduledEnd', 'SchedEnd', 'Scheduled End']);
-  const actualStartIdx = findIndex(['ActualStart', 'ClockIn', 'Login', 'Actual Start']);
-  const actualEndIdx = findIndex(['ActualEnd', 'ClockOut', 'Logout', 'Actual End']);
-  const workedMinutesIdx = findIndex(['WorkedMinutes', 'Worked', 'ActualMinutes', 'Worked Minutes']);
-  const scheduledMinutesIdx = findIndex(['ScheduledMinutes', 'Scheduled', 'PlannedMinutes', 'Scheduled Minutes', 'Planned Minutes']);
+    const timestampMs = ensureTimestampMs(row);
+    if (!Number.isFinite(timestampMs)) continue;
 
-  if (dateIdx === -1) {
-    // Try any header that mentions "date" even if not an exact match
-    dateIdx = headers.findIndex(h => h && h.toLowerCase().includes('date'));
-  }
-
-  if (userIdIdx === -1 && userNameIdx === -1) {
-    const fuzzyIdx = headers.findIndex(h => {
-      const lower = (h || '').toLowerCase();
-      return lower.includes('user') || lower.includes('agent') || lower.includes('employee');
-    });
-    if (fuzzyIdx !== -1) {
-      userNameIdx = fuzzyIdx;
-    }
-  }
-
-  if (dateIdx === -1) {
-    // As a last resort, scan the first few rows for a parsable date value
-    const maxSampleRows = Math.min(values.length, 6);
-    outer: for (let r = 1; r < maxSampleRows; r++) {
-      const candidateRow = values[r];
-      for (let c = 0; c < candidateRow.length; c++) {
-        const candidateDate = normalizeDateValue(candidateRow[c]);
-        if (candidateDate instanceof Date && !isNaN(candidateDate.getTime())) {
-          dateIdx = c;
-          break outer;
-        }
-      }
-    }
-  }
-
-  if (dateIdx === -1) {
-    throw new Error('Unable to locate a date column in the adherence data.');
-  }
-
-  const rows = [];
-  for (let i = 1; i < values.length; i++) {
-    const row = values[i];
-    const dateVal = row[dateIdx];
-    const normalizedDate = normalizeDateValue(dateVal);
-    if (!(normalizedDate instanceof Date) || isNaN(normalizedDate.getTime())) {
+    const dateKey = Utilities.formatDate(new Date(timestampMs), timezone, 'yyyy-MM-dd');
+    const state = String(row.state || row.State || '').trim();
+    if (state !== 'Break' && state !== 'Lunch') {
       continue;
     }
 
-    const localDateOnly = createDateInLocalTime(
-      normalizedDate.getFullYear(),
-      normalizedDate.getMonth() + 1,
-      normalizedDate.getDate(),
-      0,
-      0,
-      0
-    );
+    const durationSec = Number.isFinite(row.durationSec)
+      ? row.durationSec
+      : Number(row.DurationMin) && !Number.isNaN(Number(row.DurationMin))
+        ? Number(row.DurationMin)
+        : Number(row.duration) || 0;
 
-    if (!localDateOnly || localDateOnly < startDate || localDateOnly > endDate) {
+    if (!Number.isFinite(durationSec) || durationSec <= 0) {
       continue;
     }
 
-    const agentNameRaw = userNameIdx !== -1 ? (row[userNameIdx] || '') : '';
-    const agentIdRaw = userIdIdx !== -1 ? (row[userIdIdx] || '') : '';
-    const agentName = agentNameRaw || agentIdRaw || 'Unknown';
-    const agentId = agentIdRaw || '';
+    const entryKey = `${user}|${dateKey}`;
+    if (!entries.has(entryKey)) {
+      const dayDate = new Date(`${dateKey}T00:00:00`);
+      const jsDay = dayDate.getUTCDay();
+      const offset = jsDay === 0 ? -6 : 1 - jsDay;
+      dayDate.setUTCDate(dayDate.getUTCDate() + offset);
+      const weekStartKey = Utilities.formatDate(dayDate, timezone, 'yyyy-MM-dd');
 
-    if (userSet.size > 0) {
-      const candidateIdentifiers = new Set([
-        String(agentNameRaw || '').trim().toLowerCase(),
-        String(agentIdRaw || '').trim().toLowerCase(),
-        String(agentName || '').trim().toLowerCase()
-      ].filter(Boolean));
-      const hasMatch = Array.from(candidateIdentifiers).some(id => userSet.has(id));
-      if (!hasMatch) {
-        continue;
-      }
+      entries.set(entryKey, {
+        dateKey,
+        weekStartKey,
+        agentName: user,
+        agentId: row.userId || row.UserId || row.UserID || '',
+        breakMinutes: 0,
+        lunchMinutes: 0
+      });
     }
 
-    const scheduledMinutes = resolveMinutesFromRow_(row, scheduledMinutesIdx, scheduledStartIdx, scheduledEndIdx, timezone);
-    const workedMinutes = resolveMinutesFromRow_(row, workedMinutesIdx, actualStartIdx, actualEndIdx, timezone);
-
-    const adherencePercent = adherenceIdx !== -1 ? resolveNumericValue_(row[adherenceIdx]) : 0;
-    const compliancePercent = complianceIdx !== -1 ? resolveNumericValue_(row[complianceIdx]) : adherencePercent;
-    const compliantEvents = resolveNumericValue_(row[compliantEventsIdx]);
-    const nonCompliantEvents = resolveNumericValue_(row[nonCompliantEventsIdx]);
-
-    const dateKey = Utilities.formatDate(localDateOnly, timezone, 'yyyy-MM-dd');
-    const weekStartKey = resolveWeekStartKey_(localDateOnly, timezone);
-
-    rows.push({
-      dateKey,
-      weekStartKey,
-      agentName,
-      agentId,
-      adherencePercent,
-      compliancePercent,
-      scheduledMinutes,
-      workedMinutes,
-      compliantEvents,
-      nonCompliantEvents
-    });
+    const target = entries.get(entryKey);
+    if (state === 'Break') {
+      target.breakMinutes += (durationSec / 60);
+    } else {
+      target.lunchMinutes += (durationSec / 60);
+    }
   }
 
-  return rows;
+  return Array.from(entries.values()).map(entry => {
+    const overBreakMinutes = Math.max(0, Math.round((entry.breakMinutes - 30) * 100) / 100);
+    const overLunchMinutes = Math.max(0, Math.round((entry.lunchMinutes - 30) * 100) / 100);
+    const adherent = overBreakMinutes <= 0 && overLunchMinutes <= 0;
+
+    return {
+      ...entry,
+      breakMinutes: Math.round(entry.breakMinutes * 100) / 100,
+      lunchMinutes: Math.round(entry.lunchMinutes * 100) / 100,
+      overBreakMinutes,
+      overLunchMinutes,
+      adherencePercent: adherent ? 100 : 0,
+      compliancePercent: adherent ? 100 : 0,
+      adherenceFlag: adherent ? 'Adherent' : 'Non-adherent'
+    };
+  }).sort((a, b) => a.dateKey.localeCompare(b.dateKey) || a.agentName.localeCompare(b.agentName));
 }
 
 function resolveMinutesFromRow_(row, explicitMinutesIdx, startIdx, endIdx, timezone) {
@@ -4090,111 +4076,103 @@ function resolveWeekStartKey_(date, timezone) {
   return Utilities.formatDate(weekStart, timezone, 'yyyy-MM-dd');
 }
 
-function summarizeWeeklyAdherence_(dailyRows, timezone) {
-  const weeklyMap = new Map();
+function summarizeAgentAdherence_(dailyRows) {
+  const agents = new Map();
 
   dailyRows.forEach(row => {
-    const key = `${row.agentName}|${row.agentId || ''}|${row.weekStartKey}`;
-    if (!weeklyMap.has(key)) {
-      weeklyMap.set(key, {
-        weekStartKey: row.weekStartKey,
+    const key = row.agentName || row.agentId || 'Unknown';
+    if (!agents.has(key)) {
+      agents.set(key, {
         agentName: row.agentName,
         agentId: row.agentId || '',
-        adherenceWeighted: 0,
-        complianceWeighted: 0,
-        weight: 0,
-        daysWithData: 0,
-        scheduledMinutes: 0,
-        workedMinutes: 0,
-        compliantEvents: 0,
-        nonCompliantEvents: 0
+        eligibleDays: 0,
+        adherentDays: 0,
+        nonAdherentDays: 0,
+        totalOverMinutes: 0
       });
     }
 
-    const entry = weeklyMap.get(key);
-    const weight = Number(row.scheduledMinutes) || 0;
-    const adherence = Number(row.adherencePercent) || 0;
-    const compliance = Number(row.compliancePercent) || 0;
-    if (weight > 0) {
-      entry.adherenceWeighted += adherence * weight;
-      entry.complianceWeighted += compliance * weight;
-      entry.weight += weight;
+    const summary = agents.get(key);
+    summary.eligibleDays += 1;
+    summary.totalOverMinutes += (row.overBreakMinutes || 0) + (row.overLunchMinutes || 0);
+    if (row.adherencePercent === 100) {
+      summary.adherentDays += 1;
     } else {
-      entry.adherenceWeighted += adherence;
-      entry.complianceWeighted += compliance;
-      entry.weight += 1;
+      summary.nonAdherentDays += 1;
     }
-
-    entry.daysWithData += 1;
-    entry.scheduledMinutes += Number(row.scheduledMinutes) || 0;
-    entry.workedMinutes += Number(row.workedMinutes) || 0;
-    entry.compliantEvents += Number(row.compliantEvents) || 0;
-    entry.nonCompliantEvents += Number(row.nonCompliantEvents) || 0;
   });
 
-  return Array.from(weeklyMap.values()).map(entry => ({
-    weekStartKey: entry.weekStartKey,
-    agentName: entry.agentName,
-    agentId: entry.agentId,
-    adherencePercent: entry.weight > 0 ? Math.round((entry.adherenceWeighted / entry.weight) * 10) / 10 : 0,
-    compliancePercent: entry.weight > 0 ? Math.round((entry.complianceWeighted / entry.weight) * 10) / 10 : 0,
-    daysWithData: entry.daysWithData,
-    scheduledMinutes: entry.scheduledMinutes,
-    workedMinutes: entry.workedMinutes,
-    compliantEvents: entry.compliantEvents,
-    nonCompliantEvents: entry.nonCompliantEvents
-  }));
+  return Array.from(agents.values()).map(entry => ({
+    ...entry,
+    adherencePercent: entry.eligibleDays > 0
+      ? Math.round((entry.adherentDays / entry.eligibleDays) * 1000) / 10
+      : 0
+  })).sort((a, b) => a.agentName.localeCompare(b.agentName));
 }
 
-function summarizeOverallAdherence_(dailyRows) {
-  if (!Array.isArray(dailyRows) || !dailyRows.length) {
+function summarizeWeeklyBreakLunch_(dailyRows) {
+  const weekly = new Map();
+
+  dailyRows.forEach(row => {
+    const key = `${row.weekStartKey}|${row.agentName}`;
+    if (!weekly.has(key)) {
+      weekly.set(key, {
+        weekStartKey: row.weekStartKey,
+        agentName: row.agentName,
+        agentId: row.agentId || '',
+        adherentDays: 0,
+        nonAdherentDays: 0,
+        totalOverMinutes: 0
+      });
+    }
+
+    const summary = weekly.get(key);
+    summary.totalOverMinutes += (row.overBreakMinutes || 0) + (row.overLunchMinutes || 0);
+    if (row.adherencePercent === 100) {
+      summary.adherentDays += 1;
+    } else {
+      summary.nonAdherentDays += 1;
+    }
+  });
+
+  return Array.from(weekly.values()).map(entry => ({
+    ...entry,
+    adherencePercent: (entry.adherentDays + entry.nonAdherentDays) > 0
+      ? Math.round((entry.adherentDays / (entry.adherentDays + entry.nonAdherentDays)) * 1000) / 10
+      : 0
+  })).sort((a, b) => a.weekStartKey.localeCompare(b.weekStartKey) || a.agentName.localeCompare(b.agentName));
+}
+
+function summarizeOverallBreakLunch_(agentSummaries) {
+  if (!Array.isArray(agentSummaries) || agentSummaries.length === 0) {
     return {
-      adherencePercent: 0,
-      compliancePercent: 0,
-      agentDays: 0,
-      scheduledMinutes: 0,
-      workedMinutes: 0,
-      compliantEvents: 0,
-      nonCompliantEvents: 0
+      overallAdherencePercent: 0,
+      totalEligibleDays: 0,
+      totalAdherentDays: 0,
+      totalNonAdherentDays: 0,
+      totalOverMinutes: 0
     };
   }
 
-  let adherenceWeighted = 0;
-  let complianceWeighted = 0;
-  let weight = 0;
-  let scheduledMinutes = 0;
-  let workedMinutes = 0;
-  let compliantEvents = 0;
-  let nonCompliantEvents = 0;
-
-  dailyRows.forEach(row => {
-    const rowWeight = Number(row.scheduledMinutes) || 0;
-    const adherence = Number(row.adherencePercent) || 0;
-    const compliance = Number(row.compliancePercent) || 0;
-    if (rowWeight > 0) {
-      adherenceWeighted += adherence * rowWeight;
-      complianceWeighted += compliance * rowWeight;
-      weight += rowWeight;
-    } else {
-      adherenceWeighted += adherence;
-      complianceWeighted += compliance;
-      weight += 1;
-    }
-    scheduledMinutes += Number(row.scheduledMinutes) || 0;
-    workedMinutes += Number(row.workedMinutes) || 0;
-    compliantEvents += Number(row.compliantEvents) || 0;
-    nonCompliantEvents += Number(row.nonCompliantEvents) || 0;
+  const totals = agentSummaries.reduce((acc, entry) => {
+    acc.totalEligibleDays += entry.eligibleDays;
+    acc.totalAdherentDays += entry.adherentDays;
+    acc.totalNonAdherentDays += entry.nonAdherentDays;
+    acc.totalOverMinutes += entry.totalOverMinutes;
+    return acc;
+  }, {
+    overallAdherencePercent: 0,
+    totalEligibleDays: 0,
+    totalAdherentDays: 0,
+    totalNonAdherentDays: 0,
+    totalOverMinutes: 0
   });
 
-  return {
-    adherencePercent: weight > 0 ? Math.round((adherenceWeighted / weight) * 10) / 10 : 0,
-    compliancePercent: weight > 0 ? Math.round((complianceWeighted / weight) * 10) / 10 : 0,
-    agentDays: dailyRows.length,
-    scheduledMinutes,
-    workedMinutes,
-    compliantEvents,
-    nonCompliantEvents
-  };
+  totals.overallAdherencePercent = totals.totalEligibleDays > 0
+    ? Math.round((totals.totalAdherentDays / totals.totalEligibleDays) * 1000) / 10
+    : 0;
+
+  return totals;
 }
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- rebuild adherence export to source break and lunch minutes directly from attendance logs
- provide per-day, weekly, and per-agent adherence metrics based on 30/30 break and lunch allowances
- update CSV and sheet exports to surface overage minutes, adherence flags, and overall adherence rates for the selected period

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d47dfb6c83269b7d92deea06356a)