### PR TITLE
QA-only open-script mode, update script URL, and harden IBTR spreadsheet setup

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -20,7 +20,7 @@ var GLOBAL_SCOPE = (typeof GLOBAL_SCOPE !== 'undefined') ? GLOBAL_SCOPE
       ? this
       : {};
 
-const SCRIPT_URL = 'https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec';
+const SCRIPT_URL = 'https://script.google.com/a/macros/vlbpo.com/s/AKfycbzPZ42F5pHwgr2GLo2Qs8RYwsuV4NmABoASb2nthFDzM5TQhimWDwh9NjhPjlUH9DB1Lg/exec';
 const FAVICON_URL = 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/3_dgitcx.png';
 
 /** Toggle for debug traces */
@@ -2450,159 +2450,21 @@ function doGet(e) {
     // Initialize system
     // initializeSystem();
 
-    // Handle special actions
-    if (e.parameter.page === 'proxy') {
-      console.log('doGet: Handling proxy request');
-      return serveEnhancedProxy(e);
-    }
+    // QA-only open script mode: ignore non-QA actions/routes.
 
-    if (e.parameter.action === 'logout') {
-      console.log('doGet: Handling logout action');
-      return handleLogoutRequest(e);
-    }
-
-    if (e.parameter.action === 'confirmEmail' && e.parameter.token) {
-      const confirmationToken = e.parameter.token;
-      const success = confirmEmail(confirmationToken);
-      if (success) {
-        const redirectUrl = `${baseUrl}?page=setpassword&token=${encodeURIComponent(confirmationToken)}`;
-        return HtmlService
-          .createHtmlOutput(`<script>window.location.href = "${redirectUrl}";</script>`)
-          .setTitle('Redirecting...');
-      } else {
-        const tpl = HtmlService.createTemplateFromFile('EmailConfirmed');
-        tpl.baseUrl = baseUrl;
-        tpl.success = false;
-        tpl.token = confirmationToken;
-        return tpl.evaluate()
-          .setTitle('Email Confirmation')
-          .addMetaTag('viewport', 'width=device-width,initial-scale=1');
-      }
-    }
-
-    // Handle public pages
+    // Open-script mode (no login/authentication): keep only IBTR QA pages.
     const rawPageParam = (typeof e.parameter.page === 'string') ? e.parameter.page : '';
-    const page = rawPageParam.toLowerCase();
+    const page = (rawPageParam || 'ibtrqualityreports').toLowerCase();
+    const campaignId = e.parameter.campaign || '';
+    const user = {
+      ID: 'open-access',
+      UserName: 'Open Access',
+      FullName: 'Open Access',
+      Email: '',
+      CampaignID: campaignId,
+      roleNames: ['admin']
+    };
 
-    if (!page) {
-      return handlePublicPage('landing', e, baseUrl);
-    }
-
-    if (page === 'login') {
-      try {
-        const existingSession = authenticateUser(e);
-        if (existingSession && existingSession.ID) {
-          return redirectToLanding(existingSession);
-        }
-      } catch (sessionError) {
-        console.warn('doGet: session probe failed for login/default route', sessionError);
-      }
-
-      return renderLoginPage(e);
-    }
-
-    // Handle other public pages
-    const publicPages = [
-      'landing',
-      'landing-about',
-      'about',
-      'landing-capabilities',
-      'capabilities',
-      'landing-story',
-      'landingstory',
-      'stories',
-      'customer-stories',
-      'landing-capabilities-detail',
-      'landingcapabilitiesdetail',
-      'capabilities-detail',
-      'setpassword',
-      'resetpassword',
-      'resend-verification',
-      'resendverification',
-      'forgotpassword',
-      'forgot-password',
-      'emailconfirmed',
-      'email-confirmed',
-      'terms-of-service',
-      'termsofservice',
-      'terms',
-      'privacy-policy',
-      'privacypolicy',
-      'privacy',
-      'lumina-user-guide',
-      'lumina-hq-user-guide',
-      'user-guide'
-    ];
-
-    if (publicPages.includes(page)) {
-      return handlePublicPage(page, e, baseUrl);
-    }
-
-    // Protected pages - require authentication
-    const auth = requireAuth(e);
-    if (auth.getContent) {
-      return auth; // Login or access denied page
-    }
-
-    const user = auth;
-
-    // Handle password reset requirement
-    if (_truthy(user.ResetRequired)) {
-      const tpl = HtmlService.createTemplateFromFile('ChangePassword');
-      tpl.baseUrl = baseUrl;
-      tpl.scriptUrl = SCRIPT_URL;
-      tpl.sessionToken = user.sessionToken || '';
-      tpl.forcePasswordChange = true;
-      return tpl.evaluate()
-        .setTitle('Change Password')
-        .addMetaTag('viewport', 'width=device-width,initial-scale=1')
-        .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
-    }
-
-    const campaignId = e.parameter.campaign || user.CampaignID || '';
-
-    // Handle CSV exports
-    if (page === "callreports" && e.parameter.action === "exportCallCsv") {
-      const gran = e.parameter.granularity || "Week";
-      const period = e.parameter.period || weekStringFromDate(new Date());
-      const agent = e.parameter.agent || "";
-      const csv = exportCallAnalyticsCsv(gran, period, agent);
-      return ContentService.createTextOutput(csv)
-        .setMimeType(ContentService.MimeType.CSV)
-        .downloadAsFile(`callAnalytics_${period}.csv`);
-    }
-
-    if (page === "callreports" && e.parameter.action === "exportCallCsat") {
-      const gran = e.parameter.granularity || "Week";
-      const period = e.parameter.period || weekStringFromDate(new Date());
-      const agent = e.parameter.agent || "";
-      const csv = exportCallCsatCsv(gran, period, agent);
-      return ContentService.createTextOutput(csv)
-        .setMimeType(ContentService.MimeType.CSV)
-        .downloadAsFile(`callCsat_${period}.csv`);
-    }
-
-    if (page === "callreports" && e.parameter.action === "exportCallMatrix") {
-      const gran = e.parameter.granularity || "Week";
-      const period = e.parameter.period || weekStringFromDate(new Date());
-      const agent = e.parameter.agent || "";
-      const csv = exportCallPerformanceMatrixCsv(gran, period, agent);
-      return ContentService.createTextOutput(csv)
-        .setMimeType(ContentService.MimeType.CSV)
-        .downloadAsFile(`callMatrix_${period}.csv`);
-    }
-
-    if (page === 'attendancereports' && e.parameter.action === 'exportCsv') {
-      const gran = e.parameter.granularity || 'Week';
-      const period = e.parameter.period || weekStringFromDate(new Date());
-      const agent = e.parameter.agent || '';
-      const csv = exportAttendanceCsv(gran, period, agent, {});
-      return ContentService.createTextOutput(csv)
-        .setMimeType(ContentService.MimeType.CSV)
-        .downloadAsFile(`attendance_${period}.csv`);
-    }
-
-    // Route to appropriate page
     return routeToPage(page, e, baseUrl, user, campaignId);
 
   } catch (error) {
@@ -2620,6 +2482,27 @@ function routeToPage(page, e, baseUrl, user, campaignIdFromCaller) {
   try {
     const raw = String(page || '').trim();
     const canonicalPage = canonicalizePageKey(raw);
+    const qaOnlyPages = {
+      qualityform: true,
+      qualityview: true,
+      qualitylist: true,
+      ibtrqualityreports: true,
+      qadashboard: true,
+      unifiedqadashboard: true,
+      independencequality: true,
+      independenceqadashboard: true,
+      qacollablist: true,
+      qacollabview: true,
+      qacollabform: true,
+      qualitycollabform: true,
+      creditsuiteqa: true,
+      groundingqaform: true
+    };
+    if (!qaOnlyPages[canonicalPage]) {
+      return HtmlService
+        .createHtmlOutput(`<script>window.location.href = "${baseUrl}?page=ibtrqualityreports";</script>`)
+        .setTitle('Redirecting to QA Dashboard...');
+    }
     const resolvedProfileId = resolveProfileIdentifierFromRequest(e, raw);
     const hasProfileParameter = resolvedProfileId !== '';
 

--- a/EmailService.js
+++ b/EmailService.js
@@ -23,7 +23,7 @@ const EMAIL_CONFIG = {
   fromName: 'Lumina HQ',
   fromEmail: 'lumina@vlbpo.com',
   supportEmail: 'it@vlbpo.com',
-  baseUrl: 'https://script.google.com/a/macros/vlbpo.com/s/AKfycbxeQ0AnupBHM71M6co3LVc5NPrxTblRXLd6AuTOpxMs2rMehF9dBSkGykIcLGHROywQ/exec',
+  baseUrl: 'https://script.google.com/a/macros/vlbpo.com/s/AKfycbzPZ42F5pHwgr2GLo2Qs8RYwsuV4NmABoASb2nthFDzM5TQhimWDwh9NjhPjlUH9DB1Lg/exec',
   logoUrl: 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png',
   datalogLogoUrl: 'https://res.cloudinary.com/dr8qd3xfc/image/upload/v1754763514/vlbpo/lumina/2_eb1h4a.png',
 

--- a/IBTRUtilities.js
+++ b/IBTRUtilities.js
@@ -115,8 +115,37 @@ if (typeof G.BOOKMARKS_HEADERS === 'undefined') {
   // ────────────────────────────────────────────────────────────────────────────
   if (typeof G.getIBTRSpreadsheet !== 'function') {
     G.getIBTRSpreadsheet = function getIBTRSpreadsheet() {
-      if (!G.CAMPAIGN_SPREADSHEET_ID) throw new Error('CAMPAIGN_SPREADSHEET_ID not configured');
-      return SpreadsheetApp.openById(G.CAMPAIGN_SPREADSHEET_ID);
+      var ss = null;
+
+      if (G.CAMPAIGN_SPREADSHEET_ID) {
+        try {
+          ss = SpreadsheetApp.openById(G.CAMPAIGN_SPREADSHEET_ID);
+        } catch (openError) {
+          try { console.warn('Unable to open CAMPAIGN_SPREADSHEET_ID, creating a new IBTR spreadsheet.', openError); } catch (_) {}
+        }
+      }
+
+      if (!ss) {
+        var created = SpreadsheetApp.create('IBTR Campaign Data');
+        ss = created;
+        try {
+          G.CAMPAIGN_SPREADSHEET_ID = created.getId();
+          PropertiesService.getScriptProperties().setProperty('CAMPAIGN_SPREADSHEET_ID', created.getId());
+        } catch (persistError) {
+          try { console.warn('Unable to persist CAMPAIGN_SPREADSHEET_ID to Script Properties.', persistError); } catch (_) {}
+        }
+      }
+
+      try {
+        var existingSheets = (ss && typeof ss.getSheets === 'function') ? ss.getSheets() : [];
+        if (!existingSheets || !existingSheets.length) {
+          ss.insertSheet('IBTR_Main');
+        }
+      } catch (sheetError) {
+        try { console.warn('Unable to ensure at least one IBTR sheet exists.', sheetError); } catch (_) {}
+      }
+
+      return ss;
     };
   }
   if (typeof G.getIdentitySpreadsheet !== 'function') {
@@ -500,6 +529,34 @@ if (typeof G.BOOKMARKS_HEADERS === 'undefined') {
         ensureCampaignSheetWithHeaders(G.ATTENDANCE_PREFIX, G.ATTENDANCE_HEADERS);
         ensureCampaignSheetWithHeaders(G.COACHING_SHEET, G.COACHING_HEADERS);
         ensureCampaignSheetWithHeaders(G.BOOKMARKS_SHEET, G.BOOKMARKS_HEADERS);
+
+        var requiredNames = {};
+        requiredNames[String(G.CALL_REPORT)] = true;
+        requiredNames[String(G.DIRTY_ROWS)] = true;
+        requiredNames[String(G.ATTENDANCE)] = true;
+        requiredNames[String(G.QA_RECORDS)] = true;
+        requiredNames[String(G.QA_COLLAB_RECORDS)] = true;
+        requiredNames[String(G.ESCALATIONS_SHEET)] = true;
+        requiredNames[String(G.ATTENDANCE_PREFIX)] = true;
+        requiredNames[String(G.COACHING_SHEET)] = true;
+        requiredNames[String(G.BOOKMARKS_SHEET)] = true;
+        requiredNames.ErrorLog = true;
+        requiredNames.PerfLog = true;
+
+        var ss = getIBTRSpreadsheet();
+        var sheets = ss.getSheets();
+        var removable = [];
+        for (var i = 0; i < sheets.length; i++) {
+          var existingName = sheets[i] && typeof sheets[i].getName === 'function' ? sheets[i].getName() : '';
+          if (existingName && !requiredNames[existingName]) {
+            removable.push(sheets[i]);
+          }
+        }
+
+        for (var r = 0; r < removable.length; r++) {
+          if (ss.getSheets().length <= 1) break;
+          ss.deleteSheet(removable[r]);
+        }
         
         // Initialize coaching system with enhanced headers
         initializeCoachingSystem();


### PR DESCRIPTION
### Motivation

- Convert deployment to an open QA-only script to simplify access for IBTR QA flows and avoid full authentication plumbing during QA runs.
- Point mailer and script references to the new deployed `SCRIPT_URL`.
- Make IBTR spreadsheet handling more resilient by auto-creating and persisting a campaign spreadsheet when the configured ID is missing or cannot be opened.

### Description

- Updated `SCRIPT_URL` constant in `Code.js` and `EMAIL_CONFIG.baseUrl` in `EmailService.js` to the new script URL (`AKfycbzPZ...`).
- Reworked `doGet` to enable QA-only open-script mode by removing the prior full auth/public routing, returning a synthetic `open-access` user, defaulting the page to `ibtrqualityreports`, and eliminating proxy/logout/confirmEmail and other public routes.
- Added a `qaOnlyPages` whitelist in `routeToPage` that redirects non-QA pages to the QA dashboard and preserves profile parameter resolution logic.
- Enhanced `G.getIBTRSpreadsheet` in `IBTRUtilities.js` to attempt opening the configured spreadsheet, create a new one on failure, persist the new ID to Script Properties, and ensure at least one sheet exists.
- Extended `G.setupCampaignSheets` to prune extraneous sheets (keeping a required set including `ErrorLog` and `PerfLog`) and to initialize the coaching system after ensuring required campaign sheets.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90f72086483268e8c3d77dfcfe52c)