### PR TITLE
Refine adherence export modal layout

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -887,6 +887,78 @@
     }
 
     /* Adherence export styles */
+    #adherenceExportModal .modal-content {
+      border-radius: 26px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      box-shadow: 0 22px 54px rgba(15, 23, 42, 0.22);
+      overflow: hidden;
+    }
+
+    #adherenceExportModal .modal-body {
+      background: linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, rgba(255, 255, 255, 0.9) 100%);
+    }
+
+    #exportModal .form-label,
+    #adherenceExportModal .form-label {
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      color: var(--gray-600);
+      text-transform: uppercase;
+      font-size: 0.75rem;
+    }
+
+    #exportModal .form-select,
+    #exportModal .form-control,
+    #adherenceExportModal .form-select,
+    #adherenceExportModal .form-control {
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      padding: 0.75rem 1rem;
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    #exportModal .form-select:focus,
+    #exportModal .form-control:focus,
+    #adherenceExportModal .form-select:focus,
+    #adherenceExportModal .form-control:focus {
+      border-color: rgba(37, 99, 235, 0.65);
+      box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+    }
+
+    #exportModal .btn-success,
+    #adherenceExportModal .btn-success {
+      background: linear-gradient(135deg, #22c55e 0%, #10b981 100%);
+      border: none;
+      box-shadow: 0 18px 40px rgba(16, 185, 129, 0.32);
+      font-weight: 600;
+      padding: 0.85rem 1.75rem;
+    }
+
+    #exportModal .btn-success:hover,
+    #adherenceExportModal .btn-success:hover {
+      box-shadow: 0 22px 48px rgba(16, 185, 129, 0.45);
+    }
+
+    #exportModal .btn-secondary,
+    #adherenceExportModal .btn-secondary {
+      border-radius: 999px;
+      padding: 0.8rem 1.6rem;
+      font-weight: 600;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      background: rgba(255, 255, 255, 0.9);
+      color: var(--gray-600);
+      transition: all 0.2s ease;
+    }
+
+    #exportModal .btn-secondary:hover,
+    #adherenceExportModal .btn-secondary:hover {
+      color: var(--navy-primary);
+      border-color: rgba(59, 130, 246, 0.35);
+      box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+    }
+
     .adherence-legend {
       display: flex;
       flex-wrap: wrap;
@@ -949,30 +1021,92 @@
       background: #f8fafc;
       font-weight: 600;
     }
-  
 
-    #exportModal .form-label {
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      color: var(--gray-600);
-      text-transform: uppercase;
-      font-size: 0.75rem;
+    .adherence-section-card {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 20px;
+      padding: 1.25rem 1.35rem;
+      box-shadow: var(--shadow-sm);
     }
 
-    #exportModal .form-select,
-    #exportModal .form-control {
+    .pill-toggle-group {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.5rem;
+    }
+
+    .pill-toggle-group .btn-check + label {
       border-radius: 16px;
-      border: 1px solid rgba(148, 163, 184, 0.35);
+      border: 1px solid rgba(148, 163, 184, 0.4);
       padding: 0.75rem 1rem;
-      background: rgba(255, 255, 255, 0.92);
-      box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.9);
+      font-weight: 600;
+      color: var(--gray-600);
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.05);
+      transition: all 0.2s ease;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
     }
 
