### PR TITLE
Fix shift slot time parsing and ID normalization

### DIFF
--- a/ScheduleService.js
+++ b/ScheduleService.js
@@ -2471,12 +2471,22 @@ function clientGetAllShiftSlots() {
     }
 
     const normalizedSlots = slots.map(slot => {
-      const slotId = (slot.SlotId || slot.ID || slot.Id || slot.slotId || '').toString().trim() || Utilities.getUuid();
+      const slotId = (
+        slot.SlotId ||
+        slot.SlotID ||
+        slot['Slot ID'] ||
+        slot['Slot Id'] ||
+        slot.ID ||
+        slot.Id ||
+        slot.slotId ||
+        slot.id ||
+        ''
+      ).toString().trim() || Utilities.getUuid();
       const slotName = (slot.SlotName || slot.Name || '').toString().trim();
       const campaign = (slot.Campaign || slot.Department || '').toString().trim();
       const location = (slot.Location || '').toString().trim() || 'Office';
-      const startTime = normalizeTimeTo12Hour(slot.StartTime || slot.startTime || '');
-      const endTime = normalizeTimeTo12Hour(slot.EndTime || slot.endTime || '');
+      const startTime = normalizeTimeTo12Hour(slot.StartTime || slot.startTime || slot['Start Time'] || slot.Start || '');
+      const endTime = normalizeTimeTo12Hour(slot.EndTime || slot.endTime || slot['End Time'] || slot.End || '');
       const daysArray = parseDaysCsv(slot.DaysCSV || slot.DaysOfWeek || '');
       const statusValue = (slot.Status || '').toString().trim().toUpperCase();
       const status = statusValue || (scheduleFlagToBool(slot.IsActive, true) ? 'Active' : 'Archived');

--- a/ScheduleUtilities.js
+++ b/ScheduleUtilities.js
@@ -366,6 +366,11 @@ function parseTimeToMinutes(timeValue) {
     return NaN;
   }
 
+  if (typeof timeValue === 'number' && Number.isFinite(timeValue)) {
+    const fraction = ((timeValue % 1) + 1) % 1;
+    return Math.round(fraction * 24 * 60);
+  }
+
   if (timeValue instanceof Date) {
     return timeValue.getHours() * 60 + timeValue.getMinutes();
   }


### PR DESCRIPTION
### Motivation
- Users reported shift generation and manual assignment failing with "no shift selected" and missing slot times because sheet values used different column names and numeric time values weren’t consistently parsed.
- The change ensures shift slot rows read from the schedule sheet map to the UI and option labels reliably, including numeric time formats produced by spreadsheets.

### Description
- Parse numeric time values in `parseTimeToMinutes` so fractional day numbers (spreadsheet time values) convert correctly to minutes. (`ScheduleUtilities.js`)
- Broaden shift slot identifier normalization to accept additional column variants (`SlotID`, `Slot ID`, `Slot Id`, `id`) when building `SlotId`. (`ScheduleService.js`)
- Add fallbacks for start/end time fields when loading slots to read `Start Time`, `Start`, `End Time`, and `End` in addition to existing keys and pass them through `normalizeTimeTo12Hour`. (`ScheduleService.js`)
- Keep existing behavior for defaulting IDs and times when values are absent and preserve existing slot configuration normalization.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973cd0b6cd08326a7fce60bd7ffc695)