### PR TITLE
Implement adherence matrix percentages and formatting

### DIFF
--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -3679,18 +3679,15 @@ function exportAdherenceComplianceSheet(payload) {
 
     const adherenceColorForPercent = (percent) => {
       if (!Number.isFinite(percent)) return '#f8fafc';
-      if (percent > 110) return '#0ea5e9';
-      if (percent >= 100) return '#22c55e';
-      if (percent >= 90) return '#f59e0b';
+      if (percent >= 95) return '#22c55e';
+      if (percent >= 85) return '#f59e0b';
       return '#ef4444';
     };
 
     const adherenceFontForPercent = (percent) => {
       if (!Number.isFinite(percent)) return '#0f172a';
-      if (percent >= 90 && percent < 100) return '#0f172a';
-      if (percent > 110) return '#ffffff';
-      if (percent >= 100) return '#ffffff';
-      if (percent >= 80) return '#0f172a';
+      if (percent >= 95) return '#ffffff';
+      if (percent >= 85) return '#0f172a';
       return '#ffffff';
     };
 
@@ -3699,7 +3696,7 @@ function exportAdherenceComplianceSheet(payload) {
       sheet.getRange(currentRow, 1).setFontWeight('bold');
       currentRow += 1;
 
-      const matrixHeaders = ['Agent', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'Weekly %'];
+      const matrixHeaders = ['Agent', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'Weekly Adherence %', 'Compliance Status', 'Eligible Days'];
       sheet.getRange(currentRow, 1, 1, matrixHeaders.length)
         .setValues([matrixHeaders])
         .setFontWeight('bold')
@@ -3707,7 +3704,7 @@ function exportAdherenceComplianceSheet(payload) {
         .setFontColor('#ffffff');
       currentRow += 1;
 
-      const dateLabels = [''].concat(matrix.dayLabels || []).concat(['']);
+      const dateLabels = [''].concat(matrix.dayLabels || []).concat(['', '', '']);
       sheet.getRange(currentRow, 1, 1, matrixHeaders.length)
         .setValues([dateLabels])
         .setFontWeight('bold')
@@ -3724,7 +3721,13 @@ function exportAdherenceComplianceSheet(payload) {
           return `${Math.round(value * 10) / 10}% (L:${lunch}m/B:${brk}m)`;
         });
         const weeklyPercentValue = Number(row.weeklyPercent) || 0;
-        return [row.agentName || 'Unknown', ...dayStrings, `${weeklyPercentValue}%`];
+        return [
+          row.agentName || 'Unknown',
+          ...dayStrings,
+          `${weeklyPercentValue}%`,
+          row.complianceStatus || '',
+          row.eligibleDays || 0
+        ];
       });
 
       if (dataValues.length > 0) {
@@ -3750,6 +3753,10 @@ function exportAdherenceComplianceSheet(payload) {
           const weeklyPercentValue = Number(matrixRow.weeklyPercent) || 0;
           bgRow.push(adherenceColorForPercent(weeklyPercentValue));
           fontRow.push(adherenceFontForPercent(weeklyPercentValue));
+          bgRow.push(matrixRow.complianceStatus === 'Pass' ? '#22c55e' : '#ef4444');
+          fontRow.push('#ffffff');
+          bgRow.push('#e2e8f0');
+          fontRow.push('#0f172a');
           backgrounds.push(bgRow);
           fontColors.push(fontRow);
         });
@@ -3769,7 +3776,46 @@ function exportAdherenceComplianceSheet(payload) {
         });
       }
 
