### PR TITLE
Add December QA seed data generator

### DIFF
--- a/SeedData.js
+++ b/SeedData.js
@@ -45,6 +45,532 @@ const SEED_LUMINA_ADMIN_PROFILE = {
   seedLabel: 'Lumina Administrator'
 };
 
+const DECEMBER_QA_AGENTS = [
+  'Sonny Cuerdo',
+  'Yonique Byfield',
+  'Gabrielle Howell',
+  'Dwayne Gordan',
+  'Alexi Martin',
+  'Romaun Grant',
+  'Terry Ann Green',
+  'Erzulye Parkes',
+  'Ayeishia Rotti',
+  'Sherika Williams',
+  'Mishaunna Morrison',
+  'Shanara Thompson',
+  'Neako Powell',
+  'Ayesha Reddie',
+  'Sashana Dixon',
+  'Sashagay Wanchope',
+  'Briana Lindo-Dixon',
+  'Vinnelle Fyine',
+  'Shanique Buchanan',
+  'Shaenelle Francis'
+];
+
+const DECEMBER_QA_CLIENTS = [
+  'CCBCU',
+  'Protective',
+  'Premier Transportation Resource Center',
+  'CCBCU',
+  'WellStreet Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU',
+  'CCBCU',
+  'CCBCU',
+  'CCBCU',
+  'Progress Rail Service Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'MSHS',
+  'Progress Rail Service Center',
+  'U.S. Silica',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'WellStreet Resource Center',
+  'CCBCU',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Mayville Engineering Company',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Progress Rail Service Center',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Mayville Engineering Company',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Mayville Engineering Company',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Columbus School District',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Parma City School District',
+  'Columbus School District',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'Columbus City Schools',
+  'Premier Transportation',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Columbus City Schools',
+  'Protective Life Corporation',
+  'Protective Life Corporation',
+  'Columbus School District',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Columbus City Schools',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Parma City School District',
+  'Protective Life Corporation',
+  'Premier Transportation',
+  'Wabash',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Columbus School District',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Wabash',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'Parma City School District',
+  'Premier Transportation',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Premier Transportation',
+  'Premier Transportation',
+  'Premier Transportation',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Premier Transportation',
+  'Premier Transportation',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Wabash',
+  'City of North Las Vegas',
+  'Premier Transportation',
+  'Premier Transportation',
+  'Enstructure',
+  'Columbus City Schools',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Wabash',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Columbus City Schools',
+  'Premier Transportation',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'Expro',
+  'CCBCU Resource Center',
+  'Columbus City Schools',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Protective Life Corporation',
+  'Premier Transportation',
+  'Audacy',
+  'CCBCU Resource Center',
+  'Expro',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Audacy',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU',
+  'Premier Transportation',
+  'Premier Transportation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Enstructure',
+  'Columbus City Schools',
+  'Enstructure',
+  'CCBCU',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Audacy',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'City of North Las Vegas',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'Audacy',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Progress Rail Service Center',
+  'Mayville Engineering Company',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Audacy',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Audacy',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Expro Americas LLC',
+  'Wabash',
+  'Expro Americas LLC',
+  'Protective Life Corporation',
+  'Protective Life Corporation',
+  'Wabash',
+  'Wabash',
+  'Wabash',
+  'Protective Life Corporation',
+  'Areas',
+  'Protective Life Corporation',
+  'Wabash',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Audacy',
+  'Audacy',
+  'Rogers Electrical',
+  'Wabash',
+  'Wabash',
+  'Areas',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Expro Americas LLC',
+  'CCBCU Resource Center',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Peachtree Orthopaedic Clinic',
+  'Sisecam Chemical Resources',
+  'Audacy',
+  'CCBCU Resource Center',
+  'Wabash',
+  'Rogers Electrical',
+  'Rogers Electrical',
+  'Areas',
+  'CCBCU Resource Center',
+  'Kidde Global Solutions',
+  'Wabash',
+  'CCBCU Resource Center',
+  'Kidde Global Solutions',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Areas',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Audacy',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Rogers Electrical',
+  'CCBCU Resource Center',
+  'Sisecam Chemical Resources LLC',
+  'Wabash',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Premier Transportation',
+  'Wabash',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'Protective Life Corporation',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'Wabash',
+  'Wabash',
+  'Areas',
+  'Areas',
+  'Premier Transportation',
+  'Audacy',
+  'CCBCU Resource Center',
+  'Protective Life Corporation',
+  'CCBCU Resource Center',
+  'Wabash'
+];
+
 const PASSWORD_UTILS = (function resolvePasswordUtilities() {
   if (typeof ensurePasswordUtilities === 'function') {
     return ensurePasswordUtilities();
@@ -80,7 +606,8 @@ function seedDefaultData() {
     roles: { created: [], existing: [] },
     campaigns: { created: [], existing: [] },
     admin: null,
-    luminaAdmin: null
+    luminaAdmin: null,
+    decemberQa: null
   };
 
   try {
@@ -104,6 +631,9 @@ function seedDefaultData() {
 
     const luminaAdminInfo = ensureLuminaAdminUser(roleIdsByName, campaignIdsByName);
     summary.luminaAdmin = luminaAdminInfo;
+
+    const decemberQaInfo = seedDecemberQualityData();
+    summary.decemberQa = decemberQaInfo;
 
     return {
       success: true,
@@ -195,6 +725,211 @@ function ensureCoreCampaigns(summary) {
 
   // Refresh to pick up any IDs assigned during creation.
   return getCampaignsIndex(true);
+}
+
+function seedDecemberQualityData(options) {
+  const config = options || {};
+  const year = typeof config.year === 'number' ? config.year : new Date().getFullYear();
+  const targetMonth = 11;
+  const sheetName = (typeof QA_RECORDS !== 'undefined' && QA_RECORDS) ? QA_RECORDS : 'Quality';
+  const headers = (typeof QA_HEADERS !== 'undefined' && Array.isArray(QA_HEADERS) && QA_HEADERS.length)
+    ? QA_HEADERS.slice()
+    : [];
+
+  if (!headers.length) {
+    throw new Error('QA_HEADERS is not available for seeding.');
+  }
+
+  const sheet = ensureSheetWithHeaders(sheetName, headers);
+  const existingCount = countDecemberQaEntries_(sheet, headers, year, targetMonth);
+  if (existingCount > 0 && !config.force) {
+    return {
+      inserted: 0,
+      skipped: existingCount,
+      message: 'December QA data already exists. Pass force=true to seed again.'
+    };
+  }
+
+  const rows = buildDecemberQaRows_(headers, year, targetMonth);
+  if (!rows.length) {
+    return { inserted: 0, skipped: existingCount, message: 'No QA rows generated.' };
+  }
+
+  sheet.getRange(sheet.getLastRow() + 1, 1, rows.length, headers.length).setValues(rows);
+
+  return { inserted: rows.length, skipped: existingCount, message: 'December QA seed data inserted.' };
+}
+
+function countDecemberQaEntries_(sheet, headers, year, targetMonth) {
+  const dateIndex = headers.indexOf('CallDate');
+  if (dateIndex === -1 || sheet.getLastRow() < 2) {
+    return 0;
+  }
+
+  const data = sheet.getRange(2, dateIndex + 1, sheet.getLastRow() - 1, 1).getValues();
+  let count = 0;
+  for (let i = 0; i < data.length; i += 1) {
+    const value = data[i][0];
+    if (Object.prototype.toString.call(value) === '[object Date]') {
+      if (value.getFullYear() === year && value.getMonth() === targetMonth) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+function buildDecemberQaRows_(headers, year, targetMonth) {
+  const rows = [];
+  const questionCount = 19;
+  const auditors = ['Quality Auditor', 'QA Team Lead', 'Quality Coach'];
+  const feedbackOptions = ['Yes', 'No'];
+  const overallFeedback = [
+    'Great call handling with clear documentation.',
+    'Solid compliance with a few improvement areas.',
+    'Needs additional attention to policy reminders.',
+    'Strong empathy and problem resolution.',
+    'Follow-up steps were well communicated.'
+  ];
+  const agentFeedback = [
+    'Keep up the strong client rapport.',
+    'Remember to confirm next steps before ending calls.',
+    'Great job keeping the call concise.',
+    'Focus on summarizing the resolution.',
+    'Nice consistency across checks.'
+  ];
+
+  for (let day = 1; day <= 31; day += 1) {
+    const callDate = new Date(year, targetMonth, day);
+    DECEMBER_QA_AGENTS.forEach((agentName, agentIndex) => {
+      const randomSeed = (day * 1000) + agentIndex;
+      const random = createSeededRandom_(randomSeed);
+      const clientName = pickRandomFrom_(DECEMBER_QA_CLIENTS, random) || 'CCBCU Resource Center';
+      const callerName = pickRandomFrom_(DECEMBER_QA_AGENTS, random);
+      const auditorName = pickRandomFrom_(auditors, random);
+      const feedbackShared = pickRandomFrom_(feedbackOptions, random);
+      const questionResults = buildQuestionResults_(questionCount, random);
+      const totalScore = questionResults.totalYes;
+      const percentage = Math.round((totalScore / questionCount) * 100);
+      const callTimestamp = new Date(year, targetMonth, day, 9 + Math.floor(random() * 7), Math.floor(random() * 60));
+      const auditDate = new Date(year, targetMonth, day, 14 + Math.floor(random() * 4), Math.floor(random() * 60));
+
+      const row = headers.map(header => buildQaCell_({
+        header: header,
+        agentName: agentName,
+        callerName: callerName,
+        clientName: clientName,
+        auditorName: auditorName,
+        feedbackShared: feedbackShared,
+        questionResults: questionResults,
+        totalScore: totalScore,
+        percentage: percentage,
+        callDate: callDate,
+        callTimestamp: callTimestamp,
+        auditDate: auditDate,
+        random: random,
+        overallFeedback: overallFeedback,
+        agentFeedback: agentFeedback
+      }));
+
+      rows.push(row);
+    });
+  }
+
+  return rows;
+}
+
+function buildQuestionResults_(questionCount, random) {
+  const results = [];
+  let totalYes = 0;
+  for (let i = 1; i <= questionCount; i += 1) {
+    const isYes = random() > 0.2;
+    results.push({
+      label: 'Q' + i,
+      value: isYes ? 'Yes' : 'No',
+      note: isYes ? '' : 'Needs improvement on Q' + i + '.'
+    });
+    if (isYes) {
+      totalYes += 1;
+    }
+  }
+  return { results: results, totalYes: totalYes };
+}
+
+function buildQaCell_(context) {
+  const header = context.header;
+  if (header === 'ID') return Utilities.getUuid();
+  if (header === 'Timestamp') return context.callTimestamp;
+  if (header === 'CallerName') return context.callerName;
+  if (header === 'AgentName') return context.agentName;
+  if (header === 'AgentEmail') return buildAgentEmail_(context.agentName);
+  if (header === 'ClientName') return context.clientName;
+  if (header === 'CallDate') return context.callDate;
+  if (header === 'CaseNumber') return 'CASE-' + String(Math.floor(context.random() * 900000) + 100000);
+  if (header === 'CallLink') return 'https://call.example.com/' + Utilities.getUuid();
+  if (header === 'AuditorName') return context.auditorName;
+  if (header === 'AuditDate') return context.auditDate;
+  if (header === 'FeedbackShared') return context.feedbackShared;
+  if (header.indexOf('Q') === 0 && header.indexOf('Note') === -1) {
+    return getQuestionValue_(header, context.questionResults);
+  }
+  if (header.indexOf('Q') === 0 && header.indexOf('Note') > -1) {
+    return getQuestionNote_(header, context.questionResults);
+  }
+  if (header === 'OverallFeedback') return pickRandomFrom_(context.overallFeedback, context.random);
+  if (header === 'TotalScore') return context.totalScore;
+  if (header === 'Percentage') return context.percentage;
+  if (header === 'Notes') return 'Seeded December QA record.';
+  if (header === 'AgentFeedback') return pickRandomFrom_(context.agentFeedback, context.random);
+  if (header === 'CoachingProvided') return context.totalScore < 15 ? 'Yes' : 'No';
+  return '';
+}
+
+function getQuestionValue_(header, questionResults) {
+  const index = parseInt(header.replace('Q', ''), 10) - 1;
+  const entry = questionResults.results[index];
+  return entry ? entry.value : '';
+}
+
+function getQuestionNote_(header, questionResults) {
+  const number = header.replace('Q', '').replace(' Note', '');
+  const index = parseInt(number, 10) - 1;
+  const entry = questionResults.results[index];
+  return entry ? entry.note : '';
+}
+
+function pickRandomFrom_(list, random) {
+  if (!list || !list.length) return '';
+  const index = Math.floor(random() * list.length);
+  return list[index];
+}
+
+function buildAgentEmail_(agentName) {
+  const normalized = String(agentName || '')
+    .toLowerCase()
+    .replace(/[^a-z\s-]/g, '')
+    .replace(/\s+/g, '.');
+  return normalized ? normalized + '@vlbpo.com' : 'agent@vlbpo.com';
+}
+
+function createSeededRandom_(seedValue) {
+  let seed = 0;
+  if (typeof seedValue === 'number') {
+    seed = seedValue;
+  } else if (seedValue) {
+    const text = String(seedValue);
+    for (let i = 0; i < text.length; i += 1) {
+      seed = (seed << 5) - seed + text.charCodeAt(i);
+      seed |= 0;
+    }
+  } else {
+    seed = Date.now();
+  }
+
+  return function seededRandom() {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Provide a quick way to populate the QA sheet with realistic test data for the month of December to support demos and local testing.
- Ensure seeded QA records align with existing sheet headers and campaign conventions by delegating to the same helpers used by production flows.

### Description
- Added agent and client source lists (`DECEMBER_QA_AGENTS`, `DECEMBER_QA_CLIENTS`) and wired a generator into the default seeding by calling `seedDecemberQualityData` from `seedDefaultData`.
- Implemented `seedDecemberQualityData` with supporting helpers (`buildDecemberQaRows_`, `countDecemberQaEntries_`, `buildQuestionResults_`, `buildQaCell_`, `createSeededRandom_`, etc.) to produce deterministic QA rows that respect `QA_HEADERS` and use `ensureSheetWithHeaders` to locate the QA sheet.
- Generated rows include timestamps, caller/agent/auditor fields, 19 question answers and notes, `TotalScore`, `Percentage`, `AgentFeedback`, and a `CoachingProvided` flag, and the seed routine supports `force=true` to re-seed.
- Uses a small seeded PRNG for deterministic randomness so repeated runs can reproduce data when using the same seed choice.

### Testing
- No automated tests were run as part of this change.
- The change was limited to `SeedData.js` and is designed to be opt-out via the `force` flag and guarded by existing header checks (`QA_HEADERS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e62a28e188326863448fd450ced14)