### PR TITLE
Enhance adherence export period selection and break/lunch metrics

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1769,13 +1769,33 @@
       </div>
       <div class="modal-body">
         <p class="text-muted small">Choose filters to export adherence and compliance with a Google Sheets-ready header. Defaults follow the dashboard filters so you can export what you see.</p>
+        <div class="row g-3 mb-3 align-items-end">
+          <div class="col-md-6">
+            <label class="form-label fw-bold">Period</label>
+            <select class="form-select" id="adherenceExportPeriodType">
+              <option value="weekly">Weekly (Mon–Sun)</option>
+              <option value="biweekly">Bi-weekly (two weeks)</option>
+              <option value="monthly">Monthly</option>
+              <option value="quarterly">Quarterly</option>
+              <option value="yearly">Yearly</option>
+              <option value="custom" selected>Custom Range</option>
+            </select>
+            <div class="form-text">Weeks start on Monday for adherence calculations.</div>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label fw-bold">Selected Range</label>
+            <div class="form-control" id="adherenceExportRangeLabel" style="height: auto; min-height: 38px;">
+              —
+            </div>
+          </div>
+        </div>
         <div class="row g-3 mb-3">
           <div class="col-md-6">
-            <label class="form-label fw-bold">Start Date</label>
+            <label class="form-label fw-bold">Start / Anchor Date</label>
             <input type="date" class="form-control" id="adherenceExportStart" />
           </div>
           <div class="col-md-6">
-            <label class="form-label fw-bold">End Date</label>
+            <label class="form-label fw-bold">End Date (Custom only)</label>
             <input type="date" class="form-control" id="adherenceExportEnd" />
           </div>
         </div>
@@ -2316,6 +2336,7 @@
       this.summaryFilters = {
         dateFrom: '',
         dateTo: '',
+        periodType: 'custom',
         userMode: 'all',
         selectedUsers: []
       };
@@ -2756,6 +2777,8 @@
 
       const startInput = document.getElementById('adherenceExportStart');
       const endInput = document.getElementById('adherenceExportEnd');
+      const periodSelect = document.getElementById('adherenceExportPeriodType');
+      const rangePreview = document.getElementById('adherenceExportRangeLabel');
       const singleSelect = document.getElementById('adherenceExportSingleSelect');
       const multiSelect = document.getElementById('adherenceExportMultiSelect');
       const modeRadios = document.querySelectorAll('input[name="adherenceExportUserMode"]');
@@ -2782,15 +2805,31 @@
         }
       };
 
+      const updateRangePreview = () => {
+        try {
+          const filters = this.adherenceExportFilters || this.summaryFilters;
+          const resolved = this.resolveAdherenceRange(filters.periodType || 'custom', filters.dateFrom, filters.dateTo);
+          if (rangePreview) {
+            rangePreview.textContent = resolved?.label || '—';
+          }
+        } catch (err) {
+          if (rangePreview) rangePreview.textContent = '—';
+        }
+      };
+
       const syncFromFilters = () => {
         const filters = this.adherenceExportFilters || this.summaryFilters;
         if (startInput) startInput.value = filters.dateFrom || this.summaryFilters.dateFrom || '';
         if (endInput) endInput.value = filters.dateTo || this.summaryFilters.dateTo || '';
+        if (periodSelect) periodSelect.value = filters.periodType || 'custom';
 
         const mode = filters.userMode || 'all';
         modeRadios.forEach((radio) => {
           radio.checked = radio.value === mode;
         });
+
+        const isCustom = (filters.periodType || 'custom') === 'custom';
+        if (endInput) endInput.disabled = !isCustom;
 
         const enableSingle = mode === 'single';
         const enableMulti = mode === 'multiple';
@@ -2805,12 +2844,15 @@
             opt.selected = Array.isArray(filters.selectedUsers) && filters.selectedUsers.includes(opt.value);
           });
         }