-      const tableHeight = Math.max(1, dataValues.length);
+      const totalsStartRow = currentRow + (dataValues.length || 1);
+      const averageLabelRow = totalsStartRow;
+      const averageRowValues = ['Averages'];
+      const avgDayPercents = matrix.averages?.dayAverages || [];
+      avgDayPercents.forEach(val => {
+        if (val == null) {
+          averageRowValues.push('');
+        } else {
+          averageRowValues.push(`${val}%`);
+        }
+      });
+      averageRowValues.push(`${matrix.averages?.weeklyAverage || 0}%`);
+      averageRowValues.push(`Pass Rate ${matrix.averages?.complianceRate || 0}%`);
+      averageRowValues.push('');
+
+      sheet.getRange(averageLabelRow, 1, 1, matrixHeaders.length)
+        .setValues([averageRowValues])
+        .setFontWeight('bold')
+        .setBackground('#f1f5f9');
+
+      const avgBackgrounds = [[]];
+      const avgFonts = [[]];
+      averageRowValues.forEach((value, idx) => {
+        if (idx === 0 || idx === matrixHeaders.length - 1 || idx === matrixHeaders.length - 2) {
+          avgBackgrounds[0].push('#f1f5f9');
+          avgFonts[0].push('#0f172a');
+          return;
+        }
+        const numeric = typeof value === 'string' && value.includes('%')
+          ? Number(value.replace(/%/g, ''))
+          : null;
+        const bg = adherenceColorForPercent(numeric);
+        avgBackgrounds[0].push(bg);
+        avgFonts[0].push(adherenceFontForPercent(numeric));
+      });
+      sheet.getRange(averageLabelRow, 1, 1, matrixHeaders.length)
+        .setBackgrounds(avgBackgrounds)
+        .setFontColors(avgFonts);
+
+      const tableHeight = Math.max(1, dataValues.length + 1);
       const noteRow = currentRow + tableHeight;
       sheet.getRange(noteRow, 1, 1, 3)
         .setValues([[
@@ -3815,11 +3861,12 @@ function exportAdherenceComplianceSheet(payload) {
       row.breakMinutes,
       row.overLunchMinutes,
       row.overBreakMinutes,
-      row.adherenceFlag
+      row.adherencePercent
     ]);
 
     sheet.getRange(currentRow, 1, dailyValues.length, dailyHeaders.length).setValues(dailyValues);
     sheet.getRange(currentRow, 5, dailyValues.length, 4).setNumberFormat('0.00');
+    sheet.getRange(currentRow, 9, dailyValues.length, 1).setNumberFormat('0.0');
     currentRow += dailyValues.length + 2;
 
     // Weekly Summary Section
@@ -3830,9 +3877,11 @@ function exportAdherenceComplianceSheet(payload) {
       'Week Start',
       'Agent Name',
       'Agent ID',
+      'Eligible Days',
       'Adherent Days',
       'Non-Adherent Days',
       'Weekly Adherence %',
+      'Compliance Status',
       'Total Over Minutes'
     ];
     sheet.getRange(currentRow, 1, 1, weeklyHeaders.length)
@@ -3846,16 +3895,20 @@ function exportAdherenceComplianceSheet(payload) {
       row.weekStartKey,
       row.agentName,
       row.agentId || '',
+      row.eligibleDays || (row.adherentDays + row.nonAdherentDays),
       row.adherentDays,
       row.nonAdherentDays,
       row.adherencePercent,
+      row.adherencePercent >= 95 ? 'Pass' : 'Fail',
       Math.round(row.totalOverMinutes || 0)
     ]);
 
     if (weeklyValues.length) {
       sheet.getRange(currentRow, 1, weeklyValues.length, weeklyHeaders.length)
         .setValues(weeklyValues);
-      sheet.getRange(currentRow, 6, weeklyValues.length, 2).setNumberFormat('0.0');
+      sheet.getRange(currentRow, 4, weeklyValues.length, 3).setNumberFormat('0');
+      sheet.getRange(currentRow, 7, weeklyValues.length, 1).setNumberFormat('0.0');
+      sheet.getRange(currentRow, 9, weeklyValues.length, 1).setNumberFormat('0');
     }
     currentRow += weeklyValues.length + 2;
 
@@ -3931,7 +3984,7 @@ function exportAdherenceComplianceSheet(payload) {
     sheet.getRange(currentRow, 6, 1, 1).setNumberFormat('0.0');
 
     sheet.autoResizeColumns(1, Math.max(dailyHeaders.length, weeklyHeaders.length, overallHeaders.length));
-    sheet.setFrozenRows(2);
+    sheet.setFrozenRows(3);
 
     const fileId = spreadsheet.getId();
     const spreadsheetUrl = spreadsheet.getUrl();
@@ -4240,9 +4293,21 @@ function loadBreakLunchAdherenceDaily_(startDate, endDate, userSet, timezone) {
   }
 
   return Array.from(entries.values()).map(entry => {
-    const overBreakMinutes = Math.max(0, Math.round((entry.breakMinutes - 30) * 100) / 100);
-    const overLunchMinutes = Math.max(0, Math.round((entry.lunchMinutes - 30) * 100) / 100);
-    const adherent = overBreakMinutes <= 0 && overLunchMinutes <= 0;
+    const allowedBreak = 30;
+    const allowedLunch = 30;
+    const allowedTotal = allowedBreak + allowedLunch;
+
+    const overBreakMinutes = Math.max(0, Math.round((entry.breakMinutes - allowedBreak) * 100) / 100);
+    const overLunchMinutes = Math.max(0, Math.round((entry.lunchMinutes - allowedLunch) * 100) / 100);
+    const totalMinutes = Math.round((entry.breakMinutes + entry.lunchMinutes) * 100) / 100;
+    const overTotalMinutes = Math.max(0, Math.round((totalMinutes - allowedTotal) * 100) / 100);
+
+    let adherencePercent = 0;
+    if (totalMinutes > 0) {
+      adherencePercent = totalMinutes <= allowedTotal
+        ? 100
+        : Math.max(0, Math.round(((allowedTotal / totalMinutes) * 100) * 10) / 10);
+    }
 
     return {
       ...entry,
@@ -4250,9 +4315,10 @@ function loadBreakLunchAdherenceDaily_(startDate, endDate, userSet, timezone) {
       lunchMinutes: Math.round(entry.lunchMinutes * 100) / 100,
       overBreakMinutes,
       overLunchMinutes,
-      adherencePercent: adherent ? 100 : 0,
-      compliancePercent: adherent ? 100 : 0,
-      adherenceFlag: adherent ? 'Adherent' : 'Non-adherent'
+      overTotalMinutes,
+      adherencePercent,
+      compliancePercent: adherencePercent,
+      adherenceFlag: `${adherencePercent}%`
     };
   }).sort((a, b) => a.dateKey.localeCompare(b.dateKey) || a.agentName.localeCompare(b.agentName));
 }
@@ -4372,14 +4438,17 @@ function summarizeAgentAdherence_(dailyRows) {
         eligibleDays: 0,
         adherentDays: 0,
         nonAdherentDays: 0,
-        totalOverMinutes: 0
+        totalOverMinutes: 0,
+        totalPercent: 0
       });
     }
 
     const summary = agents.get(key);
     summary.eligibleDays += 1;
