### PR TITLE
Add escalation coaching module and dashboard (plus Weekly Operating Template page)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2651,6 +2651,10 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
       return serveGlobalPage('GoalSetting', e, baseUrl, user);
     }
 
+    if (page === 'weekly-operating-template' || page === 'weeklyoperatingtemplate') {
+      return serveGlobalPage('WeeklyOperatingTemplate', e, baseUrl, user);
+    }
+
     // Task Management (Default Pages)
     if (page === "tasklist" || page === "task-list") {
       return serveGlobalPage('TaskList', e, baseUrl, user);

--- a/Escalations.html
+++ b/Escalations.html
@@ -613,10 +613,232 @@
   .icon-link:hover {
     color: #4a90e2;
   }
+
+  .dashboard-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .dashboard-stat {
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    padding: 1.25rem;
+    text-align: center;
+  }
+
+  .dashboard-stat h3 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+    color: var(--navy-primary);
+  }
+
+  .dashboard-stat span {
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .dashboard-panels {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .dashboard-panel {
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    padding: 1.25rem;
+    background: #ffffff;
+  }
+
+  .dashboard-panel h4 {
+    margin-bottom: 0.75rem;
+    font-size: 1.05rem;
+    color: var(--text-primary);
+  }
+
+  .dashboard-panel ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .dashboard-panel li strong {
+    color: var(--text-primary);
+  }
+
+  .coaching-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+  }
+
+  .coaching-badge span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+
+  .coaching-badge.coaching-required {
+    background: rgba(255, 184, 0, 0.15);
+    color: #d97706;
+  }
+
+  .coaching-badge.coaching-scheduled {
+    background: rgba(0, 191, 255, 0.15);
+    color: #0284c7;
+  }
+
+  .coaching-badge.coaching-complete {
+    background: rgba(16, 185, 129, 0.15);
+    color: #059669;
+  }
+
+  .coaching-summary {
+    background: #f8fafc;
+    border-radius: 12px;
+    padding: 1rem;
+    border: 1px dashed var(--border-color);
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+  }
 </style>
 
 <div class="container my-4">
   <div class="stagger-animation">
+    <!-- Escalation Coaching Dashboard -->
+    <div class="modern-card" id="escalationDashboard">
+      <div class="modern-card-header">
+        <i class="fas fa-chart-line"></i>
+        Escalation Coaching Dashboard
+      </div>
+      <div class="modern-card-body">
+        <div class="dashboard-grid">
+          <div class="dashboard-stat">
+            <h3 id="dashTotalEscalations">0</h3>
+            <span>Total Escalations</span>
+          </div>
+          <div class="dashboard-stat">
+            <h3 id="dashOpenEscalations">0</h3>
+            <span>Open / In Progress</span>
+          </div>
+          <div class="dashboard-stat">
+            <h3 id="dashCoachingRequired">0</h3>
+            <span>Coaching Needed</span>
+          </div>
+          <div class="dashboard-stat">
+            <h3 id="dashCoached">0</h3>
+            <span>Coached</span>
+          </div>
+        </div>
+
+        <div class="dashboard-panels">
+          <div class="dashboard-panel">
+            <h4>Upcoming Coaching Follow-Ups</h4>
+            <ul id="dashFollowUps">
+              <li>No follow-ups due yet.</li>
+            </ul>
+          </div>
+          <div class="dashboard-panel">
+            <h4>Recent Coaching Notes</h4>
+            <ul id="dashCoachingNotes">
+              <li>No coaching notes logged yet.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Escalation Coaching Module -->
+    <div class="modern-card" id="escalationCoachingModule">
+      <div class="modern-card-header">
+        <i class="fas fa-chalkboard-teacher"></i>
+        Escalation Coaching Module
+      </div>
+      <div class="modern-card-body">
+        <form id="coachingForm" class="modern-form">
+          <div class="form-floating">
+            <select id="coachEscalationSelect" class="form-select" required>
+              <option value="">Select escalation</option>
+            </select>
+            <label for="coachEscalationSelect">Escalation</label>
+          </div>
+
+          <div class="form-floating">
+            <input type="text" id="coachName" class="form-control" placeholder="Coach name">
+            <label for="coachName">Coach</label>
+          </div>
+
+          <div class="form-floating">
+            <select id="coachStatus" class="form-select" required>
+              <option value="Coaching Required">Coaching Required</option>
+              <option value="Coaching Scheduled">Coaching Scheduled</option>
+              <option value="Coached">Coached</option>
+            </select>
+            <label for="coachStatus">Coaching Status</label>
+          </div>
+
+          <div class="form-floating">
+            <input type="date" id="coachDate" class="form-control">
+            <label for="coachDate">Coaching Date</label>
+          </div>
+
+          <div class="form-floating">
+            <input type="date" id="coachFollowUp" class="form-control">
+            <label for="coachFollowUp">Follow-Up Date</label>
+          </div>
+
+          <div class="form-floating" style="grid-column: 1 / -1;">
+            <textarea id="coachIssueSummary" class="form-control" placeholder="Issue summary"></textarea>
+            <label for="coachIssueSummary">Issue Summary (what happened)</label>
+          </div>
+
+          <div class="form-floating" style="grid-column: 1 / -1;">
+            <textarea id="coachStandard" class="form-control" placeholder="Standard/SOP impacted"></textarea>
+            <label for="coachStandard">Standard / SOP Impacted</label>
+          </div>
+
+          <div class="form-floating" style="grid-column: 1 / -1;">
+            <textarea id="coachExpectations" class="form-control" placeholder="Expectations"></textarea>
+            <label for="coachExpectations">Expectations (what “good” looks like)</label>
+          </div>
+
+          <div class="form-floating" style="grid-column: 1 / -1;">
+            <textarea id="coachActions" class="form-control" placeholder="Action items"></textarea>
+            <label for="coachActions">Action Items (2–3 max)</label>
+          </div>
+
+          <div class="coaching-summary" id="coachEscalationSummary" style="grid-column: 1 / -1;">
+            Select an escalation to see its summary here.
+          </div>
+
+          <div class="action-buttons" style="grid-column: 1 / -1;">
+            <button type="submit" class="modern-btn modern-btn-primary">
+              <i class="fas fa-save"></i>
+              Save Coaching Notes
+            </button>
+            <button type="button" class="modern-btn modern-btn-secondary" id="coachReset">
+              <i class="fas fa-undo"></i>
+              Reset
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <!-- Escalation Form Card -->
     <div class="modern-card">
       <div class="modern-card-header">
@@ -682,6 +904,9 @@
               <option value="Open" selected>Open</option>
               <option value="In Progress">In Progress</option>
               <option value="Monitoring">Monitoring</option>
+              <option value="Coaching Required">Coaching Required</option>
+              <option value="Coaching Scheduled">Coaching Scheduled</option>
+              <option value="Coached">Coached</option>
               <option value="Resolved">Resolved</option>
               <option value="Closed">Closed</option>
             </select>
@@ -742,6 +967,10 @@
                   Status
                 </th>
                 <th>
+                  <i class="fas fa-user-check me-2"></i>
+                  Coaching
+                </th>
+                <th>
                   <i class="fas fa-clock me-2"></i>
                   Timestamp
                 </th>
@@ -757,7 +986,7 @@
             </thead>
             <tbody>
               <tr>
-                <td colspan="8" class="text-center py-4">Loading…</td>
+                <td colspan="9" class="text-center py-4">Loading…</td>
               </tr>
             </tbody>
           </table>
@@ -780,7 +1009,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const impactField = document.getElementById('escImpact');
   const statusField = document.getElementById('escStatus');
   const timestampField = document.getElementById('escTimestamp');
+  const dashboardTotal = document.getElementById('dashTotalEscalations');
+  const dashboardOpen = document.getElementById('dashOpenEscalations');
+  const dashboardCoachingRequired = document.getElementById('dashCoachingRequired');
+  const dashboardCoached = document.getElementById('dashCoached');
+  const dashboardFollowUps = document.getElementById('dashFollowUps');
+  const dashboardCoachingNotes = document.getElementById('dashCoachingNotes');
+  const coachingForm = document.getElementById('coachingForm');
+  const coachingSelect = document.getElementById('coachEscalationSelect');
+  const coachingName = document.getElementById('coachName');
+  const coachingStatus = document.getElementById('coachStatus');
+  const coachingDate = document.getElementById('coachDate');
+  const coachingFollowUp = document.getElementById('coachFollowUp');
+  const coachingIssueSummary = document.getElementById('coachIssueSummary');
+  const coachingStandard = document.getElementById('coachStandard');
+  const coachingExpectations = document.getElementById('coachExpectations');
+  const coachingActions = document.getElementById('coachActions');
+  const coachingSummary = document.getElementById('coachEscalationSummary');
   let editingId = null;
+  let escalationCache = [];
+  const currentUserName = <?= JSON.stringify(user && (user.FullName || user.DisplayName || user.UserName || user.Email || '')) ?>;
 
   const issueTypeCatalog = {
     'Connectivity (Internet/VPN)': [
@@ -869,6 +1117,9 @@ document.addEventListener('DOMContentLoaded', () => {
     'Open': 'open',
     'In Progress': 'progress',
     'Monitoring': 'monitoring',
+    'Coaching Required': 'monitoring',
+    'Coaching Scheduled': 'progress',
+    'Coached': 'resolved',
     'Resolved': 'resolved',
     'Closed': 'closed'
   };
@@ -905,6 +1156,78 @@ document.addEventListener('DOMContentLoaded', () => {
     return `<span class="status-chip status-${key}"><span class="dot"></span>${label}</span>`;
   };
 
+  const buildCoachingBadge = coachingStatus => {
+    if (!coachingStatus) {
+      return '<span class="coaching-badge coaching-required"><span></span>Unassigned</span>';
+    }
+
+    const normalized = String(coachingStatus).toLowerCase();
+    let className = 'coaching-required';
+    if (normalized.includes('scheduled')) {
+      className = 'coaching-scheduled';
+    } else if (normalized.includes('coached') || normalized.includes('complete')) {
+      className = 'coaching-complete';
+    }
+
+    return `<span class="coaching-badge ${className}"><span></span>${escapeHtml(coachingStatus)}</span>`;
+  };
+
+  const extractCoachingMeta = notesHtml => {
+    if (!notesHtml) return null;
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(notesHtml, 'text/html');
+      const entries = Array.from(doc.querySelectorAll('.coaching-entry'))
+        .map(entry => entry.getAttribute('data-coaching'))
+        .filter(Boolean)
+        .map(raw => {
+          try {
+            return JSON.parse(decodeURIComponent(raw));
+          } catch (error) {
+            return null;
+          }
+        })
+        .filter(Boolean);
+      return entries.length ? entries[entries.length - 1] : null;
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const buildCoachingEntry = coachingData => {
+    const payload = encodeURIComponent(JSON.stringify(coachingData));
+    return `
+      <div class="coaching-entry" data-coaching="${payload}">
+        <p><strong>Escalation Coaching</strong></p>
+        <p><strong>Coach:</strong> ${escapeHtml(coachingData.coach || '')}</p>
+        <p><strong>Status:</strong> ${escapeHtml(coachingData.status || '')}</p>
+        <p><strong>Coaching Date:</strong> ${escapeHtml(coachingData.coachingDate || '')}</p>
+        <p><strong>Follow-Up Date:</strong> ${escapeHtml(coachingData.followUpDate || '')}</p>
+        <p><strong>Issue Summary:</strong> ${escapeHtml(coachingData.issueSummary || '')}</p>
+        <p><strong>Standard/SOP:</strong> ${escapeHtml(coachingData.standard || '')}</p>
+        <p><strong>Expectations:</strong> ${escapeHtml(coachingData.expectations || '')}</p>
+        <p><strong>Action Items:</strong> ${escapeHtml(coachingData.actionItems || '')}</p>
+      </div>
+    `;
+  };
+
+  const appendCoachingEntry = (notesHtml, coachingHtml) => {
+    if (!notesHtml) return coachingHtml;
+    return `${notesHtml}<hr>${coachingHtml}`;
+  };
+
+  const summarizeEscalation = escalation => {
+    if (!escalation) return 'Select an escalation to see its summary here.';
+    const parts = [
+      `User: ${escalation.user || 'N/A'}`,
+      `Category: ${escalation.category || 'N/A'}`,
+      `Issue: ${escalation.issueType || 'N/A'}`,
+      `Impact: ${escalation.impact || 'N/A'}`,
+      `Status: ${escalation.status || 'N/A'}`
+    ];
+    return parts.join(' | ');
+  };
+
   const populateIssueTypeOptions = (category, selectedValue = '') => {
     const options = issueTypeCatalog[category] || issueTypeCatalog['Other / General'];
     const opts = ['<option value="">Select issue type</option>']
@@ -932,12 +1255,99 @@ document.addEventListener('DOMContentLoaded', () => {
     quill.root.innerHTML = '';
   };
 
+  const resetCoachingForm = () => {
+    coachingForm.reset();
+    coachingStatus.value = 'Coaching Required';
+    coachingSummary.textContent = 'Select an escalation to see its summary here.';
+    coachingName.value = currentUserName || '';
+  };
+
   const showOverlay = () => overlay.classList.add('show');
   const hideOverlay = () => overlay.classList.remove('show');
 
   categoryField.addEventListener('change', () => {
     populateIssueTypeOptions(categoryField.value);
   });
+
+  coachingSelect.addEventListener('change', () => {
+    const selectedId = coachingSelect.value;
+    const escalation = escalationCache.find(item => item.id === selectedId);
+    populateCoachingFields(escalation);
+  });
+
+  const renderCoachingSelect = items => {
+    const options = ['<option value="">Select escalation</option>']
+      .concat(items.map(item => {
+        const label = `${item.user || 'Unknown'} - ${item.category || 'Uncategorized'} (${item.status || 'Open'})`;
+        return `<option value="${escapeHtml(item.id)}">${escapeHtml(label)}</option>`;
+      }));
+    coachingSelect.innerHTML = options.join('');
+  };
+
+  const updateDashboard = items => {
+    const total = items.length;
+    const open = items.filter(item => !['Resolved', 'Closed'].includes(item.status)).length;
+    const coachingNeeded = items.filter(item => ['Coaching Required', 'Coaching Scheduled'].includes(item.status)).length;
+    const coached = items.filter(item => item.status === 'Coached').length;
+
+    dashboardTotal.textContent = total;
+    dashboardOpen.textContent = open;
+    dashboardCoachingRequired.textContent = coachingNeeded;
+    dashboardCoached.textContent = coached;
+
+    const followUps = [];
+    const recentNotes = [];
+    items.forEach(item => {
+      const coachingMeta = extractCoachingMeta(item.notes || '');
+      if (!coachingMeta) return;
+
+      if (coachingMeta.followUpDate) {
+        followUps.push({
+          user: item.user,
+          followUpDate: coachingMeta.followUpDate,
+          status: coachingMeta.status || item.status
+        });
+      }
+
+      if (coachingMeta.issueSummary || coachingMeta.actionItems) {
+        recentNotes.push({
+          user: item.user,
+          summary: coachingMeta.issueSummary || coachingMeta.actionItems,
+          status: coachingMeta.status || item.status
+        });
+      }
+    });
+
+    const dueFollowUps = followUps
+      .sort((a, b) => String(a.followUpDate).localeCompare(String(b.followUpDate)))
+      .slice(0, 5);
+
+    dashboardFollowUps.innerHTML = dueFollowUps.length
+      ? dueFollowUps.map(entry => `
+          <li><strong>${escapeHtml(entry.user || 'Unknown')}</strong> — ${escapeHtml(entry.followUpDate)} (${escapeHtml(entry.status || '')})</li>
+        `).join('')
+      : '<li>No follow-ups due yet.</li>';
+
+    const recentList = recentNotes.slice(0, 5);
+    dashboardCoachingNotes.innerHTML = recentList.length
+      ? recentList.map(entry => `
+          <li><strong>${escapeHtml(entry.user || 'Unknown')}</strong> — ${escapeHtml(entry.summary || '')}</li>
+        `).join('')
+      : '<li>No coaching notes logged yet.</li>';
+  };
+
+  const populateCoachingFields = escalation => {
+    const coachingMeta = extractCoachingMeta(escalation?.notes || '');
+    coachingSummary.textContent = summarizeEscalation(escalation);
+    coachingName.value = coachingMeta?.coach || currentUserName || '';
+    coachingStatus.value = coachingMeta?.status || escalation?.status || 'Coaching Required';
+    coachingDate.value = coachingMeta?.coachingDate || '';
+    coachingFollowUp.value = coachingMeta?.followUpDate || '';
+    coachingIssueSummary.value = coachingMeta?.issueSummary || '';
+    coachingStandard.value = coachingMeta?.standard || '';
+    coachingExpectations.value = coachingMeta?.expectations || '';
+    coachingActions.value = coachingMeta?.actionItems || '';
+  };
 
   function loadEscalations() {
     showOverlay();
@@ -948,11 +1358,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function renderEscalations(items) {
+    escalationCache = items.slice();
+    renderCoachingSelect(escalationCache);
+    updateDashboard(escalationCache);
     tableBody.innerHTML = '';
     if (!items.length) {
       tableBody.innerHTML = `
         <tr>
-          <td colspan="8" class="empty-state">
+          <td colspan="9" class="empty-state">
             <i class="fas fa-clipboard-list"></i>
             <h3>No Escalations Found</h3>
             <p>No escalation records available. Start by logging a new escalation.</p>
@@ -970,6 +1383,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const shortenedNotes = notesPlain.length > 100
         ? `${notesPlain.substring(0, 100)}…`
         : notesPlain;
+      const coachingMeta = extractCoachingMeta(it.notes || '');
+      const coachingStatusLabel = coachingMeta ? coachingMeta.status : '';
 
       tr.innerHTML = `
         <td><strong>${escapeHtml(it.user || '')}</strong></td>
@@ -977,6 +1392,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <td>${escapeHtml(it.issueType || '')}</td>
         <td>${buildImpactBadge(it.impact)}</td>
         <td>${buildStatusChip(it.status)}</td>
+        <td>${buildCoachingBadge(coachingStatusLabel)}</td>
         <td>${escapeHtml(it.timestamp || '')}</td>
         <td><span class="text-muted">${escapeHtml(shortenedNotes)}</span></td>
         <td>
@@ -1053,6 +1469,64 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  coachingForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const selectedId = coachingSelect.value;
+    if (!selectedId) {
+      alert('Select an escalation to attach coaching notes.');
+      return;
+    }
+
+    const escalation = escalationCache.find(item => item.id === selectedId);
+    if (!escalation) {
+      alert('Selected escalation not found.');
+      return;
+    }
+
+    const coachingData = {
+      coach: coachingName.value,
+      status: coachingStatus.value,
+      coachingDate: coachingDate.value,
+      followUpDate: coachingFollowUp.value,
+      issueSummary: coachingIssueSummary.value,
+      standard: coachingStandard.value,
+      expectations: coachingExpectations.value,
+      actionItems: coachingActions.value
+    };
+
+    const coachingHtml = buildCoachingEntry(coachingData);
+    const updatedNotes = appendCoachingEntry(escalation.notes || '', coachingHtml);
+    const normalizedTimestamp = escalation.timestamp
+      ? escalation.timestamp.replace(' ', 'T').slice(0, 16)
+      : '';
+
+    const updatedRecord = {
+      user: escalation.user,
+      category: escalation.category,
+      issueType: escalation.issueType,
+      impact: escalation.impact,
+      status: coachingStatus.value || escalation.status || 'Coaching Required',
+      timestamp: normalizedTimestamp,
+      notes: updatedNotes
+    };
+
+    showOverlay();
+    google.script.run
+      .withSuccessHandler(() => {
+        resetCoachingForm();
+        loadEscalations();
+      })
+      .withFailureHandler(err => {
+        alert(err.message || err);
+        hideOverlay();
+      })
+      .updateEscalation(escalation.id, updatedRecord);
+  });
+
+  document.getElementById('coachReset').addEventListener('click', () => {
+    resetCoachingForm();
+  });
+
   document.getElementById('escCancel').addEventListener('click', () => {
     editingId = null;
     resetForm();
@@ -1066,6 +1540,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   populateIssueTypeOptions(categoryField.value || 'Other / General');
   setDefaultTimestamp();
+  resetCoachingForm();
   loadEscalations();
 });
 </script>

--- a/WeeklyOperatingTemplate.html
+++ b/WeeklyOperatingTemplate.html
@@ -1,0 +1,573 @@
+<?!= include('layout', {
+  baseUrl: baseUrl,
+  scriptUrl: scriptUrl,
+  user: user,
+  currentPage: currentPage || 'weekly-operating-template'
+}) ?>
+
+<style>
+  .weekly-template {
+    max-width: 1100px;
+    margin: 2rem auto 3rem;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+  }
+
+  .weekly-template__header {
+    padding: 2.5rem 2.5rem 2rem;
+    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+    color: #fff;
+  }
+
+  .weekly-template__header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+  }
+
+  .weekly-template__header p {
+    margin: 0;
+    opacity: 0.9;
+    font-size: 1rem;
+  }
+
+  .weekly-template__body {
+    padding: 2rem 2.5rem 3rem;
+    background: #f8fafc;
+  }
+
+  .section-card {
+    background: #ffffff;
+    border-radius: 14px;
+    padding: 1.75rem;
+    box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+    margin-bottom: 1.5rem;
+    border: 1px solid #e2e8f0;
+  }
+
+  .section-card h2 {
+    font-size: 1.35rem;
+    margin-bottom: 1rem;
+    color: #1f2937;
+  }
+
+  .section-card h3 {
+    font-size: 1.1rem;
+    margin: 1.5rem 0 0.75rem;
+    color: #374151;
+  }
+
+  .info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+
+  .field-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .field-group label {
+    font-weight: 600;
+    color: #475569;
+  }
+
+  .field-group input,
+  .field-group textarea,
+  .field-group select {
+    border-radius: 10px;
+    border: 1px solid #cbd5f5;
+    padding: 0.65rem 0.75rem;
+    font-size: 0.95rem;
+    color: #1f2937;
+    background: #fff;
+  }
+
+  .field-group textarea {
+    min-height: 90px;
+    resize: vertical;
+  }
+
+  .time-blocks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .time-blocks li {
+    background: #f8fafc;
+    border-radius: 10px;
+    border: 1px solid #e2e8f0;
+    padding: 0.75rem 1rem;
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .time-blocks strong {
+    color: #1f2937;
+    font-weight: 700;
+  }
+
+  .inline-list {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .checklist {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .checklist label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: #374151;
+  }
+
+  .two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+  }
+
+  .table-grid {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .table-grid__row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .note-field {
+    min-height: 70px;
+  }
+
+  .muted {
+    color: #6b7280;
+    font-size: 0.95rem;
+  }
+</style>
+
+<div class="weekly-template">
+  <header class="weekly-template__header">
+    <h1>Weekly Operating Template (Tue–Fri)</h1>
+    <p>Use this template to plan priorities, track QA/coaching, and document weekly reporting requirements.</p>
+  </header>
+
+  <div class="weekly-template__body">
+    <section class="section-card">
+      <h2>Week Information</h2>
+      <div class="info-grid">
+        <div class="field-group">
+          <label for="week-start">Week of (Tue)</label>
+          <input id="week-start" type="text" placeholder="MM/DD/YYYY">
+        </div>
+        <div class="field-group">
+          <label for="week-end">Week of (Fri)</label>
+          <input id="week-end" type="text" placeholder="MM/DD/YYYY">
+        </div>
+      </div>
+      <div class="info-grid" style="margin-top: 1rem;">
+        <div class="field-group">
+          <label for="primary-focus">Primary focus this week (1–2 items)</label>
+          <textarea id="primary-focus" placeholder="List top focus areas..."></textarea>
+        </div>
+        <div class="field-group">
+          <label for="risks">Risks / watch items (escalations, trends, staffing)</label>
+          <textarea id="risks" placeholder="Capture risks or watch items..."></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>1) Fixed Time-Blocks (Repeat Tue–Fri)</h2>
+      <ul class="time-blocks">
+        <li>
+          <strong>10:30 AM–10:45 AM — Day Setup / Priorities</strong>
+          <span class="muted">Review escalations, QA targets, coaching targets, and any agent blockers.</span>
+        </li>
+        <li>
+          <strong>10:45 AM–11:15 AM — Daily Logging Audit (Contacts + Robocode + Required Fields)</strong>
+          <span class="muted">Check for missing contact linkage, missing robocode, or incomplete logs. Log issues to tracker and assign correction.</span>
+        </li>
+        <li><strong>11:15 AM–12:15 PM — QA Block 1 (2 files)</strong></li>
+        <li><strong>12:15 PM–12:45 PM — Coaching Session #1 (30 min)</strong></li>
+        <li><strong>12:45 PM–1:15 PM — Coaching Documentation / Admin Buffer</strong></li>
+        <li><strong>1:15 PM–2:15 PM — QA Block 2 (3 files)</strong></li>
+        <li><strong>2:15 PM–2:45 PM — Coaching Session #2 (30 min)</strong></li>
+        <li><strong>2:45 PM–3:15 PM — Lunch (30 min)</strong></li>
+        <li><strong>3:15 PM–4:15 PM — QA Block 3 (2 files) (Total = 7 QA/day)</strong></li>
+        <li><strong>4:15 PM–4:45 PM — Re-coaching / Follow-ups (Daily)</strong></li>
+        <li><strong>4:45 PM–5:30 PM — Monitoring / Escalations / Supervisor Calls</strong></li>
+        <li><strong>5:30 PM–6:30 PM — Process Oversight (Trends + Problem-Logging Quality + Fixes)</strong></li>
+        <li><strong>6:30 PM–7:00 PM — Wrap-Up + Tracker Updates</strong></li>
+      </ul>
+      <h3>Thursday add-on to reach all 18 agents (bi-weekly)</h3>
+      <p class="muted">4:45 PM–5:15 PM — Extra Coaching Slot (replaces 30 minutes of Monitoring on Thursdays)</p>
+    </section>
+
+    <section class="section-card">
+      <h2>2) Bi-Weekly Coaching Roster (18 Agents) – Tue–Fri Only</h2>
+      <div class="two-column">
+        <div>
+          <h3>Week 1</h3>
+          <div class="inline-list">
+            <div class="field-group">
+              <label>Tue (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Wed (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Thu (12:15 / 2:15 / 4:45 extra)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Fri (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+          </div>
+        </div>
+        <div>
+          <h3>Week 2</h3>
+          <div class="inline-list">
+            <div class="field-group">
+              <label>Tue (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Wed (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Thu (12:15 / 2:15 / 4:45 extra)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___ | Agent ___">
+            </div>
+            <div class="field-group">
+              <label>Fri (12:15 / 2:15)</label>
+              <input type="text" placeholder="Agent ___ | Agent ___">
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <h3>Coaching checklist (each session)</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>Issue summary (what happened)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Standard/SOP impacted</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Expectations (what “good” looks like)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Action items (2–3 max)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Due date + follow-up date</label>
+          <input type="text" placeholder="__________________">
+        </div>
+      </div>
+
+      <h3>Daily Re-Coaching Block (4:15–4:45) focus list</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <input type="text" placeholder="Agent ___">
+          <input type="text" placeholder="Status: Not started / In progress / Complete">
+        </div>
+        <div class="table-grid__row">
+          <input type="text" placeholder="Agent ___">
+          <input type="text" placeholder="Status: Not started / In progress / Complete">
+        </div>
+      </div>
+      <div class="field-group" style="margin-top: 0.75rem;">
+        <label>Notes</label>
+        <textarea class="note-field" placeholder="__________________"></textarea>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>3) QA Plan (7 Files per Day)</h2>
+      <h3>Daily QA Target Tracker</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <label>Tue: 7/7 complete?</label>
+          <div class="checklist">
+            <label><input type="checkbox"> Yes</label>
+            <label><input type="checkbox"> No</label>
+          </div>
+          <input type="text" placeholder="Notes">
+        </div>
+        <div class="table-grid__row">
+          <label>Wed: 7/7 complete?</label>
+          <div class="checklist">
+            <label><input type="checkbox"> Yes</label>
+            <label><input type="checkbox"> No</label>
+          </div>
+          <input type="text" placeholder="Notes">
+        </div>
+        <div class="table-grid__row">
+          <label>Thu: 7/7 complete?</label>
+          <div class="checklist">
+            <label><input type="checkbox"> Yes</label>
+            <label><input type="checkbox"> No</label>
+          </div>
+          <input type="text" placeholder="Notes">
+        </div>
+        <div class="table-grid__row">
+          <label>Fri: 7/7 complete?</label>
+          <div class="checklist">
+            <label><input type="checkbox"> Yes</label>
+            <label><input type="checkbox"> No</label>
+          </div>
+          <input type="text" placeholder="Notes">
+        </div>
+      </div>
+      <h3>QA Findings Summary (weekly roll-up)</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>Top 3 failure themes</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Top 3 improvement wins</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Agents requiring immediate remediation</label>
+          <input type="text" placeholder="__________________">
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>4) Daily Logging Integrity (Contacts + Robocode + Required Fields)</h2>
+      <h3>Daily Integrity Results</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <label>Tue</label>
+          <input type="text" placeholder="Missing contact">
+          <input type="text" placeholder="Missing robocode">
+          <input type="text" placeholder="Other logging gaps">
+        </div>
+        <div class="table-grid__row">
+          <label>Wed</label>
+          <input type="text" placeholder="Missing contact">
+          <input type="text" placeholder="Missing robocode">
+          <input type="text" placeholder="Other logging gaps">
+        </div>
+        <div class="table-grid__row">
+          <label>Thu</label>
+          <input type="text" placeholder="Missing contact">
+          <input type="text" placeholder="Missing robocode">
+          <input type="text" placeholder="Other logging gaps">
+        </div>
+        <div class="table-grid__row">
+          <label>Fri</label>
+          <input type="text" placeholder="Missing contact">
+          <input type="text" placeholder="Missing robocode">
+          <input type="text" placeholder="Other logging gaps">
+        </div>
+      </div>
+      <h3>Corrective Actions</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>Re-trained agents (names)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Process gaps identified</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Fix implemented (what changed)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>5) Escalations + Supervisor Calls + On-Call Assistance</h2>
+      <h3>Supervisor Calls (weekly tracker)</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <input type="text" placeholder="Call #">
+          <input type="text" placeholder="Date">
+          <input type="text" placeholder="Agent">
+          <input type="text" placeholder="Reason">
+          <input type="text" placeholder="Outcome">
+          <input type="text" placeholder="Follow-up needed (Y/N)">
+        </div>
+        <div class="table-grid__row">
+          <input type="text" placeholder="Call #">
+          <input type="text" placeholder="Date">
+          <input type="text" placeholder="Agent">
+          <input type="text" placeholder="Reason">
+          <input type="text" placeholder="Outcome">
+          <input type="text" placeholder="Follow-up needed (Y/N)">
+        </div>
+      </div>
+
+      <h3>Escalated Case Management (in-scope)</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <input type="text" placeholder="Case">
+          <input type="text" placeholder="Owner">
+          <input type="text" placeholder="Status">
+          <input type="text" placeholder="Next step">
+          <input type="text" placeholder="Due date">
+        </div>
+      </div>
+
+      <h3>On-Call Assistance (chat support) – pattern capture</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>Common questions</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Knowledge gaps to address</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Items to convert into a help doc</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>6) Schedule Creation / Publishing (Omni)</h2>
+      <div class="checklist">
+        <label><input type="checkbox"> Schedule generated</label>
+        <label><input type="checkbox"> Published in Omni</label>
+        <label><input type="checkbox"> Changes communicated to team</label>
+      </div>
+      <div class="field-group" style="margin-top: 0.75rem;">
+        <label>Notes / exceptions</label>
+        <textarea class="note-field" placeholder="__________________"></textarea>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>7) Meetings & Documentation</h2>
+      <h3>Pre-Shift Meetings (1–2 per week)</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <input type="text" placeholder="Meeting #1 (Date/Time)">
+          <div class="checklist">
+            <label><input type="checkbox"> Recorded</label>
+            <label><input type="checkbox"> Uploaded</label>
+          </div>
+        </div>
+        <div class="table-grid__row">
+          <input type="text" placeholder="Meeting #2 (Date/Time)">
+          <div class="checklist">
+            <label><input type="checkbox"> Recorded</label>
+            <label><input type="checkbox"> Uploaded</label>
+          </div>
+        </div>
+      </div>
+      <h3>Discussion points (copy/paste)</h3>
+      <ul class="time-blocks">
+        <li>KPI review &amp; targets</li>
+        <li>Updates / procedures / system changes</li>
+        <li>Recognition</li>
+        <li>Goal commitments</li>
+        <li>Open discussion + agent concerns</li>
+        <li>Service notes review</li>
+        <li>Schedule announcements</li>
+      </ul>
+      <h3>Monthly Team Progress Notes (if due this week)</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>Key themes</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Agent concerns</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Continuous improvement actions</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card">
+      <h2>8) Reporting Deliverables</h2>
+      <h3>Daily EOD Report (Tue–Fri)</h3>
+      <div class="info-grid">
+        <div class="field-group">
+          <label>QA completed (count + major themes)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Coaching completed (who + outcomes)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Logging integrity results (counts + fixes)</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Escalations/supervisor calls handled</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+        <div class="field-group">
+          <label>Blocks/risks for tomorrow</label>
+          <textarea placeholder="__________________"></textarea>
+        </div>
+      </div>
+      <h3>Weekly Report (Friday)</h3>
+      <p class="muted">Friday 6:00 PM–7:00 PM — Weekly Report Build + Send</p>
+      <ul class="time-blocks">
+        <li>Call count</li>
+        <li>Attendance &amp; adherence</li>
+        <li>CSAT</li>
+        <li>Agent pay rate</li>
+        <li>Supervisor call volume + reasons (summary)</li>
+        <li>QA summary (averages + themes)</li>
+      </ul>
+    </section>
+
+    <section class="section-card">
+      <h2>9) Communications (Email / CC Norm)</h2>
+      <h3>Emails to send this week</h3>
+      <div class="table-grid">
+        <div class="table-grid__row">
+          <input type="text" placeholder="Topic">
+          <input type="text" placeholder="Audience">
+          <input type="text" placeholder="Due date">
+          <input type="text" placeholder="Status">
+        </div>
+      </div>
+      <h3>CC list (default)</h3>
+      <p class="muted">Earl, Chris, plus anyone else who should be kept informed for the specific issue.</p>
+      <div class="field-group" style="margin-top: 0.75rem;">
+        <label>Domornie Responsibilities Table</label>
+        <textarea class="note-field" placeholder="__________________"></textarea>
+      </div>
+    </section>
+  </div>
+</div>


### PR DESCRIPTION
### Motivation
- Provide an in-app escalation coaching workflow so supervisors can record coaching when an escalation occurs and track coaching outcomes and follow-ups.
- Surface coaching state on the Escalations log and provide a simple dashboard for at-a-glance coaching metrics and upcoming follow-ups.
- Deliver a frontend template for weekly operating planning (Tue–Fri) accessible via the app route.

### Description
- Added an escalation coaching dashboard and coaching module to `Escalations.html`, including UI panels, forms, summary stats, follow-up lists, and coaching notes storage rendered into the escalation notes field.
- Extended the Escalations table to show a Coaching column and added coaching-related status options (`Coaching Required`, `Coaching Scheduled`, `Coached`) and mappings for display styles in the log.
- Implemented client-side helpers to build/store coaching entries (embedded JSON payloads inside a coaching entry block), extract coaching metadata from escalation notes, append coaching entries to notes, and update escalation records via existing `updateEscalation`/`fetchAllEscalations` calls.
- Added a `WeeklyOperatingTemplate.html` static page and registered a route in `Code.js` so `?page=weekly-operating-template` (and `weeklyoperatingtemplate`) serves the weekly template page.

### Testing
- Launched a static server with `python -m http.server 8000` and used a Playwright script to visit `/Escalations.html` and capture a full-page screenshot; the script completed and produced `artifacts/escalations-coaching.png` successfully.
- Static inspection of the updated `Code.js` shows the `serveGlobalPage('WeeklyOperatingTemplate')` route entry was added (no backend migrations were created or required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a706f87c883268535586b3b769ca3)