### PR TITLE
Handle empty attendance breakdown data and ignore channel-closed promise rejections

### DIFF
--- a/AttendanceReports.html
+++ b/AttendanceReports.html
@@ -2283,6 +2283,14 @@
   // Client hardening helpers
   const ChannelClosedRegex = /message channel closed/i;
 
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event && 'reason' in event ? event.reason : null;
+    const message = reason && reason.message ? String(reason.message) : String(reason || '');
+    if (ChannelClosedRegex.test(message)) {
+      event.preventDefault();
+    }
+  });
+
   function debounce(fn, wait = 250) {
     let t; 
     return function debounced(...args) { 
@@ -5026,25 +5034,29 @@
 
           let lunchAllowed, breakAllowed, displayUnit;
 
-          if (isAllAgents && uniqueAgents > 1) {
-            // For all agents, calculate based on actual users who had lunch/break that day
-            const lunchUserCount = lunchUsers.length || uniqueAgents;
-            const breakUserCount = breakUsers.length || uniqueAgents;
-            
-            lunchAllowed = 30 * lunchUserCount;
-            breakAllowed = 30 * breakUserCount;
-            displayUnit = '';
-          } else {
-            lunchAllowed = 30;
-            breakAllowed = 30;
-            displayUnit = '';
-          }
+        if (isAllAgents && uniqueAgents > 0) {
+          // For all agents, calculate based on actual users who had lunch/break that day
+          const lunchUserCount = lunchUsers.length || uniqueAgents;
+          const breakUserCount = breakUsers.length || uniqueAgents;
+          
+          lunchAllowed = 30 * lunchUserCount;
+          breakAllowed = 30 * breakUserCount;
+          displayUnit = '';
+        } else if (isAllAgents && uniqueAgents === 0) {
+          lunchAllowed = 0;
+          breakAllowed = 0;
+          displayUnit = '';
+        } else {
+          lunchAllowed = 30;
+          breakAllowed = 30;
+          displayUnit = '';
+        }
 
-          const lunchPercent = Math.min((lunchMinutes / lunchAllowed) * 100, 150);
-          const breakPercent = Math.min((breakMinutes / breakAllowed) * 100, 150);
+        const lunchPercent = lunchAllowed > 0 ? Math.min((lunchMinutes / lunchAllowed) * 100, 150) : 0;
+        const breakPercent = breakAllowed > 0 ? Math.min((breakMinutes / breakAllowed) * 100, 150) : 0;
 
-          const lunchColor = lunchMinutes <= lunchAllowed ? '#10b981' : '#dc2626';
-          const breakColor = breakMinutes <= breakAllowed ? '#10b981' : '#dc2626';
+        const lunchColor = lunchAllowed === 0 ? '#9ca3af' : (lunchMinutes <= lunchAllowed ? '#10b981' : '#dc2626');
+        const breakColor = breakAllowed === 0 ? '#9ca3af' : (breakMinutes <= breakAllowed ? '#10b981' : '#dc2626');
 
           html += `
             <div class="col-lg col-md-6 col-sm-12">
@@ -5116,7 +5128,7 @@
       try {
         if (!this.currentData || !this.currentData.filteredRows) {
           console.warn('No current data available for agent count');
-          return 1;
+          return 0;
         }
         
         if (this.currentAgent && this.currentAgent !== '') {
@@ -5133,13 +5145,13 @@
             }
           });
           
-          const count = Math.max(1, uniqueUsers.size);
+          const count = uniqueUsers.size;
           console.log('Unique agents found:', Array.from(uniqueUsers), 'Total count:', count);
           return count;
         }
       } catch (error) {
         console.error('Error getting unique agent count:', error);
-        return 1;
+        return 0;
       }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent noisy uncaught promise errors for the known "message channel closed" case that pollute console and user experience when server channels are closed unexpectedly.
- Avoid divide-by-zero or misleading daily breakdown visuals when there are no filtered attendance rows or no unique agents.
- Make unique-agent counts reflect actual data instead of forcing a minimum of 1 when no rows exist.

### Description
- Added a global `unhandledrejection` handler that suppresses errors whose message matches `ChannelClosedRegex` so the known channel-closed rejection is ignored (`AttendanceReports.html`).
- Updated daily breakdown allowance computation to handle `uniqueAgents === 0` by setting `lunchAllowed`/`breakAllowed` to `0`, guarding percent calculations and using a neutral color when no data is present (`AttendanceReports.html`).
- Changed percent calculations to avoid division by zero by returning `0` when allowed minutes are `0`, and adjusted the color logic to a neutral gray when allowances are zero (`AttendanceReports.html`).
- Modified `getUniqueAgentsCount()` to return `0` when there are no `filteredRows` and to return the actual unique user count (removed forced `Math.max(1, ...)`) so downstream logic can correctly handle empty datasets (`AttendanceReports.html`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697763490d988326b511bca4f30d1294)