### PR TITLE
Add 'Outbound Car' to attendance billable states and UI

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -1568,7 +1568,7 @@
         <i class="fas fa-chart-line"></i>
         <div class="label">Billable Hours</div>
         <div class="value text-success" id="kpi-productive">Loading...</div>
-        <small class="text-muted">Available, Administrative, Training, Meeting & Break</small>
+        <small class="text-muted">Available, Administrative, Training, Meeting, Outbound Car & Break</small>
       </div>
     </div>
     <div class="col-lg-6">
@@ -3749,6 +3749,7 @@
           { name: 'Administrative Work', icon: 'fa-tasks', type: 'info' },
           { name: 'Training', icon: 'fa-chalkboard-teacher', type: 'warning' },
           { name: 'Meeting', icon: 'fa-users', type: 'info' },
+          { name: 'Outbound Car', icon: 'fa-car-side', type: 'info' },
           { name: 'Break', icon: 'fa-coffee', type: 'danger' },
           { name: 'Lunch', icon: 'fa-utensils', type: 'danger' }
         ];

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -21,7 +21,7 @@
 // CONFIGURATION & CONSTANTS
 // ────────────────────────────────────────────────────────────────────────────
 
-const BILLABLE_STATES = ['Available', 'Administrative Work', 'Training', 'Meeting', 'Break'];
+const BILLABLE_STATES = ['Available', 'Administrative Work', 'Training', 'Meeting', 'Outbound Car', 'Break'];
 const BILLABLE_STATE_LABELS = [...new Set([...BILLABLE_STATES])];
 const NON_PRODUCTIVE_STATES = ['Break', 'Lunch'];
 const BILLABLE_DISPLAY_STATES = [...BILLABLE_STATE_LABELS];


### PR DESCRIPTION
### Motivation
- Include the new "Outbound Car" activity in attendance calculations so it is counted as billable time in reports and KPIs.

### Description
- Update `AttendanceService.js` by adding `'Outbound Car'` to the `BILLABLE_STATES` array so existing aggregation logic will include it.
- Update `AttendanceReports.html` to include "Outbound Car" in the billable hours description and to render a KPI card entry with icon `fa-car-side` in `renderKPICards`.
- No other business logic changes were required because the report code uses the `BILLABLE_STATES` / stateDuration maps to compute totals.

### Testing
- No unit tests were added or executed for this change.
- An automated UI snapshot attempt using Playwright was performed but failed with `ERR_FILE_NOT_FOUND` when loading `AttendanceReports.html` in the runner environment.
- Attendance aggregation code was not executed in this environment, so runtime verification should be performed in a staging environment or via existing attendance data imports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bbd8e31c83269ed1754e3298712e)