### PR TITLE
Refine attendance scoring for exports

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -4274,20 +4274,91 @@ function applyCalendarExportFormatting(sheet, headers, rowCount, dayColumnStart)
   }
 }
 
+function buildUserDisplayNameMap() {
+  const displayNameMap = new Map();
+
+  try {
+    const users = readSheet(USERS_SHEET) || [];
+    users.forEach(user => {
+      const userName = (user.UserName || user.Username || user.userName || '').toString().trim();
+      if (!userName) {
+        return;
+      }
+
+      const fullName = (user.FullName || user.fullName || '').toString().trim();
+      displayNameMap.set(userName, fullName || userName);
+    });
+  } catch (error) {
+    console.warn('Unable to build user display name map:', error && error.message ? error.message : error);
+  }
+
+  return displayNameMap;
+}
+
+function isWeekdayDate(date) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    return false;
+  }
+
+  const day = date.getDay();
+  return day !== 0 && day !== 6;
+}
+
+function getWeekdayIsoDatesInRange(start, end) {
+  const dates = [];
+  if (!(start instanceof Date) || !(end instanceof Date)) {
+    return dates;
+  }
+
+  const cursor = new Date(start.getTime());
+  while (cursor <= end) {
+    if (isWeekdayDate(cursor)) {
+      dates.push(cursor.toISOString().split('T')[0]);
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return dates;
+}
+
 function exportAttendanceDashboard(periodType, startDate, endDate) {
   try {
     const range = normalizeDateRangeForExport(periodType, startDate, endDate);
     const attendanceData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
+    const displayNameMap = buildUserDisplayNameMap();
+    const workingDates = getWeekdayIsoDatesInRange(range.start, range.end);
+    const totalWorkingDays = workingDates.length || 1;
+    const positiveStatuses = new Set(['present', 'punctual', 'training']);
+    const negativeStatuses = new Set([
+      'absent',
+      'bereavement',
+      'late',
+      'no call no show',
+      'no call/no show',
+      'no call/no-show',
+      'vacation',
+      'sick',
+      'sick leave',
+      'leave of absent',
+      'leave of absence',
+      'maternity leave',
+      'personal leave'
+    ]);
+    const normalizeStatus = (status) => (status || '').toString().trim().toLowerCase();
 
     const filtered = attendanceData.filter(record => {
       const date = record && record.Date ? new Date(record.Date) : null;
-      return date && !isNaN(date.getTime()) && date >= range.start && date <= range.end;
+      return date && !isNaN(date.getTime()) && isWeekdayDate(date) && date >= range.start && date <= range.end;
     });
 
     const userMap = new Map();
     filtered.forEach(record => {
       const user = record.UserName || record.User || record.userName;
       if (user) {
+        const fullName = (record.FullName || record.fullName || '').toString().trim();
+        if (fullName && !displayNameMap.has(user)) {
+          displayNameMap.set(user, fullName);
+        }
         userMap.set(user, user);
       }
     });
@@ -4309,43 +4380,37 @@ function exportAttendanceDashboard(periodType, startDate, endDate) {
       };
 
       stats.forEach(record => {
-        const status = (record.Status || record.status || '').toString();
-        switch (status) {
-          case 'Present':
-            totals.present += 1;
-            break;
-          case 'Late':
+        const rawStatus = record.Status || record.status || '';
+        const status = normalizeStatus(rawStatus);
+
+        if (positiveStatuses.has(status)) {
+          totals.present += 1;
+        } else if (negativeStatuses.has(status)) {
+          if (status === 'late') {
             totals.late += 1;
-            break;
-          case 'Absent':
-          case 'No Call No Show':
-            totals.absent += 1;
-            break;
-          case 'Sick Leave':
-            totals.sick += 1;
-            break;
-          case 'Vacation':
+          } else if (status === 'vacation') {
             totals.vacation += 1;
-            break;
-          case 'Holiday':
-            totals.holiday += 1;
-            break;
-          default:
-            break;
+          } else if (status === 'sick' || status === 'sick leave') {
+            totals.sick += 1;
+          } else {
+            totals.absent += 1;
+          }
+        } else if (status === 'holiday') {
+          totals.holiday += 1;
         }
       });
 
-      const totalDays = stats.length;
-      const worked = totals.present + totals.late;
-      const onTime = Math.max(0, worked - totals.late);
+      const totalDays = totalWorkingDays;
+      const negativeImpactDays = totals.late + totals.absent + totals.sick + totals.vacation;
+      const onTime = totals.present;
       const pct = (count) => totalDays > 0 ? Math.round((count / totalDays) * 10000) / 100 : 0;
-      const attendanceScore = pct(worked);
+      const attendanceScore = pct(Math.max(0, totalDays - negativeImpactDays));
 
       return [
-        user,
+        displayNameMap.get(user) || user,
         range.label,
         totalDays,
-        worked,
+        totals.present,
         totals.absent,
         totals.sick,
         totals.vacation,
@@ -4386,27 +4451,42 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
   try {
     const range = normalizeDateRangeForExport(periodType, startDate, endDate);
     const attendanceData = readScheduleSheet(ATTENDANCE_STATUS_SHEET) || [];
+    const displayNameMap = buildUserDisplayNameMap();
+    const dates = getWeekdayIsoDatesInRange(range.start, range.end);
+    const positiveStatuses = new Set(['present', 'punctual', 'training']);
+    const negativeStatuses = new Set([
+      'absent',
+      'bereavement',
+      'late',
+      'no call no show',
+      'no call/no show',
+      'no call/no-show',
+      'vacation',
+      'sick',
+      'sick leave',
+      'leave of absent',
+      'leave of absence',
+      'maternity leave',
+      'personal leave'
+    ]);
+    const normalizeStatus = (status) => (status || '').toString().trim().toLowerCase();
 
     const filtered = attendanceData.filter(record => {
       const date = record && record.Date ? new Date(record.Date) : null;
-      return date && !isNaN(date.getTime()) && date >= range.start && date <= range.end;
+      return date && !isNaN(date.getTime()) && isWeekdayDate(date) && date >= range.start && date <= range.end;
     });
 
     const users = new Set();
     filtered.forEach(record => {
       const user = record.UserName || record.User || record.userName;
       if (user) {
+        const fullName = (record.FullName || record.fullName || '').toString().trim();
+        if (fullName && !displayNameMap.has(user)) {
+          displayNameMap.set(user, fullName);
+        }
         users.add(user);
       }
     });
-
-    const dates = [];
-    const cursor = new Date(range.start.getTime());
-    while (cursor <= range.end) {
-      const iso = cursor.toISOString().split('T')[0];
-      dates.push(iso);
-      cursor.setDate(cursor.getDate() + 1);
-    }
 
     const headers = [
       'Agent', 'Period', 'Total Days', 'Present', 'Absent', 'Sick', 'Vacation', 'Holiday', 'Late',
@@ -4427,49 +4507,43 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
         })();
         if (!iso) return;
 
-        const status = (record.Status || record.status || '').toString();
-        dayStatus.set(iso, status);
+        const rawStatus = record.Status || record.status || '';
+        const status = normalizeStatus(rawStatus);
+        dayStatus.set(iso, rawStatus);
 
-        switch (status) {
-          case 'Present':
-            totals.present += 1;
-            break;
-          case 'Late':
+        if (positiveStatuses.has(status)) {
+          totals.present += 1;
+        } else if (negativeStatuses.has(status)) {
+          if (status === 'late') {
             totals.late += 1;
-            break;
-          case 'Absent':
-          case 'No Call No Show':
-            totals.absent += 1;
-            break;
-          case 'Sick Leave':
-            totals.sick += 1;
-            break;
-          case 'Vacation':
+          } else if (status === 'vacation') {
             totals.vacation += 1;
-            break;
-          case 'Holiday':
-            totals.holiday += 1;
-            break;
-          default:
-            break;
+          } else if (status === 'sick' || status === 'sick leave') {
+            totals.sick += 1;
+          } else {
+            totals.absent += 1;
+          }
+        } else if (status === 'holiday') {
+          totals.holiday += 1;
         }
       });
 
       const totalDays = dates.length || 1;
+      const negativeImpactDays = totals.late + totals.absent + totals.sick + totals.vacation;
       const pct = (count) => totalDays > 0 ? Math.round((count / totalDays) * 10000) / 100 : 0;
       const calendarStatuses = dates.map(dateKey => dayStatus.get(dateKey) || '');
 
       return [
-        user,
+        displayNameMap.get(user) || user,
         range.label,
         totalDays,
-        totals.present + totals.late,
+        totals.present,
         totals.absent,
         totals.sick,
         totals.vacation,
         totals.holiday,
         totals.late,
-        pct(totals.present + totals.late),
+        pct(Math.max(0, totalDays - negativeImpactDays)),
         pct(totals.absent),
         pct(totals.sick),
         pct(totals.vacation),


### PR DESCRIPTION
## Summary
- classify attendance statuses into positive (present/punctual/training) and negative (late/absent/bereavement/vacation/sick/leave variants)
- compute dashboard attendance scores as full unless negative statuses are present while still exporting weekday-only date ranges
- update calendar export percentages and present counts to reflect the new positive/negative attendance status treatment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c60eb86c48326bc026dd7d07e8468)