### PR TITLE
Add unified export workbook option

### DIFF
--- a/DataExportHub.html
+++ b/DataExportHub.html
@@ -63,6 +63,35 @@
   .export-results {
     margin-top: 1.25rem;
   }
+
+  .unified-toggle {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(16, 185, 129, 0.12));
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-radius: 12px;
+    padding: 1rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .unified-toggle .form-check-input {
+    width: 2.25rem;
+    height: 1.25rem;
+  }
+
+  .unified-toggle h6 {
+    margin: 0;
+    font-weight: 700;
+    color: #0f172a;
+  }
+
+  .unified-toggle p {
+    margin: 0;
+    color: #334155;
+    font-size: 0.95rem;
+  }
 </style>
 
 <div class="export-hub">
@@ -74,13 +103,24 @@
     <h3 class="export-section-title"><i class="fas fa-file-export"></i>Data Export Hub</h3>
     <p class="helper-text">Download attendance, QA, adherence, schedule, and call report data by campaign, user, and date filters.</p>
 
+    <div class="unified-toggle">
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" role="switch" id="combineExports" />
+      </div>
+      <div>
+        <h6>Combine every export on one sheet</h6>
+        <p>Creates a single, well-formatted workbook with attendance, adherence, and export catalog details for the selected period.</p>
+      </div>
+    </div>
+
     <div class="export-grid">
       <div>
-        <label class="form-label fw-semibold">Export type</label>
+        <label class="form-label fw-semibold" id="exportTypeLabel">Export type</label>
         <select id="exportType" class="form-select">
           <!-- Options injected via script -->
         </select>
         <small class="helper-text" id="exportDescription"></small>
+        <small class="helper-text" id="unifiedHint" style="display:none;">Used as the focus section inside the unified workbook.</small>
       </div>
 
       <div>
