### PR TITLE
Add dedicated adherence export matrix

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -886,6 +886,61 @@
       color: #b91c1c;
     }
 
+    /* Adherence export styles */
+    .adherence-legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0.25rem 0 0;
+    }
+
+    .adherence-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      padding: 0.35rem 0.8rem;
+      border-radius: 999px;
+      font-weight: 600;
+      font-size: 0.82rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .adherence-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.06);
+    }
+
+    .adherence-chip.low { border-color: rgba(255, 193, 7, 0.45); color: #b76e00; }
+    .adherence-chip.low .adherence-dot { background: #ffc107; }
+
+    .adherence-chip.red { border-color: rgba(248, 113, 113, 0.4); color: #9b1c1c; }
+    .adherence-chip.red .adherence-dot { background: #ef4444; }
+
+    .adherence-chip.good { border-color: rgba(74, 222, 128, 0.45); color: #0f5132; }
+    .adherence-chip.good .adherence-dot { background: #22c55e; }
+
+    .adherence-chip.excellent { border-color: rgba(168, 85, 247, 0.4); color: #5b21b6; }
+    .adherence-chip.excellent .adherence-dot { background: #a855f7; }
+
+    .adherence-preview-card {
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      border-radius: 18px;
+      padding: 1rem;
+      background: linear-gradient(135deg, rgba(226, 232, 240, 0.35) 0%, rgba(255, 255, 255, 0.9) 100%);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .adherence-preview-table th,
+    .adherence-preview-table td {
+      font-size: 0.85rem;
+      vertical-align: middle;
+      text-align: center;
+    }
+  
 
     #exportModal .form-label {
       font-weight: 600;
@@ -1220,6 +1275,9 @@
   <div class="d-flex gap-3 mb-4 flex-wrap">
     <button id="exportBtn" class="btn btn-light" onclick="showEnhancedExportModal()">
       <i class="fas fa-table me-2"></i>Export Matrix
+    </button>
+    <button id="adherenceExportBtn" class="btn btn-outline-success" onclick="showAdherenceExportModal()">
+      <i class="fas fa-clipboard-check me-2"></i>Adherence Export
     </button>
     <button id="viewExportsBtn" class="btn btn-outline-primary" onclick="window.exportHistoryManager?.show()">
       <i class="fas fa-folder-open me-2"></i>Saved Exports
@@ -1751,6 +1809,156 @@
         <button type="button" class="btn btn-success" id="executeExport">
           <i class="fas fa-download me-2"></i>Export Matrix
         </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Adherence Export Modal -->
+<div class="modal fade" id="adherenceExportModal" tabindex="-1" aria-labelledby="adherenceExportLabel" aria-hidden="true">
+  <div class="modal-dialog modal-xl modal-dialog-centered">
+    <div class="modal-content export-modal-content">
+      <div class="modal-header export-modal-header">
+        <h5 class="modal-title" id="adherenceExportLabel">
+          <i class="fas fa-clipboard-check"></i>
+          Adherence & Compliance Matrix
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body export-modal-body">
+        <div class="export-intro-card">
+          <div class="intro-icon">
+            <i class="fas fa-stopwatch"></i>
+          </div>
+          <div>
+            <h6>Adherence Matrix</h6>
+            <p class="mb-1">Export color-coded adherence percentages with weekend visibility, daily totals, and an overall average row.</p>
+            <p class="mb-0"><strong>Goal:</strong> 95% target, weekend work can exceed 100% and will be highlighted.</p>
+          </div>
+        </div>
+
+        <form id="adherenceExportForm">
+          <div class="row mb-4">
+            <div class="col-lg-6">
+              <h6 class="section-heading"><i class="fas fa-calendar-alt"></i>Time Period</h6>
+              <div class="row g-3 align-items-end">
+                <div class="col-md-6">
+                  <label class="form-label fw-bold">Period Type</label>
+                  <div class="btn-group w-100 period-toggle" role="group" aria-label="Adherence period">
+                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceWeek" value="Week" checked>
+                    <label class="btn btn-outline-primary" for="adherenceWeek">Weekly</label>
+                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceBiWeekly" value="BiWeekly">
+                    <label class="btn btn-outline-primary" for="adherenceBiWeekly">Bi-Weekly</label>
+                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceMonth" value="Month">
+                    <label class="btn btn-outline-primary" for="adherenceMonth">Monthly</label>
+                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceQuarter" value="Quarter">
+                    <label class="btn btn-outline-primary" for="adherenceQuarter">Quarterly</label>
+                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceCustom" value="Custom">
+                    <label class="btn btn-outline-primary" for="adherenceCustom">Custom</label>
+                  </div>
+                </div>
+                <div class="col-md-6" id="adherenceStandardPeriod">
+                  <label class="form-label fw-bold">Period</label>
+                  <select class="form-select" id="adherencePeriodSelect"></select>
+                </div>
+                <div class="col-md-6" id="adherenceYearWrapper">
+                  <label class="form-label fw-bold">Year</label>
+                  <select class="form-select" id="adherenceYearSelect"></select>
+                </div>
+                <div class="col-md-3 d-none" id="adherenceStartWrapper">
+                  <label class="form-label fw-bold">Start</label>
+                  <input type="date" class="form-control" id="adherenceStartDate">
+                </div>
+                <div class="col-md-3 d-none" id="adherenceEndWrapper">
+                  <label class="form-label fw-bold">End</label>
+                  <input type="date" class="form-control" id="adherenceEndDate">
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-6">
+              <h6 class="section-heading"><i class="fas fa-users"></i>User Selection</h6>
+              <div class="row g-3 align-items-end">
+                <div class="col-md-5">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceAllUsers" value="all" checked>
+                    <label class="form-check-label" for="adherenceAllUsers">All Users</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceSingleUser" value="single">
+                    <label class="form-check-label" for="adherenceSingleUser">Single User</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceMultipleUsers" value="multiple">
+                    <label class="form-check-label" for="adherenceMultipleUsers">Multiple Users</label>
+                  </div>
+                </div>
+                <div class="col-md-7" id="adherenceSingleWrapper" style="display:none;">
+                  <label class="form-label fw-bold">Choose User</label>
+                  <select class="form-select" id="adherenceSingleUserSelect"></select>
+                </div>
+                <div class="col-12" id="adherenceMultiWrapper" style="display:none;">
+                  <label class="form-label fw-bold">Select Users</label>
+                  <div class="border rounded p-2" style="max-height: 200px; overflow-y: auto;" id="adherenceUserCheckboxes"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="row mb-4">
+            <div class="col-lg-6">
+              <h6 class="section-heading"><i class="fas fa-palette"></i>Display Options</h6>
+              <div class="option-grid">
+                <div class="form-check futuristic-option">
+                  <input class="form-check-input" type="checkbox" id="adherenceIncludeWeekends" checked>
+                  <label class="form-check-label" for="adherenceIncludeWeekends">
+                    <i class="fas fa-calendar-weekend text-secondary me-1"></i>Show Weekend Columns
+                  </label>
+                  <small class="text-muted d-block">Include Saturday & Sunday columns with overtime color coding.</small>
+                </div>
+                <div class="form-check futuristic-option">
+                  <input class="form-check-input" type="checkbox" id="adherenceIncludeTotals" checked>
+                  <label class="form-check-label" for="adherenceIncludeTotals">
+                    <i class="fas fa-plus-circle text-info me-1"></i>Daily Average Row
+                  </label>
+                  <small class="text-muted d-block">Adds a daily average adherence row before the summary.</small>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-6">
+              <h6 class="section-heading"><i class="fas fa-eye"></i>Preview</h6>
+              <div class="adherence-preview-card">
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                  <div>
+                    <div class="fw-bold" id="adherencePreviewPeriod">Weekly · Current Week</div>
+                    <div class="text-muted small" id="adherencePreviewUsers">All Users</div>
+                  </div>
+                  <div class="adherence-legend">
+                    <div class="adherence-chip low"><span class="adherence-dot"></span><span>&lt;95%</span></div>
+                    <div class="adherence-chip red"><span class="adherence-dot"></span><span>&lt;80%</span></div>
+                    <div class="adherence-chip good"><span class="adherence-dot"></span><span>95-110%</span></div>
+                    <div class="adherence-chip excellent"><span class="adherence-dot"></span><span>&gt;110%</span></div>
+                  </div>
+                </div>
+
+                <div class="table-responsive">
+                  <table class="table table-sm table-bordered adherence-preview-table mb-0">
+                    <thead class="table-light" id="adherencePreviewHead"></thead>
+                    <tbody id="adherencePreviewBody"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="d-flex justify-content-end gap-2">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-success" id="adherenceExecuteExport">
+              <i class="fas fa-download me-2"></i>Export Adherence Matrix
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -6026,6 +6234,566 @@
     }
   }
 
+  class AdherenceExportManager {
+    constructor(primaryManager = null) {
+      this.primaryManager = primaryManager;
+      this.userList = [];
+      this.periodCache = {};
+      this.init();
+    }
+
+    init() {
+      this.initializeYearSelector();
+      this.setupEventListeners();
+      this.loadUserList();
+      this.updatePeriodOptions(true);
+      this.updateUserSelectionVisibility();
+      this.renderPreview();
+    }
+
+    initializeYearSelector() {
+      const select = document.getElementById('adherenceYearSelect');
+      if (!select) return;
+
+      const currentYear = new Date().getFullYear();
+      const years = new Set([currentYear - 1, currentYear, currentYear + 1]);
+      select.innerHTML = '';
+      Array.from(years).sort((a, b) => b - a).forEach(year => {
+        const option = document.createElement('option');
+        option.value = year;
+        option.textContent = year;
+        select.appendChild(option);
+      });
+      select.value = currentYear.toString();
+    }
+
+    setupEventListeners() {
+      const typeRadios = document.querySelectorAll('input[name="adherencePeriodType"]');
+      typeRadios.forEach(r => r.addEventListener('change', () => this.updatePeriodOptions()));
+
+      const yearSelect = document.getElementById('adherenceYearSelect');
+      if (yearSelect) {
+        yearSelect.addEventListener('change', () => this.updatePeriodOptions());
+      }
+
+      const executeBtn = document.getElementById('adherenceExecuteExport');
+      if (executeBtn) {
+        executeBtn.addEventListener('click', () => this.executeExport());
+      }
+
+      document.querySelectorAll('input[name="adherenceUserSelection"]').forEach(radio => {
+        radio.addEventListener('change', () => this.updateUserSelectionVisibility());
+      });
+
+      ['adherenceIncludeWeekends', 'adherenceIncludeTotals'].forEach(id => {
+        document.getElementById(id)?.addEventListener('change', () => this.renderPreview());
+      });
+
+      ['adherencePeriodSelect', 'adherenceStartDate', 'adherenceEndDate'].forEach(id => {
+        document.getElementById(id)?.addEventListener('change', () => this.renderPreview());
+      });
+
+      ['adherenceSingleUserSelect', 'adherenceUserCheckboxes'].forEach(id => {
+        document.getElementById(id)?.addEventListener('change', () => this.renderPreview());
+      });
+    }
+
+    setUserLoadingState(isLoading, message = 'Loading users...') {
+      const singleSelect = document.getElementById('adherenceSingleUserSelect');
+      const checkboxContainer = document.getElementById('adherenceUserCheckboxes');
+
+      if (singleSelect) {
+        singleSelect.disabled = isLoading;
+        if (isLoading) {
+          singleSelect.innerHTML = '';
+          const option = document.createElement('option');
+          option.value = '';
+          option.textContent = message;
+          singleSelect.appendChild(option);
+        }
+      }
+
+      if (checkboxContainer) {
+        checkboxContainer.innerHTML = isLoading
+          ? `<div class="text-muted small">${message}</div>`
+          : checkboxContainer.innerHTML;
+      }
+    }
+
+    showUserLoadError(message) {
+      const singleSelect = document.getElementById('adherenceSingleUserSelect');
+      const checkboxContainer = document.getElementById('adherenceUserCheckboxes');
+
+      if (singleSelect) {
+        singleSelect.innerHTML = '';
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = message;
+        singleSelect.appendChild(option);
+        singleSelect.disabled = true;
+      }
+
+      if (checkboxContainer) {
+        checkboxContainer.innerHTML = `<div class="text-danger small">${message}</div>`;
+      }
+    }
+
+    async loadUserList() {
+      this.setUserLoadingState(true);
+      try {
+        let users = [];
+
+        if (window.exportManager && Array.isArray(window.exportManager.userList) && window.exportManager.userList.length) {
+          users = [...window.exportManager.userList];
+        } else if (window.dashboard?.currentData?.userCompliance) {
+          users = window.dashboard.currentData.userCompliance.map(u => u.user).filter(Boolean);
+        }
+
+        const managerId = typeof window.MANAGER_USER_ID === 'string' ? window.MANAGER_USER_ID : '';
+        if ((!Array.isArray(users) || users.length === 0) && managerId) {
+          users = await safeServerCall('clientGetAssignedAgentNames', [managerId], { timeoutMs: 8000 });
+        }
+
+        if (!Array.isArray(users) || users.length === 0) {
+          const fallbackUsers = await safeServerCall('getUsers', [{ excludeGuests: true }], { timeoutMs: 7000 });
+          if (Array.isArray(fallbackUsers)) {
+            users = fallbackUsers.map(u => u.FullName || u.UserName || u.name || u.Email).filter(Boolean);
+          }
+        }
+
+        this.userList = Array.from(new Set(
+          (Array.isArray(users) ? users : [])
+            .filter(name => typeof name === 'string')
+            .map(name => name.trim())
+            .filter(Boolean)
+        )).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+        if (this.userList.length === 0) {
+          this.showUserLoadError('No users available.');
+        } else {
+          this.populateUserSelections();
+        }
+      } catch (error) {
+        console.error('Adherence export user load error:', error);
+        this.userList = [];
+        this.showUserLoadError('Unable to load users.');
+      } finally {
+        this.setUserLoadingState(false);
+      }
+    }
+
+    populateUserSelections() {
+      const singleSelect = document.getElementById('adherenceSingleUserSelect');
+      const checkboxContainer = document.getElementById('adherenceUserCheckboxes');
+
+      if (singleSelect) {
+        singleSelect.innerHTML = '<option value="">Select a user</option>';
+        this.userList.forEach(user => {
+          const option = document.createElement('option');
+          option.value = user;
+          option.textContent = user;
+          singleSelect.appendChild(option);
+        });
+      }
+
+      if (checkboxContainer) {
+        checkboxContainer.innerHTML = '';
+        this.userList.forEach(user => {
+          const id = `adherence-user-${user.replace(/[^a-z0-9]/gi, '-')}`;
+          const wrapper = document.createElement('div');
+          wrapper.className = 'form-check';
+          wrapper.innerHTML = `
+            <input class="form-check-input" type="checkbox" value="${escapeHtml(user)}" id="${id}">
+            <label class="form-check-label" for="${id}">${escapeHtml(user)}</label>
+          `;
+          checkboxContainer.appendChild(wrapper);
+        });
+      }
+    }
+
+    updateUserSelectionVisibility() {
+      const selection = document.querySelector('input[name="adherenceUserSelection"]:checked')?.value || 'all';
+      const singleWrapper = document.getElementById('adherenceSingleWrapper');
+      const multiWrapper = document.getElementById('adherenceMultiWrapper');
+
+      if (singleWrapper) singleWrapper.style.display = selection === 'single' ? 'block' : 'none';
+      if (multiWrapper) multiWrapper.style.display = selection === 'multiple' ? 'block' : 'none';
+    }
+
+    updatePeriodOptions(triggerDefault = false) {
+      const type = document.querySelector('input[name="adherencePeriodType"]:checked')?.value || 'Week';
+      const year = parseInt(document.getElementById('adherenceYearSelect')?.value, 10) || new Date().getFullYear();
+      const standardWrapper = document.getElementById('adherenceStandardPeriod');
+      const customStart = document.getElementById('adherenceStartWrapper');
+      const customEnd = document.getElementById('adherenceEndWrapper');
+
+      if (type === 'Custom') {
+        standardWrapper?.classList.add('d-none');
+        customStart?.classList.remove('d-none');
+        customEnd?.classList.remove('d-none');
+      } else {
+        standardWrapper?.classList.remove('d-none');
+        customStart?.classList.add('d-none');
+        customEnd?.classList.add('d-none');
+        this.populatePeriodSelect(type, year, triggerDefault);
+      }
+
+      this.renderPreview();
+    }
+
+    populatePeriodSelect(type, year, triggerDefault = false) {
+      const select = document.getElementById('adherencePeriodSelect');
+      if (!select) return;
+
+      select.innerHTML = '';
+      let options = [];
+
+      if (type === 'Week') {
+        const weeks = this.getISOWeeksInYear(year);
+        options = Array.from({ length: weeks }, (_, i) => ({
+          value: `${year}-W${(i + 1).toString().padStart(2, '0')}`,
+          label: `Week ${i + 1} - ${year}`
+        }));
+      } else if (type === 'BiWeekly') {
+        options = Array.from({ length: 26 }, (_, i) => ({
+          value: `${year}-BW${(i + 1).toString().padStart(2, '0')}`,
+          label: `Bi-Week ${i + 1} - ${year}`
+        }));
+      } else if (type === 'Month') {
+        options = Array.from({ length: 12 }, (_, i) => ({
+          value: `${year}-${(i + 1).toString().padStart(2, '0')}`,
+          label: `${new Date(year, i, 1).toLocaleString(undefined, { month: 'long' })} ${year}`
+        }));
+      } else if (type === 'Quarter') {
+        options = Array.from({ length: 4 }, (_, i) => ({
+          value: `Q${i + 1}-${year}`,
+          label: `Quarter ${i + 1} ${year}`
+        }));
+      }
+
+      options.forEach(opt => {
+        const option = document.createElement('option');
+        option.value = opt.value;
+        option.textContent = opt.label;
+        select.appendChild(option);
+      });
+
+      const cached = this.periodCache[type];
+      const defaultValue = cached || this.getDefaultPeriodForType(type, year) || (options[0]?.value || '');
+      select.value = defaultValue;
+      this.periodCache[type] = select.value;
+
+      if (!select.dataset.adherenceChangeBound) {
+        select.addEventListener('change', () => {
+          this.periodCache[type] = select.value;
+          this.renderPreview();
+        });
+        select.dataset.adherenceChangeBound = '1';
+      }
+    }
+
+    getDefaultPeriodForType(type, year) {
+      const today = new Date();
+      if (today.getFullYear() !== year) return '';
+      if (type === 'Week') return this.getIsoWeekFromDate(today);
+      if (type === 'BiWeekly') return `${year}-BW01`;
+      if (type === 'Month') return `${year}-${(today.getMonth() + 1).toString().padStart(2, '0')}`;
+      if (type === 'Quarter') return `Q${Math.floor(today.getMonth() / 3) + 1}-${year}`;
+      return '';
+    }
+
+    getIsoWeekFromDate(date) {
+      const tempDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+      const dayNumber = tempDate.getUTCDay() || 7;
+      tempDate.setUTCDate(tempDate.getUTCDate() + 4 - dayNumber);
+      const yearStart = new Date(Date.UTC(tempDate.getUTCFullYear(), 0, 1));
+      const weekNo = Math.ceil(((tempDate - yearStart) / 86400000 + 1) / 7);
+      return `${tempDate.getUTCFullYear()}-W${weekNo.toString().padStart(2, '0')}`;
+    }
+
+    getISOWeeksInYear(year) {
+      const dec28 = new Date(Date.UTC(year, 11, 28));
+      const isoWeek = this.getIsoWeekFromDate(dec28);
+      const parts = isoWeek.split('-W');
+      const weekNumber = parts.length === 2 ? parseInt(parts[1], 10) : 52;
+      return Number.isFinite(weekNumber) ? weekNumber : 52;
+    }
+
+    collectParameters() {
+      const periodType = document.querySelector('input[name="adherencePeriodType"]:checked')?.value || 'Week';
+      const periodValue = document.getElementById('adherencePeriodSelect')?.value || '';
+      const startDate = document.getElementById('adherenceStartDate')?.value || '';
+      const endDate = document.getElementById('adherenceEndDate')?.value || '';
+      const includeWeekends = document.getElementById('adherenceIncludeWeekends')?.checked !== false;
+      const includeDailyTotals = document.getElementById('adherenceIncludeTotals')?.checked !== false;
+      const userSelection = document.querySelector('input[name="adherenceUserSelection"]:checked')?.value || 'all';
+
+      let users = [];
+      if (userSelection === 'single') {
+        const selected = document.getElementById('adherenceSingleUserSelect')?.value;
+        if (selected) users = [selected];
+      } else if (userSelection === 'multiple') {
+        const checked = document.querySelectorAll('#adherenceUserCheckboxes input[type="checkbox"]:checked');
+        users = Array.from(checked).map(cb => cb.value);
+      }
+
+      return {
+        periodType,
+        period: periodValue,
+        periodId: periodValue,
+        startDateIso: startDate,
+        endDateIso: endDate,
+        includeWeekends,
+        includeDailyTotals,
+        users,
+        userSelection
+      };
+    }
+
+    validateParameters(params) {
+      if (params.periodType === 'Custom') {
+        if (!params.startDateIso || !params.endDateIso) {
+          alert('Please select both start and end dates for custom range.');
+          return false;
+        }
+        if (new Date(params.startDateIso) > new Date(params.endDateIso)) {
+          alert('Start date must be on or before the end date.');
+          return false;
+        }
+      } else if (!params.period) {
+        alert('Please select a period for the export.');
+        return false;
+      }
+
+      if (params.userSelection === 'single' && params.users.length === 0) {
+        alert('Please select a user for the export.');
+        return false;
+      }
+
+      if (params.userSelection === 'multiple' && params.users.length === 0) {
+        alert('Please select at least one user.');
+        return false;
+      }
+
+      return true;
+    }
+
+    renderPreview() {
+      const includeWeekends = document.getElementById('adherenceIncludeWeekends')?.checked !== false;
+      const includeTotals = document.getElementById('adherenceIncludeTotals')?.checked !== false;
+      const periodType = document.querySelector('input[name="adherencePeriodType"]:checked')?.value || 'Week';
+      const periodValue = document.getElementById('adherencePeriodSelect')?.value || 'Current';
+      const startDate = document.getElementById('adherenceStartDate')?.value;
+      const endDate = document.getElementById('adherenceEndDate')?.value;
+      const userSelection = document.querySelector('input[name="adherenceUserSelection"]:checked')?.value || 'all';
+
+      const periodLabel = periodType === 'Custom'
+        ? `Custom · ${startDate || 'Start'} to ${endDate || 'End'}`
+        : `${periodType} · ${periodValue || 'Current'}`;
+      const previewPeriod = document.getElementById('adherencePreviewPeriod');
+      if (previewPeriod) previewPeriod.textContent = periodLabel;
+
+      let usersLabel = 'All Users';
+      if (userSelection === 'single') {
+        usersLabel = document.getElementById('adherenceSingleUserSelect')?.value || 'No user selected';
+      } else if (userSelection === 'multiple') {
+        const checked = document.querySelectorAll('#adherenceUserCheckboxes input[type="checkbox"]:checked');
+        usersLabel = checked.length ? `${checked.length} users selected` : 'No users selected';
+      }
+      const previewUsers = document.getElementById('adherencePreviewUsers');
+      if (previewUsers) previewUsers.textContent = usersLabel;
+
+      const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+      if (includeWeekends) days.push('Sat', 'Sun');
+
+      const head = document.getElementById('adherencePreviewHead');
+      const body = document.getElementById('adherencePreviewBody');
+      if (!head || !body) return;
+
+      head.innerHTML = `
+        <tr>
+          <th class="text-start">Agent</th>
+          ${days.map(day => `<th>${day}</th>`).join('')}
+          <th>Avg %</th>
+        </tr>`;
+
+      const sampleRows = [
+        { name: 'Alex', values: [102, 94, 97, 89, 120, 130, 88] },
+        { name: 'Taylor', values: [91, 76, 99, 104, 96, 0, 0] }
+      ];
+
+      const thresholdClass = val => {
+        if (val > 110) return 'excellent';
+        if (val >= 95) return 'good';
+        if (val >= 80) return 'low';
+        return 'red';
+      };
+
+      body.innerHTML = sampleRows.map(row => {
+        const values = includeWeekends ? row.values : row.values.slice(0, 5);
+        const cleanValues = values.map(v => typeof v === 'number' && v > 0 ? v : '');
+        const numeric = cleanValues.filter(v => typeof v === 'number');
+        const avg = numeric.length ? Math.round((numeric.reduce((a, b) => a + b, 0) / numeric.length) * 100) / 100 : '';
+
+        const cells = cleanValues.map(val => {
+          if (typeof val !== 'number') return '<td class="text-muted">—</td>';
+          return `<td><span class="adherence-chip ${thresholdClass(val)}"><span class="adherence-dot"></span>${val}%</span></td>`;
+        }).join('');
+
+        return `<tr><th class="text-start">${row.name}</th>${cells}<td>${avg || ''}</td></tr>`;
+      }).join('');
+
+      if (includeTotals) {
+        const dailyAverages = days.map((_, idx) => {
+          const values = sampleRows
+            .map(r => (includeWeekends ? r.values : r.values.slice(0, 5))[idx])
+            .filter(v => typeof v === 'number' && v > 0);
+          if (!values.length) return '';
+          return Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100;
+        });
+
+        const dailyCells = dailyAverages.map(val => {
+          if (typeof val !== 'number') return '<td class="text-muted">—</td>';
+          return `<td><span class="adherence-chip ${thresholdClass(val)}"><span class="adherence-dot"></span>${val}%</span></td>`;
+        }).join('');
+
+        const overallAvg = dailyAverages.filter(v => typeof v === 'number');
+        const avgVal = overallAvg.length
+          ? Math.round((overallAvg.reduce((a, b) => a + b, 0) / overallAvg.length) * 100) / 100
+          : '';
+
+        body.innerHTML += `<tr class="table-light"><th class="text-start">Daily Avg</th>${dailyCells}<td>${avgVal}</td></tr>`;
+      }
+    }
+
+    updateExportProgress(percent, message) {
+      const progressBar = document.getElementById('exportProgressBar');
+      const messageEl = document.getElementById('exportProgressMessage');
+      if (progressBar) progressBar.style.width = `${percent}%`;
+      if (messageEl) messageEl.textContent = message || '';
+    }
+
+    async executeExport() {
+      try {
+        const params = this.collectParameters();
+        if (!this.validateParameters(params)) return;
+
+        const modal = bootstrap.Modal.getInstance(document.getElementById('adherenceExportModal'));
+        const progressModal = new bootstrap.Modal(document.getElementById('exportProgressModal'));
+        modal?.hide();
+        progressModal?.show();
+
+        this.updateExportProgress(25, 'Preparing adherence matrix...');
+        const result = await safeServerCall('exportAdherenceComplianceSheet', [params], { timeoutMs: 45000 });
+        this.updateExportProgress(75, 'Finalizing export...');
+
+        if (result && result.success !== false) {
+          const openSpreadsheet = (url) => {
+            if (!url) return false;
+            if (this.primaryManager?.openSpreadsheet) {
+              this.primaryManager.openSpreadsheet.call(this.primaryManager, url);
+            } else {
+              const anchor = document.createElement('a');
+              anchor.href = url;
+              anchor.target = '_blank';
+              anchor.rel = 'noopener';
+              anchor.style.display = 'none';
+              document.body.appendChild(anchor);
+              anchor.click();
+              document.body.removeChild(anchor);
+            }
+            return true;
+          };
+
+          const downloadFile = (data, filename, mimeType, isBase64 = false) => {
+            if (this.primaryManager?.downloadFile) {
+              this.primaryManager.downloadFile.call(
+                this.primaryManager,
+                data,
+                filename,
+                mimeType,
+                isBase64
+              );
+              return true;
+            }
+
+            try {
+              let blob;
+              if (isBase64) {
+                const byteCharacters = atob(data);
+                const byteNumbers = new Array(byteCharacters.length);
+                for (let i = 0; i < byteCharacters.length; i++) {
+                  byteNumbers[i] = byteCharacters.charCodeAt(i);
+                }
+                const byteArray = new Uint8Array(byteNumbers);
+                blob = new Blob([byteArray], { type: mimeType || 'application/octet-stream' });
+              } else {
+                blob = new Blob([data], { type: mimeType || 'application/octet-stream' });
+              }
+              const url = window.URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = filename || `adherence_export_${new Date().toISOString().split('T')[0]}.xlsx`;
+              document.body.appendChild(a);
+              a.click();
+              document.body.removeChild(a);
+              window.URL.revokeObjectURL(url);
+              return true;
+            } catch (error) {
+              console.error('Adherence export download failed:', error);
+              return false;
+            }
+          };
+
+          const notifySuccess = (message) => {
+            if (this.primaryManager?.showSuccessMessage) {
+              this.primaryManager.showSuccessMessage.call(this.primaryManager, message);
+            } else {
+              console.log(message);
+            }
+          };
+
+          const isGoogleSheetExport = (result.fileType === 'google_sheet')
+            || (typeof result.filename === 'string' && result.filename.toLowerCase().endsWith('.gsheet'));
+
+          let handled = false;
+          if (isGoogleSheetExport) {
+            this.updateExportProgress(90, 'Opening Google Sheets export...');
+            const targetUrl = result.spreadsheetUrl || result.url;
+            handled = openSpreadsheet(targetUrl);
+          } else if (result.spreadsheetUrl) {
+            handled = openSpreadsheet(result.spreadsheetUrl);
+          }
+
+          if (!handled && result.fileData) {
+            handled = downloadFile(
+              result.fileData,
+              result.filename || `adherence_export_${new Date().toISOString().split('T')[0]}.xlsx`,
+              result.mimeType || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              (result.encoding || '').toLowerCase() === 'base64'
+            );
+          }
+
+          this.updateExportProgress(100, 'Export completed successfully!');
+          setTimeout(() => progressModal?.hide(), 800);
+          const successMessage = isGoogleSheetExport
+            ? 'Adherence matrix opened in Google Sheets.'
+            : 'Adherence matrix export ready.';
+          notifySuccess(successMessage);
+        } else {
+          throw new Error(result?.error || 'Export failed - no data received');
+        }
+      } catch (error) {
+        console.error('Adherence export failed:', error);
+        const progressModal = bootstrap.Modal.getInstance(document.getElementById('exportProgressModal'));
+        progressModal?.hide();
+        if (this.primaryManager?.showErrorMessage) {
+          this.primaryManager.showErrorMessage.call(this.primaryManager, 'Export failed: ' + error.message);
+        }
+      }
+    }
+  }
+
   // GLOBAL FUNCTIONS
   let dashboard;
   let analyticsModalInstance;
@@ -6240,6 +7008,17 @@
     modal.show();
   }
 
+  function showAdherenceExportModal() {
+    if (!window.adherenceExportManager) {
+      window.adherenceExportManager = new AdherenceExportManager(window.exportManager || null);
+    } else {
+      window.adherenceExportManager.updateUserSelectionVisibility();
+      window.adherenceExportManager.renderPreview();
+    }
+    const modal = new bootstrap.Modal(document.getElementById('adherenceExportModal'));
+    modal.show();
+  }
+
   function exportData() {
     showEnhancedExportModal();
   }
@@ -6316,6 +7095,12 @@
     document.getElementById('exportModal')?.addEventListener('shown.bs.modal', function () {
       if (!window.exportManager) {
         window.exportManager = new EnhancedExportManager();
+      }
+    });
+
+    document.getElementById('adherenceExportModal')?.addEventListener('shown.bs.modal', function () {
+      if (!window.adherenceExportManager) {
+        window.adherenceExportManager = new AdherenceExportManager(window.exportManager || null);
       }
     });
 

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -1660,6 +1660,14 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
         timezone: ATTENDANCE_TIMEZONE,
         timezoneLabel: ATTENDANCE_TIMEZONE_LABEL
       },
+      adherenceDayMetrics: Array.from(userDayMetrics.values()).map(entry => ({
+        user: entry.user,
+        dateKey: entry.dateKey,
+        prod: entry.prod,
+        break: entry.break,
+        lunch: entry.lunch,
+        isWeekend: !!entry.isWeekend
+      })),
       manualSecondsDelta: Number(overridesData.totalDeltaSeconds) || 0,
       manualSecondsDeltaHours: Math.round((((Number(overridesData.totalDeltaSeconds) || 0) / 3600)) * 100) / 100,
       manualTimingOverrides: overrideEntries.map(entry => ({
@@ -3723,6 +3731,321 @@ function exportAttendanceCsv(granularity, periodId, agentFilter, policyOptions) 
 
     return [...summaryLines, '', ...detailLines, ...notes].join('\n') + '\n';
   }, '');
+}
+
+function buildDateRangeList_(startIso, endIso) {
+  const start = normalizeDateValue(startIso);
+  const end = normalizeDateValue(endIso);
+
+  if (!(start instanceof Date) || !(end instanceof Date)) {
+    return [];
+  }
+
+  const cursor = new Date(start.getTime());
+  cursor.setHours(0, 0, 0, 0);
+  const endMs = end.getTime();
+
+  const days = [];
+  while (cursor.getTime() <= endMs) {
+    days.push(Utilities.formatDate(cursor, ATTENDANCE_TIMEZONE, 'yyyy-MM-dd'));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}
+
+function isWeekendKey_(dateKey) {
+  const dt = normalizeDateValue(dateKey);
+  if (!(dt instanceof Date) || isNaN(dt.getTime())) {
+    return false;
+  }
+
+  const day = dt.getDay();
+  return day === 0 || day === 6;
+}
+
+function getAdherenceComplianceExportData(params) {
+  return rpc('getAdherenceComplianceExportData', () => {
+    const payload = params || {};
+    const granularity = (payload.periodType || payload.granularity || 'Week').toString();
+    let periodId = (payload.period || payload.periodId || '').toString();
+    const startDateIso = payload.startDateIso || payload.startDate || '';
+    const endDateIso = payload.endDateIso || payload.endDate || '';
+    const includeWeekends = payload.includeWeekends !== false;
+    const agentFilter = Array.isArray(payload.users) && payload.users.length
+      ? payload.users[0]
+      : (payload.userId || payload.agent || '');
+
+    if (!periodId && granularity.toLowerCase() === 'custom') {
+      const safeStart = startDateIso || Utilities.formatDate(new Date(), ATTENDANCE_TIMEZONE, 'yyyy-MM-dd');
+      const safeEnd = endDateIso || safeStart;
+      periodId = `${safeStart}_${safeEnd}`;
+    }
+
+    const analytics = getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, payload.policyOptions || {});
+    const dayMetrics = Array.isArray(analytics.adherenceDayMetrics) ? analytics.adherenceDayMetrics : [];
+
+    const startIso = analytics.periodInfo?.startDateIso
+      ? Utilities.formatDate(new Date(analytics.periodInfo.startDateIso), ATTENDANCE_TIMEZONE, 'yyyy-MM-dd')
+      : startDateIso;
+    const endIso = analytics.periodInfo?.endDateIso
+      ? Utilities.formatDate(new Date(analytics.periodInfo.endDateIso), ATTENDANCE_TIMEZONE, 'yyyy-MM-dd')
+      : endDateIso;
+
+    const dateKeys = buildDateRangeList_(startIso, endIso)
+      .filter(Boolean)
+      .filter(day => includeWeekends || !isWeekendKey_(day));
+    const userMap = new Map();
+
+    dayMetrics.forEach(entry => {
+      if (!entry || !entry.user || !entry.dateKey) return;
+      if (!includeWeekends && isWeekendKey_(entry.dateKey)) return;
+      const calc = calculateBreakLunchDeductions(entry.break, entry.lunch);
+      const basePercent = computeAdherencePercent_({
+        exceededBreakDays: calc.breakOver > 0 ? 1 : 0,
+        exceededLunchDays: calc.lunchOver > 0 ? 1 : 0,
+        exceededWeeklyCount: 0
+      });
+      const weekendBonus = entry.isWeekend ? Math.min(50, Math.round((entry.prod / DAILY_SHIFT_SECS) * 100)) : 0;
+      const percent = Math.min(150, Math.max(0, basePercent + weekendBonus));
+
+      if (!userMap.has(entry.user)) {
+        userMap.set(entry.user, { user: entry.user, days: new Map() });
+      }
+      userMap.get(entry.user).days.set(entry.dateKey, { percent, isWeekend: !!entry.isWeekend });
+    });
+
+    const rows = Array.from(userMap.values()).map(userEntry => {
+      const percents = dateKeys.map(day => {
+        const record = userEntry.days.get(day);
+        return record ? record.percent : '';
+      });
+
+      const numericPercents = percents.filter(v => typeof v === 'number');
+      const avg = numericPercents.length
+        ? Math.round((numericPercents.reduce((a, b) => a + b, 0) / numericPercents.length) * 100) / 100
+        : 0;
+      const compliantDays = numericPercents.filter(v => v >= 95).length;
+      const flaggedDays = numericPercents.filter(v => v > 0 && v < 95).length;
+
+      return {
+        user: userEntry.user,
+        dayPercents: percents,
+        average: avg,
+        compliantDays,
+        flaggedDays
+      };
+    });
+
+    const goal = 95;
+
+    return {
+      success: true,
+      granularity,
+      periodId,
+      startDateIso: startIso,
+      endDateIso: endIso,
+      dateKeys,
+      rows,
+      goal,
+      summary: {
+        totalAgents: rows.length,
+        totalCompliantDays: rows.reduce((sum, r) => sum + r.compliantDays, 0),
+        totalFlaggedDays: rows.reduce((sum, r) => sum + r.flaggedDays, 0),
+        averageScore: rows.length
+          ? Math.round((rows.reduce((sum, r) => sum + r.average, 0) / rows.length) * 100) / 100
+          : 0
+      }
+    };
+  }, { success: false, error: 'Unable to load adherence and compliance data.' }, MAX_PROCESSING_TIME);
+}
+
+function applyAdherenceComplianceFormatting_(sheet, headers, rowCount, dayColumnStart) {
+  const totalRows = Math.max(1, rowCount + 2);
+  sheet.setFrozenRows(1);
+
+  const headerRange = sheet.getRange(1, 1, 1, headers.length);
+  headerRange
+    .setFontWeight('bold')
+    .setFontColor('#ffffff')
+    .setBackground('#1f4e79')
+    .setHorizontalAlignment('center')
+    .setVerticalAlignment('middle')
+    .setWrap(true);
+
+  if (rowCount > 0) {
+    const dataRange = sheet.getRange(2, 1, rowCount, headers.length);
+    dataRange.setHorizontalAlignment('center').setVerticalAlignment('middle');
+
+    sheet.getRange(2, 1, rowCount, 1).setBackground('#f4f5f7'); // Agent
+    sheet.getRange(2, 2, rowCount, 1).setBackground('#e8f4fd'); // Period
+    sheet.getRange(2, dayColumnStart, rowCount, headers.length - dayColumnStart + 1).setBackground('#f7f7f7');
+
+    const rules = sheet.getConditionalFormatRules() || [];
+    const addRule = builder => rules.push(builder.build());
+
+    const dayRangeWidth = Math.max(1, headers.length - dayColumnStart - 3);
+    const dayRange = sheet.getRange(2, dayColumnStart, rowCount, dayRangeWidth);
+    const pctRange = sheet.getRange(2, headers.length - 2, rowCount, 1);
+
+    [dayRange, pctRange].forEach(range => {
+      addRule(SpreadsheetApp.newConditionalFormatRule()
+        .whenNumberGreaterThan(110)
+        .setBackground('#ede9fe')
+        .setFontColor('#5b21b6')
+        .setRanges([range]));
+      addRule(SpreadsheetApp.newConditionalFormatRule()
+        .whenNumberBetween(100, 110)
+        .setBackground('#b7e4c7')
+        .setFontColor('#114b00')
+        .setRanges([range]));
+      addRule(SpreadsheetApp.newConditionalFormatRule()
+        .whenNumberBetween(95, 99.99)
+        .setBackground('#d9ead3')
+        .setFontColor('#114b00')
+        .setRanges([range]));
+      addRule(SpreadsheetApp.newConditionalFormatRule()
+        .whenNumberBetween(80, 94.99)
+        .setBackground('#fff4ce')
+        .setFontColor('#8a6d00')
+        .setRanges([range]));
+      addRule(SpreadsheetApp.newConditionalFormatRule()
+        .whenNumberLessThan(80)
+        .setBackground('#f8d7da')
+        .setFontColor('#6b0000')
+        .setRanges([range]));
+    });
+
+    const statusRange = sheet.getRange(2, headers.length, rowCount, 1);
+    addRule(SpreadsheetApp.newConditionalFormatRule()
+      .whenTextEqualTo('Excellent')
+      .setBackground('#d9ead3')
+      .setFontColor('#114b00')
+      .setRanges([statusRange]));
+    addRule(SpreadsheetApp.newConditionalFormatRule()
+      .whenTextEqualTo('Pass')
+      .setBackground('#d9ead3')
+      .setFontColor('#114b00')
+      .setRanges([statusRange]));
+    addRule(SpreadsheetApp.newConditionalFormatRule()
+      .whenTextEqualTo('Needs Attention')
+      .setBackground('#fff4ce')
+      .setFontColor('#8a6d00')
+      .setRanges([statusRange]));
+    addRule(SpreadsheetApp.newConditionalFormatRule()
+      .whenTextEqualTo('Non-Compliant')
+      .setBackground('#f8d7da')
+      .setFontColor('#6b0000')
+      .setRanges([statusRange]));
+
+    sheet.setConditionalFormatRules(rules);
+  }
+
+  sheet.setRowHeight(1, 30);
+  sheet.setColumnWidths(1, 2, 170);
+  if (headers.length >= dayColumnStart) {
+    const dayCols = Math.max(1, headers.length - dayColumnStart - 3);
+    sheet.setColumnWidths(dayColumnStart, dayCols, 80);
+  }
+  sheet.setColumnWidths(headers.length - 2, 3, 120);
+}
+
+function exportAdherenceComplianceSheet(payload) {
+  return rpc('exportAdherenceComplianceSheet', () => {
+    const data = getAdherenceComplianceExportData(payload || {});
+    if (!data || !data.success) {
+      throw new Error(data && data.error ? data.error : 'Unable to build adherence export');
+    }
+
+    const headers = ['Agent', 'Period'];
+    const dayLabels = data.dateKeys.map(day => {
+      const dt = normalizeDateValue(day);
+      return dt instanceof Date && !isNaN(dt.getTime())
+        ? Utilities.formatDate(dt, ATTENDANCE_TIMEZONE, 'EEE MMM d')
+        : day;
+    });
+    headers.push(...dayLabels);
+    headers.push('Compliant Days', 'Flagged Days', 'Average %', 'Status');
+
+    const rows = (data.rows || []).map(row => {
+      const status = row.average >= 100
+        ? 'Excellent'
+        : row.average >= data.goal
+          ? 'Pass'
+          : row.average >= 80
+            ? 'Needs Attention'
+            : 'Non-Compliant';
+
+      const dayValues = (row.dayPercents || []).map(val => typeof val === 'number' ? val : '');
+      return [
+        row.user,
+        `${data.startDateIso || ''} to ${data.endDateIso || ''}`,
+        ...dayValues,
+        row.compliantDays,
+        row.flaggedDays,
+        row.average,
+        status
+      ];
+    });
+
+    const dailyAverages = dayLabels.map((_, index) => {
+      const values = (data.rows || [])
+        .map(r => typeof r.dayPercents?.[index] === 'number' ? r.dayPercents[index] : null)
+        .filter(v => typeof v === 'number');
+      if (!values.length) return '';
+      return Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 100) / 100;
+    });
+
+    const dailyAverageRow = [
+      'Daily Averages',
+      `${data.startDateIso || ''} to ${data.endDateIso || ''}`,
+      ...dailyAverages,
+      '',
+      '',
+      dailyAverages.filter(v => typeof v === 'number').length
+        ? Math.round((dailyAverages.filter(v => typeof v === 'number').reduce((a, b) => a + b, 0) / dailyAverages.filter(v => typeof v === 'number').length) * 100) / 100
+        : '',
+      ''
+    ];
+
+    const summaryRow = [
+      'Totals / Averages',
+      `${data.startDateIso || ''} to ${data.endDateIso || ''}`,
+      ...new Array(dayLabels.length).fill(''),
+      data.summary.totalCompliantDays,
+      data.summary.totalFlaggedDays,
+      data.summary.averageScore,
+      data.summary.averageScore >= data.goal ? 'Pass' : 'Needs Attention'
+    ];
+
+    const { spreadsheet, sheet } = ensureAttendanceExportSheet('Adherence & Compliance Export');
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    if (rows.length) {
+      sheet.getRange(2, 1, rows.length, headers.length).setValues(rows);
+    }
+
+    let nextRow = rows.length + 2;
+    if (payload.includeDailyTotals !== false) {
+      sheet.getRange(nextRow, 1, 1, headers.length).setValues([dailyAverageRow]);
+      nextRow += 1;
+    }
+
+    sheet.getRange(nextRow, 1, 1, headers.length).setValues([summaryRow]);
+
+    const dayColumnStart = 3;
+    const formattedRows = rows.length + (payload.includeDailyTotals !== false ? 1 : 0);
+    applyAdherenceComplianceFormatting_(sheet, headers, formattedRows + 1, dayColumnStart);
+
+    return {
+      success: true,
+      fileId: spreadsheet.getId(),
+      fileUrl: spreadsheet.getUrl(),
+      fileName: spreadsheet.getName(),
+      folderId: '',
+      folderUrl: '',
+      folderName: ''
+    };
+  }, { success: false, error: 'Unable to generate adherence export.' }, MAX_PROCESSING_TIME);
 }
 
 function calculateComplianceScore(user) {


### PR DESCRIPTION
## Summary
- add an adherence/compliance export modal with period and user filters plus legend preview
- route export to the new sheet builder with weekend filtering and optional daily averages
- enhance adherence sheet formatting with overtime highlighting and safer weekend handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c43c5739483268f8ab38a99183c80)