+    const dailyPercent = Number(row.adherencePercent) || 0;
+    summary.totalPercent += dailyPercent;
     summary.totalOverMinutes += (row.overBreakMinutes || 0) + (row.overLunchMinutes || 0);
-    if (row.adherencePercent === 100) {
+    if (dailyPercent >= 95) {
       summary.adherentDays += 1;
     } else {
       summary.nonAdherentDays += 1;
@@ -4389,7 +4458,7 @@ function summarizeAgentAdherence_(dailyRows) {
   return Array.from(agents.values()).map(entry => ({
     ...entry,
     adherencePercent: entry.eligibleDays > 0
-      ? Math.round((entry.adherentDays / entry.eligibleDays) * 1000) / 10
+      ? Math.round((entry.totalPercent / entry.eligibleDays) * 10) / 10
       : 0
   })).sort((a, b) => (a.agentName || '').localeCompare(b.agentName || '')
     || (a.agentId || '').localeCompare(b.agentId || ''));
@@ -4409,13 +4478,18 @@ function summarizeAgentAdherence_(dailyRows) {
         agentId,
         adherentDays: 0,
         nonAdherentDays: 0,
-        totalOverMinutes: 0
+        totalOverMinutes: 0,
+        eligibleDays: 0,
+        totalPercent: 0
       });
     }
 
     const summary = weekly.get(key);
+    summary.eligibleDays += 1;
     summary.totalOverMinutes += (row.overBreakMinutes || 0) + (row.overLunchMinutes || 0);
-    if (row.adherencePercent === 100) {
+    const dailyPercent = Number(row.adherencePercent) || 0;
+    summary.totalPercent += dailyPercent;
+    if (dailyPercent >= 95) {
       summary.adherentDays += 1;
     } else {
       summary.nonAdherentDays += 1;
@@ -4424,9 +4498,10 @@ function summarizeAgentAdherence_(dailyRows) {
 
     return Array.from(weekly.values()).map(entry => ({
       ...entry,
-      adherencePercent: (entry.adherentDays + entry.nonAdherentDays) > 0
-        ? Math.round((entry.adherentDays / (entry.adherentDays + entry.nonAdherentDays)) * 1000) / 10
-        : 0
+      adherencePercent: entry.eligibleDays > 0
+        ? Math.round((entry.totalPercent / entry.eligibleDays) * 10) / 10
+        : 0,
+      eligibleDays: entry.eligibleDays
     })).sort((a, b) => a.weekStartKey.localeCompare(b.weekStartKey)
       || (a.agentName || '').localeCompare(b.agentName || '')
       || (a.agentId || '').localeCompare(b.agentId || ''));
@@ -4528,6 +4603,7 @@ function summarizeAgentAdherence_(dailyRows) {
         let adherentDays = 0;
         let totalOverMinutes = 0;
         let eligibleDays = 0;
+        let totalPercent = 0;
 
         const dayDetails = week.dayKeys.map((dateKey, idx) => {
           const entry = agent.dayMap.get(dateKey);
@@ -4540,7 +4616,8 @@ function summarizeAgentAdherence_(dailyRows) {
 
           totalOverMinutes += overMinutes;
           eligibleDays += 1;
-          if (percent === 100) {
+          totalPercent += percent;
+          if (percent >= 95) {
             adherentDays += 1;
           }
 
@@ -4554,7 +4631,7 @@ function summarizeAgentAdherence_(dailyRows) {
         });
 
         const weeklyPercent = eligibleDays > 0
-          ? Math.round(((adherentDays / eligibleDays) * 100) * 10) / 10
+          ? Math.round(((totalPercent / eligibleDays)) * 10) / 10
           : 0;
 
         return {
@@ -4563,16 +4640,44 @@ function summarizeAgentAdherence_(dailyRows) {
           dayDetails,
           weeklyPercent,
           adherentDays,
-          totalOverMinutes: Math.round(totalOverMinutes * 100) / 100
+          totalOverMinutes: Math.round(totalOverMinutes * 100) / 100,
+          eligibleDays,
+          complianceStatus: weeklyPercent >= 95 ? 'Pass' : 'Fail'
         };
       }).sort((a, b) => (a.agentName || '').localeCompare(b.agentName || '')
         || (a.agentId || '').localeCompare(b.agentId || ''));
+
+      const dayAverages = week.dayKeys.map(dateKey => {
+        const values = [];
+        week.agents.forEach(agent => {
+          const entry = agent.dayMap.get(dateKey);
+          if (entry && Number.isFinite(entry.adherencePercent)) {
+            values.push(Number(entry.adherencePercent));
+          }
+        });
+        if (!values.length) return null;
+        const avg = values.reduce((sum, val) => sum + val, 0) / values.length;
+        return Math.round(avg * 10) / 10;
+      });
+
+      const weeklyPercents = rows.map(r => Number(r.weeklyPercent) || 0).filter(val => Number.isFinite(val));
+      const weeklyAverage = weeklyPercents.length
+        ? Math.round((weeklyPercents.reduce((sum, val) => sum + val, 0) / weeklyPercents.length) * 10) / 10
+        : 0;
+      const complianceRate = rows.length
+        ? Math.round(((rows.filter(r => (Number(r.weeklyPercent) || 0) >= 95).length / rows.length) * 100) * 10) / 10
+        : 0;
 
       return {
         weekStartKey: week.weekStartKey,
         dayKeys: week.dayKeys,
         dayLabels: week.dayLabels,
-        rows
+        rows,
+        averages: {
+          dayAverages,
+          weeklyAverage,
+          complianceRate
+        }
       };
     });
 


### PR DESCRIPTION
## Summary
- compute daily adherence percentages from break and lunch overages with penalty beyond 30/30 limits
- rebuild weekly adherence matrices with compliance status, eligible day counts, and team averages
- update export formatting with conditional color coding, average rows, and refreshed weekly/daily summaries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382c6f12208326a2556ec66a8a8b75)