@@ -235,6 +275,10 @@
     document.getElementById('exportType').addEventListener('change', function (evt) {
       const selected = exportOptions.find(opt => opt.key === evt.target.value);
       document.getElementById('exportDescription').textContent = selected ? selected.description : '';
+      const hint = document.getElementById('unifiedHint');
+      if (document.getElementById('combineExports').checked) {
+        hint.style.display = selected ? 'block' : 'none';
+      }
     });
 
     Array.from(document.querySelectorAll('.chip-group button')).forEach(function (btn) {
@@ -247,6 +291,18 @@
     document.getElementById('exportButton').addEventListener('click', function () {
       runExport();
     });
+
+    document.getElementById('combineExports').addEventListener('change', function () {
+      syncUnifiedMode();
+    });
+  }
+
+  function syncUnifiedMode() {
+    const combine = document.getElementById('combineExports').checked;
+    const label = document.getElementById('exportTypeLabel');
+    const hint = document.getElementById('unifiedHint');
+    label.textContent = combine ? 'Focus export (optional)' : 'Export type';
+    hint.style.display = combine ? 'block' : 'none';
   }
 
   function setStatus(message, isError) {
@@ -273,8 +329,11 @@
   }
 
   function runExport() {
+    const combine = document.getElementById('combineExports').checked;
+    const selectedType = document.getElementById('exportType').value;
     const payload = {
-      type: document.getElementById('exportType').value,
+      type: combine ? 'unified-export-sheet' : selectedType,
+      focusType: selectedType,
       campaignId: document.getElementById('campaign').value,
       userId: document.getElementById('user').value,
       granularity: document.getElementById('granularity').value,
@@ -283,7 +342,7 @@
       endDate: document.getElementById('endDate').value
     };
 
-    setStatus('Preparing export...', false);
+    setStatus(combine ? 'Building unified workbook...' : 'Preparing export...', false);
     document.getElementById('exportButton').disabled = true;
 
     google.script.run
@@ -308,6 +367,7 @@
   (function init() {
     initSelectors();
     wireEvents();
+    syncUnifiedMode();
     setQuickRange('week');
   })();
 </script>

--- a/DataExportService.js
+++ b/DataExportService.js
@@ -4,6 +4,12 @@ function listDataExportOptions(context) {
   const globalScope = (typeof GLOBAL_SCOPE === 'object' && GLOBAL_SCOPE) ? GLOBAL_SCOPE : this;
   const options = [
     {
+      key: 'unified-export-sheet',
+      title: 'Unified Multi-export Workbook',
+      description: 'Compiles attendance, adherence, and export catalog data onto a single, well-formatted sheet.',
+      requires: 'exportUnifiedWorkbook'
+    },
+    {
       key: 'attendance-daily-pivot',
       title: 'Attendance Daily Pivot',
       description: 'Enhanced attendance pivot by user with custom ranges and granular periods.',
@@ -111,6 +117,8 @@ function runDataExport(payload) {
       return exportCallCsatCsv(normalized.granularity, normalized.period, normalized.userId || '');
     case 'call-performance-matrix':
       return exportCallPerformanceMatrixCsv(normalized.granularity, normalized.period, normalized.userId || '');
+    case 'unified-export-sheet':
+      return exportUnifiedWorkbook(normalized);
     default:
       return { success: false, error: 'Unsupported export type requested.' };
   }
@@ -134,6 +142,7 @@ function normalizeExportPayload_(payload) {
     type: payload.type || '',
     campaignId: payload.campaignId || payload.campaign || '',
     userId: payload.userId || payload.agent || '',
+    focusType: payload.focusType || '',
     granularity: granularity,
     period: periodValue,
     periodType: granularity,
@@ -179,4 +188,173 @@ function executeDailyPivot_(normalized) {
   }
 
   return result || { success: false, error: 'Unable to generate daily pivot export.' };
+}
+
+function exportUnifiedWorkbook(normalized) {
+  try {
+    var timezone = normalized.timezone || (typeof Session !== 'undefined' && Session.getScriptTimeZone ? Session.getScriptTimeZone() : 'America/Jamaica');
+    var periodLabel = normalized.period
+      || (normalized.startDateIso && normalized.endDateIso ? normalized.startDateIso + ' → ' + normalized.endDateIso : normalized.granularity);
+    var name = 'Unified Export - ' + Utilities.formatDate(new Date(), timezone, 'yyyyMMdd_HHmm');
+    var ss = SpreadsheetApp.create(name);
+    var sheet = ss.getActiveSheet();
+    sheet.setName('Unified Export');
+
+    var currentRow = 1;
+    currentRow = writeUnifiedHeader_(sheet, currentRow, normalized, periodLabel);
+    currentRow = appendAttendanceSection_(sheet, currentRow, normalized, periodLabel);
+    currentRow = appendAdherenceSection_(sheet, currentRow, normalized);
+    currentRow = appendExportCatalogSection_(sheet, currentRow);
+
+    sheet.autoResizeColumns(1, Math.max(1, sheet.getLastColumn()));
+
+    return {
+      success: true,
+      url: ss.getUrl(),
+      name: ss.getName(),
+      message: 'Unified workbook created with attendance, adherence, and export catalog insights.'
+    };
+  } catch (error) {
+    console.error('exportUnifiedWorkbook failed:', error);
+    return { success: false, error: error && error.message ? error.message : 'Unable to create unified export workbook.' };
+  }
+}
+
+function writeUnifiedHeader_(sheet, startRow, normalized, periodLabel) {
+  var headerValues = [
+    ['Unified Data Export'],
+    ['Period', periodLabel],
+    ['Granularity', normalized.granularity],
+    ['Campaign', normalized.campaignId || 'All campaigns'],
+    ['User filter', normalized.userId || 'All users']
+  ];
+
+  var headerRange = sheet.getRange(startRow, 1, headerValues.length, 2);
+  headerRange.setValues(headerValues);
+  headerRange.setFontSize(11);
+  headerRange.setFontWeight('bold');
+  headerRange.setBackground('#eef2ff');
+  headerRange.setBorder(true, true, true, true, true, true);
+  headerRange.setHorizontalAlignment('left');
+
+  sheet.getRange(startRow, 1).setFontSize(14);
+  sheet.getRange(startRow, 1, 1, 2).mergeAcross();
+
+  return startRow + headerValues.length + 2;
+}
+
+function appendAttendanceSection_(sheet, startRow, normalized, periodLabel) {
+  var analytics = {};
+  try {
+    analytics = getAttendanceAnalyticsByPeriod(normalized.granularity, normalized.period, normalized.userId || '', normalized.policyOptions || {}) || {};
+  } catch (attendanceError) {
+    console.error('appendAttendanceSection_ attendanceError:', attendanceError);
+  }
+
+  var userCompliance = Array.isArray(analytics.userCompliance) ? analytics.userCompliance : [];
+  var rows = userCompliance.map(function (user) {
+    var compliance = typeof calculateComplianceScore === 'function' ? calculateComplianceScore(user) : '';
+    var baseBillableSecs = Number.isFinite(user.baseBillableSecs) ? user.baseBillableSecs : 0;
+    var breakCreditSecs = Number.isFinite(user.breakCreditSecs) ? user.breakCreditSecs : 0;
+    var lunchAdjustmentSecs = Number.isFinite(user.lunchAdjustmentSecs) ? user.lunchAdjustmentSecs : 0;
+    var adjustedBillableSecs = Number.isFinite(user.adjustedBillableSecs)
+      ? user.adjustedBillableSecs
+      : Math.max(0, baseBillableSecs + breakCreditSecs + lunchAdjustmentSecs);
+
+    var formatHours = function (secs) {
+      var hours = Number.isFinite(secs) ? secs / 3600 : 0;
+      return (Math.abs(hours) < 0.005 ? 0 : hours).toFixed(2);
+    };
+
+    var formatMinutes = function (secs) {
+      var minutes = Number.isFinite(secs) ? secs / 60 : 0;
+      return (Math.abs(minutes) < 0.005 ? 0 : minutes).toFixed(2);
+    };
+
+    return [
+      user.user,
+      formatHours(adjustedBillableSecs),
+      compliance,
+      formatMinutes(user.breakOverSecs),
+      formatMinutes(user.lunchOverSecs)
+    ];
+  });
+
+  var sectionTitle = 'Attendance summary (' + (periodLabel || normalized.granularity) + ')';
+  var headers = ['User', 'Adjusted Billable Hours', 'Compliance Score', 'Break Over (mins)', 'Lunch Over (mins)'];
+
+  return writeUnifiedSection_(sheet, startRow, sectionTitle, headers, rows, 'Attendance performance spotlight');
+}
+
+function appendAdherenceSection_(sheet, startRow, normalized) {
+  var dataset = {};
+  try {
+    dataset = getAdherenceComplianceExportData({
+      startDateIso: normalized.startDateIso,
+      endDateIso: normalized.endDateIso,
+      periodType: normalized.periodType || normalized.granularity,
+      users: normalized.userId ? [normalized.userId] : [],
+      timezone: normalized.timezone
+    }) || {};
+  } catch (adherenceError) {
+    console.error('appendAdherenceSection_ adherenceError:', adherenceError);
+  }
+
+  var rows = Array.isArray(dataset.rows) ? dataset.rows : [];
+  var compactRows = rows.map(function (entry) {
+    return [
+      entry.user,
+      entry.average,
+      entry.compliantDays,
+      entry.flaggedDays,
+      entry.overtimeDays,
+      entry.daysWorked
+    ];
+  });
+
+  var headers = ['User', 'Average %', 'Compliant Days', 'Flagged Days', 'Overtime Days', 'Days Worked'];
+  return writeUnifiedSection_(sheet, startRow, 'Adherence scorecard', headers, compactRows, 'Daily adherence heatmap summary');
+}
+
+function appendExportCatalogSection_(sheet, startRow) {
+  var options = listDataExportOptions({}) || [];
+  var rows = options.map(function (opt) {
+    return [opt.title, opt.description, opt.key];
+  });
+  var headers = ['Export', 'Description', 'Key'];
+  return writeUnifiedSection_(sheet, startRow, 'Export catalog', headers, rows, 'Reference for every export available in the hub');
+}
+
+function writeUnifiedSection_(sheet, startRow, title, headers, rows, subtitle) {
+  var titleRow = [[title]];
+  var titleRange = sheet.getRange(startRow, 1, 1, Math.max(1, headers.length));
+  titleRange.setValues(titleRow);
+  titleRange.mergeAcross();
+  titleRange.setFontSize(12).setFontWeight('bold').setBackground('#e0f2fe');
+
+  if (subtitle) {
+    var subtitleRange = sheet.getRange(startRow + 1, 1, 1, Math.max(1, headers.length));
+    subtitleRange.setValues([[subtitle]]);
+    subtitleRange.mergeAcross();
+    subtitleRange.setFontColor('#475569');
+  }
+
+  var headerRange = sheet.getRange(startRow + 2, 1, 1, headers.length);
+  headerRange.setValues([headers]);
+  headerRange.setFontWeight('bold');
+  headerRange.setBackground('#1f4e79');
+  headerRange.setFontColor('#ffffff');
+
+  var dataRowCount = Math.max(1, rows.length);
+  var dataRange = sheet.getRange(startRow + 3, 1, dataRowCount, headers.length);
+  if (rows.length) {
+    dataRange.setValues(rows);
+  } else {
+    dataRange.setValues([['No data available for this period']]);
+  }
+
+  dataRange.setHorizontalAlignment('center');
+  dataRange.setBorder(true, true, true, true, true, true);
+
+  return startRow + 3 + dataRowCount + 2;
 }


### PR DESCRIPTION
## Summary
- add a unified export workbook option to the Data Export Hub UI with a combine-all toggle
- build an Apps Script export that compiles attendance, adherence, and catalog data into a single formatted sheet
- allow the selected export type to be used as a focus hint inside the combined workbook flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb5605f24832682197c1b64ebbf03)