### PR TITLE
Keep attendance dashboard rendering without compliance rows

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -3545,9 +3545,11 @@
         }
 
         if (!Array.isArray(data.userCompliance) || data.userCompliance.length === 0) {
-          console.warn('Attendance data returned without compliance rows — rendering empty dashboard.');
+          console.warn('Attendance data returned without compliance rows — rendering dashboard without compliance rows.');
           this.showToast('No attendance compliance data available for the selected filters.', 'warning');
-          data = this.createEmptyAttendanceData();
+          if (!Array.isArray(data.userCompliance)) {
+            data.userCompliance = [];
+          }
         }
         
         this.currentData = data;


### PR DESCRIPTION
### Motivation
- Prevent the entire attendance dashboard from being replaced with an empty payload when the server returns valid attendance metrics but omits `data.userCompliance`, while still warning the user that compliance rows are missing.

### Description
- In `AttendanceReports.html` inside `loadData()`, changed the handling of missing compliance rows so the code no longer overwrites the returned `data` with `createEmptyAttendanceData()` and instead normalizes `data.userCompliance` to an empty array when it is not present, while leaving the warning `showToast` in place.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973edfb02e48326b813293208592a98)