-    #exportModal .form-select:focus,
-    #exportModal .form-control:focus {
-      border-color: rgba(37, 99, 235, 0.65);
-      box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+    .pill-toggle-group .btn-check:checked + label {
+      color: var(--navy-primary);
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.14) 0%, rgba(14, 165, 233, 0.16) 100%);
+      border-color: rgba(59, 130, 246, 0.45);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.14);
+    }
+
+    .pill-toggle-group label i {
+      background: rgba(59, 130, 246, 0.12);
+      border-radius: 10px;
+      width: 28px;
+      height: 28px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--navy-primary);
+    }
+
+    .user-list-shell {
+      border: 1px dashed rgba(148, 163, 184, 0.45);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.85);
+      padding: 0.75rem;
+      max-height: 230px;
+      overflow-y: auto;
+    }
+
+    .user-chip-check {
+      padding: 0.4rem 0.5rem;
+      border-radius: 12px;
+      border: 1px solid transparent;
+      transition: all 0.2s ease;
+    }
+
+    .user-chip-check:hover {
+      background: rgba(59, 130, 246, 0.06);
+      border-color: rgba(59, 130, 246, 0.25);
+    }
+
+    .user-chip-check .form-check-input {
+      margin-top: 0.25rem;
+    }
+
+    .display-option-grid {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .display-option-grid .futuristic-option {
+      margin: 0;
+    }
+
+    .adherence-footer {
+      border-top: 1px solid rgba(148, 163, 184, 0.2);
+      padding-top: 1rem;
+      margin-top: 0.5rem;
     }
 
     .export-format-badge {
@@ -1847,121 +1981,126 @@
         </div>
 
         <form id="adherenceExportForm">
-          <div class="row mb-4">
+          <div class="row gy-4">
             <div class="col-lg-6">
-              <h6 class="section-heading"><i class="fas fa-calendar-alt"></i>Time Period</h6>
-              <div class="row g-3 align-items-end">
-                <div class="col-md-6">
-                  <label class="form-label fw-bold">Period Type</label>
-                  <div class="btn-group w-100 period-toggle" role="group" aria-label="Adherence period">
-                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceWeek" value="Week" checked>
-                    <label class="btn btn-outline-primary" for="adherenceWeek">Weekly</label>
-                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceBiWeekly" value="BiWeekly">
-                    <label class="btn btn-outline-primary" for="adherenceBiWeekly">Bi-Weekly</label>
-                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceMonth" value="Month">
-                    <label class="btn btn-outline-primary" for="adherenceMonth">Monthly</label>
-                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceQuarter" value="Quarter">
-                    <label class="btn btn-outline-primary" for="adherenceQuarter">Quarterly</label>
-                    <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceCustom" value="Custom">
-                    <label class="btn btn-outline-primary" for="adherenceCustom">Custom</label>
+              <div class="adherence-section-card h-100">
+                <h6 class="section-heading"><i class="fas fa-calendar-alt"></i>Time Period</h6>
+                <div class="row g-3 align-items-end">
+                  <div class="col-md-6">
+                    <label class="form-label fw-bold">Period Type</label>
+                    <div class="btn-group w-100 period-toggle" role="group" aria-label="Adherence period">
+                      <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceWeek" value="Week" checked>
+                      <label class="btn btn-outline-primary" for="adherenceWeek">Weekly</label>
+                      <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceBiWeekly" value="BiWeekly">
+                      <label class="btn btn-outline-primary" for="adherenceBiWeekly">Bi-Weekly</label>
+                      <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceMonth" value="Month">
+                      <label class="btn btn-outline-primary" for="adherenceMonth">Monthly</label>
+                      <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceQuarter" value="Quarter">
+                      <label class="btn btn-outline-primary" for="adherenceQuarter">Quarterly</label>
+                      <input type="radio" class="btn-check" name="adherencePeriodType" id="adherenceCustom" value="Custom">
+                      <label class="btn btn-outline-primary" for="adherenceCustom">Custom</label>
+                    </div>
                   </div>
-                </div>
-                <div class="col-md-6" id="adherenceStandardPeriod">
-                  <label class="form-label fw-bold">Period</label>
-                  <select class="form-select" id="adherencePeriodSelect"></select>
-                </div>
-                <div class="col-md-6" id="adherenceYearWrapper">
-                  <label class="form-label fw-bold">Year</label>
-                  <select class="form-select" id="adherenceYearSelect"></select>
-                </div>
-                <div class="col-md-3 d-none" id="adherenceStartWrapper">
-                  <label class="form-label fw-bold">Start</label>
-                  <input type="date" class="form-control" id="adherenceStartDate">
-                </div>
-                <div class="col-md-3 d-none" id="adherenceEndWrapper">
-                  <label class="form-label fw-bold">End</label>
-                  <input type="date" class="form-control" id="adherenceEndDate">
+                  <div class="col-md-6" id="adherenceStandardPeriod">
+                    <label class="form-label fw-bold">Period</label>
+                    <select class="form-select" id="adherencePeriodSelect"></select>
+                  </div>
+                  <div class="col-md-6" id="adherenceYearWrapper">
+                    <label class="form-label fw-bold">Year</label>
+                    <select class="form-select" id="adherenceYearSelect"></select>
+                  </div>
+                  <div class="col-md-3 d-none" id="adherenceStartWrapper">
+                    <label class="form-label fw-bold">Start</label>
+                    <input type="date" class="form-control" id="adherenceStartDate">
+                  </div>
+                  <div class="col-md-3 d-none" id="adherenceEndWrapper">
+                    <label class="form-label fw-bold">End</label>
+                    <input type="date" class="form-control" id="adherenceEndDate">
+                  </div>
                 </div>
               </div>
             </div>
 
             <div class="col-lg-6">
-              <h6 class="section-heading"><i class="fas fa-users"></i>User Selection</h6>
-              <div class="row g-3 align-items-end">
-                <div class="col-md-5">
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceAllUsers" value="all" checked>
-                    <label class="form-check-label" for="adherenceAllUsers">All Users</label>
-                  </div>
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceSingleUser" value="single">
-                    <label class="form-check-label" for="adherenceSingleUser">Single User</label>
-                  </div>
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="adherenceUserSelection" id="adherenceMultipleUsers" value="multiple">
-                    <label class="form-check-label" for="adherenceMultipleUsers">Multiple Users</label>
-                  </div>
-                </div>
-                <div class="col-md-7" id="adherenceSingleWrapper" style="display:none;">
-                  <label class="form-label fw-bold">Choose User</label>
-                  <select class="form-select" id="adherenceSingleUserSelect"></select>
-                </div>
-                <div class="col-12" id="adherenceMultiWrapper" style="display:none;">
-                  <label class="form-label fw-bold">Select Users</label>
-                  <div class="border rounded p-2" style="max-height: 200px; overflow-y: auto;" id="adherenceUserCheckboxes"></div>
-                </div>
-              </div>
-            </div>
-          </div>
+              <div class="adherence-section-card h-100">
+                <h6 class="section-heading"><i class="fas fa-users"></i>User Selection</h6>
+                <div class="pill-toggle-group mb-3" role="group" aria-label="Adherence user selection">
+                  <input class="btn-check" type="radio" name="adherenceUserSelection" id="adherenceAllUsers" value="all" checked>
+                  <label class="btn btn-light" for="adherenceAllUsers"><i class="fas fa-users"></i>All Users</label>
 
-          <div class="row mb-4">
-            <div class="col-lg-6">
-              <h6 class="section-heading"><i class="fas fa-palette"></i>Display Options</h6>
-              <div class="option-grid">
-                <div class="form-check futuristic-option">
-                  <input class="form-check-input" type="checkbox" id="adherenceIncludeWeekends" checked>
-                  <label class="form-check-label" for="adherenceIncludeWeekends">
-                    <i class="fas fa-calendar-weekend text-secondary me-1"></i>Show Weekend Columns
-                  </label>
-                  <small class="text-muted d-block">Include Saturday & Sunday columns with overtime color coding.</small>
-                </div>
-                <div class="form-check futuristic-option">
-                  <input class="form-check-input" type="checkbox" id="adherenceIncludeTotals" checked>
-                  <label class="form-check-label" for="adherenceIncludeTotals">
-                    <i class="fas fa-plus-circle text-info me-1"></i>Daily Average Row
-                  </label>
-                  <small class="text-muted d-block">Adds a daily average adherence row before the summary.</small>
-                </div>
-              </div>
-            </div>
+                  <input class="btn-check" type="radio" name="adherenceUserSelection" id="adherenceSingleUser" value="single">
+                  <label class="btn btn-light" for="adherenceSingleUser"><i class="fas fa-user"></i>Single User</label>
 
-            <div class="col-lg-6">
-              <h6 class="section-heading"><i class="fas fa-eye"></i>Preview</h6>
-              <div class="adherence-preview-card">
-                <div class="d-flex justify-content-between align-items-start mb-2">
-                  <div>
-                    <div class="fw-bold" id="adherencePreviewPeriod">Weekly · Current Week</div>
-                    <div class="text-muted small" id="adherencePreviewUsers">All Users</div>
-                  </div>
-                  <div class="adherence-legend">
-                    <div class="adherence-chip low"><span class="adherence-dot"></span><span>&lt;95%</span></div>
-                    <div class="adherence-chip red"><span class="adherence-dot"></span><span>&lt;80%</span></div>
-                    <div class="adherence-chip good"><span class="adherence-dot"></span><span>95-110%</span></div>
-                    <div class="adherence-chip excellent"><span class="adherence-dot"></span><span>&gt;110%</span></div>
-                  </div>
+                  <input class="btn-check" type="radio" name="adherenceUserSelection" id="adherenceMultipleUsers" value="multiple">
+                  <label class="btn btn-light" for="adherenceMultipleUsers"><i class="fas fa-user-friends"></i>Multiple Users</label>
                 </div>
 
-                <div class="table-responsive">
-                  <table class="table table-sm table-bordered adherence-preview-table mb-0">
-                    <thead class="table-light" id="adherencePreviewHead"></thead>
-                    <tbody id="adherencePreviewBody"></tbody>
-                  </table>
+                <div class="row g-3 align-items-end">
+                  <div class="col-md-7" id="adherenceSingleWrapper" style="display:none;">
+                    <label class="form-label fw-bold">Choose User</label>
+                    <select class="form-select" id="adherenceSingleUserSelect"></select>
+                  </div>
+                  <div class="col-12" id="adherenceMultiWrapper" style="display:none;">
+                    <label class="form-label fw-bold">Select Users</label>
+                    <div class="user-list-shell" id="adherenceUserCheckboxes"></div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <div class="d-flex justify-content-end gap-2">
+          <div class="row gy-4">
+            <div class="col-lg-6">
+              <div class="adherence-section-card h-100">
+                <h6 class="section-heading"><i class="fas fa-palette"></i>Display Options</h6>
+                <div class="display-option-grid">
+                  <div class="form-check futuristic-option">
+                    <input class="form-check-input" type="checkbox" id="adherenceIncludeWeekends" checked>
+                    <label class="form-check-label" for="adherenceIncludeWeekends">
+                      <i class="fas fa-calendar-weekend text-secondary me-1"></i>Show Weekend Columns
+                    </label>
+                    <small class="text-muted d-block">Include Saturday & Sunday columns with overtime color coding.</small>
+                  </div>
+                  <div class="form-check futuristic-option">
+                    <input class="form-check-input" type="checkbox" id="adherenceIncludeTotals" checked>
+                    <label class="form-check-label" for="adherenceIncludeTotals">
+                      <i class="fas fa-plus-circle text-info me-1"></i>Daily Average Row
+                    </label>
+                    <small class="text-muted d-block">Adds a daily average adherence row before the summary.</small>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-6">
+              <div class="adherence-section-card h-100">
+                <h6 class="section-heading"><i class="fas fa-eye"></i>Preview</h6>
+                <div class="adherence-preview-card">
+                  <div class="d-flex justify-content-between align-items-start mb-2">
+                    <div>
+                      <div class="fw-bold" id="adherencePreviewPeriod">Weekly · Current Week</div>
+                      <div class="text-muted small" id="adherencePreviewUsers">All Users</div>
+                    </div>
+                    <div class="adherence-legend">
+                      <div class="adherence-chip low"><span class="adherence-dot"></span><span>&lt;95%</span></div>
+                      <div class="adherence-chip red"><span class="adherence-dot"></span><span>&lt;80%</span></div>
+                      <div class="adherence-chip good"><span class="adherence-dot"></span><span>95-110%</span></div>
+                      <div class="adherence-chip excellent"><span class="adherence-dot"></span><span>&gt;110%</span></div>
+                    </div>
+                  </div>
+
+                  <div class="table-responsive">
+                    <table class="table table-sm table-bordered adherence-preview-table mb-0">
+                      <thead class="table-light" id="adherencePreviewHead"></thead>
+                      <tbody id="adherencePreviewBody"></tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="d-flex justify-content-end gap-2 adherence-footer">
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
             <button type="button" class="btn btn-success" id="adherenceExecuteExport">
               <i class="fas fa-download me-2"></i>Export Adherence Matrix
@@ -6410,7 +6549,7 @@
         this.userList.forEach(user => {
           const id = `adherence-user-${user.replace(/[^a-z0-9]/gi, '-')}`;
           const wrapper = document.createElement('div');
-          wrapper.className = 'form-check';
+          wrapper.className = 'form-check user-chip-check d-flex align-items-center gap-2';
           wrapper.innerHTML = `
             <input class="form-check-input" type="checkbox" value="${escapeHtml(user)}" id="${id}">
             <label class="form-check-label" for="${id}">${escapeHtml(user)}</label>


### PR DESCRIPTION
## Summary
- unify the adherence export modal with shared form styling and refreshed container visuals
- convert user selection controls into pill-style toggles with improved multi-user list styling
- regroup display options and preview inside consistent cards for clearer hierarchy

## Testing
- Not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c89bcec0c83269055e79ea43a38a1)