### PR TITLE
Apply weekly 2.5h break/lunch allowance and deduct weekly overages

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -4090,8 +4090,30 @@
         const endIndex = Math.min(startIndex + this.pagination.itemsPerPage, filteredCompliance.length);
         const currentPageData = filteredCompliance.slice(startIndex, endIndex);
 
-        const BREAK_ALLOWANCE_SECS = 30 * 60;
-        const LUNCH_ALLOWANCE_SECS = 30 * 60;
+        const periodInfo = this.currentData.periodInfo || {};
+        const countWeeksInRange = (startIso, endIso) => {
+          if (!startIso || !endIso) return 1;
+          const start = new Date(startIso);
+          const end = new Date(endIso);
+          if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+            return 1;
+          }
+          const alignToMonday = (date) => {
+            const aligned = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+            const weekday = aligned.getUTCDay();
+            const diff = weekday === 0 ? -6 : 1 - weekday;
+            aligned.setUTCDate(aligned.getUTCDate() + diff);
+            return aligned;
+          };
+          const startWeek = alignToMonday(start);
+          const endWeek = alignToMonday(end);
+          const diffMs = endWeek.getTime() - startWeek.getTime();
+          const weekCount = Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000)) + 1;
+          return Math.max(1, weekCount);
+        };
+        const weekCount = countWeeksInRange(periodInfo.startDateIso, periodInfo.endDateIso);
+        const BREAK_ALLOWANCE_SECS = 30 * 60 * 5 * weekCount;
+        const LUNCH_ALLOWANCE_SECS = 30 * 60 * 5 * weekCount;
         const hourPolicy = this.currentData.hourPolicy || {};
         const overtimeEnabled = Boolean(hourPolicy.overtimeEnabled);
         const dailyCapHours = typeof hourPolicy.effectiveCapHours === 'number' ? hourPolicy.effectiveCapHours : 8;
@@ -4323,8 +4345,6 @@
               });
             }
           });
