### PR TITLE
Refine attendance absence handling with late penalties

### DIFF
--- a/DataExportService.js
+++ b/DataExportService.js
@@ -130,6 +130,16 @@ function normalizeExportPayload_(payload) {
   var startDateIso = normalizeDateString_(payload.startDate);
   var endDateIso = normalizeDateString_(payload.endDate);
 
+  try {
+    if (typeof normalizeDateRangeForExport === 'function' && (startDateIso || endDateIso)) {
+      var aligned = normalizeDateRangeForExport(granularity, startDateIso, endDateIso);
+      startDateIso = aligned.startIso;
+      endDateIso = aligned.endIso;
+    }
+  } catch (e) {
+    console.error('Failed to normalize export dates:', e);
+  }
+
   if (!startDateIso && granularity.toLowerCase() === 'custom') {
     startDateIso = normalizeDateString_(new Date());
   }

--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -3787,36 +3787,65 @@ function calculateAttendanceMetrics(attendanceData) {
     Present: 0,
     Absent: 0,
     Late: 0,
+    Training: 0,
     'Sick Leave': 0,
     'Bereavement': 0,
     'Vacation': 0,
     'Leave Of Absence': 0,
+    'Maternity Leave': 0,
     'No Call No Show': 0,
     Other: 0
   };
 
+  const statusKeyMap = {
+    present: 'Present',
+    punctual: 'Present',
+    late: 'Late',
+    training: 'Training',
+    'sick leave': 'Sick Leave',
+    sick: 'Sick Leave',
+    bereavement: 'Bereavement',
+    vacation: 'Vacation',
+    'leave of absence': 'Leave Of Absence',
+    'leave of absent': 'Leave Of Absence',
+    'maternity leave': 'Maternity Leave',
+    'no call no show': 'No Call No Show',
+    'no call/no show': 'No Call No Show',
+    'no call/no-show': 'No Call No Show'
+  };
+
   attendanceData.forEach(record => {
-    const status = record.Status || 'Other';
-    if (statusCounts.hasOwnProperty(status)) {
-      statusCounts[status]++;
+    const normalized = (record.Status || 'Other').toString().trim().toLowerCase();
+    const key = statusKeyMap[normalized] || (statusCounts.hasOwnProperty(record.Status) ? record.Status : 'Other');
+    if (statusCounts.hasOwnProperty(key)) {
+      statusCounts[key]++;
     } else {
       statusCounts.Other++;
     }
   });
 
   const total = Object.values(statusCounts).reduce((sum, count) => sum + count, 0);
+  const totalAbsences = statusCounts.Absent
+    + statusCounts['Sick Leave']
+    + statusCounts['Leave Of Absence']
+    + statusCounts['No Call No Show'];
 
   const percentages = {};
   Object.keys(statusCounts).forEach(status => {
     percentages[status] = total > 0 ? Math.round((statusCounts[status] / total) * 100) : 0;
   });
 
+  const baseAttendanceRate = total > 0 ? Math.round(((total - totalAbsences) / total) * 100) : 0;
+  const latePenalty = Math.min(statusCounts.Late, 100);
+  const attendanceRate = Math.max(0, Math.min(100, baseAttendanceRate - latePenalty));
+  const absenceRate = total > 0 ? Math.round((totalAbsences / total) * 100) : 0;
+
   return {
     counts: statusCounts,
     percentages: percentages,
     total: total,
-    attendanceRate: percentages.Present,
-    absenceRate: percentages.Absent + percentages['No Call No Show']
+    attendanceRate,
+    absenceRate
   };
 }
 
@@ -3847,19 +3876,46 @@ function calculateUserAttendanceStats(attendanceData, userMap) {
     const stats = userStats[userName];
     stats.totalRecords++;
 
-    switch (record.Status) {
-      case 'Present': stats.present++; break;
-      case 'Absent': stats.absent++; break;
-      case 'Late': stats.late++; break;
-      case 'Sick Leave': stats.sick++; break;
-      default: stats.other++; break;
+    const normalized = (record.Status || '').toString().trim().toLowerCase();
+    const isNoCall = normalized === 'no call no show' || normalized === 'no call/no show' || normalized === 'no call/no-show';
+    const isSick = normalized === 'sick' || normalized === 'sick leave';
+    const isLeaveOfAbsence = normalized === 'leave of absence' || normalized === 'leave of absent';
+
+    switch (normalized) {
+      case 'present':
+      case 'punctual':
+        stats.present++;
+        break;
+      case 'late':
+        stats.present++;
+        stats.late++;
+        break;
+      case 'training':
+        stats.present++;
+        stats.other++;
+        break;
+      case 'absent':
+        stats.absent++;
+        break;
+      default:
+        if (isSick) {
+          stats.sick++;
+          stats.absent++;
+        } else if (isNoCall || isLeaveOfAbsence) {
+          stats.absent++;
+        } else {
+          stats.other++;
+        }
+        break;
     }
   });
 
   // Calculate attendance rates
   Object.values(userStats).forEach(stats => {
     if (stats.totalRecords > 0) {
-      stats.attendanceRate = Math.round((stats.present / stats.totalRecords) * 100);
+      const baseRate = Math.round((stats.present / stats.totalRecords) * 100);
+      const latePenalty = Math.min(stats.late, 100);
+      stats.attendanceRate = Math.max(0, Math.min(100, baseRate - latePenalty));
     }
   });
 
@@ -3880,15 +3936,27 @@ function calculateAttendanceTrends(attendanceData) {
 
     const dayKey = date;
     const weekKey = weekStringFromDate(new Date(date)); // Use ScheduleUtilities function
+    const normalized = (record.Status || '').toString().trim().toLowerCase();
+    const presentStatuses = new Set(['present', 'punctual', 'training', 'late']);
+    const absenceStatuses = new Set([
+      'absent',
+      'sick',
+      'sick leave',
+      'leave of absence',
+      'leave of absent',
+      'no call no show',
+      'no call/no show',
+      'no call/no-show'
+    ]);
 
     // Daily stats
     if (!dailyStats[dayKey]) {
       dailyStats[dayKey] = { date: dayKey, present: 0, absent: 0, total: 0 };
     }
     dailyStats[dayKey].total++;
-    if (record.Status === 'Present') {
+    if (presentStatuses.has(normalized)) {
       dailyStats[dayKey].present++;
-    } else {
+    } else if (absenceStatuses.has(normalized)) {
       dailyStats[dayKey].absent++;
     }
 
@@ -3897,9 +3965,9 @@ function calculateAttendanceTrends(attendanceData) {
       weeklyStats[weekKey] = { week: weekKey, present: 0, absent: 0, total: 0 };
     }
     weeklyStats[weekKey].total++;
-    if (record.Status === 'Present') {
+    if (presentStatuses.has(normalized)) {
       weeklyStats[weekKey].present++;
-    } else {
+    } else if (absenceStatuses.has(normalized)) {
       weeklyStats[weekKey].absent++;
     }
   });
@@ -4048,17 +4116,44 @@ function normalizeDateRangeForExport(periodType, startDate, endDate) {
     throw new Error('A valid start and end date are required for export.');
   }
 
+  const getMondayStart = (date) => {
+    const base = new Date(date.getTime());
+    const day = (base.getDay() + 6) % 7; // Sunday -> 6, Monday -> 0
+    base.setDate(base.getDate() - day);
+    base.setHours(0, 0, 0, 0);
+    return base;
+  };
+
   const normalizedStart = new Date(safeStart.getTime());
   const normalizedEnd = new Date(safeEnd.getTime());
   normalizedStart.setHours(0, 0, 0, 0);
   normalizedEnd.setHours(23, 59, 59, 999);
 
   const type = typeof periodType === 'string' && periodType.trim() ? periodType.trim() : 'Custom';
+  const normalizedType = type.toLowerCase();
+
+  // Enforce Monday-Sunday alignment for weekly exports
+  if (normalizedType === 'week' || normalizedType === 'weekly') {
+    const weekStart = getMondayStart(normalizedStart);
+    normalizedStart.setTime(weekStart.getTime());
+    normalizedEnd.setTime(weekStart.getTime());
+    normalizedEnd.setDate(normalizedEnd.getDate() + 6);
+    normalizedEnd.setHours(23, 59, 59, 999);
+  }
+
+  if (normalizedType === 'biweekly' || normalizedType === 'bi-weekly') {
+    const weekStart = getMondayStart(normalizedStart);
+    normalizedStart.setTime(weekStart.getTime());
+    normalizedEnd.setTime(weekStart.getTime());
+    normalizedEnd.setDate(normalizedEnd.getDate() + 13);
+    normalizedEnd.setHours(23, 59, 59, 999);
+  }
+
   const pad = (num) => String(num).padStart(2, '0');
   const startIso = `${normalizedStart.getFullYear()}-${pad(normalizedStart.getMonth() + 1)}-${pad(normalizedStart.getDate())}`;
   const endIso = `${normalizedEnd.getFullYear()}-${pad(normalizedEnd.getMonth() + 1)}-${pad(normalizedEnd.getDate())}`;
   const label = (() => {
-    switch (type.toLowerCase()) {
+    switch (normalizedType) {
       case 'week':
       case 'weekly':
         return `Week of ${startIso}`;
@@ -4202,8 +4297,17 @@ function applyCalendarExportFormatting(sheet, headers, rowCount, dayColumnStart)
     dataRange.setHorizontalAlignment('center').setVerticalAlignment('middle');
 
     sheet.getRange(2, 1, rowCount, 2).setBackground('#f4f5f7'); // Agent + Period
-    sheet.getRange(2, 3, rowCount, 7).setBackground('#e8f4fd'); // Summary counts
-    sheet.getRange(2, 10, rowCount, 6).setBackground('#fdf7e3'); // Percentage section
+    const percentStartIndex = headers.findIndex(h => h.includes('%')) + 1;
+    const summaryCountStart = 3;
+    const summaryCountCols = Math.max(0, (percentStartIndex || headers.length) - summaryCountStart);
+    const percentageCols = Math.max(0, dayColumnStart - percentStartIndex);
+
+    if (summaryCountCols > 0) {
+      sheet.getRange(2, summaryCountStart, rowCount, summaryCountCols).setBackground('#e8f4fd');
+    }
+    if (percentStartIndex > 0 && percentageCols > 0) {
+      sheet.getRange(2, percentStartIndex, rowCount, percentageCols).setBackground('#fdf7e3');
+    }
     if (headers.length >= dayColumnStart) {
       const dayCols = headers.length - dayColumnStart + 1;
       sheet.getRange(2, dayColumnStart, rowCount, dayCols).setBackground('#f7f7f7');
@@ -4356,19 +4460,15 @@ function exportAttendanceDashboard(periodType, startDate, endDate) {
     const workingDates = getWeekdayIsoDatesInRange(range.start, range.end);
     const totalWorkingDays = workingDates.length || 1;
     const positiveStatuses = new Set(['present', 'punctual', 'training']);
-    const negativeStatuses = new Set([
+    const absenceStatuses = new Set([
       'absent',
-      'bereavement',
-      'late',
       'no call no show',
       'no call/no show',
       'no call/no-show',
-      'vacation',
       'sick',
       'sick leave',
       'leave of absent',
-      'leave of absence',
-      'maternity leave'
+      'leave of absence'
     ]);
     const normalizeStatus = (status) => (status || '').toString().trim().toLowerCase();
 
@@ -4418,28 +4518,29 @@ function exportAttendanceDashboard(periodType, startDate, endDate) {
         const rawStatus = record.Status || record.status || '';
         const status = normalizeStatus(rawStatus);
 
-        if (positiveStatuses.has(status)) {
+        if (status === 'late') {
           totals.present += 1;
-        } else if (negativeStatuses.has(status)) {
-          if (status === 'late') {
-            totals.late += 1;
-          } else if (status === 'vacation') {
-            totals.vacation += 1;
-          } else if (status === 'sick' || status === 'sick leave') {
+          totals.late += 1;
+        } else if (positiveStatuses.has(status)) {
+          totals.present += 1;
+        } else if (absenceStatuses.has(status)) {
+          totals.absent += 1;
+          if (status === 'sick' || status === 'sick leave') {
             totals.sick += 1;
-          } else {
-            totals.absent += 1;
           }
+        } else if (status === 'vacation') {
+          totals.vacation += 1;
         } else if (status === 'holiday') {
           totals.holiday += 1;
         }
       });
 
       const totalDays = totalWorkingDays;
-      const negativeImpactDays = totals.late + totals.absent + totals.sick + totals.vacation;
-      const onTime = totals.present;
+      const onTime = Math.max(0, totals.present - totals.late);
       const pct = (count) => totalDays > 0 ? Math.round((count / totalDays) * 10000) / 100 : 0;
-      const attendanceScore = pct(Math.max(0, totalDays - negativeImpactDays));
+      const baseAttendanceScore = pct(Math.max(0, totalDays - totals.absent));
+      const latePenalty = Math.min(totals.late, 100);
+      const attendanceScore = Math.max(0, Math.min(100, baseAttendanceScore - latePenalty));
 
       return [
         displayNameMap.get(user) || user,
@@ -4489,19 +4590,15 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
     const displayNameMap = buildUserDisplayNameMap();
     const dates = getWeekdayIsoDatesInRange(range.start, range.end);
     const positiveStatuses = new Set(['present', 'punctual', 'training']);
-    const negativeStatuses = new Set([
+    const absentStatuses = new Set([
       'absent',
-      'bereavement',
-      'late',
       'no call no show',
       'no call/no show',
       'no call/no-show',
-      'vacation',
       'sick',
       'sick leave',
       'leave of absent',
-      'leave of absence',
-      'maternity leave'
+      'leave of absence'
     ]);
     const normalizeStatus = (status) => (status || '').toString().trim().toLowerCase();
 
@@ -4524,7 +4621,8 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
 
     const headers = [
       'Agent', 'Period', 'Total Days', 'Present', 'Absent', 'Sick', 'Vacation', 'Holiday', 'Late',
-      'Present %', 'Absent %', 'Sick %', 'Vacation %', 'Holiday %', 'Late %',
+      'Bereavement', 'Maternity Leave', 'Training',
+      'Present %', 'Absent %', 'Sick %', 'Vacation %', 'Holiday %', 'Late %', 'Bereavement %', 'Maternity Leave %', 'Training %',
       ...dates
     ];
 
@@ -4542,7 +4640,17 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
 
       const uniqueIsos = new Set(normalizedRecords.map(entry => entry.iso));
       const missingDays = Math.max(0, dates.length - uniqueIsos.size);
-      const totals = { present: 0, absent: missingDays, sick: 0, vacation: 0, holiday: 0, late: 0 };
+      const totals = {
+        present: 0,
+        absent: missingDays,
+        sick: 0,
+        vacation: 0,
+        holiday: 0,
+        late: 0,
+        bereavement: 0,
+        maternity: 0,
+        training: 0
+      };
 
       normalizedRecords.forEach(({ record, iso }) => {
         const rawStatus = record.Status || record.status || '';
@@ -4551,42 +4659,56 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
 
         if (positiveStatuses.has(status)) {
           totals.present += 1;
-        } else if (negativeStatuses.has(status)) {
-          if (status === 'late') {
-            totals.late += 1;
-          } else if (status === 'vacation') {
-            totals.vacation += 1;
-          } else if (status === 'sick' || status === 'sick leave') {
-            totals.sick += 1;
-          } else {
-            totals.absent += 1;
+          if (status === 'training') {
+            totals.training += 1;
           }
+        } else if (absentStatuses.has(status)) {
+          totals.absent += 1;
+          if (status === 'sick' || status === 'sick leave') {
+            totals.sick += 1;
+          }
+        } else if (status === 'late') {
+          totals.present += 1;
+          totals.late += 1;
+        } else if (status === 'vacation') {
+          totals.vacation += 1;
         } else if (status === 'holiday') {
           totals.holiday += 1;
+        } else if (status === 'bereavement') {
+          totals.bereavement += 1;
+        } else if (status === 'maternity leave') {
+          totals.maternity += 1;
         }
       });
 
       const totalDays = dates.length || 1;
-      const negativeImpactDays = totals.late + totals.absent + totals.sick + totals.vacation;
+      const absentDays = totals.absent;
       const pct = (count) => totalDays > 0 ? Math.round((count / totalDays) * 10000) / 100 : 0;
       const calendarStatuses = dates.map(dateKey => dayStatus.get(dateKey) || 'Absent');
+      const presentDays = Math.max(0, totalDays - absentDays);
 
       return [
         displayNameMap.get(user) || user,
         range.label,
         totalDays,
-        totals.present,
+        presentDays,
         totals.absent,
         totals.sick,
         totals.vacation,
         totals.holiday,
         totals.late,
-        pct(Math.max(0, totalDays - negativeImpactDays)),
+        totals.bereavement,
+        totals.maternity,
+        totals.training,
+        pct(presentDays),
         pct(totals.absent),
         pct(totals.sick),
         pct(totals.vacation),
         pct(totals.holiday),
         pct(totals.late),
+        pct(totals.bereavement),
+        pct(totals.maternity),
+        pct(totals.training),
         ...calendarStatuses
       ];
     });
@@ -4597,7 +4719,7 @@ function exportAttendanceCalendar(periodType, startDate, endDate) {
       sheet.getRange(2, 1, rows.length, headers.length).setValues(rows);
     }
 
-    const dayColumnStart = 16;
+    const dayColumnStart = headers.length - dates.length + 1;
     applyCalendarExportFormatting(sheet, headers, rows.length, dayColumnStart);
 
     return {


### PR DESCRIPTION
## Summary
- treat only absence-related statuses as absences for attendance metrics and user stats while applying a 1% deduction per late day instead of counting lateness as an absence
- ensure attendance trends and dashboard exports treat late shifts as worked time, separating on-time counts and applying the per-day late penalty to attendance scores
- expand attendance calendar export to surface bereavement, maternity leave, and training counts without penalizing late entries as absences, keeping dynamic column formatting for the new status coverage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69400887ef7083269ed33b418b716e67)