### PR TITLE
Add Orders dashboard UI and navigation links

### DIFF
--- a/Orders.html
+++ b/Orders.html
@@ -1,0 +1,542 @@
+<!-- Orders.html -->
+<?
+  var safeBaseUrl = (typeof baseUrl !== 'undefined' && baseUrl) ? baseUrl : (typeof scriptUrl !== 'undefined' && scriptUrl ? scriptUrl : '');
+?>
+<?!= include('layout', {
+  baseUrl: safeBaseUrl,
+  scriptUrl: scriptUrl,
+  user: user || {},
+  currentPage: currentPage || 'Orders',
+  pageSlug: 'orders',
+  pageTitle: 'Orders',
+  pageDescription: 'Track orders, products, and shipping updates in LuminaHQ.'
+}) ?>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-b7H3c5ZLfuD3yF5uxoFODdgNpTiFqouBZfyqCkCmZJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZMRYPdP4h4lrw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+<style>
+  :root {
+    --orders-navy: #0b1f33;
+    --orders-cyan: #0ea5e9;
+    --orders-mint: #22c55e;
+    --orders-lavender: #6366f1;
+    --orders-surface: #ffffff;
+    --orders-soft: #f3f5fb;
+    --orders-border: #d7deed;
+    --orders-text: #0f172a;
+    --orders-text-secondary: #475569;
+    --orders-shadow: 0 22px 45px rgba(11, 31, 51, 0.12);
+    --orders-radius-lg: 20px;
+    --orders-radius-md: 18px;
+    --orders-radius-sm: 12px;
+    --orders-transition: all 0.2s ease;
+  }
+
+  body {
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(180deg, #f5f7fb 0%, #ffffff 60%);
+    color: var(--orders-text);
+  }
+
+  .orders-page {
+    padding: clamp(1.5rem, 4vw, 3.5rem) 0 4rem;
+  }
+
+  .orders-wrapper {
+    width: min(1280px, 100% - clamp(2rem, 7vw, 7.5rem));
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 2.5vw, 3rem);
+  }
+
+  .orders-hero {
+    background: var(--orders-surface);
+    border-radius: var(--orders-radius-lg);
+    padding: clamp(1.6rem, 3vw, 2.5rem);
+    box-shadow: var(--orders-shadow);
+    border: 1px solid rgba(11, 31, 51, 0.05);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .orders-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 60%);
+    pointer-events: none;
+    opacity: 0.8;
+  }
+
+  .orders-hero__content {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    align-items: center;
+  }
+
+  .orders-hero__headline {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  .orders-hero__eyebrow {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--orders-cyan);
+  }
+
+  .orders-hero__title {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 700;
+    color: var(--orders-navy);
+  }
+
+  .orders-hero__subtitle {
+    font-size: 1rem;
+    color: var(--orders-text-secondary);
+    max-width: 34rem;
+  }
+
+  .orders-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .orders-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 999px;
+    padding: 0.55rem 0.95rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border: 1px solid rgba(14, 165, 233, 0.2);
+    color: var(--orders-navy);
+    background: rgba(14, 165, 233, 0.08);
+  }
+
+  .orders-pill i {
+    color: var(--orders-cyan);
+  }
+
+  .orders-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+  }
+
+  .orders-metric {
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(14, 165, 233, 0.15);
+    border-radius: var(--orders-radius-md);
+    padding: 1rem 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .orders-metric__label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: var(--orders-text-secondary);
+  }
+
+  .orders-metric__value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--orders-navy);
+  }
+
+  .orders-section {
+    background: var(--orders-surface);
+    border-radius: var(--orders-radius-lg);
+    padding: clamp(1.4rem, 2.6vw, 2.2rem);
+    box-shadow: var(--orders-shadow);
+    border: 1px solid rgba(11, 31, 51, 0.05);
+  }
+
+  .orders-section__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.4rem;
+  }
+
+  .orders-section__title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--orders-navy);
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .orders-section__title i {
+    color: var(--orders-cyan);
+  }
+
+  .orders-link {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--orders-cyan);
+    text-decoration: none;
+  }
+
+  .orders-link:hover,
+  .orders-link:focus {
+    text-decoration: underline;
+  }
+
+  .orders-index {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .orders-card {
+    border-radius: var(--orders-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 1rem 1.2rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 0.9fr) auto;
+    gap: 0.8rem;
+    align-items: center;
+    transition: var(--orders-transition);
+  }
+
+  .orders-card:hover {
+    border-color: rgba(14, 165, 233, 0.4);
+    box-shadow: 0 12px 20px rgba(14, 165, 233, 0.12);
+  }
+
+  .orders-card__title {
+    font-weight: 700;
+    color: var(--orders-navy);
+  }
+
+  .orders-card__meta {
+    font-size: 0.9rem;
+    color: var(--orders-text-secondary);
+  }
+
+  .orders-badge {
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .orders-badge--ship {
+    background: rgba(34, 197, 94, 0.12);
+    color: #15803d;
+  }
+
+  .orders-badge--prep {
+    background: rgba(99, 102, 241, 0.12);
+    color: #4338ca;
+  }
+
+  .orders-badge--action {
+    background: rgba(14, 165, 233, 0.12);
+    color: #0369a1;
+  }
+
+  .orders-products {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .orders-product {
+    border-radius: var(--orders-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: rgba(255, 255, 255, 0.9);
+  }
+
+  .orders-product__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(14, 165, 233, 0.12);
+    color: var(--orders-cyan);
+    font-size: 1.2rem;
+  }
+
+  .orders-product__name {
+    font-weight: 700;
+    color: var(--orders-navy);
+  }
+
+  .orders-product__meta {
+    font-size: 0.9rem;
+    color: var(--orders-text-secondary);
+  }
+
+  .orders-tracking {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .orders-track-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.8rem;
+    align-items: start;
+  }
+
+  .orders-track-marker {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(14, 165, 233, 0.15);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--orders-cyan);
+    font-size: 0.95rem;
+  }
+
+  .orders-track-body {
+    border-radius: var(--orders-radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 0.9rem 1rem;
+    background: rgba(255, 255, 255, 0.92);
+  }
+
+  .orders-track-title {
+    font-weight: 700;
+    color: var(--orders-navy);
+  }
+
+  .orders-track-meta {
+    font-size: 0.9rem;
+    color: var(--orders-text-secondary);
+  }
+
+  .orders-links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .orders-link-card {
+    border-radius: var(--orders-radius-md);
+    border: 1px dashed rgba(14, 165, 233, 0.3);
+    padding: 1.1rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    background: rgba(14, 165, 233, 0.06);
+    color: var(--orders-navy);
+  }
+
+  .orders-link-card span {
+    font-size: 0.9rem;
+    color: var(--orders-text-secondary);
+  }
+
+  .orders-link-card a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .orders-link-card a:hover,
+  .orders-link-card a:focus {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 992px) {
+    .orders-hero__content {
+      grid-template-columns: 1fr;
+    }
+
+    .orders-card {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+<main class="orders-page">
+  <div class="orders-wrapper">
+    <section class="orders-hero">
+      <div class="orders-hero__content">
+        <div class="orders-hero__headline">
+          <span class="orders-hero__eyebrow">Orders Overview</span>
+          <h1 class="orders-hero__title">Your Order Index &amp; Shipping Command Center</h1>
+          <p class="orders-hero__subtitle">Stay on top of new purchases, tracking updates, and product fulfillment in one profile-style workspace.</p>
+          <div class="orders-hero__actions">
+            <span class="orders-pill"><i class="fa-solid fa-location-dot"></i> Track Shipping</span>
+            <span class="orders-pill"><i class="fa-solid fa-boxes-stacked"></i> Products in Motion</span>
+            <span class="orders-pill"><i class="fa-solid fa-list-check"></i> Order Index</span>
+          </div>
+        </div>
+        <div class="orders-metrics">
+          <div class="orders-metric">
+            <span class="orders-metric__label">Active Shipments</span>
+            <span class="orders-metric__value">6 In Transit</span>
+          </div>
+          <div class="orders-metric">
+            <span class="orders-metric__label">Orders This Month</span>
+            <span class="orders-metric__value">28 Confirmed</span>
+          </div>
+          <div class="orders-metric">
+            <span class="orders-metric__label">Next Delivery</span>
+            <span class="orders-metric__value">Mar 18, 2:30 PM</span>
+          </div>
+          <div class="orders-metric">
+            <span class="orders-metric__label">Returns Queue</span>
+            <span class="orders-metric__value">2 Pending</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="orders-section">
+      <div class="orders-section__header">
+        <div class="orders-section__title"><i class="fa-solid fa-table-list"></i>Order Index</div>
+        <a class="orders-link" href="#">View all orders</a>
+      </div>
+      <div class="orders-index">
+        <article class="orders-card">
+          <div>
+            <div class="orders-card__title">Order #LM-20418 • Lumina Essentials Kit</div>
+            <div class="orders-card__meta">Placed Mar 8 • 3 items • Standard fulfillment</div>
+          </div>
+          <div class="orders-card__meta">Warehouse: East Hub</div>
+          <div><span class="orders-badge orders-badge--ship"><i class="fa-solid fa-truck-fast"></i>Out for delivery</span></div>
+          <div><a class="orders-link" href="#">Track</a></div>
+        </article>
+        <article class="orders-card">
+          <div>
+            <div class="orders-card__title">Order #LM-20402 • Workstation Refresh</div>
+            <div class="orders-card__meta">Placed Mar 5 • 5 items • Priority</div>
+          </div>
+          <div class="orders-card__meta">Warehouse: North Hub</div>
+          <div><span class="orders-badge orders-badge--prep"><i class="fa-solid fa-layer-group"></i>Preparing</span></div>
+          <div><a class="orders-link" href="#">Manage</a></div>
+        </article>
+        <article class="orders-card">
+          <div>
+            <div class="orders-card__title">Order #LM-20376 • Team Starter Packs</div>
+            <div class="orders-card__meta">Placed Feb 28 • 12 items • Bulk shipment</div>
+          </div>
+          <div class="orders-card__meta">Warehouse: West Hub</div>
+          <div><span class="orders-badge orders-badge--action"><i class="fa-solid fa-circle-check"></i>Delivered</span></div>
+          <div><a class="orders-link" href="#">Receipt</a></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="orders-section">
+      <div class="orders-section__header">
+        <div class="orders-section__title"><i class="fa-solid fa-cubes"></i>Products on Deck</div>
+        <a class="orders-link" href="#">Manage inventory</a>
+      </div>
+      <div class="orders-products">
+        <div class="orders-product">
+          <div class="orders-product__icon"><i class="fa-solid fa-headset"></i></div>
+          <div class="orders-product__name">Agent Audio Kit</div>
+          <div class="orders-product__meta">Qty 12 • ETA Mar 19</div>
+        </div>
+        <div class="orders-product">
+          <div class="orders-product__icon"><i class="fa-solid fa-laptop"></i></div>
+          <div class="orders-product__name">Device Refresh Bundle</div>
+          <div class="orders-product__meta">Qty 5 • ETA Mar 21</div>
+        </div>
+        <div class="orders-product">
+          <div class="orders-product__icon"><i class="fa-solid fa-mug-hot"></i></div>
+          <div class="orders-product__name">Welcome Kit Merchandise</div>
+          <div class="orders-product__meta">Qty 18 • ETA Mar 24</div>
+        </div>
+        <div class="orders-product">
+          <div class="orders-product__icon"><i class="fa-solid fa-bolt"></i></div>
+          <div class="orders-product__name">Power &amp; Dock Station</div>
+          <div class="orders-product__meta">Qty 7 • ETA Mar 27</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="orders-section">
+      <div class="orders-section__header">
+        <div class="orders-section__title"><i class="fa-solid fa-route"></i>Track Shipping</div>
+        <a class="orders-link" href="#">Open tracking hub</a>
+      </div>
+      <div class="orders-tracking">
+        <div class="orders-track-item">
+          <div class="orders-track-marker"><i class="fa-solid fa-check"></i></div>
+          <div class="orders-track-body">
+            <div class="orders-track-title">Shipment scanned at East Hub</div>
+            <div class="orders-track-meta">Mar 15 • 8:42 AM • ETA update sent to requester</div>
+          </div>
+        </div>
+        <div class="orders-track-item">
+          <div class="orders-track-marker"><i class="fa-solid fa-location-dot"></i></div>
+          <div class="orders-track-body">
+            <div class="orders-track-title">Courier en route to delivery zone</div>
+            <div class="orders-track-meta">Mar 16 • 12:05 PM • 2 stops remaining</div>
+          </div>
+        </div>
+        <div class="orders-track-item">
+          <div class="orders-track-marker"><i class="fa-solid fa-circle-info"></i></div>
+          <div class="orders-track-body">
+            <div class="orders-track-title">Dock appointment confirmed</div>
+            <div class="orders-track-meta">Mar 17 • 4:00 PM • Receiving team notified</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="orders-section">
+      <div class="orders-section__header">
+        <div class="orders-section__title"><i class="fa-solid fa-link"></i>Order Links</div>
+        <span class="orders-link">Profile-ready actions</span>
+      </div>
+      <div class="orders-links">
+        <div class="orders-link-card">
+          <strong>Track Shipping</strong>
+          <span>Monitor carrier scans and delivery ETAs.</span>
+          <a href="#">Open live tracking</a>
+        </div>
+        <div class="orders-link-card">
+          <strong>Products &amp; Kits</strong>
+          <span>Review product bundles and assigned kits.</span>
+          <a href="#">View product index</a>
+        </div>
+        <div class="orders-link-card">
+          <strong>Invoices &amp; Receipts</strong>
+          <span>Download receipts, invoices, and proof of delivery.</span>
+          <a href="#">Go to billing desk</a>
+        </div>
+        <div class="orders-link-card">
+          <strong>Returns Portal</strong>
+          <span>Start a return or exchange with SLA guidance.</span>
+          <a href="#">Start a return</a>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>

--- a/navigationSidebar.html
+++ b/navigationSidebar.html
@@ -794,6 +794,11 @@
             data-bs-toggle="tooltip" data-bs-placement="right" title="Bookmarks">
             <i class="fas fa-bookmark"></i><span>Bookmarks</span>
           </a>
+          <a href="<?= generateLink('orders') ?>" class="<?= currentPage==='Orders'?'active':'' ?>"
+            data-page-key="orders" data-page-title="Orders"
+            data-bs-toggle="tooltip" data-bs-placement="right" title="Orders">
+            <i class="fas fa-box"></i><span>Orders</span>
+          </a>
         </div>
       </div>
 

--- a/navigationTopbar.html
+++ b/navigationTopbar.html
@@ -169,6 +169,12 @@
         title: 'Bookmarks',
         icon: 'fas fa-bookmark',
         description: 'Quick access to saved links'
+      },
+      {
+        key: 'orders',
+        title: 'Orders',
+        icon: 'fas fa-box',
+        description: 'Track orders and shipping status'
       }
     ]);
 
@@ -348,4 +354,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
### Motivation
- Provide a profile-style Orders workspace that mirrors the existing `UserProfile` UI so users can view order index, products, and shipping/tracking in the same familiar layout. 
- Surface Orders in global navigation so the page is discoverable from both the sidebar and topbar dropdown when the sidebar is hidden.

### Description
- Add a new page `Orders.html` that implements a profile-themed Orders dashboard with hero metrics, an Order Index, Products on Deck, Track Shipping, and quick Order Links sections. 
- Add an `Orders` entry to the sidebar by updating `navigationSidebar.html` so the page appears in the main navigation. 
- Add an `Orders` entry to the topbar dropdown by updating `navigationTopbar.html` so the page appears in the topbar menu when the sidebar is hidden. 

### Testing
- Launched a local static server with `python -m http.server 8000` and used a Playwright script to open `http://127.0.0.1:8000/Orders.html` and capture a full-page screenshot at `artifacts/orders-page.png`, which completed successfully. 
- Verified the new files were staged and committed (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703ec7acb08326990ce4019110c3f7)