+
+        updateRangePreview();
       };
 
       const syncFilters = () => {
         this.adherenceExportFilters = {
           dateFrom: startInput?.value || this.summaryFilters.dateFrom || '',
           dateTo: endInput?.value || this.summaryFilters.dateTo || '',
+          periodType: periodSelect?.value || 'custom',
           userMode: document.querySelector('input[name="adherenceExportUserMode"]:checked')?.value || 'all',
           selectedUsers: []
         };
@@ -2821,10 +2863,16 @@
         if (this.adherenceExportFilters.userMode === 'multiple' && multiSelect) {
           this.adherenceExportFilters.selectedUsers = Array.from(multiSelect.selectedOptions).map((opt) => opt.value);
         }
+
+        updateRangePreview();
       };
 
       if (startInput) startInput.addEventListener('change', syncFilters);
       if (endInput) endInput.addEventListener('change', syncFilters);
+      if (periodSelect) periodSelect.addEventListener('change', () => {
+        syncFilters();
+        syncFromFilters();
+      });
       modeRadios.forEach((radio) => {
         radio.addEventListener('change', () => {
           syncFilters();
@@ -4673,14 +4721,89 @@
       return compliance;
     }
 
+    resolveAdherenceRange(periodType = 'custom', startDate, endDate) {
+      const normalizeDate = (value, isEnd = false) => {
+        if (!value) return null;
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) return null;
+        if (isEnd) {
+          date.setHours(23, 59, 59, 999);
+        } else {
+          date.setHours(0, 0, 0, 0);
+        }
+        return date;
+      };
+
+      const formatIso = (date) => (date instanceof Date && !Number.isNaN(date.getTime()))
+        ? date.toISOString().slice(0, 10)
+        : '';
+
+      const resolveWeekStart = (anchor) => {
+        const weekDate = new Date(anchor);
+        const day = weekDate.getDay();
+        const diff = day === 0 ? -6 : 1 - day;
+        weekDate.setDate(weekDate.getDate() + diff);
+        weekDate.setHours(0, 0, 0, 0);
+        return weekDate;
+      };
+
+      const type = (periodType || 'custom').toLowerCase().replace(/[^a-z]/g, '');
+      const anchor = normalizeDate(startDate || endDate || new Date());
+      if (!anchor) return null;
+
+      switch (type) {
+        case 'week':
+        case 'weekly': {
+          const start = resolveWeekStart(anchor);
+          const end = new Date(start);
+          end.setDate(start.getDate() + 6);
+          end.setHours(23, 59, 59, 999);
+          return { startIso: formatIso(start), endIso: formatIso(end), label: `Week of ${formatIso(start)}` };
+        }
+        case 'biweek':
+        case 'biweekly': {
+          const start = resolveWeekStart(anchor);
+          const end = new Date(start);
+          end.setDate(start.getDate() + 13);
+          end.setHours(23, 59, 59, 999);
+          return { startIso: formatIso(start), endIso: formatIso(end), label: `Bi-week of ${formatIso(start)}` };
+        }
+        case 'month':
+        case 'monthly': {
+          const start = new Date(anchor.getFullYear(), anchor.getMonth(), 1, 0, 0, 0, 0);
+          const end = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0, 23, 59, 59, 999);
+          return {
+            startIso: formatIso(start),
+            endIso: formatIso(end),
+            label: `${start.toLocaleString('default', { month: 'long' })} ${start.getFullYear()}`
+          };
+        }
+        case 'quarter':
+        case 'quarterly': {
+          const quarter = Math.floor(anchor.getMonth() / 3);
+          const start = new Date(anchor.getFullYear(), quarter * 3, 1, 0, 0, 0, 0);
+          const end = new Date(anchor.getFullYear(), (quarter * 3) + 3, 0, 23, 59, 59, 999);
+          return { startIso: formatIso(start), endIso: formatIso(end), label: `Q${quarter + 1} ${start.getFullYear()}` };
+        }
+        case 'year':
+        case 'yearly': {
+          const start = new Date(anchor.getFullYear(), 0, 1, 0, 0, 0, 0);
+          const end = new Date(anchor.getFullYear(), 11, 31, 23, 59, 59, 999);
+          return { startIso: formatIso(start), endIso: formatIso(end), label: `${start.getFullYear()}` };
+        }
+        case 'custom':
+        default: {
+          const start = normalizeDate(startDate, false);
+          const end = normalizeDate(endDate, true);
+          if (!start || !end) return null;
+          return { startIso: formatIso(start), endIso: formatIso(end), label: `${formatIso(start)} to ${formatIso(end)}` };
+        }
+      }
+    }
+
     async exportAdherenceCompliance(format = 'sheet', filters = null) {
       const effectiveFilters = filters || this.summaryFilters;
-      const { dateFrom, dateTo, userMode, selectedUsers } = effectiveFilters;
-
-      if (!dateFrom || !dateTo) {
-        this.showToast('Please select a start and end date for the adherence export.', 'warning');
-        return;
-      }
+      const { dateFrom, dateTo, userMode, selectedUsers, periodType } = effectiveFilters;
 
       const resolvedUsers = (() => {
         if (userMode === 'single' && Array.isArray(selectedUsers) && selectedUsers.length) {
@@ -4692,9 +4815,16 @@
         return [];
       })();
 
+      const resolvedRange = this.resolveAdherenceRange(periodType || 'custom', dateFrom, dateTo);
+      if (!resolvedRange) {
+        this.showToast('Please select a valid period for the adherence export.', 'warning');
+        return;
+      }
+
       const payload = {
-        startDateIso: dateFrom,
-        endDateIso: dateTo,
+        startDateIso: resolvedRange.startIso,
+        endDateIso: resolvedRange.endIso,
+        periodType: periodType || 'custom',
         users: resolvedUsers
       };
 
@@ -4722,7 +4852,7 @@
 
           const dailyHeader = ['Date', 'Week Start', 'Agent Name', 'Agent ID', 'Lunch Minutes', 'Break Minutes', 'Over Lunch Minutes', 'Over Break Minutes', 'Daily Adherence'];
           const weeklyHeader = ['Week Start', 'Agent Name', 'Agent ID', 'Adherent Days', 'Non-Adherent Days', 'Weekly Adherence %', 'Total Over Minutes'];
-          const agentHeader = ['Agent Name', 'Agent ID', 'Eligible Days', 'Adherent Days', 'Non-Adherent Days', 'Total Over Minutes', 'Adherence %'];
+          const agentHeader = ['Agent Name', 'Agent ID', 'Period', 'Eligible Days', 'Adherent Days', 'Non-Adherent Days', 'Total Over Minutes', 'Adherence %'];
           const overallHeader = ['Start Date', 'End Date', 'Total Eligible Agent-Days', 'Adherent Agent-Days', 'Non-Adherent Agent-Days', 'Overall Adherence %', 'Total Over Minutes'];
           const weeklyMatrixHeader = ['Agent', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'Weekly %'];
 
@@ -4783,6 +4913,7 @@
             lines.push([
               row.agentName,
               row.agentId || '',
+              exportData.periodLabel || '',
               row.eligibleDays,
               row.adherentDays,
               row.nonAdherentDays,

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -3644,21 +3644,26 @@ function exportAdherenceComplianceSheet(payload) {
         ? Session.getScriptTimeZone()
         : 'America/Jamaica');
 
+    const periodType = (payload && payload.periodType) ? String(payload.periodType).trim() : 'custom';
     const startDateIso = (payload && payload.startDateIso) ? String(payload.startDateIso).trim() : '';
     const endDateIso = (payload && payload.endDateIso) ? String(payload.endDateIso).trim() : '';
-    if (!startDateIso || !endDateIso) {
-      return { success: false, error: 'A start date and end date are required for the adherence export.' };
-    }
 
     const filterUsers = Array.isArray(payload?.users) ? payload.users : [];
-
-    const exportData = buildAdherenceComplianceDataset_(startDateIso, endDateIso, filterUsers, timezone);
+    let exportData;
+    try {
+      exportData = buildAdherenceComplianceDataset_(periodType, startDateIso, endDateIso, filterUsers, timezone);
+    } catch (rangeError) {
+      return { success: false, error: rangeError.message || 'Unable to prepare adherence range.' };
+    }
     if (!exportData || !Array.isArray(exportData.dailyRows) || exportData.dailyRows.length === 0) {
       return { success: false, error: 'No adherence data available to export.' };
     }
 
     const now = new Date();
-    const periodLabel = `${Utilities.formatDate(exportData.startDate, timezone, 'yyyy-MM-dd')} to ${Utilities.formatDate(exportData.endDate, timezone, 'yyyy-MM-dd')}`;
+    const exportStartIso = Utilities.formatDate(exportData.startDate, timezone, 'yyyy-MM-dd');
+    const exportEndIso = Utilities.formatDate(exportData.endDate, timezone, 'yyyy-MM-dd');
+    const periodLabel = exportData.periodLabel
+      || `${exportStartIso} to ${exportEndIso}`;
     const userScope = exportData.userScopeLabel || 'All Users';
     const spreadsheetName = (payload?.spreadsheetName && payload.spreadsheetName.trim())
       ? payload.spreadsheetName.trim()
@@ -3768,7 +3773,7 @@ function exportAdherenceComplianceSheet(payload) {
       const noteRow = currentRow + tableHeight;
       sheet.getRange(noteRow, 1, 1, 3)
         .setValues([[
-          'Weekly % uses Monday–Friday as the 100% baseline; compliant weekend days can push the rate above 100%.'
+          'Weekly % is calculated from Monday–Sunday using recorded break and lunch entries for each agent.'
         ]])
         .setFontStyle('italic')
         .setFontColor('#475569');
@@ -3861,6 +3866,7 @@ function exportAdherenceComplianceSheet(payload) {
     const agentHeaders = [
       'Agent Name',
       'Agent ID',
+      'Period',
       'Eligible Days',
       'Adherent Days',
       'Non-Adherent Days',
@@ -3877,6 +3883,7 @@ function exportAdherenceComplianceSheet(payload) {
     const agentValues = exportData.agentSummaries.map(row => [
       row.agentName,
       row.agentId || '',
+      exportData.periodLabel || '',
       row.eligibleDays,
       row.adherentDays,
       row.nonAdherentDays,
@@ -3887,7 +3894,7 @@ function exportAdherenceComplianceSheet(payload) {
     if (agentValues.length) {
       sheet.getRange(currentRow, 1, agentValues.length, agentHeaders.length)
         .setValues(agentValues);
-      sheet.getRange(currentRow, 7, agentValues.length, 1).setNumberFormat('0.0');
+      sheet.getRange(currentRow, 8, agentValues.length, 1).setNumberFormat('0.0');
     }
     currentRow += agentValues.length + 2;
 
@@ -3977,8 +3984,8 @@ function exportAdherenceComplianceSheet(payload) {
         sheetTitle,
         periodLabel,
         userScope,
-        startDateIso: startDateIso,
-        endDateIso: endDateIso,
+        startDateIso: exportStartIso,
+        endDateIso: exportEndIso,
         folderId,
         folderName,
         folderUrl,
@@ -4004,14 +4011,17 @@ function getAdherenceComplianceExportData(payload) {
         ? Session.getScriptTimeZone()
         : 'America/Jamaica');
 
+    const periodType = (payload && payload.periodType) ? String(payload.periodType).trim() : 'custom';
     const startDateIso = (payload && payload.startDateIso) ? String(payload.startDateIso).trim() : '';
     const endDateIso = (payload && payload.endDateIso) ? String(payload.endDateIso).trim() : '';
-    if (!startDateIso || !endDateIso) {
-      return { success: false, error: 'A start date and end date are required for the adherence export.' };
-    }
 
     const filterUsers = Array.isArray(payload?.users) ? payload.users : [];
-    const exportData = buildAdherenceComplianceDataset_(startDateIso, endDateIso, filterUsers, timezone);
+    let exportData;
+    try {
+      exportData = buildAdherenceComplianceDataset_(periodType, startDateIso, endDateIso, filterUsers, timezone);
+    } catch (rangeError) {
+      return { success: false, error: rangeError.message || 'Unable to prepare adherence range.' };
+    }
     if (!exportData || !Array.isArray(exportData.dailyRows) || exportData.dailyRows.length === 0) {
       return { success: false, error: 'No adherence data available to export.' };
     }
@@ -4020,15 +4030,8 @@ function getAdherenceComplianceExportData(payload) {
   }, { success: false, error: 'Unable to prepare adherence export data.' }, MAX_PROCESSING_TIME);
 }
 
-function buildAdherenceComplianceDataset_(startDateIso, endDateIso, filterUsers, timezone) {
-  const startDate = new Date(startDateIso);
-  const endDate = new Date(endDateIso);
-  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-    throw new Error('Invalid date range provided.');
-  }
-  if (startDate > endDate) {
-    throw new Error('Start date must be before end date.');
-  }
+function buildAdherenceComplianceDataset_(periodType, startDateIso, endDateIso, filterUsers, timezone) {
+  const { startDate, endDate, periodLabel } = resolveAdherencePeriodRange_(periodType, startDateIso, endDateIso, timezone);
 
   const normalizedStart = createDateInLocalTime(startDate.getFullYear(), startDate.getMonth() + 1, startDate.getDate(), 0, 0, 0);
   const normalizedEnd = createDateInLocalTime(endDate.getFullYear(), endDate.getMonth() + 1, endDate.getDate(), 23, 59, 59);
@@ -4047,7 +4050,114 @@ function buildAdherenceComplianceDataset_(startDateIso, endDateIso, filterUsers,
     ? `Selected Users (${userSet.size})`
     : 'All Users';
 
-  return { startDate: normalizedStart, endDate: normalizedEnd, dailyRows: adherenceDaily, weeklyRows, weeklyMatrices, agentSummaries, overall, userScopeLabel };
+  return {
+    startDate: normalizedStart,
+    endDate: normalizedEnd,
+    periodLabel,
+    dailyRows: adherenceDaily,
+    weeklyRows,
+    weeklyMatrices,
+    agentSummaries,
+    overall,
+    userScopeLabel
+  };
+}
+
+function resolveAdherencePeriodRange_(periodType, startDateIso, endDateIso, timezone) {
+  const normalizeDate = (value, isEnd) => {
+    const date = value instanceof Date ? value : new Date(value);
+    if (isNaN(date.getTime())) return null;
+    const hours = isEnd ? 23 : 0;
+    const minutes = isEnd ? 59 : 0;
+    const seconds = isEnd ? 59 : 0;
+    const millis = isEnd ? 999 : 0;
+    const adjusted = createDateInLocalTime(date.getFullYear(), date.getMonth() + 1, date.getDate(), hours, minutes, seconds);
+    adjusted.setMilliseconds(millis);
+    return adjusted;
+  };
+
+  const typeRaw = String(periodType || 'custom').toLowerCase();
+  const type = typeRaw.replace(/[^a-z]/g, '');
+  const anchor = normalizeDate(startDateIso || endDateIso || new Date());
+
+  if (!anchor) {
+    throw new Error('A valid date is required for adherence export.');
+  }
+
+  const formatWithTimezone = (date, format) => {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+    if (typeof Utilities !== 'undefined' && Utilities.formatDate) {
+      try {
+        return Utilities.formatDate(date, timezone, format);
+      } catch (err) {
+        // fall through to local formatting
+      }
+    }
+    if (format === 'MMMM yyyy') {
+      return date.toLocaleString('default', { month: 'long', year: 'numeric' });
+    }
+    return date.toISOString().slice(0, 10);
+  };
+
+  const finalize = (start, end, label) => {
+    if (!(start instanceof Date) || !(end instanceof Date) || isNaN(start.getTime()) || isNaN(end.getTime())) {
+      throw new Error('Invalid date range provided.');
+    }
+    if (start.getTime() > end.getTime()) {
+      throw new Error('Start date must be before end date.');
+    }
+    return { startDate: start, endDate: end, periodLabel: label };
+  };
+
+  const weekStartKey = resolveWeekStartKey_(anchor, timezone);
+  const weekStartParts = weekStartKey ? weekStartKey.split('-').map(Number) : [];
+  const weekStartDate = weekStartParts.length === 3
+    ? createDateInLocalTime(weekStartParts[0], weekStartParts[1], weekStartParts[2], 0, 0, 0)
+    : normalizeDate(anchor, false);
+
+  switch (type) {
+    case 'week':
+    case 'weekly': {
+      const start = weekStartDate;
+      const end = createDateInLocalTime(start.getFullYear(), start.getMonth() + 1, start.getDate() + 6, 23, 59, 59);
+      return finalize(start, end, `Week of ${weekStartKey}`);
+    }
+    case 'biweekly':
+    case 'biweek': {
+      const start = weekStartDate;
+      const end = createDateInLocalTime(start.getFullYear(), start.getMonth() + 1, start.getDate() + 13, 23, 59, 59);
+      return finalize(start, end, `Bi-week of ${weekStartKey}`);
+    }
+    case 'month':
+    case 'monthly': {
+      const start = createDateInLocalTime(anchor.getFullYear(), anchor.getMonth() + 1, 1, 0, 0, 0);
+      const end = createDateInLocalTime(anchor.getFullYear(), anchor.getMonth() + 2, 0, 23, 59, 59);
+      return finalize(start, end, `Month of ${formatWithTimezone(start, 'MMMM yyyy')}`);
+    }
+    case 'quarter':
+    case 'quarterly': {
+      const quarterIndex = Math.floor(anchor.getMonth() / 3);
+      const start = createDateInLocalTime(anchor.getFullYear(), (quarterIndex * 3) + 1, 1, 0, 0, 0);
+      const end = createDateInLocalTime(anchor.getFullYear(), (quarterIndex * 3) + 4, 0, 23, 59, 59);
+      return finalize(start, end, `Q${quarterIndex + 1} ${anchor.getFullYear()}`);
+    }
+    case 'year':
+    case 'yearly': {
+      const start = createDateInLocalTime(anchor.getFullYear(), 1, 1, 0, 0, 0);
+      const end = createDateInLocalTime(anchor.getFullYear(), 12, 31, 23, 59, 59);
+      return finalize(start, end, `${anchor.getFullYear()}`);
+    }
+    case 'custom':
+    default: {
+      const customStart = normalizeDate(startDateIso, false);
+      const customEnd = normalizeDate(endDateIso, true);
+      if (!customStart || !customEnd) {
+        throw new Error('A start date and end date are required for the adherence export.');
+      }
+      const label = `${Utilities.formatDate(customStart, timezone, 'yyyy-MM-dd')} to ${Utilities.formatDate(customEnd, timezone, 'yyyy-MM-dd')}`;
+      return finalize(customStart, customEnd, label);
+    }
+  }
 }
 
 function loadBreakLunchAdherenceDaily_(startDate, endDate, userSet, timezone) {
@@ -4413,12 +4523,11 @@ function summarizeAgentAdherence_(dailyRows) {
       week.agents.get(agentKey).dayMap.set(row.dateKey, row);
     });
 
-    const WORK_WEEK_DAYS = 5;
-
     const weeksArray = Array.from(weeks.values()).map(week => {
       const rows = Array.from(week.agents.values()).map(agent => {
         let adherentDays = 0;
         let totalOverMinutes = 0;
+        let eligibleDays = 0;
 
         const dayDetails = week.dayKeys.map((dateKey, idx) => {
           const entry = agent.dayMap.get(dateKey);
@@ -4430,6 +4539,7 @@ function summarizeAgentAdherence_(dailyRows) {
           const overMinutes = (Number(entry.overBreakMinutes) || 0) + (Number(entry.overLunchMinutes) || 0);
 
           totalOverMinutes += overMinutes;
+          eligibleDays += 1;
           if (percent === 100) {
             adherentDays += 1;
           }
@@ -4443,8 +4553,8 @@ function summarizeAgentAdherence_(dailyRows) {
           };
         });
 
-        const weeklyPercent = adherentDays > 0
-          ? Math.round(((adherentDays / WORK_WEEK_DAYS) * 100) * 10) / 10
+        const weeklyPercent = eligibleDays > 0
+          ? Math.round(((adherentDays / eligibleDays) * 100) * 10) / 10
           : 0;
 
         return {

--- a/DataExportService.js
+++ b/DataExportService.js
@@ -90,7 +90,13 @@ function runDataExport(payload) {
     case 'attendance-adherence-sheet':
       return exportAdherenceComplianceSheet(normalized);
     case 'adherence-data':
-      return getAdherenceComplianceExportData(normalized.startDateIso, normalized.endDateIso, normalized.userId ? [normalized.userId] : [], normalized.timezone);
+      return getAdherenceComplianceExportData({
+        startDateIso: normalized.startDateIso,
+        endDateIso: normalized.endDateIso,
+        periodType: normalized.periodType || normalized.granularity || 'custom',
+        users: normalized.userId ? [normalized.userId] : [],
+        timezone: normalized.timezone
+      });
     case 'qa-agent-matrix':
       return clientExportAgentMatrix({
         granularity: normalized.granularity,


### PR DESCRIPTION
## Summary
- add period type selection and range previews to the adherence export modal, deriving anchor-based weekly through yearly ranges
- compute adherence datasets from break and lunch details for the selected period, including per-agent adherence percentages and updated weekly calculations
- include period labels in agent summaries and exports while improving handling for download requests

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382681c4108326a82605a387759565)