-
-          const periodInfo = this.currentData.periodInfo || {};
 
           const parseIsoKeyToDate = (key) => {
             if (typeof key !== 'string') return null;
@@ -4685,7 +4705,7 @@
           <div class="mt-3">
             <small class="text-muted">
               <i class="fas fa-info-circle me-1"></i>
-              Up to 30 minutes of daily break time remains paid and billable while any break or lunch overages deduct minute-for-minute from productive availability. ${policyNote} All durations shown in decimal hours using ${timezoneLabel} (${timezoneValue}).
+              Up to 2.5 hours of weekly break time remains paid and billable while any break or lunch overages above the weekly allowance deduct minute-for-minute from productive availability. ${policyNote} All durations shown in decimal hours using ${timezoneLabel} (${timezoneValue}).
             </small>
           </div>`;
 

--- a/AttendanceService.js
+++ b/AttendanceService.js
@@ -61,6 +61,8 @@ var GLOBAL_SCOPE = (typeof GLOBAL_SCOPE !== 'undefined') ? GLOBAL_SCOPE
 const DAILY_SHIFT_SECS = 8 * 3600;       // 8 hours in seconds
 const DAILY_BREAKS_SECS = 30 * 60;       // 30 minutes in seconds
 const DAILY_LUNCH_SECS = 30 * 60;        // 30 minutes in seconds
+const WEEKLY_BREAK_SECS = DAILY_BREAKS_SECS * 5; // 2.5 hours per week
+const WEEKLY_LUNCH_SECS = DAILY_LUNCH_SECS * 5;  // 2.5 hours per week
 const WEEKLY_OVERTIME_SECS = 40 * 3600;  // 40 hours in seconds
 
 // Primary attendance timezone configuration (defaults to script timezone)
@@ -1387,24 +1389,29 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
 
     const userWeeklyTotals = new Map();
 
-    userDayMetrics.forEach(metrics => {
-      const { breakOver, lunchOver, combinedOver, deduction } = calculateBreakLunchDeductions(metrics.break, metrics.lunch);
+    const weeklyDayEntries = [];
+    userDayMetrics.forEach((metrics, key) => {
+      weeklyDayEntries.push({
+        user: metrics.user,
+        dateKey: metrics.dateKey,
+        break: metrics.break,
+        lunch: metrics.lunch,
+        prod: metrics.prod,
+        key
+      });
+    });
 
-      if (breakOver > 0 || lunchOver > 0 || combinedOver > 0) {
+    const { dailyDeductions: weeklyDailyDeductions, weeklyOverages } =
+      buildWeeklyBreakLunchDeductions_(weeklyDayEntries);
+
+    userDayMetrics.forEach(metrics => {
+      const dailyDeduction = weeklyDailyDeductions.get(`${metrics.user}|${metrics.dateKey}`) || 0;
+
+      if (dailyDeduction > 0) {
         violationDays++;
       }
 
-      const complianceStats = userComplianceMap.get(metrics.user);
-      if (complianceStats) {
-        if (breakOver > 0) {
-          complianceStats.breakOverageDays += 1;
-        }
-        if (lunchOver > 0) {
-          complianceStats.lunchOverageDays += 1;
-        }
-      }
-
-      const baseProd = Math.max(0, metrics.prod - deduction);
+      const baseProd = Math.max(0, metrics.prod - dailyDeduction);
       const baseCapped = Math.min(baseProd, hourPolicy.effectiveCapSeconds);
       const adjustedTotal = baseCapped;
       const overtime = Math.max(0, Math.min(baseProd, hourPolicy.effectiveCapSeconds) - (hourPolicy.baseCapHours * 3600));
@@ -1448,6 +1455,13 @@ function getAttendanceAnalyticsByPeriod(granularity, periodId, agentFilter, poli
       }
 
       dailyAdjustedTotals.set(metrics.dateKey, (dailyAdjustedTotals.get(metrics.dateKey) || 0) + adjustedTotal);
+    });
+
+    weeklyOverages.forEach((overage, user) => {
+      const compliance = userComplianceMap.get(user);
+      if (!compliance) return;
+      compliance.breakOverageDays += overage.breakOverWeeks || 0;
+      compliance.lunchOverageDays += overage.lunchOverWeeks || 0;
     });
 
     userWeeklyTotals.forEach((totalSecs, key) => {
@@ -1856,11 +1870,19 @@ function calculateProductivityMetrics(filtered) {
     const breakSecs = stateDuration['Break'] || 0;
     const lunchSecs = stateDuration['Lunch'] || 0;
     const billableSecs = BILLABLE_STATES.reduce((sum, state) => sum + (stateDuration[state] || 0), 0);
-    let totalDeductionSecs = 0;
-    dayMetrics.forEach(metrics => {
-        const { deduction } = calculateBreakLunchDeductions(metrics.break, metrics.lunch);
-        totalDeductionSecs += deduction;
+    const weeklyEntries = [];
+    dayMetrics.forEach((metrics, key) => {
+        const keyParts = key.split('|');
+        const user = keyParts[0] || '';
+        const dateKey = keyParts[1] || '';
+        weeklyEntries.push({
+            user,
+            dateKey,
+            break: metrics.break,
+            lunch: metrics.lunch
+        });
     });
+    const totalDeductionSecs = calculateWeeklyBreakLunchDeductionTotals_(weeklyEntries);
     const billableWithBreakSecs = Math.max(0, billableSecs - totalDeductionSecs);
 
     const totalBillableHours = Math.round((billableWithBreakSecs / 3600) * 100) / 100;
@@ -1914,12 +1936,14 @@ function calculateUserCompliance(filtered) {
             dailyBuckets.set(bucketKey, {
                 break: 0,
                 lunch: 0,
+                prod: 0,
                 dayOfWeek: attendanceDayOfWeek
             });
         }
         const bucket = dailyBuckets.get(bucketKey);
         if (r.state === 'Break') bucket.break += secs;
         if (r.state === 'Lunch') bucket.lunch += secs;
+        if (BILLABLE_STATES.includes(r.state)) bucket.prod += secs;
         if (typeof bucket.dayOfWeek !== 'number' || isNaN(bucket.dayOfWeek)) {
             bucket.dayOfWeek = attendanceDayOfWeek;
         }
@@ -1933,11 +1957,27 @@ function calculateUserCompliance(filtered) {
         }
     });
 
+    const weeklyEntries = [];
+    dailyBuckets.forEach((bucket, key) => {
+        const keyParts = key.split('|');
+        const user = keyParts[0] || '';
+        const dateKey = keyParts[1] || '';
+        weeklyEntries.push({
+            user,
+            dateKey,
+            break: bucket.break,
+            lunch: bucket.lunch,
+            prod: bucket.prod,
+            dayOfWeek: bucket.dayOfWeek
+        });
+    });
+    const { dailyDeductions } = buildWeeklyBreakLunchDeductions_(weeklyEntries);
+
     dailyBuckets.forEach((bucket, key) => {
         const [user] = key.split('|');
         const stats = userStats.get(user);
         if (!stats) return;
-        const { deduction } = calculateBreakLunchDeductions(bucket.break, bucket.lunch);
+        const deduction = dailyDeductions.get(key) || 0;
         const isWeekend = bucket.dayOfWeek >= 6;
 
         if (isWeekend) {
@@ -1981,6 +2021,101 @@ function formatSecsAsHhMm(secs) {
   const hours = Math.floor(secs / 3600);
   const minutes = Math.floor((secs % 3600) / 60);
   return `${hours}h ${minutes}m`;
+}
+
+function getWeekStartDate_(dateValue) {
+  if (!(dateValue instanceof Date) || Number.isNaN(dateValue.getTime())) {
+    return null;
+  }
+  const weekStart = new Date(dateValue.getTime());
+  const jsDay = weekStart.getDay();
+  const offset = jsDay === 0 ? -6 : 1 - jsDay;
+  weekStart.setDate(weekStart.getDate() + offset);
+  weekStart.setHours(0, 0, 0, 0);
+  return weekStart;
+}
+
+function buildWeeklyBreakLunchDeductions_(dayEntries) {
+  const weeklyMap = new Map();
+
+  (dayEntries || []).forEach(entry => {
+    if (!entry || !entry.user || !entry.dateKey) return;
+    const dayDate = normalizeDateValue(entry.dateKey);
+    const weekStart = getWeekStartDate_(dayDate);
+    if (!weekStart) return;
+    const weekKey = `${entry.user}|${weekStart.toISOString().slice(0, 10)}`;
+    if (!weeklyMap.has(weekKey)) {
+      weeklyMap.set(weekKey, {
+        user: entry.user,
+        breakSecs: 0,
+        lunchSecs: 0,
+        entries: []
+      });
+    }
+    const week = weeklyMap.get(weekKey);
+    week.breakSecs += Number(entry.break) || 0;
+    week.lunchSecs += Number(entry.lunch) || 0;
+    week.entries.push({
+      key: `${entry.user}|${entry.dateKey}`,
+      date: dayDate,
+      prod: Number(entry.prod) || 0,
+      dayOfWeek: entry.dayOfWeek
+    });
+  });
+
+  const dailyDeductions = new Map();
+  const weeklyOverages = new Map();
+
+  weeklyMap.forEach(week => {
+    const breakOver = Math.max(0, week.breakSecs - WEEKLY_BREAK_SECS);
+    const lunchOver = Math.max(0, week.lunchSecs - WEEKLY_LUNCH_SECS);
+
+    if (breakOver > 0 || lunchOver > 0) {
+      const current = weeklyOverages.get(week.user) || { breakOverWeeks: 0, lunchOverWeeks: 0 };
+      if (breakOver > 0) current.breakOverWeeks += 1;
+      if (lunchOver > 0) current.lunchOverWeeks += 1;
+      weeklyOverages.set(week.user, current);
+    }
+
+    let remaining = breakOver + lunchOver;
+    if (remaining <= 0) return;
+
+    const sorted = week.entries.slice().sort((a, b) => a.date.getTime() - b.date.getTime());
+    for (let i = sorted.length - 1; i >= 0 && remaining > 0; i -= 1) {
+      const entry = sorted[i];
+      const available = Number.isFinite(entry.prod) ? entry.prod : 0;
+      if (available <= 0) continue;
+      const applied = Math.min(remaining, available);
+      dailyDeductions.set(entry.key, (dailyDeductions.get(entry.key) || 0) + applied);
+      remaining -= applied;
+    }
+  });
+
+  return { dailyDeductions, weeklyOverages };
+}
+
+function calculateWeeklyBreakLunchDeductionTotals_(dayEntries) {
+  const weeklyTotals = new Map();
+  (dayEntries || []).forEach(entry => {
+    if (!entry || !entry.user || !entry.dateKey) return;
+    const dayDate = normalizeDateValue(entry.dateKey);
+    const weekStart = getWeekStartDate_(dayDate);
+    if (!weekStart) return;
+    const weekKey = `${entry.user}|${weekStart.toISOString().slice(0, 10)}`;
+    if (!weeklyTotals.has(weekKey)) {
+      weeklyTotals.set(weekKey, { breakSecs: 0, lunchSecs: 0 });
+    }
+    const totals = weeklyTotals.get(weekKey);
+    totals.breakSecs += Number(entry.break) || 0;
+    totals.lunchSecs += Number(entry.lunch) || 0;
+  });
+
+  let totalDeduction = 0;
+  weeklyTotals.forEach(totals => {
+    totalDeduction += Math.max(0, totals.breakSecs - WEEKLY_BREAK_SECS);
+    totalDeduction += Math.max(0, totals.lunchSecs - WEEKLY_LUNCH_SECS);
+  });
+  return totalDeduction;
 }
 
 function calculateBreakOverageSecs(breakSeconds) {
@@ -3305,8 +3440,8 @@ function generateEnhancedDailyPivotExport(pivotMatrix, params, context) {
     const notes = [
       'Data Quality Notes',
       `All productive durations are converted from seconds into decimal hours using ${ATTENDANCE_TIMEZONE_LABEL || ATTENDANCE_TIMEZONE}.`,
-      'Break allowances assume 30 minutes per day; lunch allowances assume 30 minutes.',
-      'Break and lunch overages are deducted minute-for-minute from productive totals.',
+      'Break allowances assume 2.5 hours per week; lunch allowances assume 2.5 hours per week.',
+      'Break and lunch overages above the weekly allowance are deducted minute-for-minute from productive totals.',
       `Billable hours include: ${BILLABLE_STATE_LABELS.join(', ')}.`
     ];
 
@@ -3552,8 +3687,8 @@ function generateEnhancedDailyPivotCsvFallback(pivotMatrix, params, context) {
   rows.push('');
   rows.push(csvEscape('Notes'));
   rows.push(csvEscape(`All productive durations are converted from seconds into decimal hours using ${ATTENDANCE_TIMEZONE_LABEL || ATTENDANCE_TIMEZONE}.`));
-  rows.push(csvEscape('Break allowances assume 30 minutes per day; lunch allowances assume 30 minutes.'));
-  rows.push(csvEscape('Break and lunch overages are deducted minute-for-minute from productive totals.'));
+  rows.push(csvEscape('Break allowances assume 2.5 hours per week; lunch allowances assume 2.5 hours per week.'));
+  rows.push(csvEscape('Break and lunch overages above the weekly allowance are deducted minute-for-minute from productive totals.'));
   rows.push(csvEscape(`Billable hours include: ${BILLABLE_STATE_LABELS.join(', ')}.`));
 
   return {
@@ -4696,8 +4831,24 @@ function createBasicAnalytics(filtered, granularity, periodId, agentFilter, peri
   let fallbackLunchAdjustmentSecs = 0;
   let fallbackBaseBillableSecs = 0;
   let fallbackAdjustedBillableSecs = 0;
-  fallbackDayMetrics.forEach(dayMetrics => {
-    const { deduction } = calculateBreakLunchDeductions(dayMetrics.break, dayMetrics.lunch);
+  const weeklyFallbackEntries = [];
+  fallbackDayMetrics.forEach((dayMetrics, key) => {
+    const keyParts = key.split('|');
+    const user = keyParts[0] || '';
+    const dateKey = keyParts[1] || '';
+    weeklyFallbackEntries.push({
+      user,
+      dateKey,
+      break: dayMetrics.break,
+      lunch: dayMetrics.lunch,
+      prod: dayMetrics.prod
+    });
+  });
+  const { dailyDeductions: fallbackDailyDeductions } =
+    buildWeeklyBreakLunchDeductions_(weeklyFallbackEntries);
+
+  fallbackDayMetrics.forEach((dayMetrics, key) => {
+    const deduction = fallbackDailyDeductions.get(key) || 0;
     const baseProd = Math.max(0, (dayMetrics.prod || 0) - deduction);
     const baseCapped = Math.min(baseProd, safeHourPolicy.effectiveCapSeconds);
     const adjustedTotal = baseCapped;


### PR DESCRIPTION
### Motivation
- Replace the prior per-day deduction behavior with a weekly allowance model so agents have 2.5 hours/week (30m × 5 days) for `Break` and `Lunch` before any deductions apply. 
- Ensure that no time is deducted if an agent does not exceed the weekly 2.5h allowance, and that only the amount above the weekly allowance is deducted when exceeded. 
- Propagate the weekly deduction behavior consistently through analytics, fallback/basic calculations, CSV/export notes, and the UI policy messaging.

### Description
- Added weekly constants `WEEKLY_BREAK_SECS` and `WEEKLY_LUNCH_SECS` and new helpers `getWeekStartDate_`, `buildWeeklyBreakLunchDeductions_`, and `calculateWeeklyBreakLunchDeductionTotals_` to compute week-aligned totals and distribute weekly overages into per-day deductions. 
- Replaced daily-only deduction calls with weekly-aware logic in the main analytics path (`getAttendanceAnalyticsByPeriod`), productivity calculations (`calculateProductivityMetrics`), and compliance aggregation (`calculateUserCompliance`) so deductions are applied only for weekly excess and are distributed across days. 
- Updated fallback/basic analytics (`createBasicAnalytics` and related CSV/export helpers) to use the weekly deduction helpers and updated export notes to state "2.5 hours per week" and that overages above the weekly allowance are deducted minute-for-minute. 
- Updated the attendance UI (`AttendanceReports.html`) to compute a period-aware weekly allowance (`BREAK_ALLOWANCE_SECS` / `LUNCH_ALLOWANCE_SECS`) based on the selected period week count and to change the policy note text to reflect the weekly allowance behavior.

### Testing
- No automated tests were executed against these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ccd20e348326a2bad4d100c2ace2)